### PR TITLE
Improve caching in RazorSourceGenerator (#18985)

### DIFF
--- a/src/RazorSdk/SourceGenerators/IncrementalValueProviderExtensions.cs
+++ b/src/RazorSdk/SourceGenerators/IncrementalValueProviderExtensions.cs
@@ -10,15 +10,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
     internal static class IncrementalValuesProviderExtensions
     {
-        internal static IncrementalValuesProvider<T> WithLambdaComparer<T>(this IncrementalValuesProvider<T> source, Func<T?, T?, bool> equal)
+        internal static IncrementalValueProvider<T> WithLambdaComparer<T>(this IncrementalValueProvider<T> source, Func<T, T, bool> equal, Func<T, int> getHashCode)
         {
-            var comparer = new LambdaComparer<T>(equal);
-            return source.WithComparer(comparer);
-        }
-
-        internal static IncrementalValueProvider<T> WithLambdaComparer<T>(this IncrementalValueProvider<T> source, Func<T?, T?, bool> equal)
-        {
-            var comparer = new LambdaComparer<T>(equal);
+            var comparer = new LambdaComparer<T>(equal, getHashCode);
             return source.WithComparer(comparer);
         }
 
@@ -53,15 +47,17 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
     internal class LambdaComparer<T> : IEqualityComparer<T>
     {
-        private readonly Func<T?, T?, bool> _equal;
+        private readonly Func<T, T, bool> _equal;
+        private readonly Func<T, int> _getHashCode;
 
-        public LambdaComparer(Func<T?, T?, bool> equal)
+        public LambdaComparer(Func<T, T, bool> equal, Func<T, int> getHashCode)
         {
             _equal = equal;
+            _getHashCode = getHashCode;
         }
 
-        public bool Equals(T? x, T? y) => _equal(x, y);
+        public bool Equals(T x, T y) => _equal(x, y);
 
-        public int GetHashCode(T obj) =>  EqualityComparer<T>.Default.GetHashCode(obj);
+        public int GetHashCode(T obj) => _getHashCode(obj);
     }
 }

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerationOptions.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerationOptions.cs
@@ -2,12 +2,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
-    internal class RazorSourceGenerationOptions
+    internal class RazorSourceGenerationOptions : IEquatable<RazorSourceGenerationOptions>
     {
         public string RootNamespace { get; set; } = "ASP";
 
@@ -40,6 +41,19 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         /// <summary>
         /// Gets the CSharp language version currently used by the compilation.
         /// </summary>
-        public LanguageVersion CSharpLanguageVersion { get; set; } = LanguageVersion.Preview;
+        public LanguageVersion CSharpLanguageVersion { get; set; } = LanguageVersion.CSharp10;
+
+        public bool Equals(RazorSourceGenerationOptions other)
+        {
+            return RootNamespace == other.RootNamespace &&
+                Configuration == other.Configuration &&
+                GenerateMetadataSourceChecksumAttributes == other.GenerateMetadataSourceChecksumAttributes &&
+                SuppressRazorSourceGenerator == other.SuppressRazorSourceGenerator &&
+                CSharpLanguageVersion == other.CSharpLanguageVersion;
+        }
+
+        public override bool Equals(object obj) => obj is RazorSourceGenerationOptions other && Equals(other);
+
+        public override int GetHashCode() => Configuration.GetHashCode();
     }
 }

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -2,14 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Text;
-using System.Threading;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.NET.Sdk.Razor.SourceGenerators
@@ -37,7 +33,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             return builder.ToString();
         }
 
-        private static RazorProjectEngine GetDiscoveryProjectEngine(StaticCompilationTagHelperFeature tagHelperFeature, IEnumerable<MetadataReference> references, IEnumerable<SourceGeneratorProjectItem> items, RazorSourceGenerationOptions razorSourceGeneratorOptions)
+        private static RazorProjectEngine GetDeclarationProjectEngine(
+            IEnumerable<SourceGeneratorProjectItem> items,
+            RazorSourceGenerationOptions razorSourceGeneratorOptions)
         {
             var fileSystem = new VirtualRazorProjectFileSystem();
             foreach (var item in items)
@@ -56,11 +54,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
                 b.SetRootNamespace(razorSourceGeneratorOptions.RootNamespace);
 
-                b.Features.Add(new DefaultMetadataReferenceFeature { References = references.ToList() });
-
-                b.Features.Add(tagHelperFeature);
-                b.Features.Add(new DefaultTagHelperDescriptorProvider());
-
                 CompilerFeatures.Register(b);
                 RazorExtensions.Register(b);
 
@@ -70,12 +63,34 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             return discoveryProjectEngine;
         }
 
