### PR TITLE
WinRT Component Support.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -68,4 +68,31 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
     
   </Target>
+
+    <Target Name="RemoveManagedWinRTComponentWinMDReferences"
+          AfterTargets="ResolveProjectReferences">
+
+    <PropertyGroup>
+      <_WinRTComponentManagedImplementation Condition="('%(_ResolvedProjectReferencePaths.Extension)' == '.winmd') And ('%(_ResolvedProjectReferencePaths.Implementation)' == 'WinRT.Host.dll')">
+%(_ResolvedProjectReferencePaths.ManagedImplementation)
+</_WinRTComponentManagedImplementation>
+    </PropertyGroup>
+
+    <!-- Managed WinRT components include both the WinMD and the .NET DLL in the result from GetTargetPath.  Managed projects need to only reference the .NET DLL, not the WinMD.
+         The WinMD in this case can be identified because the Implementation metadata value is WinRT.Host.dll.  So here we remove any such WinMD references. -->
+    <ItemGroup>
+     <_ResolvedProjectReferencePaths Remove="@(_ResolvedProjectReferencePaths)"
+                                     Condition="('%(_ResolvedProjectReferencePaths.Extension)' == '.winmd') And ('%(_ResolvedProjectReferencePaths.Implementation)' == 'WinRT.Host.dll')"
+                                      />
+    </ItemGroup>
+    
+  </Target>
+
+  <Target Name="AddWinRTComponentImplementationReference" AfterTargets="ResolveProjectReferences" Condition="'$(_WinRTComponentManagedImplementation)' != ''">
+    
+    <ItemGroup>
+      <Reference Include="$(_WinRTComponentManagedImplementation)"/>
+    </ItemGroup>
+
+  </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -58,6 +58,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="RemoveManagedWinRTComponentWinMDReferences"
           AfterTargets="ResolveProjectReferences">
+    
+    <ItemGroup>
+      <!-- Before we remove them from _ResolvedProjectReferencePaths, grab the implementation .dll's path -->
+      <ManagedWinRTComponentImplementations 
+        Include="@(_ResolvedProjectReferencePaths->'%(ManagedImplementation)')" 
+        Condition="('%(_ResolvedProjectReferencePaths.Extension)' == '.winmd') And ('%(_ResolvedProjectReferencePaths.Implementation)' == 'WinRT.Host.dll')"
+      />
+    </ItemGroup>
 
     <!-- Managed WinRT components include both the WinMD and the .NET DLL in the result from GetTargetPath.  Managed projects need to only reference the .NET DLL, not the WinMD.
          The WinMD in this case can be identified because the Implementation metadata value is WinRT.Host.dll.  So here we remove any such WinMD references. -->
@@ -69,29 +77,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     
   </Target>
 
-    <Target Name="RemoveManagedWinRTComponentWinMDReferences"
-          AfterTargets="ResolveProjectReferences">
-
-    <PropertyGroup>
-      <_WinRTComponentManagedImplementation Condition="('%(_ResolvedProjectReferencePaths.Extension)' == '.winmd') And ('%(_ResolvedProjectReferencePaths.Implementation)' == 'WinRT.Host.dll')">
-%(_ResolvedProjectReferencePaths.ManagedImplementation)
-</_WinRTComponentManagedImplementation>
-    </PropertyGroup>
-
-    <!-- Managed WinRT components include both the WinMD and the .NET DLL in the result from GetTargetPath.  Managed projects need to only reference the .NET DLL, not the WinMD.
-         The WinMD in this case can be identified because the Implementation metadata value is WinRT.Host.dll.  So here we remove any such WinMD references. -->
-    <ItemGroup>
-     <_ResolvedProjectReferencePaths Remove="@(_ResolvedProjectReferencePaths)"
-                                     Condition="('%(_ResolvedProjectReferencePaths.Extension)' == '.winmd') And ('%(_ResolvedProjectReferencePaths.Implementation)' == 'WinRT.Host.dll')"
-                                      />
-    </ItemGroup>
-    
-  </Target>
-
-  <Target Name="AddWinRTComponentImplementationReference" AfterTargets="ResolveProjectReferences" Condition="'$(_WinRTComponentManagedImplementation)' != ''">
+  <Target Name="AddWinRTComponentImplementationReference" AfterTargets="ResolveProjectReferences" DependsOnTargets="RemoveManagedWinRTComponentWinMDReferences">
     
     <ItemGroup>
-      <Reference Include="$(_WinRTComponentManagedImplementation)"/>
+      <Reference Include="@(ManagedWinRTComponentImplementations)"/>
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -77,7 +77,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     
   </Target>
 
-  <Target Name="AddWinRTComponentImplementationReference" AfterTargets="ResolveProjectReferences" DependsOnTargets="RemoveManagedWinRTComponentWinMDReferences">
+  <Target Name="AddWinRTComponentImplementationReference" AfterTargets="ResolveProjectReferences" DependsOnTargets="RemoveManagedWinRTComponentWinMDReferences" Condition="'@(ManagedWinRTComponentImplementations)' != ''">
     
     <ItemGroup>
       <Reference Include="@(ManagedWinRTComponentImplementations)"/>


### PR DESCRIPTION
Authoring C#/WinRT components has been working towards supporting native and managed consumers. This PR provides the needed changes to support consumers using project references. To do so, we must have some custom logic for Windows Runtime components. 

Components typically output a .dll, but C#/WinRT components output a .winmd, which has a general implementation .dll "WinRT.Host.dll". This has complicated getting user scenarios working, as multiple assemblies need to be distributed for "one" assembly. 

I am proposing we add a property in an existing target, which was made for WinRT support recently. As well as add a new target that uses the property set in the existing target to add a reference. We need this to support C# project reference consumers. Because C# consumers only get a .winmd via GetTargetPath, they do not have the assembly containing the *managed* implementation, so we annotate the .winmd to have the path to the implementation, and we add it as a reference here. 

(FWIW: C++ consumers use the WinRT.Host.dll as the implementation assembly for the component.)


@dsplaisted 