### PR TITLE
[API Compat] Add rule to validate members are not added to interfaces

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
@@ -13,5 +13,6 @@ namespace Microsoft.DotNet.ApiCompatibility
         public const string AssemblyIdentityMustMatch = "CP0003";
         public const string MatchingAssemblyDoesNotExist = "CP0004";
         public const string CannotAddAbstractMember = "CP0005";
+        public const string CannotAddMemberToInterface = "CP0006";
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Resources.resx
@@ -192,4 +192,7 @@
   <data name="VisitorRightCountShouldMatchMappersSetSize" xml:space="preserve">
     <value>The provided right count when creating the visitor should match the right set size specified for the mappers.</value>
   </data>
+  <data name="CannotAddMemberToInterface" xml:space="preserve">
+    <value>Cannot add interface member '{0}' to {1} because does not exist on {2}</value>
+  </data>
 </root>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Resources.resx
@@ -130,7 +130,7 @@
     <value>Provided assembly search directory '{0}' does not exist.</value>
   </data>
   <data name="CannotAddAbstractMember" xml:space="preserve">
-    <value>Cannot add abstract member '{0}' to {1} because does not exist on {2}</value>
+    <value>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</value>
   </data>
   <data name="AssembyCultureDoesNotMatch" xml:space="preserve">
     <value>{2} assembly culture '{0}' does not match with {3} assembly culture '{1}'.</value>
@@ -193,6 +193,6 @@
     <value>The provided right count when creating the visitor should match the right set size specified for the mappers.</value>
   </data>
   <data name="CannotAddMemberToInterface" xml:space="preserve">
-    <value>Cannot add interface member '{0}' to {1} because does not exist on {2}</value>
+    <value>Cannot add interface member '{0}' to {1} because it does not exist on {2}</value>
   </data>
 </root>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+
+namespace Microsoft.DotNet.ApiCompatibility.Rules
+{
+    public class CannotAddMemberToInterface : Rule
+    {
+        public override void Initialize(RuleRunnerContext context)
+        {
+            // StrictMode scenario should be handled by MembersMustExist rule.
+            if (!Settings.StrictMode)
+            {
+                context.RegisterOnMemberSymbolAction(RunOnMemberSymbol);
+            }
+        }
+
+        private void RunOnMemberSymbol(ISymbol left, ISymbol right, string leftName, string rightName, IList<CompatDifference> differences)
+        {
+            if (left == null && right != null && right.ContainingType.TypeKind == TypeKind.Interface)
+            {
+                // Fields in interface can only be static which is not considered a break.
+                if (right is IFieldSymbol)
+                    return;
+
+                // Event and property accessors are covered by finding the property or event implementation
+                // for interface member on the containing type.
+                if (right is IMethodSymbol ms && IsEventOrPropertyAccessor(ms))
+                    return;
+
+                // If there is a default implementation provided is not a breaking change to add an interface member.
+                if (right.ContainingType.FindImplementationForInterfaceMember(right) == null)
+                {
+                    differences.Add(new CompatDifference(DiagnosticIds.CannotAddMemberToInterface, string.Format(Resources.CannotAddMemberToInterface, right.ToDisplayString(), rightName, leftName), DifferenceType.Added, right));
+                }
+            }
+
+        }
+
+        private bool IsEventOrPropertyAccessor(IMethodSymbol symbol) =>
+            symbol.MethodKind == MethodKind.PropertyGet ||
+            symbol.MethodKind == MethodKind.PropertySet ||
+            symbol.MethodKind == MethodKind.EventAdd ||
+            symbol.MethodKind == MethodKind.EventRemove;
+    }
+}

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
 

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotAddMemberToInterface">
+        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
         <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
         <target state="new">Could not resolve reference '{0}' in any of the provided search directories.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