-        private static RazorProjectEngine GetGenerationProjectEngine(IReadOnlyList<TagHelperDescriptor> tagHelpers, IEnumerable<SourceGeneratorProjectItem> items, RazorSourceGenerationOptions razorSourceGeneratorOptions)
+        private static RazorProjectEngine GetDiscoveryProjectEngine(
+            IReadOnlyList<MetadataReference> references,
+            StaticCompilationTagHelperFeature tagHelperFeature)
+        {
+            var discoveryProjectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, new VirtualRazorProjectFileSystem(), b =>
+            {
+                b.Features.Add(new DefaultMetadataReferenceFeature { References = references });
+                b.Features.Add(tagHelperFeature);
+                b.Features.Add(new DefaultTagHelperDescriptorProvider());
+
+                CompilerFeatures.Register(b);
+                RazorExtensions.Register(b);
+            });
+
+            return discoveryProjectEngine;
+        }
+
+        private static RazorProjectEngine GetGenerationProjectEngine(
+            IReadOnlyList<TagHelperDescriptor> tagHelpers,
+            SourceGeneratorProjectItem item,
+            IEnumerable<SourceGeneratorProjectItem> imports,
+            RazorSourceGenerationOptions razorSourceGeneratorOptions)
         {
             var fileSystem = new VirtualRazorProjectFileSystem();
-            foreach (var item in items)
+            fileSystem.Add(item);
+            foreach (var import in imports)
             {
-                fileSystem.Add(item);
+                fileSystem.Add(import);
             }
 
             var projectEngine = RazorProjectEngine.Create(razorSourceGeneratorOptions.Configuration, fileSystem, b =>
@@ -98,20 +113,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             });
 
             return projectEngine;
-        }
-
-        private static TFeature? GetFeature<TFeature>(RazorProjectEngine engine)
-        {
-            var count = engine.EngineFeatures.Count;
-            for (var i = 0; i < count; i++)
-            {
-                if (engine.EngineFeatures[i] is TFeature feature)
-                {
-                    return feature;
-                }
-            }
-
-            return default;
         }
     }
 }

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
@@ -40,11 +40,11 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             
             var razorSourceGenerationOptions = new RazorSourceGenerationOptions()
             {
+                Configuration = razorConfiguration,
                 WaitForDebugger = waitForDebugger == "true",
                 SuppressRazorSourceGenerator = suppressRazorSourceGenerator == "true",
                 GenerateMetadataSourceChecksumAttributes = generateMetadataSourceChecksumAttributes == "true",
                 RootNamespace = rootNamespace ?? "ASP",
-                Configuration = razorConfiguration,
                 CSharpLanguageVersion = ((CSharpParseOptions)parseOptions).LanguageVersion,
             };
 

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.TagHelpers.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.TagHelpers.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             return descriptors;
         }
 
-        private IReadOnlyList<TagHelperDescriptor> GetTagHelpersFromCompilation(Compilation compilation, StaticCompilationTagHelperFeature tagHelperFeature, SyntaxTree syntaxTrees)
+        private static IReadOnlyList<TagHelperDescriptor> GetTagHelpersFromCompilation(Compilation compilation, StaticCompilationTagHelperFeature tagHelperFeature, SyntaxTree syntaxTrees)
         {
             var compilationWithDeclarations = compilation.AddSyntaxTrees(syntaxTrees);
 

--- a/src/RazorSdk/SourceGenerators/StaticCompilationTagHelperFeature.cs
+++ b/src/RazorSdk/SourceGenerators/StaticCompilationTagHelperFeature.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
@@ -12,18 +11,18 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
     internal sealed class StaticCompilationTagHelperFeature : RazorEngineFeatureBase, ITagHelperFeature
     {
+        private static readonly List<TagHelperDescriptor> EmptyList = new();
+        
         private ITagHelperDescriptorProvider[]? _providers;
 
-        public IReadOnlyList<TagHelperDescriptor> GetDescriptors()
+        public List<TagHelperDescriptor> GetDescriptors()
         {
             if (Compilation is null)
             {
-                return Array.Empty<TagHelperDescriptor>();
+                return EmptyList;
             }
 
-
             var results = new List<TagHelperDescriptor>();
-
             var context = TagHelperDescriptorProviderContext.Create(results);
             context.SetCompilation(Compilation);
             context.Items.SetTargetAssembly(TargetAssembly!);
@@ -35,6 +34,8 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
             return results;
         }
+
+        IReadOnlyList<TagHelperDescriptor> ITagHelperFeature.GetDescriptors() => GetDescriptors();
 
         public Compilation? Compilation { get; set; }
 


### PR DESCRIPTION
* Cache tag helpers when the declaration build of razor files does not change
* Cache generated output invariant of other non _Import files


## Description

As part of .NET preview7, the compiler added new sets of APIs to support incremental source generators. We updated the Razor Source Generator use these APIs to benefit from improved performance. We've since discovered issues in the compiler's implementation of incrementalism (that are being addressed for p7) as well as issues with our source generator. The latter is what this PR is being addressed. In the absence of these changes, there's significant degradation (up to 3x slower) in the inner loop perf for compiling razor files. This degradation affects VS and hot reload.

## Customer Impact

Improvements here would benefit compilation in Visual Studio as well as hot reload in VS and dotnet-watch, particularly in projects containing a large number of Razor (.razor / .cshtml) files.

## Regression?
- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [x] Medium
- [ ] Low

We have tests for correctness in build incrementalism in the SDK, unfortunately source generator incrementalism is currently disabled in CLI's implementation of the compiler. This is [being addressed](https://github.com/dotnet/roslyn/pull/55023) for p7, but it's possible in my current manual verification I missed scenarios where we are over-caching (bad for correctness) or under-caching (bad for perf, but no biggie since the results are still better).

[Justify the selection above]

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses [issue number]