### PR TITLE
Adding OS and arch command line options

### DIFF
--- a/src/Cli/dotnet/CommonLocalizableStrings.resx
+++ b/src/Cli/dotnet/CommonLocalizableStrings.resx
@@ -674,4 +674,13 @@ setx PATH "%PATH%;{0}"
   <data name="CommandPrereleaseOptionDescription" xml:space="preserve">
     <value>Allows prerelease packages to be installed.</value>
   </data>
+  <data name="ArchitectureOptionDescription" xml:space="preserve">
+    <value>The target architecture.</value>
+  </data>
+  <data name="OperatingSystemOptionDescription" xml:space="preserve">
+    <value>The target operating system.</value>
+  </data>
+  <data name="CannotResolveRuntimeIdentifier" xml:space="preserve">
+    <value>Resolving the current runtime identifier failed.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/CommonLocalizableStrings.resx
+++ b/src/Cli/dotnet/CommonLocalizableStrings.resx
@@ -683,4 +683,10 @@ setx PATH "%PATH%;{0}"
   <data name="CannotResolveRuntimeIdentifier" xml:space="preserve">
     <value>Resolving the current runtime identifier failed.</value>
   </data>
+  <data name="CannotSpecifyBothRuntimeAndArchOptions" xml:space="preserve">
+    <value>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</value>
+  </data>
+  <data name="CannotSpecifyBothRuntimeAndOsOptions" xml:space="preserve">
+    <value>Specifying both the `-r|--runtime` and `-os` options is not supported.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -165,7 +165,8 @@ namespace Microsoft.DotNet.Cli
         private static string GetCurrentRuntimeId()
         {
             var dotnetRootPath = Path.GetDirectoryName(Environment.ProcessPath);
-            dotnetRootPath = dotnetRootPath.Contains("dotnet") ? dotnetRootPath : Path.Combine(dotnetRootPath, "dotnet");
+            // When running under test the path does not always contain "dotnet" and Product.Version is empty.
+            dotnetRootPath = Path.GetFileName(dotnetRootPath).Contains("dotnet") ? dotnetRootPath : Path.Combine(dotnetRootPath, "dotnet");
             var ridFileName = "NETCoreSdkRuntimeIdentifierChain.txt";
             string runtimeIdentifierChainPath = string.IsNullOrEmpty(Product.Version) ?
                 Path.Combine(Directory.GetDirectories(Path.Combine(dotnetRootPath, "sdk"))[0], ridFileName) :

--- a/src/Cli/dotnet/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/OptionForwardingExtensions.cs
@@ -11,9 +11,9 @@ namespace Microsoft.DotNet.Cli
 {
     public static class OptionForwardingExtensions
     {
-        public static ForwardedOption<T> Forward<T>(this ForwardedOption<T> option) => option.SetForwardingFunction((o) => new string[] { option.Name });
+        public static ForwardedOption<T> Forward<T>(this ForwardedOption<T> option) => option.SetForwardingFunction((T o) => new string[] { option.Name });
 
-        public static ForwardedOption<T> ForwardAs<T>(this ForwardedOption<T> option, string value) => option.SetForwardingFunction((o) => new string[] { value });
+        public static ForwardedOption<T> ForwardAs<T>(this ForwardedOption<T> option, string value) => option.SetForwardingFunction((T o) => new string[] { value });
 
         public static ForwardedOption<T> ForwardAsSingle<T>(this ForwardedOption<T> option, Func<T, string> format) => option.SetForwardingFunction(format);
 
@@ -78,6 +78,12 @@ namespace Microsoft.DotNet.Cli
         public ForwardedOption<T> SetForwardingFunction(Func<T, string> format)
         {
             ForwardingFunction = GetForwardingFunction((o) => new string[] { format(o) });
+            return this;
+        }
+
+        public ForwardedOption<T> SetForwardingFunction(Func<T, ParseResult, IEnumerable<string>> func)
+        {
+            ForwardingFunction = (ParseResult parseResult) => parseResult.HasOption(Aliases.First()) ? func(parseResult.ValueForOption<T>(Aliases.First()), parseResult) : Array.Empty<string>();
             return this;
         }
 

--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -85,5 +85,9 @@ namespace Microsoft.DotNet.Cli
                 return string.Empty;
             }
         }
+
+        public static bool BothArchAndOsOptionsSpecified(this ParseResult parseResult) =>
+            parseResult.HasOption(CommonOptions.ArchitectureOption().Aliases.First()) && 
+            parseResult.HasOption(CommonOptions.OperatingSystemOption().Aliases.First());
     }
 }

