### PR TITLE
Pin MSBuild, Roslyn and Nuget for package validation, also carry nuget

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.0-1.21304.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -4,11 +4,13 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <!--We need to compare ISymbols in a special way (by name) and roslyn symbol comparers take more heuristics into consideration.-->
+    <!-- We need to compare ISymbols in a special way (by name) and roslyn symbol comparers take more heuristics into consideration.-->
     <NoWarn>RS1024;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- We pin the versions of the assets that ship with the SDK in order to be able to run on older SDKs. 
+    Currently we support .NET 6 Preview5 or later. -->
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.0-1.21304.5" />
   </ItemGroup>
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -13,6 +13,8 @@
 
   <ItemGroup>
     <Compile Include="..\..\Tasks\Common\**\*.cs" LinkBase="Common" />
+    <!-- We pin the versions of the assets that ship with the SDK in order to be able to run on older SDKs. 
+    Currently we support .NET 6 Preview5 or later. -->
     <PackageReference Include="Microsoft.Build.Framework" Version="15.4.8" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.4.8" ExcludeAssets="Runtime" />
     <PackageReference Include="NuGet.Frameworks" Version="6.0.0-preview.1.66" />

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -13,13 +13,12 @@
 
   <ItemGroup>
     <Compile Include="..\..\Tasks\Common\**\*.cs" LinkBase="Common" />
-    <!-- We pin the versions of the assets that ship with the SDK in order to be able to run on older SDKs. 
-    Currently we support .NET 6 Preview5 or later. -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.4.8" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.4.8" ExcludeAssets="Runtime" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.0.0-preview.1.66" />
-    <PackageReference Include="NuGet.Packaging" Version="6.0.0-preview.1.66" />
-    <PackageReference Include="NuGet.Protocol" Version="6.0.0-preview.1.66" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="Runtime" />
+    <!-- We carry NuGet as part of the package in case the package is used with an older SDKs or with full framework MSBuild. -->
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetBuildTasksPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetBuildTasksPackageVersion)" />
+    <PackageReference Include="NuGet.Protocol" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" ExcludeAssets="Runtime" />
   </ItemGroup>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="NuGet.Protocol" Version="$(NuGetBuildTasksPackageVersion)" />
-    <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" ExcludeAssets="Runtime" />
+    <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="NuGet.Protocol" Version="$(NuGetBuildTasksPackageVersion)" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" ExcludeAssets="Runtime" />
   </ItemGroup>
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <Compile Include="..\..\Tasks\Common\**\*.cs" LinkBase="Common" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetBuildTasksPackageVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetBuildTasksPackageVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="NuGet.Protocol" Version="$(NuGetBuildTasksPackageVersion)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.4.8" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.4.8" ExcludeAssets="Runtime" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.0.0-preview.1.66" />
+    <PackageReference Include="NuGet.Packaging" Version="6.0.0-preview.1.66" />
+    <PackageReference Include="NuGet.Protocol" Version="6.0.0-preview.1.66" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" ExcludeAssets="Runtime" />
   </ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/19472

I chose the versions from the Preview5 release branch from the SDK so that we can run in older than rc1 SDKs. 