### PR TITLE
Exclude run arguments from parsing logic

### DIFF
--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.CommandLine.Parsing;
 using System.Linq;
 using static Microsoft.DotNet.Cli.Parser;
@@ -57,13 +58,18 @@ namespace Microsoft.DotNet.Cli
         public static string[] GetSubArguments(this string[] args)
         {
             var subargs = args.ToList();
+
+            // Don't remove any arguments that are being passed to the app in dotnet run
+            var runArgs = subargs.Contains("--") ? subargs.GetRange(subargs.IndexOf("--"), subargs.Count() - subargs.IndexOf("--")) : new List<string>();
+            subargs = subargs.Contains("--") ? subargs.GetRange(0, subargs.IndexOf("--")) : subargs;
+
             subargs.RemoveAll(arg => DiagOption.Aliases.Contains(arg));
             if (subargs[0].Equals("dotnet"))
             {
                 subargs.RemoveAt(0);
             }
             subargs.RemoveAt(0); // remove top level command (ex build or publish)
-            return subargs.ToArray();
+            return subargs.Concat(runArgs).ToArray();
         }
 
         private static string GetSymbolResultValue(ParseResult parseResult, SymbolResult symbolResult)

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -270,6 +270,23 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
+        public void ItCanPassOptionArgumentsToSubjectAppByDoubleDash()
+        {
+            const string testAppName = "MSBuildTestApp";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            var testProjectDirectory = testInstance.Path;
+
+            new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("--", "-d", "-a")
+                .Should()
+                .Pass()
+                .And.HaveStdOutContaining("echo args:-d;-a");
+        }
+
+        [Fact]
         public void ItGivesAnErrorWhenAttemptingToUseALaunchProfileThatDoesNotExistWhenThereIsNoLaunchSettingsFile()
         {
             var testAppName = "MSBuildTestApp";

--- a/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
         [InlineData(new string[] { "dotnet", "add", "package", "-h" }, new string[] { "package", "-h" })]
         [InlineData(new string[] { "add", "package", "-h" }, new string[] { "package", "-h" })]
         [InlineData(new string[] { "dotnet", "-d", "help" }, new string[] { })]
+        [InlineData(new string[] { "dotnet", "run", "--", "-d" }, new string[] { "--", "-d" })]
         public void GetSubArgumentsRemovesTopLevelCommands(string[] input, string[] expected)
         {
             input.GetSubArguments()


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/16120