### PR TITLE
[API Compat] Make sure test syntax trees don't have any syntax errors

### DIFF
--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/CustomSideNameTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/CustomSideNameTests.cs
@@ -50,7 +50,7 @@ namespace CompatTests
 {
   public class First
   {
-    public string Method1() { }
+    public string Method1() => string.Empty;
   }
 }
 ";
@@ -94,7 +94,7 @@ namespace CompatTests
 {
   public class First
   {
-    public string Method1() { }
+    public string Method1() => string.Empty;
   }
 }
 ";

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddAbstractMemberTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddAbstractMemberTests.cs
@@ -82,9 +82,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             string leftSyntax = @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
-    public class FirstNested
+    public abstract class FirstNested
     {
       public class SecondNested
       {
@@ -99,9 +99,9 @@ namespace CompatTests
             { @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
-    public class FirstNested
+    public abstract class FirstNested
     {
       public class SecondNested
       {
@@ -114,14 +114,14 @@ namespace CompatTests
             @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
-    public class FirstNested
+    public abstract class FirstNested
     {
-      public class SecondNested
+      public abstract class SecondNested
       {
         public void SomeMethod() { }
-        public abstract void SomeAbstractMethod() { }
+        public abstract void SomeAbstractMethod();
       }
     }
   }
@@ -130,11 +130,11 @@ namespace CompatTests
             @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
-    public class FirstNested
+    public abstract class FirstNested
     {
-      public abstract void FirstNestedAbstract() { }
+      public abstract void FirstNestedAbstract();
       public class SecondNested
       {
         public void SomeMethod() { }
@@ -185,10 +185,10 @@ namespace CompatTests
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     public void SomeMethod() { }
-    public abstract void SomeAbstractMember() { }
+    public abstract void SomeAbstractMember();
   }
 }
 "
@@ -199,7 +199,7 @@ namespace CompatTests
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     private First() { }
     public void SomeMethod() { }
@@ -209,11 +209,11 @@ namespace CompatTests
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     public First() { }
     public void SomeMethod() { }
-    public abstract void SomeAbstractMember() { }
+    public abstract void SomeAbstractMember();
   }
 }
 "
@@ -224,7 +224,7 @@ namespace CompatTests
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     internal First() { }
     public void SomeMethod() { }
@@ -234,11 +234,11 @@ namespace CompatTests
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     protected First() { }
     public void SomeMethod() { }
-    public abstract void SomeAbstractMember() { }
+    public abstract void SomeAbstractMember();
   }
 }
 "
@@ -252,19 +252,19 @@ namespace CompatTests
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
-    public abstract void FirstAbstract() { }
+    public abstract void FirstAbstract();
   }
 }
 ",
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
-    public abstract void FirstAbstract() { }
-    public abstract string SecondAbstract() => throw null;
+    public abstract void FirstAbstract();
+    public abstract string SecondAbstract();
   }
 }
 "
@@ -275,21 +275,21 @@ namespace CompatTests
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     protected First() { }
-    public abstract void FirstAbstract() { }
+    public abstract void FirstAbstract();
   }
 }
 ",
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     protected First() { }
-    public abstract void FirstAbstract() { }
-    public abstract string SecondAbstract() => throw null;
+    public abstract void FirstAbstract();
+    public abstract string SecondAbstract();
   }
 }
 "
@@ -302,21 +302,21 @@ namespace CompatTests
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     private First() { }
-    public abstract void FirstAbstract() { }
+    public abstract void FirstAbstract();
   }
 }
 ",
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     private First() { }
-    public abstract void FirstAbstract() { }
-    public abstract string SecondAbstract() => throw null;
+    public abstract void FirstAbstract();
+    public abstract string SecondAbstract();
   }
 }
 "
