### PR TITLE
Separate launching a browser from injecting browser refresh middleware

### DIFF
--- a/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -35,6 +36,7 @@ namespace Microsoft.DotNet.Watcher
                 new MSBuildEvaluationFilter(fileSetFactory),
                 new NoRestoreFilter(),
                 new LaunchBrowserFilter(dotNetWatchOptions),
+                new BrowserRefreshFilter(dotNetWatchOptions, _reporter),
             };
         }
 

--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Graph;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public sealed class BrowserRefreshFilter : IWatchFilter, IAsyncDisposable
+    {
+        private readonly bool _suppressBrowserRefresh;
+        private readonly IReporter _reporter;
+        private BrowserRefreshServer? _refreshServer;
+
+        public BrowserRefreshFilter(DotNetWatchOptions dotNetWatchOptions, IReporter reporter)
+        {
+            _suppressBrowserRefresh = dotNetWatchOptions.SuppressBrowserRefresh;
+            _reporter = reporter;
+        }
+
+        public async ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
+        {
+            if (_suppressBrowserRefresh)
+            {
+                return;
+            }
+
+            if (context.Iteration == 0)
+            {
+                if (context.ProjectGraph is null)
+                {
+                    _reporter.Verbose("Unable to determine if this project is a webapp.");
+                    return;
+                }
+                else if (IsWebApp(context.ProjectGraph))
+                {
+                    _reporter.Verbose("Configuring the app to use browser-refresh middleware.");
+                }
+                else
+                {
+                    _reporter.Verbose("Skipping configuring browser-refresh middleware since this is not a webapp.");
+                    return;
+                }
+
+                _refreshServer = new BrowserRefreshServer(context.Reporter);
+                context.BrowserRefreshServer = _refreshServer;
+                var serverUrls = string.Join(',', await _refreshServer.StartAsync(cancellationToken));
+                context.Reporter.Verbose($"Refresh server running at {serverUrls}.");
+                context.ProcessSpec.EnvironmentVariables["ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT"] = serverUrls;
+
+                var pathToMiddleware = Path.Combine(AppContext.BaseDirectory, "middleware", "Microsoft.AspNetCore.Watch.BrowserRefresh.dll");
+                context.ProcessSpec.EnvironmentVariables.DotNetStartupHooks.Add(pathToMiddleware);
+                context.ProcessSpec.EnvironmentVariables.AspNetCoreHostingStartupAssemblies.Add("Microsoft.AspNetCore.Watch.BrowserRefresh");
+            }
+            else if (!_suppressBrowserRefresh)
+            {
+                // We've detected a change. Notify the browser.
+                await (_refreshServer?.SendWaitMessageAsync(cancellationToken) ?? default);
+            }
+        }
+
+        private static bool IsWebApp(ProjectGraph projectGraph)
+        {
+            // We only want to enable browser refreshes if this is a WebApp (ASP.NET Core / Blazor app).
+            return projectGraph.GraphRoots.FirstOrDefault() is { } projectNode &&
+                projectNode.ProjectInstance.GetItems("ProjectCapability").Any(p => p.EvaluatedInclude is "AspNetCore" or "WebAssembly");
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_refreshServer != null)
+            {
+                await _refreshServer.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/Filters/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/LaunchBrowserFilter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -17,31 +16,29 @@ namespace Microsoft.DotNet.Watcher.Tools
         private static readonly Regex NowListeningRegex = new Regex(@"Now listening on: (?<url>.*)\s*$", RegexOptions.None | RegexOptions.Compiled, TimeSpan.FromSeconds(10));
         private readonly bool _runningInTest;
         private readonly bool _suppressLaunchBrowser;
-        private readonly bool _suppressBrowserRefresh;
         private readonly string _browserPath;
-
         private bool _attemptedBrowserLaunch;
         private Process _browserProcess;
-        private BrowserRefreshServer _refreshServer;
         private IReporter _reporter;
         private string _launchPath;
         private CancellationToken _cancellationToken;
+        private DotNetWatchContext _watchContext;
 
-        public LaunchBrowserFilter(DotNetWatchOptions dotNetWatchOptions)
+        public LaunchBrowserFilter(DotNetWatchOptions dotNetWatchOptions, bool allowBrowserRefreshWithoutLaunchBrowser = false)
         {
             _suppressLaunchBrowser = dotNetWatchOptions.SuppressLaunchBrowser;
-            _suppressBrowserRefresh = dotNetWatchOptions.SuppressBrowserRefresh;
             _runningInTest = dotNetWatchOptions.RunningAsTest;
-
             _browserPath = Environment.GetEnvironmentVariable("DOTNET_WATCH_BROWSER_PATH");
         }
 
-        public async ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
+        public ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
             if (_suppressLaunchBrowser)
             {
-                return;
+                return default;
             }
+
+            _watchContext = context;
 
             if (context.Iteration == 0)
             {
@@ -56,26 +53,10 @@ namespace Microsoft.DotNet.Watcher.Tools
                     // We've redirected the output, but want to ensure that it continues to appear in the user's console.
                     context.ProcessSpec.OnOutput += (_, eventArgs) => Console.WriteLine(eventArgs.Data);
                     context.ProcessSpec.OnOutput += OnOutput;
-
-                    if (!_suppressBrowserRefresh)
-                    {
-                        _refreshServer = new BrowserRefreshServer(context.Reporter);
-                        context.BrowserRefreshServer = _refreshServer;
-                        var serverUrls = string.Join(',', await _refreshServer.StartAsync(cancellationToken));
-                        context.Reporter.Verbose($"Refresh server running at {serverUrls}.");
-                        context.ProcessSpec.EnvironmentVariables["ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT"] = serverUrls;
-
-                        var pathToMiddleware = Path.Combine(AppContext.BaseDirectory, "middleware", "Microsoft.AspNetCore.Watch.BrowserRefresh.dll");
-                        context.ProcessSpec.EnvironmentVariables.DotNetStartupHooks.Add(pathToMiddleware);
-                        context.ProcessSpec.EnvironmentVariables.AspNetCoreHostingStartupAssemblies.Add("Microsoft.AspNetCore.Watch.BrowserRefresh");
-                    }
                 }
             }
-            else if (!_suppressBrowserRefresh)
-            {
-                // We've detected a change. Notify the browser.
-                await (_refreshServer?.SendWaitMessageAsync(cancellationToken) ?? default);
-            }
+
+            return default;
         }
 
         private void OnOutput(object sender, DataReceivedEventArgs eventArgs)
