### PR TITLE
Use case insensitive comparison when looking up _Imports and _ViewImports

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -36,11 +36,13 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 var path = file.FilePath;
                 if (path.EndsWith(".razor"))
                 {
-                    return Path.GetFileNameWithoutExtension(path) == "_Imports";
+                    var fileName = Path.GetFileNameWithoutExtension(path);
+                    return string.Equals(fileName, "_Imports", StringComparison.OrdinalIgnoreCase);
                 }
                 else if (path.EndsWith(".cshtml"))
                 {
-                    return Path.GetFileNameWithoutExtension(path) == "_ViewImports";
+                    var fileName = Path.GetFileNameWithoutExtension(path);
+                    return string.Equals(fileName, "_ViewImports", StringComparison.OrdinalIgnoreCase);
                 }
 
                 return false;


### PR DESCRIPTION
Razor compiler supports looking up these files in a case insensitive manner and we found an instance of a different case in the AspNetCore repo. Updating the incremental filter to also use case insensitive lookup.