### PR TITLE
Update linker version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -112,14 +112,14 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>3ce6efc333f38499506dbe79430e09458c5b7a53</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.6.21365.1">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.6.21369.3">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>9ecf5bd2809f93d98c1dbea640790ca5a88d35ec</Sha>
+      <Sha>8d49e169d872d6225bcf73ae14ae50b002f39319</Sha>
       <SourceBuild RepoName="linker" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="6.0.100-preview.6.21365.1">
+    <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="6.0.100-preview.6.21369.3">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>9ecf5bd2809f93d98c1dbea640790ca5a88d35ec</Sha>
+      <Sha>8d49e169d872d6225bcf73ae14ae50b002f39319</Sha>
     </Dependency>
     <Dependency Name="System.CodeDom" Version="6.0.0-preview.7.21370.18">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -76,7 +76,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/mono/linker -->
-    <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.6.21365.1</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.6.21369.3</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksPackageVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
The last linker update to the runtime found several bugs, which are now
fixed, but the linker needs to be updated between the runtime and the
SDK to bring in all the fixes and match up adjustments for linker
warnings in the framework.

Corresponds to runtime PR https://github.com/dotnet/runtime/pull/56106