### PR TITLE
[Package Validation] Don't write suppressions file if there are no suppressions

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ErrorSuppression/SuppressionEngine.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ErrorSuppression/SuppressionEngine.cs
@@ -132,17 +132,21 @@ namespace Microsoft.DotNet.Compatibility.ErrorSuppression
         }
 
         /// <summary>
-        /// Writes all suppressions in collection down to a file.
+        /// Writes all suppressions in collection down to a file, if empty it doesn't write anything.
         /// </summary>
         /// <param name="supressionFile">The path to the file to be written.</param>
-        public void WriteSuppressionsToFile(string supressionFile)
+        /// <returns>Whether it wrote the file.</returns>
+        public bool WriteSuppressionsToFile(string supressionFile)
         {
+            if (_validationSuppressions.Count <= 0)
+                return false;
+
             using (Stream writer = GetWritableStream(supressionFile))
             {
                 _readerWriterLock.EnterReadLock();
                 try
                 {
-                    XmlTextWriter xmlWriter = new XmlTextWriter(writer, Encoding.UTF8);
+                    XmlTextWriter xmlWriter = new(writer, Encoding.UTF8);
                     xmlWriter.Formatting = Formatting.Indented;
                     xmlWriter.Indentation = 2;
                     _serializer.Serialize(xmlWriter, _validationSuppressions.ToArray());
@@ -153,6 +157,8 @@ namespace Microsoft.DotNet.Compatibility.ErrorSuppression
                     _readerWriterLock.ExitReadLock();
                 }
             }
+
+            return true;
         }
 
         protected virtual void AfterWrittingSuppressionsCallback(Stream stream)

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/PackageValidationLogger.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/PackageValidationLogger.cs
@@ -45,8 +45,8 @@ namespace Microsoft.DotNet.PackageValidation
 
         public void GenerateSuppressionsFile(string suppressionsFile)
         {
-            _suppressionEngine.WriteSuppressionsToFile(suppressionsFile);
-            LogMessage(MessageImportance.High, Resources.WroteSuppressions, suppressionsFile);
+            if (_suppressionEngine.WriteSuppressionsToFile(suppressionsFile))
+                LogMessage(MessageImportance.High, Resources.WroteSuppressions, suppressionsFile);
         }
     }
 }


### PR DESCRIPTION
While working on adding support to run API Compat with references from Package Validation I noticed that we would generate an empty suppressions file if no suppressions are present. We should not do that, as that can pollute the output. i.e if I run 

`dotnet pack /p:GenerateCompatibilitySuppressionFile=true` on a solution file with multiple packages, I would expect a suppression file to be generated only for those packages that have suppressions.