@@ -328,21 +328,21 @@ namespace CompatTests
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     internal First() { }
-    public abstract void FirstAbstract() { }
+    public abstract void FirstAbstract();
   }
 }
 ",
                 @"
 namespace CompatTests
 {
-  public class First
+  public abstract class First
   {
     internal First() { }
-    public abstract void FirstAbstract() { }
-    public abstract string SecondAbstract() => throw null;
+    public abstract void FirstAbstract();
+    public abstract string SecondAbstract();
   }
 }
 "

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
@@ -28,11 +28,15 @@ namespace CompatTests
   public interface IFoo
   {
     string MyMethod();
-    static MyField = 2;
-    int MyPropertyWithDefaultImplementation { get { } set { } }
-    event EventHandler MyEvent { add { } remove { } }
     byte MyPropertyWithoutDefaultImplementation { get; set; }
-    event EventHandler MyEventWithoutImplementation;
+    event System.EventHandler MyEventWithoutImplementation;
+
+    // .NET Framework doesn't support default implementations.
+#if !NETFRAMEWORK
+    static int MyField = 2;
+    event System.EventHandler MyEvent { add { } remove { } }
+    int MyPropertyWithDefaultImplementation { get => 0; set { } }
+#endif
   }
 }
 ";
@@ -82,11 +86,15 @@ namespace CompatTests
   public interface IFoo
   {
     string MyMethod();
-    static MyField = 2;
-    int MyPropertyWithDefaultImplementation { get { } set { } }
-    event EventHandler MyEvent { add { } remove { } }
     byte MyPropertyWithoutDefaultImplementation { get; set; }
-    event EventHandler MyEventWithoutImplementation;
+    event System.EventHandler MyEventWithoutImplementation;
+
+    // .NET Framework doesn't support default implementations.
+#if !NETFRAMEWORK
+    static int MyField = 2;
+    int MyPropertyWithDefaultImplementation { get => 0; set { } }
+    event System.EventHandler MyEvent { add { } remove { } }
+#endif
   }
 }
 ";
@@ -114,7 +122,7 @@ namespace CompatTests
   {
     string MyMethod();
     int MyProperty { get; set; }
-    event EventHandler MyEvent;
+    event System.EventHandler MyEvent;
   }
 }
 ";
@@ -127,8 +135,12 @@ namespace CompatTests
   {
     string MyMethod();
     int MyProperty { get; set; }
-    event EventHandler MyEvent;
+    event System.EventHandler MyEvent;
+
+    // .NET Framework doesn't support default implementations.
+#if !NETFRAMEWORK
     int MyPropertyWithDIM { get => 0; set { } }
+#endif
   }
 }
 ",
@@ -139,9 +151,13 @@ namespace CompatTests
   {
     string MyMethod();
     int MyProperty { get; set; }
-    event EventHandler MyEvent;
-    event EventHandler MyOtherEvent;
+    event System.EventHandler MyEvent;
+    event System.EventHandler MyOtherEvent;
+
+    // .NET Framework doesn't support default implementations.
+#if !NETFRAMEWORK
     static int MyField = 3;
+#endif
   }
 }
 ",
@@ -152,11 +168,15 @@ namespace CompatTests
   {
     string MyMethod();
     string MyOtherMethod();
-    string MyOtherMethodWithDIM() => string.Empty;
     int MyProperty { get; set; }
-    event EventHandler MyEvent;
-    event EventHandler MyOtherEventWithDIM { add { } remove { } }
+    event System.EventHandler MyEvent;
+
+    // .NET Framework doesn't support default implementations.
+#if !NETFRAMEWORK
+    string MyOtherMethodWithDIM() => string.Empty;
+    event System.EventHandler MyOtherEventWithDIM { add { } remove { } }
     static int MyField = 3;
+#endif
   }
 }
 "};
@@ -205,7 +225,7 @@ namespace CompatTests
   public interface IFoo
   {
     string MyMethod();
-    private string MyPrivateMethod();
+    internal string MyPrivateMethod();
   }
 }
 "
@@ -227,7 +247,11 @@ namespace CompatTests
   public interface IFoo
   {
     int MyProperty { get; set; }
+
+    // .NET Framework doesn't support default implementations.
+#if !NETFRAMEWORK
     byte MyOtherProperty { get => (byte)0; set { } }
+#endif
   }
 }
 "
@@ -239,7 +263,7 @@ namespace CompatTests
 {
   public interface IFoo
   {
-    event EventHandler EventHandler;
+    event System.EventHandler MyEvent;
   }
 }
 ",
