### PR TITLE
Support project references to WinRT Components

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -58,6 +58,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="RemoveManagedWinRTComponentWinMDReferences"
           AfterTargets="ResolveProjectReferences">
+    
+    <ItemGroup>
+      <!-- Before we remove them from _ResolvedProjectReferencePaths, grab the implementation .dll's path -->
+      <ManagedWinRTComponentImplementations 
+        Include="@(_ResolvedProjectReferencePaths->'%(ManagedImplementation)')" 
+        Condition="('%(_ResolvedProjectReferencePaths.Extension)' == '.winmd') And ('%(_ResolvedProjectReferencePaths.Implementation)' == 'WinRT.Host.dll')"
+      />
+    </ItemGroup>
 
     <!-- Managed WinRT components include both the WinMD and the .NET DLL in the result from GetTargetPath.  Managed projects need to only reference the .NET DLL, not the WinMD.
          The WinMD in this case can be identified because the Implementation metadata value is WinRT.Host.dll.  So here we remove any such WinMD references. -->
@@ -67,5 +75,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                                       />
     </ItemGroup>
     
+  </Target>
+
+  <Target Name="AddWinRTComponentImplementationReference" AfterTargets="ResolveProjectReferences" DependsOnTargets="RemoveManagedWinRTComponentWinMDReferences" Condition="'@(ManagedWinRTComponentImplementations)' != ''">
+    
+    <ItemGroup>
+      <Reference Include="@(ManagedWinRTComponentImplementations)"/>
+    </ItemGroup>
+
   </Target>
 </Project>


### PR DESCRIPTION

## Description

Authoring C#/WinRT components has been working towards supporting native and managed consumers. This PR provides the needed changes to support consumers using project references. To do so, we must have some custom logic for Windows Runtime components.

Components typically output a .dll, but C#/WinRT components output a .winmd, which has a general implementation .dll "WinRT.Host.dll". This has complicated getting user scenarios working, as multiple assemblies need to be distributed for "one" assembly.

I am proposing we add a property in an existing target, which was made for WinRT support recently. As well as add a new target that uses the property set in the existing target to add a reference. We need this to support C# project reference consumers. Because C# consumers only get a .winmd via GetTargetPath, they do not have the assembly containing the managed implementation, so we annotate the .winmd to have the path to the implementation, and we add it as a reference here.

(FWIW: C++ consumers use the WinRT.Host.dll as the implementation assembly for the component.)

## Customer Impact

Native app (C++) developers should be able to reference WinRT components made with C#/WinRT simply by adding a project reference. This PR removes the need for a project reference and a reference to the winmd made by the project -- the latter of which required an extra build step before the reference could be added. 

## Regression?

 - [ ] Yes
 - [X] No

## Risk 

 - [ ] High
 - [ ] Medium
 - [X] Low

## Verification 

- [x] Manual (required)
- [ ] Automated