### PR TITLE
Move from XliffTasks to Microsoft.DotNet.XliffTasks

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -271,10 +271,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d019e70d2b7c2f7cd1137fac084dbcdc3d2e05f5</Sha>
     </Dependency>
-    <Dependency Name="XliffTasks" Version="1.0.0-beta.21371.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21376.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
-      <Sha>31d2b6c3aa2f874e9e93a005e773101468b8612a</Sha>
-      <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
+      <Sha>397ff033b467003d51619f9ac3928e02a4d4178f</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -274,6 +274,7 @@
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21376.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
       <Sha>397ff033b467003d51619f9ac3928e02a4d4178f</Sha>
+      <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -152,6 +152,10 @@
     <!-- Dependencies from https://github.com/microsoft/MSBuildLocator -->
     <MicrosoftBuildLocatorPackageVersion>1.4.1</MicrosoftBuildLocatorPackageVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Dependencies from https://github.com/dotnet/xliff-tasks -->
+    <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.21376.1</MicrosoftDotNetXliffTasksVersion>
+  </PropertyGroup>
   <!-- Get .NET Framework reference assemblies from NuGet packages -->
   <PropertyGroup>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>

--- a/src/Tests/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <EmbeddedResource Include="..\..\Tasks\Common\Resources\Strings.resx" LinkBase="Resources" GenerateSource="True" Namespace="Microsoft.NET.Build.Tasks" />
     <None Include="..\..\Tasks\Common\Resources\xlf\**\*" LinkBase="Resources\xlf" />
-    <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.DotNet.XliffTasks" Version="$(MicrosoftDotNetXliffTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
   </ItemGroup>
 


### PR DESCRIPTION
The package name was changed to start with a reserved name (https://github.com/dotnet/xliff-tasks/issues/412)

