### PR TITLE
Append instead of override DefaultExcludesInProjectFolder

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -37,7 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- WARNING: This pattern is there to ignore folders such as .git and .vs, but it will also match items included with a
          relative path outside the project folder (for example "..\Shared\Shared.cs").  So be sure only to apply it to items
          that are in the project folder. -->
-    <DefaultExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
+    <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
 
   </PropertyGroup>
 


### PR DESCRIPTION
The definition of `DefaultExcludesInProjectFolder` in Microsoft.NET.Sdk.DefaultItems.targets overrides the
existing definition of the property due to a typo that references `DefaultItemExcludesInProjectFolder` instead
of `DefaultExcludesInProjectFolder`.

This appears to have been introduced in #803 where the property was renamed from 
`DefaultItemExcludesInProjectFolder` to `DefaultExcludesInProjectFolder` but the inner reference was not
updated.