### PR TITLE
Use MetadataInformation object and left  vs multiple right optimization

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/MetadataInformation.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/MetadataInformation.cs
@@ -14,12 +14,14 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         public readonly string AssemblyName;
         public readonly string TargetFramework;
         public readonly string AssemblyId;
+        public readonly string DisplayString;
 
-        public MetadataInformation(string name, string targetFramework, string assemblyId)
+        public MetadataInformation(string name, string targetFramework, string assemblyId, string displayString = null)
         {
             AssemblyName = name ?? string.Empty;
             TargetFramework = targetFramework ?? string.Empty;
             AssemblyId = assemblyId ?? string.Empty;
+            DisplayString = displayString ?? assemblyId;
         }
 
         public bool Equals(MetadataInformation other) =>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
@@ -134,11 +134,11 @@ namespace Microsoft.DotNet.ApiCompatibility
                 }
 
                 ElementContainer<IAssemblySymbol> element = right[i];
-                rightNames[i] = element.MetadataInformation.AssemblyId;
+                rightNames[i] = element.MetadataInformation.DisplayString;
                 mapper.AddElement(element.Element, ElementSide.Right, i);
             }
 
-            mapper.Settings = GetComparingSettingsCore(left.MetadataInformation.AssemblyId, rightNames);
+            mapper.Settings = GetComparingSettingsCore(left.MetadataInformation.DisplayString, rightNames);
 
             DifferenceVisitor visitor = new(rightCount: rightCount, noWarn: NoWarn, ignoredDifferences: IgnoredDifferences);
             visitor.Visit(mapper);

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -18,9 +19,13 @@ namespace Microsoft.DotNet.PackageValidation
     /// </summary>
     public class ApiCompatRunner
     {
-        private List<(string leftAssemblyPackagePath, MetadataInformation leftAssembly, string rightAssemblyPackagePath, MetadataInformation rightAssembly, string compatibilityReason, string header)> _queue = new();
+        private Dictionary<MetadataInformation, List<(MetadataInformation rightAssembly, string header)>> _dict = new();
         private readonly ApiComparer _differ = new();
         private readonly IPackageLogger _log;
+
+        private bool _isBaselineSuppression = false;
+        private string _leftPackagePath;
+        private string _rightPackagePath;
 
         public ApiCompatRunner(string noWarn, (string, string)[] ignoredDifferences, bool enableStrictMode, IPackageLogger log)
         {
@@ -31,63 +36,88 @@ namespace Microsoft.DotNet.PackageValidation
         }
 
         /// <summary>
-        /// Runs the api compat for the tuples in the queue.
+        /// Runs the api compat for the tuples in the dictionary.
         /// </summary>
         public void RunApiCompat()
         {
-            foreach (var apicompatTuples in _queue.Distinct())
+            foreach (var left in _dict.Keys)
             {
-                // TODO: Add optimisations tuples.
-                using (Stream leftAssemblyStream = GetFileStreamFromPackage(apicompatTuples.leftAssemblyPackagePath, apicompatTuples.leftAssembly.AssemblyId))
-                using (Stream rightAssemblyStream = GetFileStreamFromPackage(apicompatTuples.rightAssemblyPackagePath, apicompatTuples.rightAssembly.AssemblyId))
+                Stream leftAssemblyStream = GetFileStreamFromPackage(_leftPackagePath, left.AssemblyId);
+                IAssemblySymbol leftSymbols = new AssemblySymbolLoader().LoadAssembly(left.AssemblyName, leftAssemblyStream);
+                leftAssemblyStream.Close();
+                ElementContainer<IAssemblySymbol> leftContainer = new(leftSymbols, left); ;
+
+                List<ElementContainer<IAssemblySymbol>> rightContainerList = new();
+                foreach (var rightTuple in _dict[left])
                 {
-                    IAssemblySymbol leftSymbols = new AssemblySymbolLoader().LoadAssembly(apicompatTuples.leftAssembly.AssemblyName, leftAssemblyStream);
-                    IAssemblySymbol rightSymbols = new AssemblySymbolLoader().LoadAssembly(apicompatTuples.rightAssembly.AssemblyName, rightAssemblyStream);
+                    Stream rightAssemblyStream = GetFileStreamFromPackage(_rightPackagePath, rightTuple.rightAssembly.AssemblyId);
+                    IAssemblySymbol rightSymbols = new AssemblySymbolLoader().LoadAssembly(rightTuple.rightAssembly.AssemblyName, rightAssemblyStream);
+                    rightAssemblyStream.Close();
+                    rightContainerList.Add(new ElementContainer<IAssemblySymbol>(rightSymbols, rightTuple.rightAssembly));
+                }
 
-                    _log.LogMessage(MessageImportance.Low, apicompatTuples.header);
+                IList<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
+                    _differ.GetDifferences(leftContainer, rightContainerList).ToList();
 
-                    string leftName = apicompatTuples.leftAssembly.AssemblyId;
-                    bool isBaselineSuppression = false;
-                    if (!apicompatTuples.leftAssemblyPackagePath.Equals(apicompatTuples.rightAssemblyPackagePath, System.StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        isBaselineSuppression = true;
-                        leftName = Resources.Baseline + " " + leftName;
-                    }
+                for (int i = 0; i < differences.Count(); i++)
+                {
+                    (MetadataInformation, MetadataInformation, IEnumerable<CompatDifference> differences) diff = differences[i];
+                    (MetadataInformation rightAssembly, string header) rightAssembly = _dict[left][i];
 
-                    IEnumerable<CompatDifference> differences = _differ.GetDifferences(leftSymbols, rightSymbols, leftName: leftName, rightName: apicompatTuples.rightAssembly.AssemblyId);
+                    _log.LogMessage(MessageImportance.Low, rightAssembly.header);
 
-                    foreach (CompatDifference difference in differences)
+                    foreach (CompatDifference difference in diff.differences)
                     {
                         _log.LogError(
                             new Suppression
                             {
                                 DiagnosticId = difference.DiagnosticId,
                                 Target = difference.ReferenceId,
-                                Left = apicompatTuples.leftAssembly.AssemblyId,
-                                Right = apicompatTuples.rightAssembly.AssemblyId,
-                                IsBaselineSuppression = isBaselineSuppression
+                                Left = left.AssemblyId,
+                                Right = rightAssembly.rightAssembly.AssemblyId,
+                                IsBaselineSuppression = _isBaselineSuppression
                             },
                             difference.DiagnosticId,
                             difference.Message);
                     }
                 }
             }
-            _queue.Clear();
+            _dict.Clear();
         }
 
         /// <summary>
         /// Queues the api compat for 2 assemblies.
         /// </summary>
-        /// <param name="leftPackagePath">Path to package containing left assembly.</param>
         /// <param name="leftMetadataInfo">Metadata information for left assembly.</param>
-        /// <param name="rightPackagePath">Path to package containing right assembly.</param>
         /// <param name="rightMetdataInfo">Metadata information for right assembly.</param>
-        /// <param name="assemblyName">The name of the assembly.</param>
-        /// <param name="compatibilityReason">The reason for assembly compatibilty.</param>
         /// <param name="header">The header for the api compat diagnostics.</param>
-        public void QueueApiCompat(string leftPackagePath, MetadataInformation leftMetadataInfo, string rightPackagePath, MetadataInformation rightMetdataInfo, string compatibilityReason, string header)
+        public void QueueApiCompat(MetadataInformation leftMetadataInfo, MetadataInformation rightMetdataInfo, string header)
         {
-            _queue.Add((leftPackagePath, leftMetadataInfo, rightPackagePath, rightMetdataInfo, compatibilityReason, header));
+            if (_dict.ContainsKey(leftMetadataInfo))
+            {
+                _dict[leftMetadataInfo].Add((rightMetdataInfo, header));
+            }
+            else
+            {
+                _dict.Add(leftMetadataInfo, new List<(MetadataInformation rightAssembly, string header)>() { (rightMetdataInfo, header) });
+            }
+        }
+
+        internal void InitializePaths(string leftPackagePath, string rightPackagePath)
+        {
+            if (string.IsNullOrEmpty(leftPackagePath))
+                throw new ArgumentException(string.Format(Resources.InvalidPackagePath, leftPackagePath));
+
+            if (string.IsNullOrEmpty(rightPackagePath))
+                throw new ArgumentException(string.Format(Resources.InvalidPackagePath, rightPackagePath));
+
+            _leftPackagePath = leftPackagePath;
+            _rightPackagePath = rightPackagePath;
+
+            if (!_leftPackagePath.Equals(rightPackagePath, System.StringComparison.InvariantCultureIgnoreCase))
+            {
+                _isBaselineSuppression = true;
+            }
         }
 
         private static Stream GetFileStreamFromPackage(string packagePath, string entry)

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.PackageValidation
                 int counter = 0;
                 foreach ((MetadataInformation, MetadataInformation, IEnumerable<CompatDifference> differences) diff in differences)
                 {
-                    (MetadataInformation rightAssembly, string header) rightTuple = _dict[left][counter];
+                    (MetadataInformation rightAssembly, string header) rightTuple = _dict[left][counter++];
                     _log.LogMessage(MessageImportance.Low, rightTuple.header);
 
                     foreach (CompatDifference difference in diff.differences)
@@ -82,7 +82,6 @@ namespace Microsoft.DotNet.PackageValidation
                             difference.DiagnosticId,
                             difference.Message);
                     }
-                    counter++;
                 }
             }
             _dict.Clear();
