### PR TITLE
Add support for building 2.1 Razor projects using the RazorSDK

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,6 +6,14 @@
     <SupportedPlatform Remove="iOS" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      The System.Threading.Tasks global import interferes with Microsoft.Build.Utilities.Task that is used extensively
+      in this repository. Remove it to avoid the conflict.
+    -->
+    <Import Remove="System.Threading.Tasks" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(OutputType)' == 'Exe' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <PackageReference Include="xunit.console" Version="$(XUnitVersion)" Private="true" />
 

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Models/ErrorViewModel.cs
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Models/ErrorViewModel.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace SimpleMvc21NetFx.Models
+{
+    public class ErrorViewModel
+    {
+        public string RequestId { get; set; }
+
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+    }
+}

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Program.cs
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Program.cs
@@ -1,0 +1,13 @@
+﻿
+namespace SimpleMvc
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            // Just make sure we have a reference to the MVC 2.1
+            var t = typeof(Microsoft.AspNetCore.Mvc.IActionResult);
+            System.Console.WriteLine(t.FullName);
+        }
+    }
+}

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/SimpleMvc21NetFx.csproj
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/SimpleMvc21NetFx.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/SimpleTagHelper.cs
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/SimpleTagHelper.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace SimpleMvc
+{
+    public class SimpleTagHelper : TagHelper
+    {
+    }
+}

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/Home/About.cshtml
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/Home/About.cshtml
@@ -1,0 +1,7 @@
+﻿@{
+    ViewData["Title"] = "About";
+}
+<h2>@ViewData["Title"]</h2>
+<h3>@ViewData["Message"]</h3>
+
+<p>Use this area to provide additional information.</p>

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/Home/Index.cshtml
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/Home/Index.cshtml
@@ -1,0 +1,7 @@
+﻿@{
+    ViewData["Title"] = "Home Page";
+}
+
+<div>
+    <p>Some test content.</p>
+</div>

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/Shared/_Layout.cshtml
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/Shared/_Layout.cshtml
@@ -1,0 +1,19 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - SimpleMvc</title>
+</head>
+<body>
+    <div class="container body-content">
+        @RenderBody()
+        <hr />
+        <footer>
+            <p>&copy; 2017 - SimpleMvc</p>
+        </footer>
+    </div>
+
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,0 +1,18 @@
+﻿<environment include="Development">
+    <script src="~/lib/jquery-validation/dist/jquery.validate.js"></script>
+    <script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>
+</environment>
+<environment exclude="Development">
+    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.14.0/jquery.validate.min.js"
+            asp-fallback-src="~/lib/jquery-validation/dist/jquery.validate.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator"
+            crossorigin="anonymous"
+            integrity="sha384-Fnqn3nxp3506LP/7Y3j/25BlWeA3PXTyT1l78LjECcPaKCV12TsZP7yyMxOe/G/k">
+    </script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validation.unobtrusive/3.2.6/jquery.validate.unobtrusive.min.js"
+            asp-fallback-src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator && window.jQuery.validator.unobtrusive"
+            crossorigin="anonymous"
+            integrity="sha384-JrXK+k53HACyavUKOsL+NkmSesD2P+73eDMrbTtTk0h4RmOF8hF8apPlkp26JlyH">
+    </script>
+</environment>

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/_ViewImports.cshtml
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+﻿@using SimpleMvc21NetFx
+@using SimpleMvc21NetFx.Models
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@namespace SimpleMvc21NetFx

--- a/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/_ViewStart.cshtml
+++ b/src/Assets/TestProjects/RazorSimpleMvc21NetFx/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.CodeGeneration.targets
@@ -17,12 +17,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
 
   <UsingTask
-    TaskName="Microsoft.AspNetCore.Razor.Tasks.RazorGenerate"
+    TaskName="Microsoft.AspNetCore.Razor.Tasks.SdkRazorGenerate"
     AssemblyFile="$(RazorSdkBuildTasksAssembly)"
     Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
   <UsingTask