--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -89,5 +89,14 @@ namespace Microsoft.DotNet.Cli
         public static bool BothArchAndOsOptionsSpecified(this ParseResult parseResult) =>
             parseResult.HasOption(CommonOptions.ArchitectureOption().Aliases.First()) && 
             parseResult.HasOption(CommonOptions.OperatingSystemOption().Aliases.First());
+
+        internal static string GetCommandLineRuntimeIdentifier(this ParseResult parseResult)
+        {
+            return parseResult.HasOption(RunCommandParser.RuntimeOption) ?
+                    parseResult.ValueForOption<string>(RunCommandParser.RuntimeOption) :
+                    CommonOptions.ResolveRidShorthandOptionsToRuntimeIdentifier(
+                        parseResult.ValueForOption<string>(CommonOptions.OperatingSystemOption().Aliases.First()),
+                        parseResult.ValueForOption<string>(CommonOptions.ArchitectureOption().Aliases.First()));
+        }
     }
 }

--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -93,10 +93,12 @@ namespace Microsoft.DotNet.Cli
         internal static string GetCommandLineRuntimeIdentifier(this ParseResult parseResult)
         {
             return parseResult.HasOption(RunCommandParser.RuntimeOption) ?
-                    parseResult.ValueForOption<string>(RunCommandParser.RuntimeOption) :
-                    CommonOptions.ResolveRidShorthandOptionsToRuntimeIdentifier(
-                        parseResult.ValueForOption<string>(CommonOptions.OperatingSystemOption().Aliases.First()),
-                        parseResult.ValueForOption<string>(CommonOptions.ArchitectureOption().Aliases.First()));
+                parseResult.ValueForOption<string>(RunCommandParser.RuntimeOption) :
+                parseResult.HasOption(CommonOptions.OperatingSystemOption().Aliases.First()) || parseResult.HasOption(CommonOptions.ArchitectureOption().Aliases.First()) ?
+                CommonOptions.ResolveRidShorthandOptionsToRuntimeIdentifier(
+                    parseResult.ValueForOption<string>(CommonOptions.OperatingSystemOption().Aliases.First()),
+                    parseResult.ValueForOption<string>(CommonOptions.ArchitectureOption().Aliases.First())) :
+                null;
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -49,6 +49,8 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(NoIncrementalOption);
             command.AddOption(NoDependenciesOption);
             command.AddOption(NoLogoOption);
+            command.AddOption(CommonOptions.ArchitectureOption());
+            command.AddOption(CommonOptions.OperatingSystemOption());
 
             return command;
         }

--- a/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -61,6 +61,8 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(CommonOptions.InteractiveMsBuildForwardOption());
             command.AddOption(NoRestoreOption);
             command.AddOption(CommonOptions.VerbosityOption());
+            command.AddOption(CommonOptions.ArchitectureOption());
+            command.AddOption(CommonOptions.OperatingSystemOption());
 
             return command;
         }