@@ -109,10 +108,10 @@ namespace Microsoft.DotNet.PackageValidation
         internal void InitializePaths(string leftPackagePath, string rightPackagePath)
         {
             if (string.IsNullOrEmpty(leftPackagePath))
-                throw new ArgumentException(string.Format(Resources.InvalidPackagePath, leftPackagePath));
+                throw new ArgumentException(nameof(leftPackagePath));
 
             if (string.IsNullOrEmpty(rightPackagePath))
-                throw new ArgumentException(string.Format(Resources.InvalidPackagePath, rightPackagePath));
+                throw new ArgumentException(nameof(rightPackagePath));
 
             _leftPackagePath = leftPackagePath;
             _rightPackagePath = rightPackagePath;

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.PackageValidation
         /// </summary>
         public void RunApiCompat()
         {
-            foreach (var left in _dict.Keys)
+            foreach (MetadataInformation left in _dict.Keys)
             {
                 Stream leftAssemblyStream = GetFileStreamFromPackage(_leftPackagePath, left.AssemblyId);
                 IAssemblySymbol leftSymbols = new AssemblySymbolLoader().LoadAssembly(left.AssemblyName, leftAssemblyStream);
@@ -62,9 +62,9 @@ namespace Microsoft.DotNet.PackageValidation
                 for (int i = 0; i < differences.Count(); i++)
                 {
                     (MetadataInformation, MetadataInformation, IEnumerable<CompatDifference> differences) diff = differences[i];
-                    (MetadataInformation rightAssembly, string header) rightAssembly = _dict[left][i];
+                    (MetadataInformation rightAssembly, string header) rightTuple = _dict[left][i];
 
-                    _log.LogMessage(MessageImportance.Low, rightAssembly.header);
+                    _log.LogMessage(MessageImportance.Low, rightTuple.header);
 
                     foreach (CompatDifference difference in diff.differences)
                     {
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.PackageValidation
                                 DiagnosticId = difference.DiagnosticId,
                                 Target = difference.ReferenceId,
                                 Left = left.AssemblyId,
-                                Right = rightAssembly.rightAssembly.AssemblyId,
+                                Right = rightTuple.rightAssembly.AssemblyId,
                                 IsBaselineSuppression = _isBaselineSuppression
                             },
                             difference.DiagnosticId,

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.DotNet.ApiCompatibility;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
@@ -40,6 +39,9 @@ namespace Microsoft.DotNet.PackageValidation
         /// <param name="package">Nuget Package that needs to be validated.</param>
         public void Validate(Package package)
         {
+            if (_runApiCompat)
+                _apiCompatRunner.InitializePaths(_baselinePackage.PackagePath, package.PackagePath);
+
             foreach (ContentItem baselineCompileTimeAsset in _baselinePackage.RefAssets)
             {
                 NuGetFramework baselineTargetFramework = (NuGetFramework)baselineCompileTimeAsset.Properties["tfm"];
@@ -57,15 +59,11 @@ namespace Microsoft.DotNet.PackageValidation
                 }
                 else if (_runApiCompat)
                 {
-                    MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineCompileTimeAsset.Properties["tfm"]).GetShortFolderName(), baselineCompileTimeAsset.Path);
+                    MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineCompileTimeAsset.Properties["tfm"]).GetShortFolderName(), baselineCompileTimeAsset.Path, Resources.Baseline + " " + baselineCompileTimeAsset.Path);
                     MetadataInformation right = new(package.PackageId, ((NuGetFramework)latestCompileTimeAsset.Properties["tfm"]).GetShortFolderName(), latestCompileTimeAsset.Path);
 
-                    _apiCompatRunner.QueueApiCompat(_baselinePackage.PackagePath,
-                        left,
-                        package.PackagePath,
-                        right,
-                        Resources.BaselineVersionValidatorHeader,
-                        string.Format(Resources.ApiCompatibilityBaselineHeader, baselineCompileTimeAsset.Path, latestCompileTimeAsset.Path, _baselinePackage.Version, package.Version));
+                    string header = string.Format(Resources.ApiCompatibilityBaselineHeader, baselineCompileTimeAsset.Path, latestCompileTimeAsset.Path, _baselinePackage.Version, package.Version);
+                    _apiCompatRunner.QueueApiCompat(left, right, header);
                 }
             }
 
