### PR TITLE
Don't produce errors when an Exe project references a test project

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1051,13 +1051,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Don't generate a NETSDK1151 error if a non self-contained Exe references a Blazor wasm Exe -->
     <ShouldBeValidatedAsExecutableReference>false</ShouldBeValidatedAsExecutableReference>
   </PropertyGroup>
-
+  
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' And '$(ValidateExecutableReferencesMatchSelfContained)' == ''">
     <!-- Don't generate an error if a test project references a self-contained Exe.  Test projects
          use an OutputType of Exe but will usually call APIs in a referenced Exe rather than try
          to run it. -->
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <!-- Don't generate an error if an Exe project references a test project. -->
+    <ShouldBeValidatedAsExecutableReference>false</ShouldBeValidatedAsExecutableReference>
+  </PropertyGroup>
+
 
   <UsingTask TaskName="ValidateExecutableReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 


### PR DESCRIPTION
This fixes another case where the NETSDK1130 error would be generated when it should not be.  When an Exe project references a test project, we should not generate this error.

This case was discovered here: https://github.com/dotnet/sdk/issues/17579#issuecomment-881646782

This is similar to #17594, except this fixes the case when the reference is in the other direction.