### PR TITLE
[ASP.NET Core] Fine tuning some of the targets for Blazor Desktop

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.ServiceWorkerAssetsManifest.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.ServiceWorkerAssetsManifest.targets
@@ -15,8 +15,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <ResolveStaticWebAssetsInputsDependsOn>$(ResolveStaticWebAssetsInputsDependsOn);_AddServiceWorkerAssets</ResolveStaticWebAssetsInputsDependsOn>
-    <CopyStaticWebAssetsToPublishDirectoryDependsOn>$(CopyStaticWebAssetsToPublishDirectoryDependsOn);_WritePublishServiceWorkerAssetsManifest</CopyStaticWebAssetsToPublishDirectoryDependsOn>
-    <CopyStaticWebAssetsToOutputFolderDependsOn>$(CopyStaticWebAssetsToOutputFolderDependsOn);_WriteBuildServiceWorkerAssetsManifest</CopyStaticWebAssetsToOutputFolderDependsOn>
+    <GenerateComputedPublishStaticWebAssetsDependsOn>$(GenerateComputedPublishStaticWebAssetsDependsOn);_WritePublishServiceWorkerAssetsManifest</GenerateComputedPublishStaticWebAssetsDependsOn>
+    <GenerateComputedBuildStaticWebAssetsDependsOn>$(GenerateComputedBuildStaticWebAssetsDependsOn);_WriteBuildServiceWorkerAssetsManifest</GenerateComputedBuildStaticWebAssetsDependsOn>
   </PropertyGroup>
 
   <Target Name="_AddServiceWorkerAssets" DependsOnTargets="_ComputeServiceWorkerAssets">
@@ -157,7 +157,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target Name="_WritePublishServiceWorkerAssetsManifest" DependsOnTargets="_ComputeServiceWorkerAssets;LoadStaticWebAssetsPublishManifest" AfterTargets="GenerateStaticWebAssetsPublishManifest">
+  <Target Name="_WritePublishServiceWorkerAssetsManifest" DependsOnTargets="_ComputeServiceWorkerAssets;LoadStaticWebAssetsPublishManifest">
 
     <ItemGroup>
       <_PublishAssetsForManifest Include="@(StaticWebAsset)" Condition="'%(AssetTraitName)' != 'BlazorServiceWorker' and '%(AssetRole)' != 'Alternative'" />

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.ServiceWorkerAssetsManifest.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.ServiceWorkerAssetsManifest.targets
@@ -108,7 +108,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target Name="_WriteBuildServiceWorkerAssetsManifest" DependsOnTargets="_ComputeServiceWorkerAssets">
+  <Target Name="_WriteBuildServiceWorkerAssetsManifest" DependsOnTargets="ResolveStaticWebAssetsInputs">
 
     <ItemGroup>
       <_BuildAssetsForManifest Include="@(StaticWebAsset)" Condition="'%(AssetTraitName)' != 'BlazorServiceWorker' and '%(AssetRole)' != 'Alternative' and '%(AssetKind)' != 'Publish' and Exists('%(Identity)')" />

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.ScopedCss.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.ScopedCss.targets
@@ -58,12 +58,12 @@ Integration with static web assets:
     _AddScopedCssBundles;
   </ResolveStaticWebAssetsInputsDependsOn>
 
-  <CopyStaticWebAssetsToOutputFolderDependsOn>
-    $(CopyStaticWebAssetsToOutputFolderDependsOn);
+  <GenerateComputedBuildStaticWebAssetsDependsOn>
+    $(GenerateComputedBuildStaticWebAssetsDependsOn);
     _ResolveBundlingConfiguration;
     _GenerateScopedCssFiles;
     BundleScopedCssFiles;
-  </CopyStaticWebAssetsToOutputFolderDependsOn>
+  </GenerateComputedBuildStaticWebAssetsDependsOn>
 
 </PropertyGroup>
 
@@ -75,10 +75,10 @@ Integration with static web assets:
     _AddGeneratedScopedCssFiles;
   </ResolveStaticWebAssetsInputsDependsOn>
 
-  <CopyStaticWebAssetsToOutputFolderDependsOn>
+  <GenerateComputedBuildStaticWebAssetsDependsOn>
     _GenerateScopedCssFiles;
