### PR TITLE
StaticWebAssets.targets: Fix `dotnet/runtime`+preview7 builds

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -284,7 +284,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="ResolveStaticWebAssetsConfiguration">
     <PropertyGroup>
-      <_StaticWebAssetsManifestBase>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework.ToLowerInvariant())\</_StaticWebAssetsManifestBase>
+      <_StaticWebAssetsManifestBase>$(IntermediateOutputPath)\</_StaticWebAssetsManifestBase>
       <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">_content/$(PackageId)</StaticWebAssetBasePath>
       <StaticWebAssetProjectMode Condition="'$(StaticWebAssetProjectMode)' == ''">Default</StaticWebAssetProjectMode>
       <StaticWebAssetBuildManifestPath>$(_StaticWebAssetsManifestBase)StaticWebAssets.build.json</StaticWebAssetBuildManifestPath>


### PR DESCRIPTION
`dotnet/runtime` builds fail using preview7(`6.0.100-preview.7.21379.14`) with:

```
/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets(425,5): error : System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/radical/dev/r3/artifacts/obj/mono/BrowserDebugHost/Release/net6.0/StaticWebAssets.build.json'. [/Users/radical/dev/r3/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj]
/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets(425,5): error :    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode) in System.Private.CoreLib.dll:token 0x60000d6+0x0 [/Users/radical/dev/r3/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj]
/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets(425,5): error :    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize) in System.Private.CoreLib.dll:token 0x60000da+0x31 [/Users/radical/dev/r3/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj]
/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets(425,5): error :    at System.IO.File.WriteAllBytes(String path, Byte[] bytes) in System.Private.CoreLib.dll:token 0x6005cce+0x2b [/Users/radical/dev/r3/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj]
/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets(425,5): error :    at Microsoft.AspNetCore.Razor.Tasks.GenerateStaticWebAssetsManifest.PersistManifest(StaticWebAssetsManifest manifest) in Microsoft.NET.Sdk.Razor.Tasks.dll:token 0x600018a+0x3b [/Users/radical/dev/r3/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj]
/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets(425,5): error :    at Microsoft.AspNetCore.Razor.Tasks.GenerateStaticWebAssetsManifest.Execute() in Microsoft.NET.Sdk.Razor.Tasks.dll:token 0x6000187+0xeb [/Users/radical/dev/r3/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj]
/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets(425,5): error : Could not find a part of the path '/Users/radical/dev/r3/artifacts/obj/mono/BrowserDebugHost/Release/net6.0/StaticWebAssets.build.json'. [/Users/radical/dev/r3/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj]
```

Specifically, the `BrowserDebugHost` project fails:

`.../Microsoft.NET.Sdk.Razor.StaticWebAssets.targets(425,5): error : System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/radical/dev/r3/artifacts/obj/mono/BrowserDebugHost/Release/net6.0/StaticWebAssets.build.json'`

And this is failing because it is building `$(StaticWebAssetBuildManifestPath)` using
`$(BaseIntermediateOutputPath)`. But for mono builds, the intermediate
output paths are changed, in `src/mono/Directory.Build.props`.

But the targets are assuming that the constructed path:

`<_StaticWebAssetsManifestBase>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework.ToLowerInvariant())\</_StaticWebAssetsManifestBase>`

.. would have already been created. But since that gets changed for mono
builds, the path being used here never gets created. And so it fails
with:

`System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/radical/dev/r3/artifacts/obj/mono/BrowserDebugHost/Release/net6.0/StaticWebAssets.build.json'`

Note that other paths, like `$(_StaticWebAssetsIntermediateOutputPath)`
are built using `$(IntermediateOutputPath)`, which correctly gets
created, so that, and others in the same targets file are not affected.

This change was added in:
```
commit 9ed247b28cba4501185dad4e546dc9c51e1c5711
Author: Javier Calvarro Nelson <jacalvar@microsoft.com>
Date:   Thu Jul 15 20:48:36 2021 +0200

    [ASP.NET Core] Static web assets improvements (#18871)
```