--- a/src/Cli/dotnet/commands/dotnet-run/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/Program.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tools.Run
             var command = new RunCommand(
                 configuration: parseResult.ValueForOption<string>(RunCommandParser.ConfigurationOption),
                 framework: parseResult.ValueForOption<string>(RunCommandParser.FrameworkOption),
-                runtime: parseResult.ValueForOption<string>(RunCommandParser.RuntimeOption),
+                runtime: parseResult.GetCommandLineRuntimeIdentifier(),
                 noBuild: parseResult.HasOption(RunCommandParser.NoBuildOption),
                 project: project,
                 launchProfile: parseResult.ValueForOption<string>(RunCommandParser.LaunchProfileOption),

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -47,6 +47,8 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(InteractiveOption);
             command.AddOption(NoRestoreOption);
             command.AddOption(CommonOptions.VerbosityOption());
+            command.AddOption(CommonOptions.ArchitectureOption());
+            command.AddOption(CommonOptions.OperatingSystemOption());
             command.TreatUnmatchedTokensAsErrors = false;
 
             return command;

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -138,6 +138,8 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(NoRestoreOption);
             command.AddOption(CommonOptions.InteractiveMsBuildForwardOption());
             command.AddOption(CommonOptions.VerbosityOption());
+            command.AddOption(CommonOptions.ArchitectureOption(false));
+            command.AddOption(CommonOptions.OperatingSystemOption());
 
             return command;
         }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
@@ -55,6 +55,8 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(ToolCommandRestorePassThroughOptions.NoCacheOption);
             command.AddOption(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption);
             command.AddOption(VerbosityOption);
+            command.AddOption(CommonOptions.ArchitectureOption());
+            command.AddOption(CommonOptions.OperatingSystemOption());
 
             return command;
         }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
@@ -55,8 +55,6 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(ToolCommandRestorePassThroughOptions.NoCacheOption);
             command.AddOption(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption);
             command.AddOption(VerbosityOption);
-            command.AddOption(CommonOptions.ArchitectureOption());
-            command.AddOption(CommonOptions.OperatingSystemOption());
 
             return command;
         }

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Umožňuje, aby se příkaz zastavil a počkal na vstup nebo akci uživatele (například na dokončení ověření).</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">V {0} se našlo několik projektů. Vyberte, který z nich chcete použít.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Umožňuje, aby se příkaz zastavil a počkal na vstup nebo akci uživatele (například na dokončení ověření).</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Hiermit wird zugelassen, dass der Befehl anhält und auf eine Benutzereingabe oder Aktion wartet (beispielsweise auf den Abschluss der Authentifizierung).</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">In "{0}" wurden mehrere Projekte gefunden. Geben Sie an, welches davon verwendet werden soll.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Hiermit wird zugelassen, dass der Befehl anhält und auf eine Benutzereingabe oder Aktion wartet (beispielsweise auf den Abschluss der Authentifizierung).</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Permite que el comando se detenga y espere la entrada o acción del usuario (por ejemplo, para autenticarse).</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Se han encontrado varios proyectos en "{0}". Especifique el que debe usarse.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Permite que el comando se detenga y espere la entrada o acción del usuario (por ejemplo, para autenticarse).</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Permet à la commande de s'arrêter et d'attendre une entrée ou une action de l'utilisateur (par exemple pour effectuer une authentification).</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Plusieurs projets dans '{0}'. Spécifiez celui à utiliser.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Permet à la commande de s'arrêter et d'attendre une entrée ou une action de l'utilisateur (par exemple pour effectuer une authentification).</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Consente al comando di arrestare l'esecuzione e attendere l'input o l'azione dell'utente, ad esempio per completare l'autenticazione.</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Sono stati trovati più progetti in `{0}`. Specificare quello da usare.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Consente al comando di arrestare l'esecuzione e attendere l'input o l'azione dell'utente, ad esempio per completare l'autenticazione.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">コマンドを停止して、ユーザーの入力またはアクション (認証の完了など) を待機できるようにします。</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">`{0}` に複数のプロジェクトが見つかりました。使用するプロジェクトを指定してください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">コマンドを停止して、ユーザーの入力またはアクション (認証の完了など) を待機できるようにします。</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">명령을 중지하고 사용자 입력 또는 작업을 기다리도록 허용합니다(예: 인증 완료).</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">'{0}'에서 프로젝트를 두 개 이상 찾았습니다. 사용할 프로젝트를 지정하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">명령을 중지하고 사용자 입력 또는 작업을 기다리도록 허용합니다(예: 인증 완료).</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Zezwala poleceniu na zatrzymanie działania i zaczekanie na wprowadzenie danych lub wykonanie akcji przez użytkownika (na przykład ukończenie uwierzytelniania).</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Znaleziono więcej niż jeden projekt w lokalizacji „{0}”. Określ, który ma zostać użyty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Zezwala poleceniu na zatrzymanie działania i zaczekanie na wprowadzenie danych lub wykonanie akcji przez użytkownika (na przykład ukończenie uwierzytelniania).</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Permite que o comando seja interrompido e aguarde a ação ou entrada do usuário (por exemplo, para concluir a autenticação).</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Foi encontrado mais de um projeto em ‘{0}’. Especifique qual deve ser usado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Permite que o comando seja interrompido e aguarde a ação ou entrada do usuário (por exemplo, para concluir a autenticação).</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Позволяет остановить команду и ожидать ввода или действия пользователя (например, для проверки подлинности).</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Найдено несколько проектов в "{0}". Выберите один.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Позволяет остановить команду и ожидать ввода или действия пользователя (например, для проверки подлинности).</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Komutun durup kullanıcı girişini veya eylemini (örneğin, kimlik doğrulamasının tamamlanmasını) beklemesine izin verir .</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">`{0}` içinde birden fazla proje bulundu. Hangisinin kullanılacağını belirtin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">Komutun durup kullanıcı girişini veya eylemini (örneğin, kimlik doğrulamasının tamamlanmasını) beklemesine izin verir .</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">允许命令停止和等待用户输入或操作(例如，用以完成身份验证)。</target>
@@ -78,6 +88,11 @@ EOF
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">在“{0}”中找到多个项目。请指定使用哪一个。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">允许命令停止和等待用户输入或操作(例如，用以完成身份验证)。</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CommonLocalizableStrings.resx">
     <body>