@@ -248,9 +272,13 @@ namespace CompatTests
 {
   public interface IFoo
   {
-    event EventHandler EventHandler;
+    event System.EventHandler MyEvent;
+
+    // .NET Framework doesn't support default implementations.
+#if !NETFRAMEWORK
     static int MyField = 32;
     int MyMethod() => 0;
+#endif
   }
 }
 "

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
@@ -22,9 +22,9 @@ namespace CompatTests
 {
   public class First
   {
-    public string Parameterless() { }
+    public string Parameterless() => string.Empty;
   }
-  public delegate void EventHandler(object sender EventArgs e);
+  public delegate void EventHandler(object sender, System.EventArgs e);
 }
 ";
 
@@ -33,15 +33,15 @@ namespace CompatTests
 {
   public class First
   {
-    public string Parameterless() { }
+    public string Parameterless() => string.Empty;
     public void ShouldReportMethod(string a, string b) { }
     public string ShouldReportMissingProperty { get; }
-    public string this[int index] { get; }
+    public string this[int index] { get => string.Empty; }
     public event EventHandler ShouldReportMissingEvent;
     public int ReportMissingField = 0;
   }
 
-  public delegate void EventHandler(object sender EventArgs e);
+  public delegate void EventHandler(object sender, System.EventArgs e);
 }
 ";
 
@@ -73,9 +73,9 @@ namespace CompatTests
   public class FirstBase
   {
     public void MyMethod() { }
-    public string MyMethodWithParams(string a, int b, FirstBase c) { }
-    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) { }
-    public virtual string MyVirtualMethod() { }
+    public string MyMethodWithParams(string a, int b, FirstBase c) => string.Empty;
+    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) => throw null;
+    public virtual string MyVirtualMethod() => string.Empty;
   }
   public class Second : FirstBase { }
 }
@@ -87,16 +87,16 @@ namespace CompatTests
   public class FirstBase
   {
     public void MyMethod() { }
-    public string MyMethodWithParams(string a, int b, FirstBase c) { }
-    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) { }
-    public virtual string MyVirtualMethod() { }
+    public string MyMethodWithParams(string a, int b, FirstBase c) => string.Empty;
+    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) => throw null;
+    public virtual string MyVirtualMethod() => string.Empty;
   }
   public class Second : FirstBase
   {
     public new void MyMethod() { }
-    public new string MyMethodWithParams(string a, int b, FirstBase c) { }
-    public new T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) { }
-    public override string MyVirtualMethod() { }
+    public new string MyMethodWithParams(string a, int b, FirstBase c) => string.Empty;
+    public new T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) => throw null;
+    public override string MyVirtualMethod() => string.Empty;
   }
 }
 ";
@@ -117,11 +117,11 @@ namespace CompatTests
 {
   public class First
   {
-    public string MultipleOverrides() { }
-    public string MultipleOverrides(string a) { }
-    public string MultipleOverrides(string a, string b) { }
-    public string MultipleOverrides(string a, int b, string c) { }
-    public string MultipleOverrides(string a, int b, int c) { }
+    public string MultipleOverrides() => string.Empty;
+    public string MultipleOverrides(string a) => string.Empty;
+    public string MultipleOverrides(string a, string b) => string.Empty;
+    public string MultipleOverrides(string a, int b, string c) => string.Empty;
+    public string MultipleOverrides(string a, int b, int c) => string.Empty;
   }
 }
 ";
@@ -131,9 +131,9 @@ namespace CompatTests
 {
   public class First
   {
-    public string MultipleOverrides() { }
-    public string MultipleOverrides(string a) { }
-    public string MultipleOverrides(string a, int b, int c) { }
+    public string MultipleOverrides() => string.Empty;
+    public string MultipleOverrides(string a) => string.Empty;
+    public string MultipleOverrides(string a, int b, int c) => string.Empty;
   }
 }
 ";
@@ -163,11 +163,11 @@ namespace CompatTests
 {
   public class First
   {
-    public string MultipleOverrides() { }
-    public string MultipleOverrides(string a) { }
-    public string MultipleOverrides(string a, string b) { }
-    public string MultipleOverrides(string a, int b, string c) { }
-    internal string MultipleOverrides(string a, int b, int c) { }
+    public string MultipleOverrides() => string.Empty;
+    public string MultipleOverrides(string a) => string.Empty;
+    public string MultipleOverrides(string a, string b) => string.Empty;
+    public string MultipleOverrides(string a, int b, string c) => string.Empty;
+    internal string MultipleOverrides(string a, int b, int c) => string.Empty;
     internal int InternalProperty { get; set; }
   }
 }