-    $(CopyStaticWebAssetsToOutputFolderDependsOn);
-  </CopyStaticWebAssetsToOutputFolderDependsOn>
+    $(GenerateComputedBuildStaticWebAssetsDependsOn);
+  </GenerateComputedBuildStaticWebAssetsDependsOn>
 
 </PropertyGroup>
 
@@ -89,8 +89,6 @@ Integration with static web assets:
   -->
   <_ScopedCssExtension>.rz.scp.css</_ScopedCssExtension>
 </PropertyGroup>
-
-<Target Name="_PrepareForScopedCss" DependsOnTargets="$(_PrepareForScopedCssDependsOn)" />
 
 <Target Name="ResolveScopedCssInputs">
     <!--

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -267,7 +267,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ComputeReferencedStaticWebAssetsPublishManifestDependsOn>
       $(ComputeReferencedStaticWebAssetsPublishManifestDependsOn);
-      StaticWebAssetsPrepareForPublishDependsOn;
+      StaticWebAssetsPrepareForPublish;
     </ComputeReferencedStaticWebAssetsPublishManifestDependsOn>
 
     <ResolvePublishStaticWebAssetsDependsOn>LoadStaticWebAssetsBuildManifest;ComputeReferencedProjectsPublishAssets;$(ResolvePublishStaticWebAssetsDependsOn)</ResolvePublishStaticWebAssetsDependsOn>
@@ -459,9 +459,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)$(TargetName).StaticWebAssets.xml" Condition="'$(_GenerateLegacyManifestFormat)' == 'true'" />
-      <StaticWebAsset Remove="@(StaticWebAsset)" />
-      <StaticWebAssetManifest Remove="@(StaticWebAssetManifest)" />
-      <StaticWebAssetDiscoveryPattern Remove="@(StaticWebAssetDiscoveryPattern)" />
       <FileWrites Include="$(StaticWebAssetBuildManifestPath)" />
     </ItemGroup>
     
@@ -529,9 +526,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       ManifestPath="$(StaticWebAssetPublishManifestPath)">
     </GenerateStaticWebAssetsManifest>
     <ItemGroup>
-      <StaticWebAsset Remove="@(StaticWebAsset)" />
-      <StaticWebAssetManifest Remove="@(StaticWebAssetManifest)" />
-      <StaticWebAssetDiscoveryPattern Remove="@(StaticWebAssetDiscoveryPattern)" />
       <FileWrites Include="$(StaticWebAssetPublishManifestPath)" />
     </ItemGroup>
   </Target>

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -243,7 +243,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PrepareForRunDependsOn>StaticWebAssetsPrepareForRun;$(PrepareForRunDependsOn)</PrepareForRunDependsOn>
 
-    <StaticWebAssetsPrepareForRunDependsOn>$(StaticWebAssetsPrepareForRunDependsOn);GenerateStaticWebAssetsManifest;CopyStaticWebAssetsToOutputFolder</StaticWebAssetsPrepareForRunDependsOn>
+    <StaticWebAssetsPrepareForRunDependsOn>$(StaticWebAssetsPrepareForRunDependsOn);GenerateStaticWebAssetsManifest;GenerateComputedBuildStaticWebAssets;CopyStaticWebAssetsToOutputFolder</StaticWebAssetsPrepareForRunDependsOn>
+
+    <!-- This is a hook for features like scoped CSS and Blazor can ensure all the assets have been generated -->
+    <GenerateComputedBuildStaticWebAssetsDependsOn></GenerateComputedBuildStaticWebAssetsDependsOn>
 
     <GenerateStaticWebAssetsManifestDependsOn>$(GenerateStaticWebAssetsManifestDependsOn);ResolveStaticWebAssetsInputs</GenerateStaticWebAssetsManifestDependsOn>
 
@@ -255,9 +258,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <!-- StaticWebAssetsPrepareForPublish -> ComputeFilesToPublish -->
 
