### PR TITLE
Don't re-run discovery for files that haven't changed

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -31,7 +31,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     (c1, c2) => c1 != null && c2 != null && c1.References != c2.References)
                 .Select((compilation, _) => compilation.References);
 
-            var sourceItemsByName = sourceItems.Collect().WithLambdaComparer((@new, old) => @new.SequenceEqual(old, new LambdaComparer<SourceGeneratorProjectItem>((l, r) => string.Equals(l?.FilePath, r?.FilePath, System.StringComparison.OrdinalIgnoreCase))));
+            var sourceItemsByName = sourceItems.Collect()
+                .WithLambdaComparer((@new, old) => @new.SequenceEqual(old, new LambdaComparer<SourceGeneratorProjectItem>(
+                    (l, r) => string.Equals(l?.FilePath, r?.FilePath, System.StringComparison.OrdinalIgnoreCase))));
 
             var discoveryProjectEngine = references
                 .Combine(razorSourceGeneratorOptions)

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -31,9 +31,11 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     (c1, c2) => c1 != null && c2 != null && c1.References != c2.References)
                 .Select((compilation, _) => compilation.References);
 
+            var sourceItemsByName = sourceItems.Collect().WithLambdaComparer((@new, old) => @new.SequenceEqual(old, new LambdaComparer<SourceGeneratorProjectItem>((l, r) => string.Equals(l?.FilePath, r?.FilePath, System.StringComparison.OrdinalIgnoreCase))));
+
             var discoveryProjectEngine = references
                 .Combine(razorSourceGeneratorOptions)
-                .Combine(sourceItems.Collect())
+                .Combine(sourceItemsByName)
                 .Select((pair, _) =>
                 {
                     var ((references, razorSourceGeneratorOptions), projectItems) = pair;


### PR DESCRIPTION
During testing we identified a bottle neck where this is always running, even though it doesn't need to.

This fix groups the source items by name, only re-running discovery if the name of the files change (or when a file is added/removed).