@@ -88,15 +86,11 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (_runApiCompat)
                     {
-                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineRuntimeAsset.Properties["tfm"]).GetShortFolderName(), baselineRuntimeAsset.Path);
+                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineRuntimeAsset.Properties["tfm"]).GetShortFolderName(), baselineRuntimeAsset.Path, Resources.Baseline + " " + baselineRuntimeAsset.Path);
                         MetadataInformation right = new(package.PackageId, ((NuGetFramework)latestRuntimeAsset.Properties["tfm"]).GetShortFolderName(), latestRuntimeAsset.Path);
 
-                        _apiCompatRunner.QueueApiCompat(_baselinePackage.PackagePath, 
-                            left,
-                            package.PackagePath, 
-                            right,
-                            Resources.BaselineVersionValidatorHeader,
-                            string.Format(Resources.ApiCompatibilityBaselineHeader, baselineRuntimeAsset.Path, latestRuntimeAsset.Path, _baselinePackage.Version, package.Version));
+                        string header = string.Format(Resources.ApiCompatibilityBaselineHeader, baselineRuntimeAsset.Path, latestRuntimeAsset.Path, _baselinePackage.Version, package.Version);
+                        _apiCompatRunner.QueueApiCompat(left, right, header);
                     }
                 }
             }