@@ -38,13 +38,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotAddAbstractMember">
-        <source>Cannot add abstract member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add abstract member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add abstract member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add abstract member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotAddMemberToInterface">
-        <source>Cannot add interface member '{0}' to {1} because does not exist on {2}</source>
-        <target state="new">Cannot add interface member '{0}' to {1} because does not exist on {2}</target>
+        <source>Cannot add interface member '{0}' to {1} because it does not exist on {2}</source>
+        <target state="new">Cannot add interface member '{0}' to {1} because it does not exist on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotResolveReference">

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
@@ -14,7 +14,7 @@ using Microsoft.NET.TestFramework.ProjectConstruction;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.DotNet.ApiCompatibility.Tests.Rules
+namespace Microsoft.DotNet.ApiCompatibility.Tests
 {
     public class AssemblyIdentityMustMatchTests : SdkTest
     {

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
 
 using System;
 using System.Collections.Generic;

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
@@ -1,0 +1,261 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.ApiCompatibility.Tests
+{
+    public class CannotAddMemberToInterfaceTests
+    {
+        [Fact]
+        public void AddedMembersAreReported()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+  }
+}
+";
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    string MyMethod();
+    static MyField = 2;
+    int MyPropertyWithDefaultImplementation { get { } set { } }
+    event EventHandler MyEvent { add { } remove { } }
+    byte MyPropertyWithoutDefaultImplementation { get; set; }
+    event EventHandler MyEventWithoutImplementation;
+  }
+}
+";
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+
+            ApiComparer differ = new();
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
+
+            CompatDifference[] expected = new[]
+            {
+                new CompatDifference(DiagnosticIds.CannotAddMemberToInterface, string.Empty, DifferenceType.Added, "M:CompatTests.IFoo.MyMethod"),
+                new CompatDifference(DiagnosticIds.CannotAddMemberToInterface, string.Empty, DifferenceType.Added, "P:CompatTests.IFoo.MyPropertyWithoutDefaultImplementation"),
+                new CompatDifference(DiagnosticIds.CannotAddMemberToInterface, string.Empty, DifferenceType.Added, "E:CompatTests.IFoo.MyEventWithoutImplementation"),
+            };
+
+            Assert.Equal(expected, differences, CompatDifferenceComparer.Default);
+        }
+
+        [Theory]
+        [MemberData(nameof(NoDifferencesShouldBeReportedData))]
+        public void NoDifferencesShouldBeReported(string leftSyntax, string rightSyntax)
+        {
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+
+            ApiComparer differ = new();
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
+
+            Assert.Empty(differences);
+        }
+
+        [Fact]
+        public void StrictModeRuleShouldNotRun()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+  }
+}
+";
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    string MyMethod();
+    static MyField = 2;
+    int MyPropertyWithDefaultImplementation { get { } set { } }
+    event EventHandler MyEvent { add { } remove { } }
+    byte MyPropertyWithoutDefaultImplementation { get; set; }
+    event EventHandler MyEventWithoutImplementation;
+  }
+}
+";
+
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
+
+            foreach (CompatDifference difference in differences)
+            {
+                Assert.NotEqual(DiagnosticIds.CannotAddMemberToInterface, difference.DiagnosticId);
+            }
+        }
+
+        [Fact]
+        public void MultipleRightsAreReported()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    string MyMethod();
+    int MyProperty { get; set; }
+    event EventHandler MyEvent;
+  }
+}
+";
+
+            string[] rightSyntaxes = new[]
+            { @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    string MyMethod();
+    int MyProperty { get; set; }
+    event EventHandler MyEvent;
+    int MyPropertyWithDIM { get => 0; set { } }
+  }
+}
+",
+            @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    string MyMethod();
+    int MyProperty { get; set; }
+    event EventHandler MyEvent;
+    event EventHandler MyOtherEvent;
+    static int MyField = 3;
+  }
+}
+",
+            @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    string MyMethod();
+    string MyOtherMethod();
+    string MyOtherMethodWithDIM() => string.Empty;
+    int MyProperty { get; set; }
+    event EventHandler MyEvent;
+    event EventHandler MyOtherEventWithDIM { add { } remove { } }
+    static int MyField = 3;
+  }
+}
+"};
+
+            ApiComparer differ = new();
+            ElementContainer<IAssemblySymbol> left =
+                new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, string.Empty, "ref"));
+
+            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+
+            IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
+                differ.GetDifferences(left, right);
+
+            CompatDifference[][] expectedDiffs =
+            {
+                Array.Empty<CompatDifference>(),
+                new[]
+                {
+                    new CompatDifference(DiagnosticIds.CannotAddMemberToInterface, string.Empty, DifferenceType.Added, "E:CompatTests.IFoo.MyOtherEvent"),
+                },
+                new[]
+                {
+                    new CompatDifference(DiagnosticIds.CannotAddMemberToInterface, string.Empty, DifferenceType.Added, "M:CompatTests.IFoo.MyOtherMethod"),
+                },
+            };
+
+            AssertExtensions.MultiRightResult(left.MetadataInformation, expectedDiffs, differences);
+        }
+
+        public static IEnumerable<object[]> NoDifferencesShouldBeReportedData()
+        {
+            yield return new[]
+            {
+                @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    string MyMethod();
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    string MyMethod();
+    private string MyPrivateMethod();
+  }
+}
+"
+            };
+            yield return new[]
+            {
+                @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    int MyProperty { get; set; }
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    int MyProperty { get; set; }
+    byte MyOtherProperty { get => (byte)0; set { } }
+  }
+}
+"
+            };
+            yield return new[]
+            {
+                @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    event EventHandler EventHandler;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public interface IFoo
+  {
+    event EventHandler EventHandler;
+    static int MyField = 32;
+    int MyMethod() => 0;
+  }
+}
+"
+            };
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/17928

I decided to not add a flag to specify if default implementations should be breaking as those can only appear on a runtime that supports them. If the target runtime that the code is being compiled for doesn't support that when adding a default implementation the compiler will error.

FYI: @terrajobst @utpilla 