### PR TITLE
Fix flaky parser tests

### DIFF
--- a/src/Cli/dotnet/CommandDirectoryContext.cs
+++ b/src/Cli/dotnet/CommandDirectoryContext.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.Cli
                     $"Calls to {nameof(CommandDirectoryContext)}.{nameof(PerformActionWithBasePath)} cannot be nested.");
             }
             _basePath = basePath;
+            Telemetry.Telemetry.CurrentSessionId = null;
             try
             {
                 action();


### PR DESCRIPTION
Some parser tests that check what arguments are being passed to MSBuild are failing because an extra parameter along the lines of `-distributedlogger:Microsoft.DotNet....` is being added occasionally. This argument comes from telemetry logic and can be removed by setting the current session id to null in tests: https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs#L26

Fixes https://github.com/dotnet/sdk/issues/19544