### PR TITLE
Add SDK support for perfmap format version

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -124,5 +124,6 @@ namespace Microsoft.NET.Build.Tasks
         public const string EmitSymbols = "EmitSymbols";
         public const string IsVersion5 = "IsVersion5";
         public const string CreateCompositeImage = "CreateCompositeImage";
+        public const string PerfmapFormatVersion = "PerfmapFormatVersion";
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -17,6 +17,7 @@ namespace Microsoft.NET.Build.Tasks
     {
         public bool EmitSymbols { get; set; }
         public bool ReadyToRunUseCrossgen2 { get; set; }
+        public string PerfmapFormatVersion { get; set; }
 
         [Required]
         public ITaskItem[] RuntimePacks { get; set; }
@@ -177,6 +178,10 @@ namespace Microsoft.NET.Build.Tasks
             {
                 Crossgen2Tool.SetMetadata(MetadataKeys.TargetOS, targetOS);
                 Crossgen2Tool.SetMetadata(MetadataKeys.TargetArch, ArchitectureToString(_targetArchitecture));
+                if (!string.IsNullOrEmpty(PerfmapFormatVersion))
+                {
+                    Crossgen2Tool.SetMetadata(MetadataKeys.PerfmapFormatVersion, PerfmapFormatVersion);
+                }
             }
 
             _crossgen2IsVersion5 = version5;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -327,6 +327,12 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     result.AppendLine("--perfmap");
                     result.AppendLine($"--perfmap-path:{Path.GetDirectoryName(_outputPDBImage)}");
+                    
+                    string perfmapFormatVersion = Crossgen2Tool.GetMetadata(MetadataKeys.PerfmapFormatVersion);
+                    if (!string.IsNullOrEmpty(perfmapFormatVersion))
+                    {
+                        result.AppendLine($"--perfmap-format-version:{perfmapFormatVersion}");
+                    }
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -22,6 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == ''">true</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '$(SelfContained)' != 'true'">false</PublishReadyToRunComposite>
     <PublishReadyToRunUseRuntimePackOptimizationData Condition="'$(PublishReadyToRunUseRuntimePackOptimizationData)' == ''">true</PublishReadyToRunUseRuntimePackOptimizationData>
+    <PublishReadyToRunPerfmapFormatVersion Condition="'$(PublishReadyToRunPerfmapFormatVersion)' == ''">1</PublishReadyToRunPerfmapFormatVersion>
   </PropertyGroup>
 
   <!--
@@ -439,7 +440,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
                                 EmitSymbols="$(PublishReadyToRunEmitSymbols)"
-                                ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)">
+                                ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
+                                PerfmapFormatVersion="$(PublishReadyToRunPerfmapFormatVersion)">
 
       <Output TaskParameter="CrossgenTool" ItemName="CrossgenTool" />
       <Output TaskParameter="Crossgen2Tool" ItemName="Crossgen2Tool" />


### PR DESCRIPTION
This PR addresses the remaining work outlined in the issue

https://github.com/dotnet/sdk/issues/18813

As of .NET 6 Preview 7 Crossgen2 supports the option
--perfmap-format-version that currently supports two values, 0
(being the legacy value / default) and 1; the only difference is
that version 1 uses a different naming scheme for the output
perfmap files, dropping the {MVID} part and using the extension
".ni.r2rmap".

This PR adds support for the new option in the SDK Crossgen2
publishing logic; for .NET 5 and prior, we naturally need to stick
to the legacy naming; for .NET 6, SDK honors a new property
PublishReadyToRunPerfmapFormatVersion that can be used to override
the default.

As of the 1st commit on this PR, the SDK default is set to 1 i.e.
the "new format". This basically means that from the point of
merging this PR onwards SDK will by default produce the new
perfmap file names on Linux.

Similarly, once the current SDK combines with the runtime repo
(which will likely happen as part of the RC1 fork), the installer
partition will start producing the new naming style for the
Crossgen2-compiled framework.

As this is technically a breaking change, we need to discuss whether
that's acceptable (e.g. if there was no prior support for perfmap
indexation, we probably don't need to care much); if we need tighter
control over the perfmap versioning / naming, there are two different
things we can do:

1) For now change the PublishReadyToRunPerfmapFormatVersion default
to 0 in the SDK Microsoft.NET.CrossGen.targets script. This means that
perfmap files will continue to use the legacy naming scheme until someone
explicitly switches over runtime or the SDK itself later on in the future.

2) We can make a counterpart check-in to the runtime repo setting
PublishReadyToRunPerfmapFormatVersion to 0 in the installer
ReadyToRun.targets script; once we're confident to switch over,
we'll just delete the property from the script.

I'm still hitting a couple of errors in local testing but I'm
publishing the PR anyway as I'm hoping to solicit early feedback for the
change.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 