### PR TITLE
Don't show .NET 6 in VS2019 TargetFramework dropdown

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
@@ -23,7 +23,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v3.0" DisplayName=".NET Core 3.0" Alias="netcoreapp3.0" />
         <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v3.1" DisplayName=".NET Core 3.1" Alias="netcoreapp3.1" />
         <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v5.0" DisplayName=".NET 5.0" Alias="net5.0" />
-        <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v6.0" DisplayName=".NET 6.0" Alias="net6.0" />
+        <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v6.0" DisplayName=".NET 6.0" Alias="net6.0"
+                                            Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), '17.0'))"/>
     </ItemGroup>
 
     <!-- .NET Standard -->

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("17.0")]
         [InlineData(".NETCoreApp")]
         [InlineData(".NETStandard")]
         public void TheMaximumVersionsAreSupported(string targetFrameworkIdentifier)


### PR DESCRIPTION
Building .NET 6 projects in VS 2019 is not supported.  (For example, you are likely to get errors for global implicit usings, as the version of Roslyn in VS 2019 doesn't fully support global usings).

So this PR hides .NET 6 from the Target Framework dropdown in the project properties in VS 2019.

I tested this manually in VS 2019 and VS 2022.