-    TaskName="Microsoft.AspNetCore.Razor.Tasks.RazorTagHelper"
+    TaskName="Microsoft.AspNetCore.Razor.Tasks.SdkRazorTagHelper"
     AssemblyFile="$(RazorSdkBuildTasksAssembly)"
     Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
@@ -94,7 +94,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <FileWrites Include="$(_RazorTagHelperInputCache)" />
     </ItemGroup>
 
-    <RazorTagHelper
+    <SdkRazorTagHelper
       Debug="$(_RazorDebugTagHelperTask)"
       DebugTool="$(_RazorDebugTagHelperTool)"
       ToolAssembly="$(_RazorSdkToolAssembly)"
@@ -112,7 +112,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
         TaskParameter="TagHelperManifest"
         ItemName="FileWrites"/>
-    </RazorTagHelper>
+    </SdkRazorTagHelper>
   </Target>
 
   <Target Name="_ResolveRazorGenerateOutputs" Condition="'@(RazorGenerateWithTargetPath)' != ''">
@@ -147,7 +147,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       Directories="%(_RazorGenerateOutput.RelativeDir)"
       Condition="!Exists('%(_RazorGenerateOutput.RelativeDir)')" />
 
-    <RazorGenerate
+    <SdkRazorGenerate
       Debug="$(_RazorDebugGenerateCodeTask)"
       DebugTool="$(_RazorDebugGenerateCodeTool)"
       ToolAssembly="$(_RazorSdkToolAssembly)"

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.Component.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.Component.targets
@@ -103,7 +103,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RazorComponentDeclarationManifest>$(IntermediateOutputPath)$(MSBuildProjectName).RazorComponents.declaration.json</_RazorComponentDeclarationManifest>
     </PropertyGroup>
 
-    <RazorGenerate
+    <SdkRazorGenerate
       Debug="$(_RazorDebugGenerateCodeTask)"
       DebugTool="$(_RazorDebugGenerateCodeTool)"
       ToolExe="$(_RazorSdkDotNetHostFileName)"

--- a/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
+++ b/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
@@ -379,15 +379,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Determine what compiler and versions of the language to target. For 2.x targeting projects, these are carried by packages referenced by the project. Use this -->
 
-  <!-- Use the 2.x compiler if we're building an application that references Microsoft.AspNetCore.Razor.Design. -->
-  <Import Project="$(RazorCodeGenerationTargetsPath)"
-    Condition="'$(IsRazorCompilerReferenced)' == 'true' AND '$(RazorCodeGenerationTargetsPath)' != '' AND Exists('$(RazorCodeGenerationTargetsPath)')" />
-
   <!-- When targeting 3.x and later projects, we have to infer configuration by inspecting the project. -->
   <Import Project="Microsoft.NET.Sdk.Razor.Configuration.targets" Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true'" />
 
-  <!-- For projects targeting 3.x and later, use the compiler that ships in the SDK -->
-  <Import Project="Microsoft.NET.Sdk.Razor.CodeGeneration.targets" Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true' AND '$(UseRazorSourceGenerator)' != 'true'" />
+  <Import Project="Microsoft.NET.Sdk.Razor.CodeGeneration.targets" Condition="'$(UseRazorSourceGenerator)' != 'true'" />
 
   <Import Project="Microsoft.NET.Sdk.Razor.Component.targets" Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true' AND '$(UseRazorSourceGenerator)' != 'true'" />
 

