### PR TITLE
Remove DisableFrameworkReferenceAnalyzers property

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -359,7 +359,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 NuGetRestoreSupported="$(_NuGetRestoreSupported)"
                                 NetCoreTargetingPackRoot="$(NetCoreTargetingPackRoot)">
       <Output TaskParameter="ReferencesToAdd" ItemName="Reference" />
-      <Output TaskParameter="AnalyzersToAdd" Condition="'$(DisableFrameworkReferenceAnalyzers)' != 'true'" ItemName="Analyzer" />
+      <Output TaskParameter="AnalyzersToAdd" ItemName="Analyzer" />
       <Output TaskParameter="PlatformManifests" ItemName="PlatformManifestsFromTargetingPacks" />
       <Output TaskParameter="PackageConflictPreferredPackages" PropertyName="PackageConflictPreferredPackages" />
       <Output TaskParameter="PackageConflictOverrides" ItemName="PackageConflictOverrides" />

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -97,7 +97,6 @@ namespace Microsoft.NET.Build.Tests
 
             //  Disable analyzers built in to the SDK so we can more easily test the ones coming from NuGet packages
             testProject.AdditionalProperties["EnableNETAnalyzers"] = "false";
-            testProject.AdditionalProperties["DisableFrameworkReferenceAnalyzers"] = "false";
 
             testProject.ProjectChanges.Add(project =>
             {


### PR DESCRIPTION
This property is of little value as it arbitrarily allows users to drop
all framework analyzers/generators.

https://github.com/dotnet/sdk/issues/19501 tracks an alternative, but in the meantime folks can use a target to remove analyzers as needed.