@@ -178,10 +178,10 @@ namespace CompatTests
 {
   public class First
   {
-    public string MultipleOverrides() { }
-    public string MultipleOverrides(string a) { }
-    public string MultipleOverrides(string a, string b) { }
-    public string MultipleOverrides(string a, int b, string c) { }
+    public string MultipleOverrides() => string.Empty;
+    public string MultipleOverrides(string a) => string.Empty;
+    public string MultipleOverrides(string a, string b) => string.Empty;
+    public string MultipleOverrides(string a, int b, string c) => string.Empty;
     internal int InternalProperty { get; }
   }
 }
@@ -218,8 +218,8 @@ namespace CompatTests
 {
   public class First
   {
-    public string Parameterless() { }
-    public string MissingMethodRight() { }
+    public string Parameterless() => string.Empty;
+    public string MissingMethodRight() => string.Empty;
   }
 }
 ";
@@ -229,7 +229,7 @@ namespace CompatTests
 {
   public class First
   {
-    public string Parameterless() { }
+    public string Parameterless() => string.Empty;
     public void MissingMethodLeft(string a, string b) { }
   }
 }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
@@ -18,15 +18,15 @@ namespace CompatTests
 {
   public class First
   {
-    public string Parameterless() { }
+    public void Parameterless() { }
     public void ShouldReportMethod(string a, string b) { }
     public string ShouldReportMissingProperty { get; }
-    public string this[int index] { get; }
+    public string this[int index] { get => string.Empty; }
     public event EventHandler ShouldReportMissingEvent;
     public int ReportMissingField = 0;
   }
 
-  public delegate void EventHandler(object sender EventArgs e);
+  public delegate void EventHandler(object sender, System.EventArgs e);
 }
 ";
 
@@ -35,9 +35,9 @@ namespace CompatTests
 {
   public class First
   {
-    public string Parameterless() { }
+    public void Parameterless() { }
   }
-  public delegate void EventHandler(object sender EventArgs e);
+  public delegate void EventHandler(object sender, System.EventArgs e);
 }
 ";
 
@@ -68,16 +68,16 @@ namespace CompatTests
   public class FirstBase
   {
     public void MyMethod() { }
-    public string MyMethodWithParams(string a, int b, FirstBase c) { }
-    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) { }
-    public virtual string MyVirtualMethod() { }
+    public string MyMethodWithParams(string a, int b, FirstBase c) => string.Empty;
+    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) => throw null;
+    public virtual string MyVirtualMethod() => string.Empty;
   }
   public class Second : FirstBase
   {
     public new void MyMethod() { }
-    public new string MyMethodWithParams(string a, int b, FirstBase c) { }
-    public new T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) { }
-    public override string MyVirtualMethod() { }
+    public new string MyMethodWithParams(string a, int b, FirstBase c) => string.Empty;
+    public new T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) => throw null;
+    public override string MyVirtualMethod() => string.Empty;
   }
 }
 ";
@@ -88,9 +88,9 @@ namespace CompatTests
   public class FirstBase
   {
     public void MyMethod() { }
-    public string MyMethodWithParams(string a, int b, FirstBase c) { }
-    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) { }
-    public virtual string MyVirtualMethod() { }
+    public string MyMethodWithParams(string a, int b, FirstBase c) => string.Empty;
+    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) => throw null;
+    public virtual string MyVirtualMethod() => string.Empty;
   }
   public class Second : FirstBase { }
 }
@@ -143,11 +143,11 @@ namespace CompatTests
 {
   public class First
   {
-    public string MultipleOverrides() { }
-    public string MultipleOverrides(string a) { }
-    public string MultipleOverrides(string a, string b) { }
-    public string MultipleOverrides(string a, int b, string c) { }
-    public string MultipleOverrides(string a, int b, int c) { }
+    public string MultipleOverrides() => string.Empty;
+    public string MultipleOverrides(string a) => a;
+    public string MultipleOverrides(string a, string b) => b;
+    public string MultipleOverrides(string a, int b, string c) => c;
+    public string MultipleOverrides(string a, int b, int c) => a;
   }
 }
 ";