@@ -122,19 +116,15 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (_runApiCompat)
                     {
-                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineRuntimeSpecificAsset.Properties["tfm"]).GetShortFolderName(), baselineRuntimeSpecificAsset.Path);
+                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineRuntimeSpecificAsset.Properties["tfm"]).GetShortFolderName(), baselineRuntimeSpecificAsset.Path, Resources.Baseline + " " + baselineRuntimeSpecificAsset.Path);
                         MetadataInformation right = new(package.PackageId, ((NuGetFramework)latestRuntimeSpecificAsset.Properties["tfm"]).GetShortFolderName(), latestRuntimeSpecificAsset.Path);
 
-                        _apiCompatRunner.QueueApiCompat(_baselinePackage.PackagePath,
-                            left,
-                            package.PackagePath,
-                            right,
-                            Resources.BaselineVersionValidatorHeader,
-                            string.Format(Resources.ApiCompatibilityBaselineHeader, baselineRuntimeSpecificAsset.Path, latestRuntimeSpecificAsset.Path, _baselinePackage.Version, package.Version)); ;
+                        string header = string.Format(Resources.ApiCompatibilityBaselineHeader, baselineRuntimeSpecificAsset.Path, latestRuntimeSpecificAsset.Path, _baselinePackage.Version, package.Version);
+                        _apiCompatRunner.QueueApiCompat(left, right, header);
                     }
                 }
             }
-            
+
             _apiCompatRunner.RunApiCompat();
         }
     }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
@@ -57,11 +57,13 @@ namespace Microsoft.DotNet.PackageValidation
                 }
                 else if (_runApiCompat)
                 {
+                    MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineCompileTimeAsset.Properties["tfm"]).GetShortFolderName(), baselineCompileTimeAsset.Path);
+                    MetadataInformation right = new(package.PackageId, ((NuGetFramework)latestCompileTimeAsset.Properties["tfm"]).GetShortFolderName(), latestCompileTimeAsset.Path);
+
                     _apiCompatRunner.QueueApiCompat(_baselinePackage.PackagePath,
-                        baselineCompileTimeAsset.Path,
+                        left,
                         package.PackagePath,
-                        latestCompileTimeAsset.Path,
-                        package.PackageId,
+                        right,
                         Resources.BaselineVersionValidatorHeader,
                         string.Format(Resources.ApiCompatibilityBaselineHeader, baselineCompileTimeAsset.Path, latestCompileTimeAsset.Path, _baselinePackage.Version, package.Version));
                 }
