### PR TITLE
add strict mode tests & fix assembly token strict mode bug

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/AssemblyIdentityMustMatch.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/AssemblyIdentityMustMatch.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     rightName,
                     rightIdentity));
             }
-            else if (Settings.StrictMode && !rightAssemblyPublicKeyToken.IsEmpty && !isRightRetargetable)
+            else if (Settings.StrictMode && !rightAssemblyPublicKeyToken.IsEmpty && !isRightRetargetable && !rightAssemblyPublicKeyToken.SequenceEqual(leftAssemblyPublicKeyToken))
             {
                 differences.Add(CreateIdentityDifference(
                     Resources.AssemblyPublicKeyTokenDoesNotMatch,

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunnerExtensions.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunnerExtensions.cs
@@ -7,7 +7,7 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.PackageValidation
 {
-    internal static class Helpers
+    internal static class ApiCompatRunnerExtensions
     {
         public static void QueueApiCompatFromContentItem(this ApiCompatRunner apiCompatRunner, string packageId, ContentItem leftItem, ContentItem rightItem, string header, bool isBaseline = false)
         {

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
@@ -188,18 +188,16 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
 
             ApiComparer differ = new();
             differ.StrictMode = strictMode;
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbols, rightSymbols);
 
             if (strictMode)
             {
-                IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbols, rightSymbols);
                 Assert.Single(differences);
-
                 CompatDifference expected = new CompatDifference(DiagnosticIds.AssemblyIdentityMustMatch, string.Empty, DifferenceType.Changed, "PublicKeyTokenValidation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
                 Assert.Equal(expected, differences.First(), CompatDifferenceComparer.Default);
             }
             else
             {
-                IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbols, rightSymbols);
                 Assert.Empty(differences);
             }
         }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         public void LeftAssemblyKeyTokenNull(bool strictMode)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("PublicKeyTokenValidation")
+                .CopyTestAsset("PublicKeyTokenValidation", allowCopyIfPresent: true)
                 .WithSource();
 
             BuildCommand buildCommand = new(testAsset);
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         public void RightAssemblyKeyTokenNull(bool strictMode)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("PublicKeyTokenValidation")
+                .CopyTestAsset("PublicKeyTokenValidation", allowCopyIfPresent: true)
                 .WithSource();
 
             BuildCommand buildCommand = new(testAsset);
@@ -235,7 +235,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         public void RetargetableFlagSet(bool strictMode)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("PublicKeyTokenValidation")
+                .CopyTestAsset("PublicKeyTokenValidation", allowCopyIfPresent: true)
                 .WithSource();
 
             BuildCommand buildCommand = new(testAsset);

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
@@ -144,8 +144,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             Assert.Equal(expected, differences.First(), CompatDifferenceComparer.Default);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
-        public void AssemblyKeyTokenMustBeCompatible()
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AssemblyKeyTokenMustBeCompatible(bool strictMode)
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("PublicKeyTokenValidation")
@@ -161,12 +163,16 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
 
             // public key tokens must match
             ApiComparer differ = new();
+            differ.StrictMode = strictMode;
+
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbols, rightSymbols);
             Assert.Empty(differences);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
-        public void LeftAssemblyKeyTokenNull()
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LeftAssemblyKeyTokenNull(bool strictMode)
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("PublicKeyTokenValidation")
@@ -181,12 +187,27 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             IAssemblySymbol rightSymbols = new AssemblySymbolLoader().LoadAssembly(rightDllPath);
 
             ApiComparer differ = new();
-            IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbols, rightSymbols);
-            Assert.Empty(differences);
+            differ.StrictMode = strictMode;
+
+            if (strictMode)
+            {
+                IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbols, rightSymbols);
+                Assert.Single(differences);
+
+                CompatDifference expected = new CompatDifference(DiagnosticIds.AssemblyIdentityMustMatch, string.Empty, DifferenceType.Changed, "PublicKeyTokenValidation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
+                Assert.Equal(expected, differences.First(), CompatDifferenceComparer.Default);
+            }
+            else
+            {
+                IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbols, rightSymbols);
+                Assert.Empty(differences);
+            }
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
-        public void RightAssemblyKeyTokenNull()
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RightAssemblyKeyTokenNull(bool strictMode)
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("PublicKeyTokenValidation")
@@ -201,6 +222,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             IAssemblySymbol rightSymbols = new AssemblySymbolLoader().LoadAssembly(rightDllPath);
 
             ApiComparer differ = new();
+            differ.StrictMode = strictMode;
+
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbols, rightSymbols);
             Assert.Single(differences);
 
@@ -208,8 +231,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             Assert.Equal(expected, differences.First(), CompatDifferenceComparer.Default);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
-        public void RetargetableFlagSet()
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RetargetableFlagSet(bool strictMode)
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("PublicKeyTokenValidation")
@@ -226,33 +251,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             IAssemblySymbol rightSymbols = new AssemblySymbolLoader().LoadAssembly(rightDllPath);
 
             ApiComparer differ = new();
+            differ.StrictMode = strictMode;
+
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbols, rightSymbols);
             Assert.Empty(differences);
-        }
-
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
-        public void LeftAssemblyKeyTokenNullStrictMode()
-        {
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("PublicKeyTokenValidation")
-                .WithSource();
-
-            BuildCommand buildCommand = new(testAsset);
-            buildCommand.Execute("-p:DisableSigningOnNetStandard2_0=true").Should().Pass();
-
-            string leftDllPath = Path.Combine(buildCommand.GetOutputDirectory("netstandard2.0").FullName, "PublicKeyTokenValidation.dll");
-            string rightDllPath = Path.Combine(buildCommand.GetOutputDirectory("net6.0").FullName, "PublicKeyTokenValidation.dll");
-            IAssemblySymbol leftSymbols = new AssemblySymbolLoader().LoadAssembly(leftDllPath);
-            IAssemblySymbol rightSymbols = new AssemblySymbolLoader().LoadAssembly(rightDllPath);
-
-            ApiComparer strictDiffer = new();
-            strictDiffer.StrictMode = true;
-
-            IEnumerable<CompatDifference> differences = strictDiffer.GetDifferences(leftSymbols, rightSymbols);
-            Assert.Single(differences);
-
-            CompatDifference expected = new CompatDifference(DiagnosticIds.AssemblyIdentityMustMatch, string.Empty, DifferenceType.Changed, "PublicKeyTokenValidation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
-            Assert.Equal(expected, differences.First(), CompatDifferenceComparer.Default);
         }
     }
 }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         public void AssemblyKeyTokenMustBeCompatible(bool strictMode)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("PublicKeyTokenValidation")
+                .CopyTestAsset("PublicKeyTokenValidation", allowCopyIfPresent: true)
                 .WithSource();
 
             BuildCommand buildCommand = new(testAsset);


### PR DESCRIPTION
- add some strict mode tests
- while updating the version in the runtime, i discovered a bug where we were missing a token equality check.