@@ -157,9 +157,9 @@ namespace CompatTests
 {
   public class First
   {
-    public string MultipleOverrides() { }
-    public string MultipleOverrides(string a) { }
-    public string MultipleOverrides(string a, int b, int c) { }
+    public string MultipleOverrides() => string.Empty;
+    public string MultipleOverrides(string a) => a;
+    public string MultipleOverrides(string a, int b, int c) => a;
   }
 }
 ";
@@ -188,11 +188,11 @@ namespace CompatTests
 {
   public class First
   {
-    public string MultipleOverrides() { }
-    public string MultipleOverrides(string a) { }
-    public string MultipleOverrides(string a, string b) { }
-    public string MultipleOverrides(string a, int b, string c) { }
-    internal string MultipleOverrides(string a, int b, int c) { }
+    public string MultipleOverrides() => string.Empty;
+    public string MultipleOverrides(string a) => a;
+    public string MultipleOverrides(string a, string b) => b;
+    public string MultipleOverrides(string a, int b, string c) => c;
+    internal string MultipleOverrides(string a, int b, int c) => a;
     internal int InternalProperty { get; set; }
   }
 }
@@ -203,10 +203,10 @@ namespace CompatTests
 {
   public class First
   {
-    public string MultipleOverrides() { }
-    public string MultipleOverrides(string a) { }
-    public string MultipleOverrides(string a, string b) { }
-    public string MultipleOverrides(string a, int b, string c) { }
+    public string MultipleOverrides() => string.Empty;
+    public string MultipleOverrides(string a) => a;
+    public string MultipleOverrides(string a, string b) => b;
+    public string MultipleOverrides(string a, int b, string c) => c;
     internal int InternalProperty { get; }
   }
 }
@@ -256,7 +256,7 @@ namespace CompatTests
   }
 }
 ";
-            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable: true, includeDefaultReferences: true);
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable: true);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new();
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
@@ -304,8 +304,8 @@ namespace CompatTests
 {
   public class First
   {
-    public string MyMethod(string? a) => throw null;
-    public void MyOutMethod(out string a) => throw null;
+    public string MyMethod(string? a) => throw null!;
+    public void MyOutMethod(out string a) => throw null!;
     public void MyRefMethod(ref string a) { }
   }
 }
@@ -316,11 +316,11 @@ namespace CompatTests
 {
   public class First
   {
-    public void OneMethod => { }
+    public void OneMethod() { }
   }
 }
 ";
-            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable: true, includeDefaultReferences: true);
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable: true);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new();
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.Strict.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.Strict.cs
@@ -30,8 +30,10 @@ namespace CompatTests
 {
   public class First { }
   public class Second { }
-  public record MyRecord(string a, string b);
   public struct MyStruct { }
+#if !NETFRAMEWORK
+  public record MyRecord(string a, string b);
+#endif
 }
 ";
 
@@ -46,8 +48,10 @@ namespace CompatTests
             CompatDifference[] expected = new[]
             {
                 new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.Second"),
-                new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.MyRecord"),
                 new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.MyStruct"),
+#if !NETFRAMEWORK
+                new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.MyRecord"),
+#endif
             };
 
             Assert.Equal(expected, differences, CompatDifferenceComparer.Default);
@@ -70,14 +74,14 @@ namespace CompatTests
 ";
 
             string rightSyntax = @"
-[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(CompatTests.ForwardedTestType))];
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(CompatTests.ForwardedTestType))]
 namespace CompatTests
 {
   public class First { }
 }
 ";
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
-            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(rightSyntax, new[] { forwardedTypeSyntax }, includeDefaultReferences: true);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(rightSyntax, new[] { forwardedTypeSyntax });
             ApiComparer differ = new();
             differ.StrictMode = true;
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
@@ -107,8 +111,8 @@ namespace CompatTests
 }
 ";
             IEnumerable<string> references = new[] { forwardedTypeSyntax };
-            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references, includeDefaultReferences: true);
-            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references, includeDefaultReferences: true);
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references);
             ApiComparer differ = new();
             differ.StrictMode = true;
             Assert.Empty(differ.GetDifferences(new[] { left }, new[] { right }));