@@ -86,11 +88,13 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (_runApiCompat)
                     {
+                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineRuntimeAsset.Properties["tfm"]).GetShortFolderName(), baselineRuntimeAsset.Path);
+                        MetadataInformation right = new(package.PackageId, ((NuGetFramework)latestRuntimeAsset.Properties["tfm"]).GetShortFolderName(), latestRuntimeAsset.Path);
+
                         _apiCompatRunner.QueueApiCompat(_baselinePackage.PackagePath, 
-                            baselineRuntimeAsset.Path,
+                            left,
                             package.PackagePath, 
-                            latestRuntimeAsset.Path,
-                            package.PackageId,
+                            right,
                             Resources.BaselineVersionValidatorHeader,
                             string.Format(Resources.ApiCompatibilityBaselineHeader, baselineRuntimeAsset.Path, latestRuntimeAsset.Path, _baselinePackage.Version, package.Version));
                     }
@@ -118,13 +122,15 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (_runApiCompat)
                     {
-                        _apiCompatRunner.QueueApiCompat(_baselinePackage.PackagePath, 
-                            baselineRuntimeSpecificAsset.Path,
-                            package.PackagePath, 
-                            latestRuntimeSpecificAsset.Path,
-                            package.PackageId,
+                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineRuntimeSpecificAsset.Properties["tfm"]).GetShortFolderName(), baselineRuntimeSpecificAsset.Path);
+                        MetadataInformation right = new(package.PackageId, ((NuGetFramework)latestRuntimeSpecificAsset.Properties["tfm"]).GetShortFolderName(), latestRuntimeSpecificAsset.Path);
+
+                        _apiCompatRunner.QueueApiCompat(_baselinePackage.PackagePath,
+                            left,
+                            package.PackagePath,
+                            right,
                             Resources.BaselineVersionValidatorHeader,
-                            string.Format(Resources.BaselineVersionValidatorHeader, baselineRuntimeSpecificAsset.Path, latestRuntimeSpecificAsset.Path, _baselinePackage.Version, package.Version));
+                            string.Format(Resources.ApiCompatibilityBaselineHeader, baselineRuntimeSpecificAsset.Path, latestRuntimeSpecificAsset.Path, _baselinePackage.Version, package.Version)); ;
                     }
                 }
             }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
@@ -59,11 +59,8 @@ namespace Microsoft.DotNet.PackageValidation
                 }
                 else if (_runApiCompat)
                 {
-                    MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineCompileTimeAsset.Properties["tfm"]).GetShortFolderName(), baselineCompileTimeAsset.Path, Resources.Baseline + " " + baselineCompileTimeAsset.Path);
-                    MetadataInformation right = new(package.PackageId, ((NuGetFramework)latestCompileTimeAsset.Properties["tfm"]).GetShortFolderName(), latestCompileTimeAsset.Path);
-
                     string header = string.Format(Resources.ApiCompatibilityBaselineHeader, baselineCompileTimeAsset.Path, latestCompileTimeAsset.Path, _baselinePackage.Version, package.Version);
-                    _apiCompatRunner.QueueApiCompat(left, right, header);
+                    _apiCompatRunner.QueueApiCompatFromContentItem(package.PackageId, baselineCompileTimeAsset, latestCompileTimeAsset, header, isBaseline: true);
                 }
             }
 
@@ -86,11 +83,8 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (_runApiCompat)
                     {
-                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineRuntimeAsset.Properties["tfm"]).GetShortFolderName(), baselineRuntimeAsset.Path, Resources.Baseline + " " + baselineRuntimeAsset.Path);
-                        MetadataInformation right = new(package.PackageId, ((NuGetFramework)latestRuntimeAsset.Properties["tfm"]).GetShortFolderName(), latestRuntimeAsset.Path);
-
                         string header = string.Format(Resources.ApiCompatibilityBaselineHeader, baselineRuntimeAsset.Path, latestRuntimeAsset.Path, _baselinePackage.Version, package.Version);
-                        _apiCompatRunner.QueueApiCompat(left, right, header);
+                        _apiCompatRunner.QueueApiCompatFromContentItem(package.PackageId, baselineRuntimeAsset, latestRuntimeAsset, header, isBaseline: true);
                     }
                 }
             }
