### PR TITLE
Rationalize default Imports for C# and VB

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -87,17 +87,15 @@ Copyright (c) .NET Foundation. All rights reserved.
                       and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                       and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
 
-    <!-- These imports are already defined as VB implicit imports, so only add them for C# here -->
-    <Import Include="System" Condition="'$(Language)' == 'C#'" />
-    <Import Include="System.Collections.Generic" Condition="'$(Language)' == 'C#'" />
-    <Import Include="System.Linq" Condition="'$(Language)' == 'C#'" />
-    <Import Include="System.Threading.Tasks" Condition="'$(Language)' == 'C#'" />
-    
-    <!-- These imports were not included by default for VB projects prior to .NET 6, so they apply to both languages -->
+    <!-- Imports already defined as VB implicit imports are conditioned to not be added twice -->
+    <Import Include="System" Condition="'$(Language)' != 'VB'" />
+    <Import Include="System.Collections.Generic" Condition="'$(Language)' != 'VB'" />
     <Import Include="System.IO" />
+    <Import Include="System.Linq" Condition="'$(Language)' != 'VB'" />
     <Import Include="System.Net.Http" />
     <Import Include="System.Threading" />
-
+    <Import Include="System.Threading.Tasks" Condition="'$(Language)' != 'VB'" />
+    
   </ItemGroup>
 
   <!-- VB implicit imports -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -82,18 +82,22 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </ItemGroup>
 
-  <!-- C# implicit imports -->
+  <!-- Implicit imports -->
   <ItemGroup Condition=" '$(DisableImplicitNamespaceImports_DotNet)' != 'true'
-                      and '$(Language)' == 'C#'
                       and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                       and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <Import Include="System" />
-    <Import Include="System.Collections.Generic" />
+
+    <!-- These imports are already defined as VB implicit imports, so only add them for C# here -->
+    <Import Include="System" Condition="'$(Language)' == 'C#'" />
+    <Import Include="System.Collections.Generic" Condition="'$(Language)' == 'C#'" />
+    <Import Include="System.Linq" Condition="'$(Language)' == 'C#'" />
+    <Import Include="System.Threading.Tasks" Condition="'$(Language)' == 'C#'" />
+    
+    <!-- These imports were not included by default for VB projects prior to .NET 6, so they apply to both languages -->
     <Import Include="System.IO" />
-    <Import Include="System.Linq" />
     <Import Include="System.Net.Http" />
     <Import Include="System.Threading" />
-    <Import Include="System.Threading.Tasks" />
+
   </ItemGroup>
 
   <!-- VB implicit imports -->


### PR DESCRIPTION
This updates the list of `Import` items for VB to include the Imports that C# by default gets for .NET 6 and higher.  This means that VB will now additionally get the following when targeting .NET 6:

- System.IO
- System.Net.Http
- System.Threading

This also reorganizes the imports so that it's more likely that if we expand the list in the future, we will apply that to both languages.

@KathleenDollard Do you think this is the right thing to do?