### PR TITLE
Mark Razor source generator files as generated

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -37,17 +37,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             return builder.ToString();
         }
 
-        private static void HandleDebugSwitch(bool waitForDebugger)
-        {
-            if (waitForDebugger)
-            {
-                while (!Debugger.IsAttached)
-                {
-                    Thread.Sleep(3000);
-                }
-            }
-        }
-
         private static RazorProjectEngine GetDiscoveryProjectEngine(StaticCompilationTagHelperFeature tagHelperFeature, IEnumerable<MetadataReference> references, IEnumerable<SourceGeneratorProjectItem> items, RazorSourceGenerationOptions razorSourceGeneratorOptions)
         {
             var fileSystem = new VirtualRazorProjectFileSystem();

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -120,7 +120,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
                 if (!razorSourceGeneratorOptions.SuppressRazorSourceGenerator)
                 {
-                    context.AddSource(GetIdentifierFromPath(projectItem.RelativePhysicalPath), csharpDocument.GeneratedCode);
+                    // Add a generated suffix so tools, such as coverlet, consider the file to be generated
+                    var hintName = GetIdentifierFromPath(projectItem.RelativePhysicalPath) + ".g.cs";
+                    context.AddSource(hintName, csharpDocument.GeneratedCode);
                 }
             });
         }

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
@@ -1,18 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework.Utilities;
-using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -102,8 +99,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var scoped = Path.Combine(intermediateOutputPath, "scopedcss", "Styles", "Pages", "Counter.rz.scp.css");
             new FileInfo(scoped).Should().Exist();
             new FileInfo(scoped).Should().Contain("b-overriden");
-            var generated = Path.Combine(intermediateOutputPath, "generated", "Microsoft.NET.Sdk.Razor.SourceGenerators", "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator", "Components_Pages_Counter_razor.cs");	
-            new FileInfo(generated).Should().Exist();	
+            var generated = Path.Combine(intermediateOutputPath, "generated", "Microsoft.NET.Sdk.Razor.SourceGenerators", "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator", "Components_Pages_Counter_razor.g.cs");	
+            new FileInfo(generated).Should().Exist();
             new FileInfo(generated).Should().Contain("b-overriden");
             new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "Components", "Pages", "Index.razor.rz.scp.css")).Should().NotExist();
         }
@@ -327,8 +324,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(generatedBundle).Should().Exist();
             var generatedProjectBundle = Path.Combine(intermediateOutputPath, "scopedcss", "projectbundle", "ComponentApp.bundle.scp.css");
             new FileInfo(generatedProjectBundle).Should().Exist();
-            var generatedCounter = Path.Combine(intermediateOutputPath, "generated", "Microsoft.NET.Sdk.Razor.SourceGenerators", "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator", "Components_Pages_Counter_razor.cs");	
-            new FileInfo(generatedCounter).Should().Exist();	
+            var generatedCounter = Path.Combine(intermediateOutputPath, "generated", "Microsoft.NET.Sdk.Razor.SourceGenerators", "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator", "Components_Pages_Counter_razor.g.cs");	
+            new FileInfo(generatedCounter).Should().Exist();
 
             var componentThumbprint = FileThumbPrint.Create(generatedCounter);
             var bundleThumbprint = FileThumbPrint.Create(generatedBundle);


### PR DESCRIPTION
Give the output files from the Razor Source Generator a `.g.cs` suffix so that they are treated as a generated file to prevent it being flagged by source analyzers for violations the application developer cannot fix themselves and so that tools such as coverlet ignore them.

I _think_ this is part of the fix (and is the same as #16777 which seems to have gone as part of somet refactoring), but I couldn't get the tests to debug through the source generator in Visual Studio 2022 preview 2, so I wasn't able to actually inspect my changes and check they were actually being applied.

I think there's _also_ an issue with coverlet, as if I try and exclude the RSG-generated files from coverage anyway using a filter of `[*]AspNetCoreGeneratedDocument*`, it still refuses to cover any of the code due to it being unable to find the files from the source-generator on disk.

I haven't gotten as far as trying to debug coverlet yet, but I noticed from structured logging that the source files from the RSG didn't have the `.g.cs` suffix:

```
[coverlet] Unable to instrument module: C:\Coding\martincostello\api\tests\API.Tests\bin\debug\net6.0\API.dll, pdb without local source files, [C:\Coding\martincostello\api\src\API\Microsoft.NET.Sdk.Razor.SourceGenerators\Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator\_Views_Docs_Index_cshtml.cs]
```

Relates to dotnet/aspnetcore#31719.

/cc @captainsafia