@@ -148,7 +152,9 @@ namespace CompatTests
             string leftSyntax = @"
 namespace CompatTests
 {
+#if !NETFRAMEWORK
   public record First(string a, string b);
+#endif
 }
 ";
 
@@ -156,7 +162,9 @@ namespace CompatTests
 
 namespace CompatTests
 {
+#if !NETFRAMEWORK
   public record First(string a, string b);
+#endif
   public class Second { }
   public class Third { }
   public class Fourth { }
@@ -411,7 +419,7 @@ namespace CompatTests
             IEnumerable<string> references = new[] { forwardedTypeSyntax };
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, string.Empty, "ref"));
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references, includeDefaultReferences: true);
+            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references);
 
             ApiComparer differ = new();
             differ.StrictMode = true;

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
@@ -22,10 +22,12 @@ namespace CompatTests
 {
   public class First { }
   public class Second { }
-  public record MyRecord(string a, string b);
   public struct MyStruct { }
   public delegate void MyDelegate(object a);
   public enum MyEnum { }
+#if !NETFRAMEWORK
+  public record MyRecord(string a, string b);
+#endif
 }
 ";
 
@@ -38,18 +40,19 @@ namespace CompatTests
 
             ApiComparer differ = new();
             differ.NoWarn = noWarn;
-            bool enableNullable = false;
-            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable);
-            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax, enableNullable);
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
 
             CompatDifference[] expected = new[]
             {
                 new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.Second"),
-                new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.MyRecord"),
                 new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.MyStruct"),
                 new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.MyDelegate"),
                 new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.MyEnum"),
+#if !NETFRAMEWORK
+                new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.MyRecord"),
+#endif
             };
 
             Assert.Equal(expected, differences, CompatDifferenceComparer.Default);
@@ -138,7 +141,7 @@ namespace CompatTests
   public class First { }
 }
 ";
-            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntaxWithReferences(leftSyntax, new[] { forwardedTypeSyntax }, includeDefaultReferences: true);
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntaxWithReferences(leftSyntax, new[] { forwardedTypeSyntax });
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new();
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
@@ -168,8 +171,8 @@ namespace CompatTests
 }
 ";
             IEnumerable<string> references = new[] { forwardedTypeSyntax };
-            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references, includeDefaultReferences: true);
-            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references, includeDefaultReferences: true);
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references);
             ApiComparer differ = new();
             Assert.Empty(differ.GetDifferences(new[] { left }, new[] { right }));
         }
@@ -207,7 +210,9 @@ namespace CompatTests
 
 namespace CompatTests
 {
+#if !NETFRAMEWORK
   public record First(string a, string b);
+#endif
   public class Second { }
   public class Third { }
   public class Fourth { }
@@ -218,7 +223,9 @@ namespace CompatTests
             string rightSyntax = @"
 namespace CompatTests
 {
+#if !NETFRAMEWORK
   public record First(string a, string b);
+#endif
 }
 ";
 
@@ -543,7 +550,7 @@ namespace CompatTests
             IEnumerable<string> references = new[] { forwardedTypeSyntax };
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(forwardedTypeSyntax), new MetadataInformation(string.Empty, string.Empty, "ref"));
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references, includeDefaultReferences: true);
+            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references);
 
             ApiComparer differ = new();
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
@@ -568,7 +575,7 @@ namespace CompatTests
             IEnumerable<string> references = new[] { forwardedTypeSyntax };
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(forwardedTypeSyntax), new MetadataInformation(string.Empty, string.Empty, "ref"));
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references, includeDefaultReferences: true);
+            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references);
 
             ApiComparer differ = new();
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SymbolFactory.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SymbolFactory.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
 
         private static IEnumerable<KeyValuePair<string, ReportDiagnostic>> DiagnosticOptions { get; } = new[]
         {
-            // Suppress warning for unused fields.
+            // Suppress warning for unused events.
             new KeyValuePair<string, ReportDiagnostic>("CS0067", ReportDiagnostic.Suppress)
         };
 


### PR DESCRIPTION
Since the API Compat tests didn't have any validation that the syntax trees were actually syntactically correct, they had a bunch of syntax errors. This fixes it and prevents from happening in the future.