@@ -116,11 +110,8 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (_runApiCompat)
                     {
-                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)baselineRuntimeSpecificAsset.Properties["tfm"]).GetShortFolderName(), baselineRuntimeSpecificAsset.Path, Resources.Baseline + " " + baselineRuntimeSpecificAsset.Path);
-                        MetadataInformation right = new(package.PackageId, ((NuGetFramework)latestRuntimeSpecificAsset.Properties["tfm"]).GetShortFolderName(), latestRuntimeSpecificAsset.Path);
-
                         string header = string.Format(Resources.ApiCompatibilityBaselineHeader, baselineRuntimeSpecificAsset.Path, latestRuntimeSpecificAsset.Path, _baselinePackage.Version, package.Version);
-                        _apiCompatRunner.QueueApiCompat(left, right, header);
+                        _apiCompatRunner.QueueApiCompatFromContentItem(package.PackageId, baselineRuntimeSpecificAsset, latestRuntimeSpecificAsset, header, isBaseline: true);
                     }
                 }
             }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
@@ -27,7 +27,8 @@ namespace Microsoft.DotNet.PackageValidation
         /// </summary>
         /// <param name="package">Nuget Package that needs to be validated.</param>
         public void Validate(Package package)
-        {       
+        {
+            _apiCompatRunner.InitializePaths(package.PackagePath, package.PackagePath);
             IEnumerable<ContentItem> compileAssets = package.CompileAssets.OrderByDescending(t => ((NuGetFramework)t.Properties["tfm"]).Version);
             ManagedCodeConventions conventions = new ManagedCodeConventions(null);
             Queue<ContentItem> compileAssetsQueue = new Queue<ContentItem>(compileAssets);
@@ -56,12 +57,8 @@ namespace Microsoft.DotNet.PackageValidation
                     MetadataInformation left = new(package.PackageId, ((NuGetFramework)compatibleFrameworkAsset.Properties["tfm"]).GetShortFolderName(), compatibleFrameworkAsset.Path);
                     MetadataInformation right = new(package.PackageId, ((NuGetFramework)compileTimeAsset.Properties["tfm"]).GetShortFolderName(), compileTimeAsset.Path);
 
-                    _apiCompatRunner.QueueApiCompat(package.PackagePath, 
-                        left,
-                        package.PackagePath,
-                        right,
-                        string.Format(Resources.CompatibleFrameworkInPackageValidatorHeader, ((NuGetFramework)compatibleFrameworkAsset.Properties["tfm"]).ToString(), framework.ToString()),
-                        string.Format(Resources.ApiCompatibilityHeader, compatibleFrameworkAsset.Path, compileTimeAsset.Path));
+                    string header = string.Format(Resources.ApiCompatibilityHeader, compatibleFrameworkAsset.Path, compileTimeAsset.Path);
+                    _apiCompatRunner.QueueApiCompat(left, right, header);
                 }
             }
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
@@ -54,11 +54,8 @@ namespace Microsoft.DotNet.PackageValidation
 
                 if (compatibleFrameworkAsset != null)
                 {
-                    MetadataInformation left = new(package.PackageId, ((NuGetFramework)compatibleFrameworkAsset.Properties["tfm"]).GetShortFolderName(), compatibleFrameworkAsset.Path);
-                    MetadataInformation right = new(package.PackageId, ((NuGetFramework)compileTimeAsset.Properties["tfm"]).GetShortFolderName(), compileTimeAsset.Path);
-
                     string header = string.Format(Resources.ApiCompatibilityHeader, compatibleFrameworkAsset.Path, compileTimeAsset.Path);
-                    _apiCompatRunner.QueueApiCompat(left, right, header);
+                    _apiCompatRunner.QueueApiCompatFromContentItem(package.PackageId, compatibleFrameworkAsset, compileTimeAsset, header);
                 }
             }
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
 using NuGet.Client;
 using NuGet.ContentModel;
 using NuGet.Frameworks;