-    <StaticWebAssetsPrepareForPublishDependsOn>$(StaticWebAssetsPrepareForPublishDependsOn);ResolveStaticWebAssetsConfiguration;GenerateStaticWebAssetsPublishManifest</StaticWebAssetsPrepareForPublishDependsOn>
+    <StaticWebAssetsPrepareForPublishDependsOn>$(StaticWebAssetsPrepareForPublishDependsOn);ResolveStaticWebAssetsConfiguration;GenerateComputedPublishStaticWebAssets;GenerateStaticWebAssetsPublishManifest</StaticWebAssetsPrepareForPublishDependsOn>
 
     <GenerateStaticWebAssetsPublishManifestDependsOn>ResolveStaticWebAssetsConfiguration;ResolvePublishStaticWebAssets;$(GenerateStaticWebAssetsPublishManifestDependsOn)</GenerateStaticWebAssetsPublishManifestDependsOn>
+
+    <!-- This is a hook for features like scoped CSS and Blazor can ensure all the assets have been generated -->
+    <GenerateComputedPublishStaticWebAssetsDependsOn></GenerateComputedPublishStaticWebAssetsDependsOn>
 
     <ComputeReferencedStaticWebAssetsPublishManifestDependsOn>
       $(ComputeReferencedStaticWebAssetsPublishManifestDependsOn);
@@ -421,6 +427,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="StaticWebAssetsPrepareForRun" DependsOnTargets="$(StaticWebAssetsPrepareForRunDependsOn)" />
 
+  <Target Name="GenerateComputedBuildStaticWebAssets" DependsOnTargets="$(GenerateComputedBuildStaticWebAssetsDependsOn)" />
+
   <Target Name="GenerateStaticWebAssetsManifest" DependsOnTargets="$(GenerateStaticWebAssetsManifestDependsOn)">
     <GenerateStaticWebAssetsManifest
       Source="$(PackageId)"
@@ -503,6 +511,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="StaticWebAssetsPrepareForPublish" 
     BeforeTargets="ComputeFilesToPublish"
     DependsOnTargets="$(StaticWebAssetsPrepareForPublishDependsOn)" />
+
+  <Target Name="GenerateComputedPublishStaticWebAssets" DependsOnTargets="$(GenerateComputedPublishStaticWebAssetsDependsOn)" />
 
   <Target Name="GenerateStaticWebAssetsPublishManifest" DependsOnTargets="$(GenerateStaticWebAssetsPublishManifestDependsOn)">
     <ComputePublishStaticWebAssetsList Assets="@(StaticWebAsset)">

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -258,7 +258,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <!-- StaticWebAssetsPrepareForPublish -> ComputeFilesToPublish -->
 
-    <StaticWebAssetsPrepareForPublishDependsOn>$(StaticWebAssetsPrepareForPublishDependsOn);ResolveStaticWebAssetsConfiguration;GenerateComputedPublishStaticWebAssets;GenerateStaticWebAssetsPublishManifest</StaticWebAssetsPrepareForPublishDependsOn>
+    <StaticWebAssetsPrepareForPublishDependsOn>$(StaticWebAssetsPrepareForPublishDependsOn);ResolveStaticWebAssetsConfiguration;GenerateStaticWebAssetsPublishManifest;GenerateComputedPublishStaticWebAssets</StaticWebAssetsPrepareForPublishDependsOn>
 
     <GenerateStaticWebAssetsPublishManifestDependsOn>ResolveStaticWebAssetsConfiguration;ResolvePublishStaticWebAssets;$(GenerateStaticWebAssetsPublishManifestDependsOn)</GenerateStaticWebAssetsPublishManifestDependsOn>
 
@@ -267,7 +267,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ComputeReferencedStaticWebAssetsPublishManifestDependsOn>
       $(ComputeReferencedStaticWebAssetsPublishManifestDependsOn);
-      GenerateStaticWebAssetsPublishManifest
+      StaticWebAssetsPrepareForPublishDependsOn;
     </ComputeReferencedStaticWebAssetsPublishManifestDependsOn>
 
     <ResolvePublishStaticWebAssetsDependsOn>LoadStaticWebAssetsBuildManifest;ComputeReferencedProjectsPublishAssets;$(ResolvePublishStaticWebAssetsDependsOn)</ResolvePublishStaticWebAssetsDependsOn>


### PR DESCRIPTION
* Adds a couple of targets to standardize the point on the build where assets get generated if they haven't been generated at an earlier point in the build.
* This helps features like CSS isolation standarize on where to generate assets and enables platforms like Blazor desktop to move the generation to an earlier point in the build without specific knowledge of the individual build features.