### PR TITLE
Only allow dlls and executable to be passed to the ReadyToRun infrastructure

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -355,6 +355,12 @@ namespace Microsoft.NET.Build.Tasks
         private static Eligibility GetInputFileEligibility(ITaskItem file, bool compositeCompile, HashSet<string> exclusionSet, HashSet<string> r2rCompositeExclusionSet)
         {
             // Check to see if this is a valid ILOnly image that we can compile
+            if (!file.ItemSpec.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && !file.ItemSpec.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                // If it isn't a dll or an exe, it certainly isn't a valid ILOnly image for compilation
+                return Eligibility.None;
+            }
+
             using (FileStream fs = new FileStream(file.ItemSpec, FileMode.Open, FileAccess.Read))
             {
                 try


### PR DESCRIPTION
Protect crossgen2 from attempting to compile non-dll and non-exe binaries
- Shouldn't have an impact on normal scenarios but when we enable mibc presence in the RuntimeList.xml file this will prevent them attempting to be compiled