--- a/src/RazorSdk/Tasks/SdkRazorGenerate.cs
+++ b/src/RazorSdk/Tasks/SdkRazorGenerate.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.Razor.Tasks
 {
-    public class RazorGenerate : DotNetToolTask
+    public class SdkRazorGenerate : DotNetToolTask
     {
         private static readonly string[] SourceRequiredMetadata = new string[]
         {
@@ -169,16 +169,16 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     builder.AppendLine(RootNamespace);
                 }
 
-                if (!string.IsNullOrEmpty(CSharpLanguageVersion))
-                {
-                    builder.AppendLine("--csharp-language-version");
-                    builder.AppendLine(CSharpLanguageVersion);
-                }
-
                 if (GenerateDeclaration)
                 {
                     builder.AppendLine("--generate-declaration");
                 }
+            }
+
+            if (!string.IsNullOrEmpty(CSharpLanguageVersion))
+            {
+                builder.AppendLine("--csharp-language-version");
+                builder.AppendLine(CSharpLanguageVersion);
             }
 
             for (var i = 0; i < Extensions.Length; i++)

--- a/src/RazorSdk/Tasks/SdkRazorTagHelper.cs
+++ b/src/RazorSdk/Tasks/SdkRazorTagHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.Razor.Tasks
 {
-    public class RazorTagHelper : DotNetToolTask
+    public class SdkRazorTagHelper : DotNetToolTask
     {
         private const string Identity = "Identity";
         private const string AssemblyName = "AssemblyName";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTest21NetFx.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTest21NetFx.cs
@@ -1,0 +1,138 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Sdk.Razor.Tests
+{
+    public class MvcBuildIntegrationTest21NetFx : AspNetSdkTest
+    {
+        private const string TestProjectName ="SimpleMvc21NetFx";
+        private const string TargetFramework = "net461";
+        public const string OutputFileName = TestProjectName + ".exe";
+        public MvcBuildIntegrationTest21NetFx(ITestOutputHelper log) : base(log) { }
+
+        [Fact]
+        public virtual void Building_Project()
+        {
+            var testAsset = $"Razor{TestProjectName}";
+            var project = CreateAspNetSdkTestAsset(testAsset);
+
+            // Build
+            var build = new BuildCommand(project);
+            build.Execute().Should().Pass();
+
+            var outputPath = build.GetOutputDirectory(TargetFramework, "Debug").ToString();
+            var intermediateOutputPath = build.GetIntermediateDirectory(TargetFramework, "Debug").ToString();
+
+            new FileInfo(Path.Combine(outputPath, OutputFileName)).Should().Exist();
+            new FileInfo(Path.Combine(outputPath, $"{TestProjectName}.pdb")).Should().Exist();
+            new FileInfo(Path.Combine(outputPath, $"{TestProjectName}.Views.dll")).Should().Exist();
+            new FileInfo(Path.Combine(outputPath, $"{TestProjectName}.Views.pdb")).Should().Exist();
+
+            // Verify RazorTagHelper works
+            new FileInfo(Path.Combine(intermediateOutputPath, $"{TestProjectName}.TagHelpers.input.cache")).Should().Exist();
+            new FileInfo(Path.Combine(intermediateOutputPath, $"{TestProjectName}.TagHelpers.output.cache")).Should().Exist();
+            new FileInfo(
+                Path.Combine(intermediateOutputPath, $"{TestProjectName}.TagHelpers.output.cache")).Should().Contain(
+                @"""Name"":""SimpleMvc.SimpleTagHelper""");
+        }
+
+        [Fact]
+        public virtual void BuildingProject_CopyToOutputDirectoryFiles()
+        {
+            var testAsset = $"Razor{TestProjectName}";
+            var project = CreateAspNetSdkTestAsset(testAsset);
+
+            // Build
+            var build = new BuildCommand(project);
+            build.Execute().Should().Pass();
+
+            var outputPath = build.GetOutputDirectory(TargetFramework, "Debug").ToString();
+
+            // No cshtml files should be in the build output directory
+            new DirectoryInfo(Path.Combine(outputPath, "Views")).Should().NotExist();
+
+            // For netfx projects, we also expect a refs folder to be present in the output directory
+            new DirectoryInfo(Path.Combine(outputPath, "refs")).Should().Exist();
+        }
+
+        [Fact]
+        public virtual void Publish_Project()
+        {
+            var testAsset = $"Razor{TestProjectName}";
+            var project = CreateAspNetSdkTestAsset(testAsset);
+
+            var publish = new PublishCommand(Log, project.TestRoot);
+            publish.Execute().Should().Pass();
+
+            var outputPath = publish.GetOutputDirectory(TargetFramework, "Debug").ToString();
+
+            new FileInfo(Path.Combine(outputPath, OutputFileName)).Should().Exist();
+            new FileInfo(Path.Combine(outputPath, $"{TestProjectName}.pdb")).Should().Exist();
+            new FileInfo(Path.Combine(outputPath, $"{TestProjectName}.Views.dll")).Should().Exist();
+            new FileInfo(Path.Combine(outputPath, $"{TestProjectName}.Views.pdb")).Should().Exist();
+
+            // By default, the refs folder and .cshtml files will not be copied on publish. However for framework projects, the refs directory is required.
+            new DirectoryInfo(Path.Combine(outputPath, "refs")).Should().NotExist();
+            new DirectoryInfo(Path.Combine(outputPath, "Views")).Should().NotExist();
+        }
+
+        [Fact]
+        public virtual void Publish_IncludesRefAssemblies_WhenCopyRefAssembliesToPublishDirectoryIsSet()
+        {
+            var testAsset = $"Razor{TestProjectName}";
+            var project = CreateAspNetSdkTestAsset(testAsset);
+
+            var publish = new PublishCommand(Log, project.TestRoot);
+            publish.Execute("/p:CopyRefAssembliesToPublishDirectory=true").Should().Pass();
+
+            var outputPath = publish.GetOutputDirectory(TargetFramework, "Debug").ToString();
+
+            new FileInfo(Path.Combine(outputPath, "refs", "System.Threading.Tasks.Extensions.dll")).Should().Exist();
+        }
+
+        [Fact]
+        public void Build_ProducesDepsFileWithCompilationContext_ButNoReferences()
+        {
+            var testAsset = $"Razor{TestProjectName}";
+            var projectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+            var customDefine = "AspNetSdkTest";
+            var build = new BuildCommand(projectDirectory);
+            build.Execute($"/p:DefineConstants={customDefine}").Should().Pass();
+
+            var outputPath = build.GetOutputDirectory(TargetFramework, "Debug").ToString();
+
+            var depsFile = new FileInfo(Path.Combine(outputPath, $"{TestProjectName}.deps.json"));
+            depsFile.Should().Exist();
+            var dependencyContext = ReadDependencyContext(depsFile.FullName);
+
+            // Ensure some compile references exist
+            var packageReference = dependencyContext.CompileLibraries.First(l => l.Name == "System.Runtime.CompilerServices.Unsafe");
+            packageReference.Assemblies.Should().NotBeEmpty();
+
+            var projectReference = dependencyContext.CompileLibraries.First(l => l.Name == TestProjectName);
+            projectReference.Assemblies.Should().NotBeEmpty();
+
+            dependencyContext.CompilationOptions.Defines.Should().Contain(customDefine);
+        }
+
+        private static DependencyContext ReadDependencyContext(string depsFilePath)
+        {
+            var reader = new DependencyContextJsonReader();
+            using (var stream = File.OpenRead(depsFilePath))
+            {
+                return reader.Read(stream);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Prior to this change, 2.1 Razor projects were built using targets and tasks
carried by the Microsoft.AspNetCore.Razor.Design package. The SDK would
import targets from this package and invoke tasks from within it.

This change allows the SDK to instead build 2.1 projects using the tasks and targets
carried by the SDK. To do this,

* The SDK ignores the CodeGeneration.targets from Razor.Design and uses it's copy.
* Ignores the tasks that are loaded as a result of referencing Razor.Design and instead uses it's own copy. The rename allows this by
working around task-name conflicts.
* Uses the 2.1 extensions dll carried by the Razor.Design for code generation. This is great because we do not have to
worry about breaking changes in newer versions of M.A.Razor.Extensions.

Fixes https://github.com/dotnet/aspnetcore/issues/34383