### PR TITLE
[release/6.0.1xx-preview7] Retarget test asset

### DIFF
--- a/src/Assets/TestProjects/WebApp/web.csproj
+++ b/src/Assets/TestProjects/WebApp/web.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <Folder Include="wwwroot\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
@@ -45,16 +45,14 @@ namespace Microsoft.NET.Publish.Tests
                 .Pass();
 
             var publishDirectory =
-                command.GetOutputDirectory(targetFramework: "netcoreapp2.0", configuration: "Release");
+                command.GetOutputDirectory(targetFramework: "net5.0", configuration: "Release");
 
             publishDirectory.Should().NotHaveSubDirectories();
-            publishDirectory.Should().OnlyHaveFiles(new[] {
+            publishDirectory.Should().HaveFiles(new[] {
                 "web.config",
                 "web.deps.json",
                 "web.dll",
                 "web.pdb",
-                "web.PrecompiledViews.dll",
-                "web.PrecompiledViews.pdb",
                 "web.runtimeconfig.json",
             });
         }


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/18974 to preview7 for https://github.com/dotnet/installer/pull/11143

Please close if there is a different preferred way of doing this.

cc @sfoslund 