@@ -119,10 +100,10 @@ namespace Microsoft.DotNet.Watcher.Tools
                         _reporter.Output($"Unable to launch the browser. Navigate to {launchUrl}");
                     }
                 }
-                else
+                else if (_watchContext?.BrowserRefreshServer is { } browserRefresh)
                 {
                     _reporter.Verbose("Reloading browser.");
-                    _ = _refreshServer?.ReloadAsync(_cancellationToken);
+                    _ = browserRefresh.ReloadAsync(_cancellationToken);
                 }
             }
         }
@@ -180,13 +161,10 @@ namespace Microsoft.DotNet.Watcher.Tools
             return true;
         }
 
-        public async ValueTask DisposeAsync()
+        public ValueTask DisposeAsync()
         {
             _browserProcess?.Dispose();
-            if (_refreshServer != null)
-            {
-                await _refreshServer.DisposeAsync();
-            }
+            return default;
         }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Build.Graph;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.Extensions.Tools.Internal;
@@ -38,7 +37,8 @@ namespace Microsoft.DotNet.Watcher
             {
                 new MSBuildEvaluationFilter(fileSetFactory),
                 new DotNetBuildFilter(_processRunner, _reporter),
-                new LaunchBrowserFilter(_dotNetWatchOptions),
+                new LaunchBrowserFilter(dotNetWatchOptions),
+                new BrowserRefreshFilter(dotNetWatchOptions, _reporter),
             };
             _rudeEditDialog = new(reporter, _console);
         }

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -287,9 +287,10 @@ Examples:
                 DefaultLaunchSettingsProfile = defaultProfile,
             };
 
-            if (!options.NoHotReload && isDefaultRunCommand && TryReadProject(projectFile, out var projectGraph) && IsHotReloadSupported(projectGraph))
+            context.ProjectGraph = TryReadProject(projectFile);
+
+            if (!options.NoHotReload && isDefaultRunCommand && context.ProjectGraph is not null && IsHotReloadSupported(context.ProjectGraph))
             {
-                context.ProjectGraph = projectGraph;
                 _reporter.Verbose($"Project supports hot reload and was configured to run with the default run-command. Watching with hot-reload");
 
                 // Use hot-reload based watching if
@@ -312,20 +313,19 @@ Examples:
             return 0;
         }
 
-        private bool TryReadProject(string project, out ProjectGraph projectInstance)
+        private ProjectGraph TryReadProject(string project)
         {
-            projectInstance = default;
             try
             {
-                projectInstance = new ProjectGraph(project);
-                return true;
+                return new ProjectGraph(project);
             }
             catch (Exception ex)
             {
                 _reporter.Verbose("Reading the project instance failed.");
                 _reporter.Verbose(ex.ToString());
-                return false;
             }
+
+            return null;
         }
 
         private static bool IsHotReloadSupported(ProjectGraph projectGraph)

--- a/src/Tests/dotnet-watch.Tests/BrowserLaunchTests.cs
+++ b/src/Tests/dotnet-watch.Tests/BrowserLaunchTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.NET.TestFramework;
 using Xunit;
@@ -39,30 +38,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             // Verify we launched the browser.
             await app.Process.GetOutputLineStartsWithAsync(expected, TimeSpan.FromMinutes(2));
-        }
-
-        [Fact]
-        public async Task RefreshesBrowserOnChange()
-        {
-            var launchBrowserMessage = "watch : Launching browser: https://localhost:5001/";
-            var refreshBrowserMessage = "watch : Reloading browser";
-
-            var testAsset = _testAssetsManager.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
-
-            using var app = new WatchableApp(testAsset, _logger);
-            app.DotnetWatchArgs.Add("--verbose");
-            var source = Path.Combine(app.SourceDirectory, "Program.cs");
-
-            await app.StartWatcherAsync();
-
-            // Verify we launched the browser.
-            await app.Process.GetOutputLineStartsWithAsync(launchBrowserMessage, TimeSpan.FromMinutes(2));
-
-            // Make a file change and verify we reloaded the browser.
-            File.SetLastWriteTime(source, DateTime.Now);
-            await app.Process.GetOutputLineStartsWithAsync(refreshBrowserMessage, TimeSpan.FromMinutes(2));
         }
 
         [Fact]


### PR DESCRIPTION
Turning off launchBrowser also prevents the browser refresh script from being injected in to the app's output. This completely prevents hot reload from working. We can separate the two and look for the presence of ProjectCapabilities to determine if the app is a webapp.

Fixes https://github.com/dotnet/aspnetcore/issues/34145