@@ -52,11 +53,13 @@ namespace Microsoft.DotNet.PackageValidation
 
                 if (compatibleFrameworkAsset != null)
                 {
+                    MetadataInformation left = new(package.PackageId, ((NuGetFramework)compatibleFrameworkAsset.Properties["tfm"]).GetShortFolderName(), compatibleFrameworkAsset.Path);
+                    MetadataInformation right = new(package.PackageId, ((NuGetFramework)compileTimeAsset.Properties["tfm"]).GetShortFolderName(), compileTimeAsset.Path);
+
                     _apiCompatRunner.QueueApiCompat(package.PackagePath, 
-                        compatibleFrameworkAsset.Path,
+                        left,
                         package.PackagePath,
-                        compileTimeAsset.Path,
-                        package.PackageId,
+                        right,
                         string.Format(Resources.CompatibleFrameworkInPackageValidatorHeader, ((NuGetFramework)compatibleFrameworkAsset.Properties["tfm"]).ToString(), framework.ToString()),
                         string.Format(Resources.ApiCompatibilityHeader, compatibleFrameworkAsset.Path, compileTimeAsset.Path));
                 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
@@ -41,6 +41,9 @@ namespace Microsoft.DotNet.PackageValidation
         /// <param name="package">Nuget Package that needs to be validated.</param>
         public void Validate(Package package)
         {
+            if (_runApiCompat)
+                _apiCompatRunner.InitializePaths(package.PackagePath, package.PackagePath);
+
             HashSet<NuGetFramework> compatibleTargetFrameworks = new();
             foreach (NuGetFramework item in package.FrameworksInPackage)
             {
@@ -87,12 +90,8 @@ namespace Microsoft.DotNet.PackageValidation
                         MetadataInformation left = new(package.PackageId, ((NuGetFramework)compileTimeAsset.Properties["tfm"]).GetShortFolderName(), compileTimeAsset.Path);
                         MetadataInformation right = new(package.PackageId, ((NuGetFramework)runtimeAsset.Properties["tfm"]).GetShortFolderName(), runtimeAsset.Path);
 
-                        _apiCompatRunner.QueueApiCompat(package.PackagePath,
-                            left,
-                            package.PackagePath,
-                            right,
-                            Resources.CompatibleTfmValidatorHeader,
-                            string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path));
+                        string header = string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path);
+                        _apiCompatRunner.QueueApiCompat(left, right, header);
                     }
                 }
  
@@ -118,12 +117,8 @@ namespace Microsoft.DotNet.PackageValidation
                             MetadataInformation left = new(package.PackageId, ((NuGetFramework)compileTimeAsset.Properties["tfm"]).GetShortFolderName(), compileTimeAsset.Path);
                             MetadataInformation right = new(package.PackageId, ((NuGetFramework)runtimeAsset.Properties["tfm"]).GetShortFolderName(), runtimeAsset.Path);
 
-                            _apiCompatRunner.QueueApiCompat(package.PackagePath, 
-                                left,
-                                package.PackagePath, 
-                                right,
-                                Resources.CompatibleTfmValidatorHeader,
-                                string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path));
+                            string header = string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path);
+                            _apiCompatRunner.QueueApiCompat(left, right, header);
                         }
                     }
                 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
@@ -87,11 +87,8 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (_runApiCompat)
                     {
-                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)compileTimeAsset.Properties["tfm"]).GetShortFolderName(), compileTimeAsset.Path);
-                        MetadataInformation right = new(package.PackageId, ((NuGetFramework)runtimeAsset.Properties["tfm"]).GetShortFolderName(), runtimeAsset.Path);
-
                         string header = string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path);
-                        _apiCompatRunner.QueueApiCompat(left, right, header);
+                        _apiCompatRunner.QueueApiCompatFromContentItem(package.PackageId, compileTimeAsset, runtimeAsset, header);
                     }
                 }
  
@@ -114,11 +111,8 @@ namespace Microsoft.DotNet.PackageValidation
                     {
                         if (_runApiCompat)
                         {
-                            MetadataInformation left = new(package.PackageId, ((NuGetFramework)compileTimeAsset.Properties["tfm"]).GetShortFolderName(), compileTimeAsset.Path);
-                            MetadataInformation right = new(package.PackageId, ((NuGetFramework)runtimeAsset.Properties["tfm"]).GetShortFolderName(), runtimeAsset.Path);
-
                             string header = string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path);
-                            _apiCompatRunner.QueueApiCompat(left, right, header);
+                            _apiCompatRunner.QueueApiCompatFromContentItem(package.PackageId, compileTimeAsset, runtimeAsset, header);
                         }
                     }
                 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