+      <trans-unit id="ArchitectureOptionDescription">
+        <source>The target architecture.</source>
+        <target state="new">The target architecture.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotResolveRuntimeIdentifier">
+        <source>Resolving the current runtime identifier failed.</source>
+        <target state="new">Resolving the current runtime identifier failed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">允許命令停止並等候使用者輸入或動作 (例如: 完成驗證)。</target>
@@ -78,6 +88,11 @@ export PATH="$PATH:{0}"
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">在 `{0}` 中找到多個專案。請指定要使用的專案。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OperatingSystemOptionDescription">
+        <source>The target operating system.</source>
+        <target state="new">The target operating system.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -12,6 +12,16 @@
         <target state="new">Resolving the current runtime identifier failed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndArchOptions">
+        <source>Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-a|--arch` options is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotSpecifyBothRuntimeAndOsOptions">
+        <source>Specifying both the `-r|--runtime` and `-os` options is not supported.</source>
+        <target state="new">Specifying both the `-r|--runtime` and `-os` options is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandInteractiveOptionDescription">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="translated">允許命令停止並等候使用者輸入或動作 (例如: 完成驗證)。</target>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 var expectedArch = Environment.Is64BitOperatingSystem ? "x64" : "x86";
                 command.GetArgumentsToMSBuild()
                     .Should()
-                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch} -property:SelfContained=true");
+                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch}");
             });
         }
 
@@ -113,7 +113,20 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 var command = BuildCommand.FromArgs(new string[] { "--arch", "arch" }, msbuildPath);
                 command.GetArgumentsToMSBuild()
                     .Should()
-                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=win-arch -property:SelfContained=true");
+                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=win-arch");
+            });
+        }
+
+        [Fact]
+        public void OSAndArchOptionsCanBeCombined()
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                var msbuildPath = "<msbuildpath>";
+                var command = BuildCommand.FromArgs(new string[] { "--arch", "arch", "--os", "os" }, msbuildPath);
+                command.GetArgumentsToMSBuild()
+                    .Should()
+                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-arch");
             });
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -4,6 +4,10 @@
 using Microsoft.DotNet.Tools.Build;
 using FluentAssertions;
 using Xunit;
+using Microsoft.DotNet.Cli.Utils;
+using System;
+using Microsoft.NET.TestFramework;
+using Microsoft.DotNet.Tools;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -84,7 +88,33 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     .Should()
                     .Be($"{ExpectedPrefix} -nologo -consoleloggerparameters:Summary{expectedAdditionalArgs}");
             });
+        }
 
+        [Fact]
+        public void OsOptionIsCorrectlyResolved()
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                var msbuildPath = "<msbuildpath>";
+                var command = BuildCommand.FromArgs(new string[] { "--os", "os" }, msbuildPath);
+                var expectedArch = Environment.Is64BitOperatingSystem ? "x64" : "x86";
+                command.GetArgumentsToMSBuild()
+                    .Should()
+                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch} -property:SelfContained=true");
+            });
+        }
+
+        [WindowsOnlyFact]
+        public void ArchOptionIsCorrectlyResolved()
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                var msbuildPath = "<msbuildpath>";
+                var command = BuildCommand.FromArgs(new string[] { "--arch", "arch" }, msbuildPath);
+                command.GetArgumentsToMSBuild()
+                    .Should()
+                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=win-arch -property:SelfContained=true");
+            });
         }
     }
 }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -4,10 +4,6 @@
 using Microsoft.DotNet.Tools.Build;
 using FluentAssertions;
 using Xunit;
-using Microsoft.DotNet.Cli.Utils;
-using System;
-using Microsoft.NET.TestFramework;
-using Microsoft.DotNet.Tools;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -87,46 +83,6 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 command.GetArgumentsToMSBuild()
                     .Should()
                     .Be($"{ExpectedPrefix} -nologo -consoleloggerparameters:Summary{expectedAdditionalArgs}");
-            });
-        }
-
-        [Fact]
-        public void OsOptionIsCorrectlyResolved()
-        {
-            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
-            {
-                var msbuildPath = "<msbuildpath>";
-                var command = BuildCommand.FromArgs(new string[] { "--os", "os" }, msbuildPath);
-                var expectedArch = Environment.Is64BitOperatingSystem ? "x64" : "x86";
-                command.GetArgumentsToMSBuild()
-                    .Should()
-                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch}");
-            });
-        }
-
-        [WindowsOnlyFact]
-        public void ArchOptionIsCorrectlyResolved()
-        {
-            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
-            {
-                var msbuildPath = "<msbuildpath>";
-                var command = BuildCommand.FromArgs(new string[] { "--arch", "arch" }, msbuildPath);
-                command.GetArgumentsToMSBuild()
-                    .Should()
-                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=win-arch");
-            });
-        }
-
-        [Fact]
-        public void OSAndArchOptionsCanBeCombined()
-        {
-            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
-            {
-                var msbuildPath = "<msbuildpath>";
-                var command = BuildCommand.FromArgs(new string[] { "--arch", "arch", "--os", "os" }, msbuildPath);
-                command.GetArgumentsToMSBuild()
-                    .Should()
-                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-arch");
             });
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
@@ -1,0 +1,134 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Xunit;
+using Microsoft.DotNet.Cli.Utils;
+using System;
+using Microsoft.NET.TestFramework;
+using Microsoft.DotNet.Tools;
+using System.Runtime.InteropServices;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.Assertions;
+using BuildCommand = Microsoft.DotNet.Tools.Build.BuildCommand;
+
+namespace Microsoft.DotNet.Cli.MSBuild.Tests
+{
+    public class GivenDotnetOsArchOptions : SdkTest
+    {
+        public GivenDotnetOsArchOptions(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m";
+
+        private static readonly string WorkingDirectory =
+            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetBuildInvocation));
+
+        [Fact]
+        public void OsOptionIsCorrectlyResolved()
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                var msbuildPath = "<msbuildpath>";
+                var command = BuildCommand.FromArgs(new string[] { "--os", "os" }, msbuildPath);
+                var expectedArch = RuntimeInformation.ProcessArchitecture.Equals(Architecture.Arm64) ? "arm64" : Environment.Is64BitOperatingSystem ? "x64" : "x86";
+                command.GetArgumentsToMSBuild()
+                    .Should()
+                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch}");
+            });
+        }
+
+        [Fact]
+        public void ArchOptionIsCorrectlyResolved()
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                var msbuildPath = "<msbuildpath>";
+                var command = BuildCommand.FromArgs(new string[] { "--arch", "arch" }, msbuildPath);
+                var expectedOs = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win" :
+                    RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux" :
+                    RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx" :
+                    null;
+                if (expectedOs == null)
+                {
+                    // Not a supported OS for running test
+                    return;
+                }
+                command.GetArgumentsToMSBuild()
+                    .Should()
+                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier={expectedOs}-arch");
+            });
+        }
+
+        [Fact]
+        public void OSAndArchOptionsCanBeCombined()
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                var msbuildPath = "<msbuildpath>";
+                var command = BuildCommand.FromArgs(new string[] { "--arch", "arch", "--os", "os" }, msbuildPath);
+                command.GetArgumentsToMSBuild()
+                    .Should()
+                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-arch");
+            });
+        }
+
+        [Fact]
+        public void OSOptionCannotBeCombinedWithRuntime()
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                var msbuildPath = "<msbuildpath>";
+                var exceptionThrown = Assert.Throws<GracefulException>(() => BuildCommand.FromArgs(new string[] { "--os", "os", "--runtime", "rid" }, msbuildPath));
+                exceptionThrown.Message.Should().Be(CommonLocalizableStrings.CannotSpecifyBothRuntimeAndOsOptions);
+            });
+        }
+
+        [Fact]
+        public void ArchOptionCannotBeCombinedWithRuntime()
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                var msbuildPath = "<msbuildpath>";
+                var exceptionThrown = Assert.Throws<GracefulException>(() => BuildCommand.FromArgs(new string[] { "--arch", "arch", "--runtime", "rid" }, msbuildPath));
+                exceptionThrown.Message.Should().Be(CommonLocalizableStrings.CannotSpecifyBothRuntimeAndArchOptions);
+            });
+        }
+
+        [Theory]
+        [InlineData("build")]
+        [InlineData("publish")]
+        [InlineData("test")]
+        [InlineData("run")]
+        public void CommandsRunWithOSOption(string command)
+        {
+            var testInstance = _testAssetsManager.CopyTestAsset("HelloWorld", identifier: command)
+                .WithSource();
+
+            new DotnetCommand(Log)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute(command, "--os", "win")
+                .Should()
+                .Pass();
+        }
+
+        [Theory]
+        [InlineData("build")]
+        [InlineData("publish")]
+        [InlineData("test")]
+        [InlineData("run")]
+        public void CommandsRunWithArchOption(string command)
+        {
+            var testInstance = _testAssetsManager.CopyTestAsset("HelloWorld", identifier: command)
+                .WithSource();
+
+            new DotnetCommand(Log)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute(command, "--arch", "x86")
+                .Should()
+                .Pass();
+        }
+    }
+}

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             });
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("build")]
         [InlineData("publish")]
         [InlineData("test")]
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 .Pass();
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("build")]
         [InlineData("publish")]
         [InlineData("test")]


### PR DESCRIPTION
Fixes first bullet of #18832

## Description
This change adds `--os` and `--arch` options to build, publish, run, and test commands. This is a shorthand syntax for the runtime identifier, where the provided values will be combined with the default RID. For example, on a win-x64 machine, specifying `--os os` will result in running with the RID set to `os-x64` and specifying `--arch arch` will result in `win-arch`. Full spec here: https://github.com/dotnet/designs/blob/d248ad68b41866eba17e80225a08518b8202ddf6/accepted/2021/architecture-targeting.md#enable-shorthand-rid-targeting-syntax
These changes are all additive and do not impact the existing CLI.

## Regression?
No

## Risk
Low, this is a new feature and won't effect existing CLI. 

## Verification
[X] Manual (required)
[x] Automated