### PR TITLE
Update rich nav yml

### DIFF
--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -34,7 +34,6 @@ stages:
         pool:
             name: NetCorePublic-Pool
             queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
-        helixTargetQueue: Windows.Server.Amd64.VS2019.Pre.Open
         strategy:
           matrix:
             Build_Debug:

--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -41,8 +41,3 @@ stages:
               _PublishType: none
               _SignType: test
               _Test: -test
-            Build_Release:
-              _BuildConfig: Release
-              _PublishType: none
-              _SignType: test
-              _Test: -test

--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -5,6 +5,8 @@ trigger:
       - main
       - release/*.*
 
+pr: none
+
 variables:
   - name: teamName
     value: Roslyn-Project-System
@@ -34,6 +36,7 @@ stages:
         pool:
             name: NetCorePublic-Pool
             queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+        helixTargetQueue: Windows.Server.Amd64.VS2019.Pre.Open
         strategy:
           matrix:
             Build_Debug:

--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -5,8 +5,6 @@ trigger:
       - main
       - release/*.*
 
-pr: none
-
 variables:
   - name: teamName
     value: Roslyn-Project-System

--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -5,6 +5,8 @@ trigger:
       - main
       - release/*.*
 
+pr: none
+
 variables:
   - name: teamName
     value: Roslyn-Project-System

--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -34,7 +34,7 @@ stages:
         pool:
             name: NetCorePublic-Pool
             queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
-          helixTargetQueue: Windows.Server.Amd64.VS2019.Pre.Open
+        helixTargetQueue: Windows.Server.Amd64.VS2019.Pre.Open
         strategy:
           matrix:
             Build_Debug:

--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -25,16 +25,16 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-    - template: /eng/build.yml
+    - template: /eng/common/templates/job/job.yml
       parameters:
+        name: Windows_NT_FullFramework
         enableRichCodeNavigation: true
         richCodeNavigationLanguage: 'csharp'
         richCodeNavigationEnvironment: 'production'
-        agentOs: Windows_NT_FullFramework
         pool:
             name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
-        helixTargetQueue: Windows.Server.Amd64.VS2019.Pre.Open
+            queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open  
+        timeoutInMinutes: 180
         strategy:
           matrix:
             Build_Debug:
@@ -42,3 +42,49 @@ stages:
               _PublishType: none
               _SignType: test
               _Test: -test
+        workspace:
+          clean: all
+        variables:
+          - _AgentOSName: Windows_NT_FullFramework
+          - _TeamName: DotNetCore
+          - _OfficialBuildIdArgs: ''
+          - _PublishArgs: ''
+          - _SignArgs: ''
+          - _InternalRuntimeDownloadArgs: ''
+        steps:
+        - script: eng\CIBuild.cmd
+                    -configuration $(_BuildConfig)
+                    $(_PublishArgs)
+                    $(_SignArgs)
+                    $(_OfficialBuildIdArgs)
+                    $(_InternalRuntimeDownloadArgs)
+                    /p:Test=false
+          displayName: Build
+          env:
+            BuildConfig: $(_BuildConfig)
+            BlobFeedUrl: $(PB_PublishBlobFeedUrl)
+            PublishType: $(_PublishType)
+            TestFullMSBuild: 'true'
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            HelixAccessToken: ${{ parameters.HelixAccessToken }}
+
+        - task: CopyFiles@2	
+          displayName: Gather Logs	
+          inputs:	
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts'	
+            Contents: |	
+              log/$(_BuildConfig)/**/*	
+              TestResults/$(_BuildConfig)/**/*	
+              SymStore/$(_BuildConfig)/**/* 
+            TargetFolder: '$(Build.ArtifactStagingDirectory)'	
+          continueOnError: true	
+          condition: always()
+
+        - task: PublishBuildArtifacts@1	
+          displayName: Publish Logs to VSTS	
+          inputs:	
+            PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
+            ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
+            publishLocation: Container	
+          continueOnError: true	
+          condition: always()

--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -66,7 +66,6 @@ stages:
             PublishType: $(_PublishType)
             TestFullMSBuild: 'true'
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-            HelixAccessToken: ${{ parameters.HelixAccessToken }}
 
         - task: CopyFiles@2	
           displayName: Gather Logs	

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -1,9 +1,6 @@
 parameters:
   # Agent OS identifier and used as job name
   agentOs: ''
-  enableRichCodeNavigation: false
-  richCodeNavigationLanguage: 'csharp'
-  richCodeNavigationEnvironment: 'production'
 
   # Agent pool
   pool: {}
@@ -27,9 +24,6 @@ jobs:
 - template: /eng/common/templates/job/job.yml
   parameters:
     name: ${{ parameters.agentOs }}
-    enableRichCodeNavigation: ${{ parameters.enableRichCodeNavigation }}
-    richCodeNavigationLanguage: ${{ parameters.richCodeNavigationLanguage }}
-    richCodeNavigationEnvironment: ${{ parameters.richCodeNavigationEnvironment }}
     enableMicrobuild: true
     enablePublishBuildAssets: true
     enableTelemetry: true


### PR DESCRIPTION
Initially, the spacing was wrong for one of the yml parameters (helixTargetQueue) and that caused the build pipeline to fail. Upon digging more into it, we don't really need to do that portion for the rich nav indexing anyways. 

So this changes the rich nav yml to base off the jobs yml instead of build yml and marks `pr: none` so it doesn't run for every pr.

Successful build pipeline result [here](https://dev.azure.com/dnceng/public/_build/results?buildId=1281221&view=results).