@@ -84,11 +84,13 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (_runApiCompat)
                     {
-                        _apiCompatRunner.QueueApiCompat(package.PackagePath, 
-                            compileTimeAsset.Path,
+                        MetadataInformation left = new(package.PackageId, ((NuGetFramework)compileTimeAsset.Properties["tfm"]).GetShortFolderName(), compileTimeAsset.Path);
+                        MetadataInformation right = new(package.PackageId, ((NuGetFramework)runtimeAsset.Properties["tfm"]).GetShortFolderName(), runtimeAsset.Path);
+
+                        _apiCompatRunner.QueueApiCompat(package.PackagePath,
+                            left,
                             package.PackagePath,
-                            runtimeAsset.Path,
-                            package.PackageId,
+                            right,
                             Resources.CompatibleTfmValidatorHeader,
                             string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path));
                     }
@@ -113,11 +115,13 @@ namespace Microsoft.DotNet.PackageValidation
                     {
                         if (_runApiCompat)
                         {
+                            MetadataInformation left = new(package.PackageId, ((NuGetFramework)compileTimeAsset.Properties["tfm"]).GetShortFolderName(), compileTimeAsset.Path);
+                            MetadataInformation right = new(package.PackageId, ((NuGetFramework)runtimeAsset.Properties["tfm"]).GetShortFolderName(), runtimeAsset.Path);
+
                             _apiCompatRunner.QueueApiCompat(package.PackagePath, 
-                                compileTimeAsset.Path,
+                                left,
                                 package.PackagePath, 
-                                runtimeAsset.Path,
-                                package.PackageId,
+                                right,
                                 Resources.CompatibleTfmValidatorHeader,
                                 string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path));
                         }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Helpers.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Helpers.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.PackageValidation
+{
+    internal static class Helpers
+    {
+        public static void QueueApiCompatFromContentItem(this ApiCompatRunner apiCompatRunner, string packageId, ContentItem leftItem, ContentItem rightItem, string header, bool isBaseline = false)
+        {
+            string displayString = isBaseline ? Resources.Baseline + " " + leftItem.Path : null;
+            MetadataInformation left = new(packageId, ((NuGetFramework)leftItem.Properties["tfm"]).GetShortFolderName(), leftItem.Path, displayString);
+            MetadataInformation right = new(packageId, ((NuGetFramework)rightItem.Properties["tfm"]).GetShortFolderName(), rightItem.Path);
+
+            apiCompatRunner.QueueApiCompat(left, right, header);
+        }
+    }
+}

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
@@ -117,12 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CompatibleFrameworkInPackageValidatorHeader" xml:space="preserve">
-    <value>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</value>
-  </data>
-  <data name="CompatibleTfmValidatorHeader" xml:space="preserve">
-    <value>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</value>
-  </data>
   <data name="ApiCompatibilityHeader" xml:space="preserve">
     <value>API compatibility errors between '{0}' (left) and '{1}' (right):</value>
   </data>
@@ -140,9 +134,6 @@
   </data>
   <data name="NoCompatibleRuntimeAsset" xml:space="preserve">
     <value>Target framework {0} does not have a compatible runtime asset in the package.</value>
-  </data>
-  <data name="BaselineVersionValidatorHeader" xml:space="preserve">
-    <value>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</value>
   </data>
   <data name="ApiCompatibilityBaselineHeader" xml:space="preserve">
     <value>Breaking changes to the API surface between '{0}' (left) and '{1}' (right) for versions {2} and {3} respectively:</value>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
@@ -17,16 +17,6 @@
         <target state="new">[Baseline]</target>
         <note />
       </trans-unit>
-      <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
-        <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
-        <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CompatibleTfmValidatorHeader">
-        <source>Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</source>
-        <target state="new">Public API surface area of compile time assemblies and runtime assemblies are not the same for all target frameworks and runtime identifiers. The following API are missing from some runtime assemblies:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EmptyPackagePath">
         <source>Package path is empty. Please provide a valid package path.</source>
         <target state="new">Package path is empty. Please provide a valid package path.</target>
@@ -60,11 +50,6 @@
       <trans-unit id="NoCompatibleRuntimeAsset">
         <source>Target framework {0} does not have a compatible runtime asset in the package.</source>
         <target state="new">Target framework {0} does not have a compatible runtime asset in the package.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="BaselineVersionValidatorHeader">
-        <source>Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</source>
-        <target state="new">Found breaking API changes between package versions. If these breaking changes are unintentional, revert them in the newer package version. Otherwise suppress this error.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonExistentPackagePath">


### PR DESCRIPTION
- add displayString to metadataInformation object to allow custom assembly names.
- closing streams early to avoid locking of package.
-  some code clean up

