### PR TITLE
Runtime pack resolution

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -17,6 +17,7 @@ using Microsoft.DotNet.Configurer;
 using NuGet.Common;
 using System.Text.Json;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install
 {
@@ -138,7 +139,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         {
             try
             {
-                var backgroundUpdatesDisabled = bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"), out var disableEnvVar) && disableEnvVar;
+                var backgroundUpdatesDisabled = bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_DISABLE), out var disableEnvVar) && disableEnvVar;
                 var adUpdatesFile = GetAdvertisingWorkloadsFilePath(CliFolderPathCalculator.DotnetHomePath);
                 if (!backgroundUpdatesDisabled && File.Exists(adUpdatesFile))
                 {
@@ -387,7 +388,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         {
             var sentinalPath = GetAdvertisingManifestSentinalPath();
             int updateIntervalHours;
-            if (!int.TryParse(_getEnvironmentVariable("DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS"), out updateIntervalHours))
+            if (!int.TryParse(_getEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS), out updateIntervalHours))
             {
                 updateIntervalHours = 24;
             }
@@ -438,7 +439,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         }
 
         private bool BackgroundUpdatesAreDisabled() =>
-            bool.TryParse(_getEnvironmentVariable("DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"), out var disableEnvVar) && disableEnvVar;
+            bool.TryParse(_getEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_DISABLE), out var disableEnvVar) && disableEnvVar;
 
         private string GetAdvertisingManifestSentinalPath() => Path.Combine(_userHome, ".dotnet", ".workloadAdvertisingManifestSentinal");
 

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -17,6 +17,7 @@
     <Compile Remove="commands\dotnet-new\**" />
     <Compile Include="commands\dotnet-new\*.cs" />
     <Compile Include="..\..\Resolvers\Microsoft.DotNet.MSBuildSdkResolver\FXVersion.cs" />
+    <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common"/>
     <EmbeddedResource Include="commands\dotnet-new\*.zip" />
     <EmbeddedResource Update="**\*.resx" GenerateSource="true" />
     <EmbeddedResource Update="*.resx" Namespace="Microsoft.DotNet.Tools" />

--- a/src/Common/EnvironmentVariableNames.cs
+++ b/src/Common/EnvironmentVariableNames.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Cli
+{
+    static class EnvironmentVariableNames
+    {
+        public static readonly string WORKLOAD_PACK_ROOTS = "DOTNETSDK_WORKLOAD_PACK_ROOTS";
+        public static readonly string WORKLOAD_MANIFEST_ROOTS = "DOTNETSDK_WORKLOAD_MANIFEST_ROOTS";
+        public static readonly string WORKLOAD_UPDATE_NOTIFY_DISABLE = "DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE";
+        public static readonly string WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS = "DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS";
+    }
+}

--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="..\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\**\*.cs" LinkBase="Microsoft.DotNet.SdkResolver"/>
     <Compile Include="..\Resolvers\Microsoft.DotNet.MSBuildSdkResolver\FXVersion.cs" LinkBase="Microsoft.DotNet.SdkResolver"/>
+    <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -68,6 +68,8 @@
     <Compile Include="..\..\Cli\dotnet\commands\dotnet-workload\install\WorkloadInstallRecords\**\*.cs" 
              Exclude="..\..\Cli\dotnet\commands\dotnet-workload\install\WorkloadInstallRecords\RegistryWorkloadInstallationRecordRepository.cs"
              LinkBase="WorkloadInstallRecords" />
+
+    <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Microsoft.NET.Sdk.WorkloadManifestReader.csproj
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Microsoft.NET.Sdk.WorkloadManifestReader.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <EmbeddedResource Update="**\*.resx" GenerateSource="true" Namespace="Microsoft.NET.Sdk.Localization" />
     <Compile Include="..\Microsoft.DotNet.MSBuildSdkResolver\FXVersion.cs" />
+    <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.DotNet.Cli;
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
@@ -53,7 +54,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             var manifestDirectory = Path.Combine(_sdkRootPath, "sdk-manifests", _sdkVersionBand);
 
-            var manifestDirectoryEnvironmentVariable = getEnvironmentVariable("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS");
+            var manifestDirectoryEnvironmentVariable = getEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_MANIFEST_ROOTS);
             if (manifestDirectoryEnvironmentVariable != null)
             {
                 //  Append the SDK version band to each manifest root specified via the environment variable.  This allows the same

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+using Microsoft.DotNet.Cli;
 using Microsoft.NET.Sdk.Localization;
 using FXVersion = Microsoft.DotNet.MSBuildSdkResolver.FXVersion;
 
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 File.ReadAllLines(runtimeIdentifierChainPath).Where(l => !string.IsNullOrEmpty(l)).ToArray() :
                 new string[] { };
 
-            var packRootEnvironmentVariable = Environment.GetEnvironmentVariable("DOTNETSDK_WORKLOAD_PACK_ROOTS");
+            var packRootEnvironmentVariable = Environment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_PACK_ROOTS);
 
             string[] dotnetRootPaths;
             if (!string.IsNullOrEmpty(packRootEnvironmentVariable))

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -828,4 +828,8 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1180: Specified runtime identifier '{0}'' implies Windows 7 compatibility. Single File publishing is not compatible with Windows 7.</value>
     <comment>{StrBegin="NETSDK1180: "}</comment>
   </data>
+  <data name="CouldNotGetPackVersionFromWorkloadManifests" xml:space="preserve">
+    <value>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</value>
+    <comment>{StrBegin="NETSDK1181: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -264,6 +264,11 @@
         <target state="translated">Vítěze nebylo možné určit, protože {0} není sestavení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: Ze souboru {0} nebylo možné načíst manifest platformy, protože neexistoval.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -264,6 +264,11 @@
         <target state="translated">Der Gewinner konnte nicht bestimmt werden, weil es sich bei "{0}" nicht um eine Assembly handelt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: PlatformManifest konnte nicht von "{0}" geladen werden, weil es nicht vorhanden ist.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -264,6 +264,11 @@
         <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -264,6 +264,11 @@
         <target state="translated">Impossible de déterminer un gagnant, car '{0}' n'est pas un assembly.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: Impossible de charger PlatformManifest à partir de '{0}', car il n'existe pas.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -264,6 +264,11 @@
         <target state="translated">Non è stato possibile determinare la versione da usare perché '{0}' non è un assembly.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: non è stato possibile caricare PlatformManifest da '{0}' perché non esiste.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -264,6 +264,11 @@
         <target state="translated">'{0}' がアセンブリでないため勝者を判別できませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: 存在しなかったため、'{0}' から PlatformManifest を読み込めませんでした。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf~RF1ea49cc.TMP
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf~RF1ea49cc.TMP
@@ -1,40 +1,40 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
-        <target state="translated">NETSDK1076: AddResource só pode ser usado com os tipos de recursos inteiros.</target>
+        <target state="translated">NETSDK1076: AddResource は、整数のリソースの種類でのみ使用できます。</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: o arquivo de configuração do aplicativo deve ter um elemento de configuração raiz.</target>
+        <target state="translated">NETSDK1070: アプリケーション構成ファイルには、ルート構成要素が必要です。</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCreationFailedWithRetry">
         <source>NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</source>
-        <target state="translated">NETSDK1113: falha ao criar appHost (tentativa {0} de {1}): {2}</target>
+        <target state="translated">NETSDK1113: apphost を作成できませんでした ({1} 回中 {0} 回目の試行): {2}</target>
         <note>{StrBegin="NETSDK1113: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="translated">NETSDK1074: o host do aplicativo executável não será personalizado porque a adição de recursos requer que o build seja executado no Windows (excluindo Nano Server).</target>
+        <target state="translated">NETSDK1074: リソースの追加ではビルドが Windows 上で実行される必要があるため、アプリケーション ホストの実行可能ファイルはカスタマイズされません (Nano Server を除く)。</target>
         <note>{StrBegin="NETSDK1074: "}</note>
       </trans-unit>
       <trans-unit id="AppHostHasBeenModified">
         <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: Não é possível usar '{0}' como executável do host de aplicativo, porque ele não contém a sequência de bytes de espaço reservado esperada '{1}' que marcaria o local em que o nome do aplicativo seria gravado.</target>
+        <target state="translated">NETSDK1029: '{0}' は、本来アプリケーション名が書き込まれる場所を示す、必要なプレースホルダー バイト シーケンス '{1}' が含まれていないため、実行可能アプリケーション ホストとして使用できません。</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
-        <target state="translated">NETSDK1078: não é possível usar '{0}' como um host de aplicativo executável porque ele não é um arquivo do Windows PE.</target>
+        <target state="translated">NETSDK1078: Windows PE ファイルではないため、'{0}' をアプリケーション ホストの実行可能ファイルとして使用することはできません。</target>
         <note>{StrBegin="NETSDK1078: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
         <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
-        <target state="translated">NETSDK1072: não é possível usar '{0}' como um host de aplicativo executável porque ele não é um executável do Windows para o subsistema CUI (Console).</target>
+        <target state="translated">NETSDK1072: CUI (コンソール) サブシステム用の Windows 実行可能ファイルではないため、'{0}' をアプリケーション ホストの実行可能ファイルとして使用することはできません。</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppHostSigningFailed">
@@ -44,162 +44,162 @@
       </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: o pacote Microsoft.AspNetCore.All não tem suporte quando direcionado ao .NET Core 3.0 ou superior. Um FrameworkReference para Microsoft.AspNetCore.App deve ser usado e será incluído implicitamente pelo Microsoft.NET.Sdk.Web.</target>
+        <target state="translated">NETSDK1079: .NET Core 3.0 以上がターゲットの場合、Microsoft.AspNetCore.All パッケージはサポートされていません。代わりに Microsoft.AspNetCore.App への FrameworkReference を使用する必要があり、これは Microsoft.NET.Sdk.Web によって暗黙的に含まれます。</target>
         <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreUsesFrameworkReference">
         <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: um PackageReference para Microsoft.AspNetCore.App não é necessário quando direcionado ao .NET Core 3.0 ou superior. Se o Microsoft.NET.Sdk.Web for usado, a estrutura compartilhada será referenciada automaticamente. Caso contrário, o PackageReference deverá ser substituído por um FrameworkReference.</target>
+        <target state="translated">NETSDK1080: .NET Core 3.0 以上がターゲットの場合、Microsoft.AspNetCore.App への PackageReference は必要ありません。Microsoft.NET.Sdk.Web が使用される場合、この共有フレームワークは自動的に参照されます。そうでない場合、PackageReference を FrameworkReference で置き換える必要があります。</target>
         <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="translated">NETSDK1017: O pré-processador de ativos precisa ser configurado antes que os ativos sejam processados.</target>
+        <target state="translated">NETSDK1017: 資産を処理する前に、資産プリプロセッサを構成する必要があります。</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingRuntimeIdentifier">
         <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: O arquivo de ativos '{0}' não tem um destino para '{1}'. Verifique se a restauração foi executada e se você incluiu '{2}' no TargetFrameworks do projeto. Talvez você também precise incluir '{3}' no RuntimeIdentifiers do projeto.</target>
+        <target state="translated">NETSDK1047: 資産ファイル '{0}' に '{1}' のターゲットがありません。復元が実行されたこと、および '{2}' がプロジェクトの TargetFrameworks に含まれていることを確認してください。プロジェクトの RuntimeIdentifiers に '{3}' を組み込む必要が生じる可能性もあります。</target>
         <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingTarget">
         <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: O arquivo de ativos '{0}' não tem um destino para '{1}'. Verifique se a restauração foi executada e se você incluiu '{2}' no TargetFrameworks do projeto.</target>
+        <target state="translated">NETSDK1005: 資産ファイル '{0}' に '{1}' のターゲットがありません。復元が実行されたことと、'{2}' がプロジェクトの TargetFrameworks に含まれていることを確認してください。</target>
         <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotFound">
         <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Arquivo de ativos '{0}' não encontrado. Execute uma restauração de pacote do NuGet para gerar esse arquivo.</target>
+        <target state="translated">NETSDK1004: 資産ファイル '{0}' が見つかりません。NuGet パッケージの復元を実行して、このファイルを生成してください。</target>
         <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
         <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: O caminho para o arquivo de ativos do projeto não foi configurado. Execute uma restauração de pacote do NuGet para gerar esse arquivo.</target>
+        <target state="translated">NETSDK1063: プロジェクト資産ファイルのパスが設定されていません。NuGet パッケージの復元を実行して、このファイルを生成してください。</target>
         <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFilePathNotRooted">
         <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: O caminho de arquivo de ativos '{0}' não tem raiz. Há suporte apenas para caminhos completos.</target>
+        <target state="translated">NETSDK1006: 資産ファイル パス '{0}' にルートが指定されていません。完全パスのみがサポートされます。</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: É necessário especificar pelo menos uma estrutura de destino possível.</target>
+        <target state="translated">NETSDK1001: 可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotEmbedClsidMapIntoComhost">
         <source>NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="translated">NETSDK1092: o CLSIDMap não pode ser inserido no host COM porque a adição de recursos requer que o build seja executado no Windows (excluindo Nano Server).</target>
+        <target state="translated">NETSDK1092: リソースの追加にはビルドが Windows 上で実行されることが要求されるため、CLSIDMap を COM ホストに埋め込むことはできません (Nano Server を除く)。</target>
         <note>{StrBegin="NETSDK1092: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindApphostForRid">
         <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: Não é possível encontrar o host do aplicativo para {0}. {0} poderia ser um RID (identificador de runtime inválido). Para obter mais informações sobre RID, confira https://aka.ms/rid-catalog.</target>
+        <target state="translated">NETSDK1065: {0} のアプリ ホストが見つかりません。{0} は無効なランタイム識別子 (RID) である可能性があります。RID の詳細については、https://aka.ms/rid-catalog をご覧ください。</target>
         <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindComhost">
         <source>NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</source>
-        <target state="translated">NETSDK1091: não é possível encontrar um host .NET Core COM. O host .NET Core COM só está disponível no .NET Core 3.0 ou superior quando direcionado ao Windows.</target>
+        <target state="translated">NETSDK1091: .NET Core COM ホストが見つかりません。Windows がターゲットの場合、.NET Core COM ホストを利用できるのは .NET Core 3.0 以上の場合のみです。</target>
         <note>{StrBegin="NETSDK1091: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindIjwhost">
         <source>NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</source>
-        <target state="translated">NETSDK1114: não é possível encontrar um host IJW do .NET Core. O host IJW do .NET Core está disponível somente no .NET Core 3.1 ou superior quando direcionado ao Windows.</target>
+        <target state="translated">NETSDK1114: .NET Core IJW ホストが見つかりません。Windows がターゲットの場合、.NET Core IJW ホストを利用できるのは .NET Core 3.1 以上の場合のみです。</target>
         <note>{StrBegin="NETSDK1114: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindProjectInfo">
         <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Não é possível localizar informações do projeto para '{0}'. Isso pode indicar a ausência de uma referência de projeto.</target>
+        <target state="translated">NETSDK1007: '{0}' のプロジェクト情報が見つかりません。これは、プロジェクト参照がないことを示している可能性があります。</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: A plataforma '{0}' do RuntimeIdentifier e o PlatformTarget '{1}' precisam ser compatíveis.</target>
+        <target state="translated">NETSDK1032: RuntimeIdentifier プラットフォーム '{0}' と PlatformTarget '{1}' には互換性が必要です。</target>
         <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="translated">NETSDK1031: não há suporte para criar nem para publicar um aplicativo autossuficiente sem especificar um RuntimeIdentifier. Você precisa especificar um RuntimeIdentifier ou definir SelfContained como false.</target>
+        <target state="translated">NETSDK1031: RuntimeIdentifier を指定せずに自己完結型アプリケーションをビルドおよび公開することはサポートされていません。RuntimeIdentifier を指定するか SelfContained を false に設定する必要があります。</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
         <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="translated">NETSDK1097: não há suporte para publicar um aplicativo em um arquivo único sem especificar um RuntimeIdentifier. Você precisa especificar um RuntimeIdentifier ou definir PublishSingleFile como false.</target>
+        <target state="translated">NETSDK1097: RuntimeIdentifier を指定せずにアプリケーションを単一ファイルに公開することはサポートされていません。RuntimeIdentifier を指定するか、PublishSingleFile を false に設定する必要があります。</target>
         <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutAppHost">
         <source>NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1098: são necessários aplicativos publicados em um arquivo único para usar o host de aplicativo. Você precisa definir PublishSingleFile como false ou UseAppHost como true.</target>
+        <target state="translated">NETSDK1098: 単一ファイルに公開されたアプリケーションでは、アプリケーション ホストを使用する必要があります。PublishSingleFile を false に設定するか、UseAppHost を true に設定する必要があります。</target>
         <note>{StrBegin="NETSDK1098: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutExecutable">
         <source>NETSDK1099: Publishing to a single-file is only supported for executable applications.</source>
-        <target state="translated">NETSDK1099: só há suporte para a publicação em um arquivo único em aplicativos executáveis.</target>
+        <target state="translated">NETSDK1099: 単一ファイルへの公開は実行可能アプリケーションに対してのみサポートされています。</target>
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
-        <target state="translated">NETSDK1134: não há suporte para a criação de uma solução com um RuntimeIdentifier específico. Se você quiser publicar para um único RID, especifique o RID no nível do projeto individual.</target>
+        <target state="translated">NETSDK1134: 特定の RuntimeIdentifier を使用したソリューションのビルドはサポートされていません。単一の RID に対して発行する場合は、個々のプロジェクト レベルで RID を指定してください。</target>
         <note>{StrBegin="NETSDK1134: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
         <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="translated">NETSDK1135: SupportedOSPlatformVersion {0} não pode ser superior a TargetPlatformVersion {1}.</target>
+        <target state="translated">NETSDK1135: SupportedOSPlatformVersion {0} を TargetPlatformVersion {1} より大きくすることはできません。</target>
         <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>
-        <target state="translated">NETSDK1143: Incluir todo o conteúdo em um pacote de arquivo único também inclui bibliotecas nativas. Se IncludeAllContentForSelfExtract for true, IncludeNativeLibrariesForSelfExtract não pode ser false.</target>
+        <target state="translated">NETSDK1143: 単一のファイル バンドルにすべてのコンテンツを含めると、ネイティブ ライブラリも含まれます。IncludeAllContentForSelfExtract が true の場合、IncludeNativeLibrariesForSelfExtract を false にすることはできません。</target>
         <note>{StrBegin="NETSDK1143: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeSymbolsInSingleFile">
         <source>NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</source>
-        <target state="translated">NETSDK1142: Não há suporte para a inclusão de símbolos em um pacote de arquivo durante a publicação para .NET5 ou superior.</target>
+        <target state="translated">NETSDK1142: .NET5 以降に対してパブリッシュする場合、単一のファイル バンドルにシンボルを含めることはサポートされていません。</target>
         <note>{StrBegin="NETSDK1142: "}</note>
       </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: O valor '{0}' do TargetFramework não foi reconhecido. Ele pode ter sido escrito com ortografia incorreta. Caso contrário, as propriedades TargetFrameworkIdentifier e/ou TargetFrameworkVersion precisarão ser especificadas explicitamente.</target>
+        <target state="translated">NETSDK1013: TargetFramework 値 '{0}' が認識されませんでした。つづりが間違っている可能性があります。間違っていない場合は、TargetFrameworkIdentifier または TargetFrameworkVersion プロパティ (あるいはその両方) を明示的に指定する必要があります。</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: os aplicativos independentes são necessários para utilizar o host do aplicativo. Defina SelfContained como falso ou defina UseAppHost como verdadeiro.</target>
+        <target state="translated">NETSDK1067: アプリケーション ホストを使用するには、自己完結型のアプリケーションが必要です。SelfContained を false に設定するか、UseAppHost を true に設定してください。</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
         <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
-        <target state="translated">NETSDK1125: há suporte para a publicação em um único arquivo somente para o destino netcoreapp.</target>
+        <target state="translated">NETSDK1125: 1 つのファイルへの発行は netcoreapp ターゲットでのみサポートされています。</target>
         <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="translated">Escolhendo '{0}' porque AssemblyVersion '{1}' é maior que '{2}'.</target>
+        <target state="translated">AssemblyVersion '{1}' が '{2}' より大きいため、'{0}' を選択しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingCopyLocalArbitrarily_Info">
         <source>Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</source>
-        <target state="translated">Escolhendo '{0}' arbitrariamente, pois os dois itens são de cópia local e têm versões iguais de arquivo e assembly.</target>
+        <target state="translated">両方の項目がローカル コピーであり、ファイルとアセンブリのバージョンが等しいため、'{0}' を任意に選択しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingFileVersion_Info">
         <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="translated">Escolhendo '{0}' porque a versão do arquivo '{1}' é maior que '{2}'.</target>
+        <target state="translated">ファイルのバージョン '{1}' が '{2}' より大きいため、'{0}' を選択しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPlatformItem_Info">
         <source>Choosing '{0}' because it is a platform item.</source>
-        <target state="translated">Escolhendo '{0}' porque é um item de plataforma.</target>
+        <target state="translated">'{0}' はプラットフォーム項目であるため、これを選択しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPreferredPackage_Info">
         <source>Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="translated">Escolhendo '{0}' porque vem de um pacote que é preferencial.</target>
+        <target state="translated">'{0}' は優先されるパッケージからのものであるため、これを選択しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ClsidMapConflictingGuids">
         <source>NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</source>
-        <target state="translated">NETSDK1089: os tipos '{0}' e '{1}' têm o mesmo CLSID '{2}' definido em seu GuidAttribute. Cada classe COMVisible precisa ter um guid distinto para seus CLSID.</target>
+        <target state="translated">NETSDK1089: 型 '{0}' および '{1}' では、GuidAttribute で同じ CLSID '{2}' が設定されています。各 COMVisible クラスでは、CLSID に異なる guid が設定されている必要があります。</target>
         <note>{StrBegin="NETSDK1089: "}
 {0} - The first type with the conflicting guid.
 {1} - The second type with the conflicting guid.
@@ -207,13 +207,13 @@
       </trans-unit>
       <trans-unit id="ClsidMapExportedTypesRequireExplicitGuid">
         <source>NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</source>
-        <target state="translated">NETSDK1088: a classe COMVisible '{0}' deve ter um GuidAttribute com o CLSID da classe para fique visível para o COM no .NET Core.</target>
+        <target state="translated">NETSDK1088: COMVisible クラス '{0}' を .NET Core 内の COM に対して参照可能にするには、クラスの CLSID を持つ GuidAttribute を含める必要があります。</target>
         <note>{StrBegin="NETSDK1088: "}
 {0} - The ComVisible class that doesn't have a GuidAttribute on it.</note>
       </trans-unit>
       <trans-unit id="ClsidMapInvalidAssembly">
         <source>NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</source>
-        <target state="translated">NETSDK1090: o assembly fornecido '{0}' não é válido. Não é possível gerar um CLSIDMap dele.</target>
+        <target state="translated">NETSDK1090: 指定されたアセンブリ '{0}' が無効です。CLSIDMap を生成できません。</target>
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
@@ -230,53 +230,48 @@
       <trans-unit id="ConflictingRuntimePackInformation">
         <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
 {1}</source>
-        <target state="translated">NETSDK1133: havia informações conflitantes sobre os pacotes de runtime disponíveis para {0}:
+        <target state="translated">NETSDK1133: {0} で使用可能なランタイム パックの情報が競合しています:
 {1}</target>
         <note>{StrBegin="NETSDK1133: "}</note>
       </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: O item de conteúdo para '{0}' define '{1}', mas não fornece '{2}' ou '{3}'.</target>
+        <target state="translated">NETSDK1014: '{0}' のコンテンツ項目で '{1}' が設定されていますが、'{2}' または '{3}' は指定されていません。</target>
         <note>{StrBegin="NETSDK1014: "}</note>
       </trans-unit>
       <trans-unit id="ContentPreproccessorParameterRequired">
         <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: A tarefa '{0}' precisa receber um valor para o parâmetro '{1}' para consumir o conteúdo pré-processado.</target>
+        <target state="translated">NETSDK1010: 前処理されたコンテンツを使用するためには、パラメーター '{1}' の値を '{0}' タスクに指定する必要があります。</target>
         <note>{StrBegin="NETSDK1010: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesNotExist_Info">
         <source>Could not determine winner because '{0}' does not exist.</source>
-        <target state="translated">Não foi possível determinar o vencedor porque '{0}' não existe.</target>
+        <target state="translated">'{0}' が存在しないため勝者を判別できませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_EqualVersions_Info">
         <source>Could not determine winner due to equal file and assembly versions.</source>
-        <target state="translated">Não foi possível determinar o vencedor porque as versões de arquivo e de assembly são iguais.</target>
+        <target state="translated">ファイルとアセンブリのバージョンが等しいため、勝者を判別できませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NoFileVersion_Info">
         <source>Could not determine a winner because '{0}' has no file version.</source>
-        <target state="translated">Não foi possível determinar um vencedor porque '{0}' não tem versão de arquivo.</target>
+        <target state="translated">'{0}' にファイルのバージョンがないため勝者を判別できませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NotAnAssembly_Info">
         <source>Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="translated">Não foi possível determinar um vencedor porque '{0}' não é um assembly.</target>
+        <target state="translated">'{0}' がアセンブリでないため勝者を判別できませんでした。</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
-        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
-        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
-        <note>{StrBegin="NETSDK1181: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: Não foi possível carregar PlatformManifest de '{0}' porque ele não existia.</target>
+        <target state="translated">NETSDK1042: 存在しなかったため、'{0}' から PlatformManifest を読み込めませんでした。</target>
         <note>{StrBegin="NETSDK1042: "}</note>
       </trans-unit>
       <trans-unit id="CppRequiresTFMVersion31">
         <source>NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</source>
-        <target state="translated">NETSDK1120: os projetos C++/CLI direcionados ao .NET Core exigem, no mínimo, a estrutura de destino 'netcoreapp3.1'.</target>
+        <target state="translated">NETSDK1120: .NET Core をターゲットとする C++/CLI プロジェクトには、少なくとも 'netcoreapp 3.1' のターゲット フレームワークが必要です。</target>
         <note>{StrBegin="NETSDK1120: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2MissingRequiredMetadata">
@@ -286,7 +281,7 @@
       </trans-unit>
       <trans-unit id="Crossgen2RequiresSelfContained">
         <source>NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</source>
-        <target state="translated">NETSDK1126: Só há suporte para a publicação do ReadyToRun com o Crossgen2 em aplicativos autocontidos.</target>
+        <target state="translated">NETSDK1126: Crossgen2 を使用した ReadyToRun の公開は、自己完結型アプリケーションでのみサポートされています。</target>
         <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolExecutableNotFound">
@@ -331,32 +326,32 @@
       </trans-unit>
       <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
         <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: O DotnetTool não é compatível com uma estrutura de destino inferior ao netcoreapp2.1.</target>
+        <target state="translated">NETSDK1055: DotnetTool は、netcoreapp2.1 未満のターゲット フレームワークをサポートしていません。</target>
         <note>{StrBegin="NETSDK1055: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolOnlySupportNetcoreapp">
         <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: É compatível apenas com o .NET Core.</target>
+        <target state="translated">NETSDK1054: .NET Core のみがサポートされています。</target>
         <note>{StrBegin="NETSDK1054: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateItemsError">
         <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Itens '{0}' duplicados foram incluídos. O SDK do .NET inclui '{0}' itens do diretório do projeto por padrão. Você poderá remover esses itens do arquivo de projeto ou configurar a propriedade '{1}' como '{2}' se desejar incluí-los explicitamente no arquivo de projeto. Para obter mais informações, confira {4}. Os itens duplicados eram: {3}</target>
+        <target state="translated">NETSDK1022: 重複する '{0}' 個のアイテムが含められました。.NET SDK には、既定でプロジェクト ディレクトリからのアイテムが '{0}' 個含まれています。これらのアイテムをプロジェクト ファイルから削除するか、'{1}' プロパティを '{2}' に設定してプロジェクト ファイルに明示的に含めることができます。詳細については、{4} をご覧ください。重複するアイテムは、{3} でした。</target>
         <note>{StrBegin="NETSDK1022: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePreprocessorToken">
         <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: O token de pré-processador '{0}' recebeu mais de um valor. Escolhendo '{1}' como o valor.</target>
+        <target state="translated">NETSDK1015: プリプロセッサ トークン '{0}' に複数の値が指定されています。値として '{1}' を選択します。</target>
         <note>{StrBegin="NETSDK1015: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePublishOutputFiles">
         <source>NETSDK1152: Found multiple publish output files with the same relative path: {0}.</source>
-        <target state="needs-review-translation">NETSDK1148: foram encontrados vários arquivos de saída de publicação com o mesmo caminho relativo: {0}.</target>
+        <target state="needs-review-translation">NETSDK1148: 同じ相対パスの発行出力ファイルが複数見つかりました: {0}。</target>
         <note>{StrBegin="NETSDK1152: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateRuntimePackAsset">
         <source>NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="translated">NETSDK1110: mais de um ativo no pacote de runtime tem o mesmo subcaminho de destino de '{0}'. Relate esse erro à equipe do .NET: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="translated">NETSDK1110: ランタイム パック内の複数のアセットに同じターゲット サブパス '{0}' が指定されています。https://aka.ms/dotnet-sdk-issue で、このエラーを .NET チームに報告してください。</target>
         <note>{StrBegin="NETSDK1110: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateTypeLibraryIds">
@@ -366,102 +361,102 @@
       </trans-unit>
       <trans-unit id="EncounteredConflict_Info">
         <source>Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="translated">Encontrado um conflito entre '{0}' e '{1}'.</target>
+        <target state="translated">'{0}' と '{1}' の間で競合が発生しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">
         <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Erro ao analisar FrameworkList de '{0}'.  {1} '{2}' era inválido.</target>
+        <target state="translated">NETSDK1051: '{0}' からの FrameworkList の解析でエラーが発生しました。{1} '{2}' が無効でした。</target>
         <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="translated">NETSDK1043: Erro ao analisar PlatformManifest de '{0}', linha {1}. As linhas precisam ter o formato {2}.</target>
+        <target state="translated">NETSDK1043: '{0}' 行 {1} からの PlatformManifest の解析でエラーが発生しました。行の形式は {2} である必要があります。</target>
         <note>{StrBegin="NETSDK1043: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="translated">NETSDK1044: Erro ao analisar PlatformManifest de '{0}', linha {1}. {2} '{3}' era inválido.</target>
+        <target state="translated">NETSDK1044: '{0}' 行 {1} からの PlatformManifest の解析でエラーが発生しました。{2} '{3}' は無効でした。</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">
         <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Erro ao ler o arquivo de ativos: {0}</target>
+        <target state="translated">NETSDK1060: アセット ファイルの読み取りでエラーが発生しました: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
       <trans-unit id="FailedToDeleteApphost">
         <source>NETSDK1111: Failed to delete output apphost: {0}</source>
-        <target state="translated">NETSDK1111: Falha ao excluir o apphost de saída: {0}</target>
+        <target state="translated">NETSDK1111: 出力 apphost を削除できませんでした: {0}</target>
         <note>{StrBegin="NETSDK1111: "}</note>
       </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: falha ao bloquear o recurso.</target>
+        <target state="translated">NETSDK1077: リソースをロックできませんでした。</target>
         <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
       <trans-unit id="FileNameIsTooLong">
         <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: O nome de arquivo '{0}' fornecido tem mais de 1024 bytes</target>
+        <target state="translated">NETSDK1030: 指定されたファイル名 '{0}' の長さが 1024 バイトを超えています。</target>
         <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
       <trans-unit id="FolderAlreadyExists">
         <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: A pasta '{0}' já existe. Exclua essa pasta ou forneça um ComposeWorkingDir diferente</target>
+        <target state="translated">NETSDK1024: フォルダー '{0}' が既に存在します。そのフォルダーを削除するか、別の ComposeWorkingDir を指定してください。</target>
         <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: o host do aplicativo dependente de estrutura exige uma estrutura de destino de, pelo menos, 'netcoreapp2.1'.</target>
+        <target state="translated">NETSDK1068: フレームワークに依存するアプリケーション ホストには、最低でも 'netcoreapp2.1' のターゲット フレームワークが必要です。</target>
         <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1052: O caminho de arquivo de lista de estrutura '{0}' não tem raiz. Há suporte apenas para caminhos completos.</target>
+        <target state="translated">NETSDK1052: フレームワーク リスト ファイル パス '{0}' にルートが指定されていません。完全パスのみがサポートされています。</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceDuplicateError">
         <source>NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</source>
-        <target state="translated">NETSDK1087: vários itens de FrameworkReference para '{0}' foram incluídos no projeto.</target>
+        <target state="translated">NETSDK1087: '{0}' に対する複数の FrameworkReference 項目がプロジェクトに含められました。</target>
         <note>{StrBegin="NETSDK1087: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceOverrideWarning">
         <source>NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1086: uma FrameworkReference para '{0}' foi incluída no projeto. Isso é referenciado implicitamente pelo SKD do .NET e, geralmente, não é necessário referenciar no seu projeto. Para obter mais informações, confira {1}</target>
+        <target state="translated">NETSDK1086: '{0}' の FrameworkReference がプロジェクトに含められました。これは .NET SDK によって暗黙的に参照されるため、通常はプロジェクトから参照する必要はありません。詳細については、{1} をご覧ください</target>
         <note>{StrBegin="NETSDK1086: "}</note>
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
         <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: O arquivo resolvido tem uma imagem inválida, não tem metadados ou está inacessível. {0} {1}</target>
+        <target state="translated">NETSDK1049: 解決されたファイルは、無効なイメージが含まれているか、メタデータが存在しないか、またはアクセスできません。{0} {1}</target>
         <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
       <trans-unit id="GlobalJsonSDKResolutionFailed">
         <source>NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</source>
-        <target state="translated">NETSDK1141: não é possível resolver a versão do SDK do .NET conforme a especificação no global.json, localizado em {0}.</target>
+        <target state="translated">NETSDK1141: {0} にある global.json で指定されている .NET SDK のバージョンを解決できません。</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
         <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
-        <target state="translated">NETSDK1144: Falha na otimização de assemblies de tamanho. A otimização pode ser desabilitada definindo a propriedade PublishTrimmed como false.</target>
+        <target state="translated">NETSDK1144: アセンブリのサイズを最適化できませんでした。PublishTrimmed プロパティを false に設定することにより、最適化を無効にすることができます。</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
-        <target state="translated">NETSDK1102: não há suporte para a otimização de assemblies para tamanho na configuração de publicação selecionada. Verifique se você está publicando um aplicativo independente.</target>
+        <target state="translated">NETSDK1102: アセンブリのサイズの最適化は、選択された公開構成に対してはサポートされていません。自己完結型のアプリを公開していることをご確認ください。</target>
         <note>{StrBegin="NETSDK1102: "}</note>
       </trans-unit>
       <trans-unit id="ILLink_Info">
         <source>Optimizing assemblies for size, which may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</source>
-        <target state="translated">Otimizando assemblies para tamanho, o que pode alterar o comportamento do aplicativo. Não se esqueça de testar após a publicação. Confira: https://aka.ms/dotnet-illink</target>
+        <target state="translated">アセンブリのサイズを最適化しています。これにより、アプリの動作が変更される可能性があります。公開した後にテストしてください。https://aka.ms/dotnet-illink を参照してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IncorrectPackageRoot">
         <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: A raiz do pacote {0} foi atribuída incorretamente para a biblioteca resolvida {1}</target>
+        <target state="translated">NETSDK1020: 解決されたライブラリ {1} に対して指定されたパッケージ ルート {0} が正しくありません。</target>
         <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectTargetFormat">
         <source>NETSDK1025: The target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: o manifesto de destino {0} fornecido não está no formato correto</target>
+        <target state="translated">NETSDK1025: 指定されたターゲット マニフェスト {0} の形式が正しくありません</target>
         <note>{StrBegin="NETSDK1025: "}</note>
       </trans-unit>
       <trans-unit id="InputAssemblyNotFound">
@@ -471,34 +466,34 @@
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Nome de estrutura inválido: '{0}'.</target>
+        <target state="translated">NETSDK1003: 無効なフレームワーク名: '{0}'。</target>
         <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="translated">NETSDK1058: Valor inválido para o parâmetro ItemSpecToUse: '{0}'. Essa propriedade precisa estar em branco ou ser definida como 'Left' ou 'Right'</target>
+        <target state="translated">NETSDK1058: ItemSpecToUse パラメーターの値が無効です: '{0}'。このプロパティは空白にするか、'Left' または 'Right' に設定する必要があります</target>
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionString">
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Cadeia de caracteres de versão do NuGet inválida: '{0}'.</target>
+        <target state="translated">NETSDK1018: 無効な NuGet バージョン文字列: '{0}'。</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidResourceUpdate">
         <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: o identificador de atualização não é válido. Esta instância não pode ser usada para obter atualizações.</target>
+        <target state="translated">NETSDK1075: 更新ハンドルが無効です。このインスタンスは、今後の更新には使用できない可能性があります。</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="InvalidRollForwardValue">
         <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
-        <target state="translated">NETSDK1104: o valor de RollForward '{0}' é inválido. Os valores permitidos são {1}.</target>
+        <target state="translated">NETSDK1104: ロールフォワード値 '{0}' が無効です。許可されている値は {1} です。</target>
         <note>{StrBegin="NETSDK1104: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTargetPlatformVersion">
         <source>NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
 {2}</source>
-        <target state="translated">NETSDK1140: {0} não é uma TargetPlatformVersion válida para {1}. As versões válidas incluem:
+        <target state="translated">NETSDK1140: {0} は {1} に対して有効な TargetPlatformVersion ではありません。有効なバージョン:
 {2}</target>
         <note>{StrBegin="NETSDK1140: "}</note>
       </trans-unit>
@@ -519,7 +514,7 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="translated">NETSDK1061: o projeto foi restaurado usando o {0} versão {1}, mas, com as configurações atuais, a versão {2} seria usada. Para resolver esse problema, verifique se as mesmas configurações são usadas para restauração e para operações subsequentes, como compilação ou publicação. Normalmente, esse problema poderá ocorrer se a propriedade RuntimeIdentifier for definida durante a compilação ou a publicação, mas não durante a restauração. Para obter mais informações, consulte https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <target state="translated">NETSDK1061: プロジェクトは {0} バージョン {1} を使用して復元されましたが、現在の設定では、バージョン {2} が代わりに使用されます。この問題を解決するには、復元およびこれ以降の操作 (ビルドや公開など) で同じ設定を使用していることをご確認ください。通常この問題は、ビルドや公開の実行時に RuntimeIdentifier プロパティを設定したが、復元時には設定していない場合に発生することがあります。詳しくは、https://aka.ms/dotnet-runtime-patch-selection を参照してください。</target>
         <note>{StrBegin="NETSDK1061: "}
 {0} - Package Identifier for platform package
 {1} - Restored version of platform package
@@ -527,7 +522,7 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="MissingItemMetadata">
         <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Metadados '{0}' ausentes no item '{1}' '{2}'.</target>
+        <target state="translated">NETSDK1008: '{1}' 項目 '{2}' の '{0}' メタデータがありません。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputPDBImagePath">
@@ -547,77 +542,77 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="MultipleFilesResolved">
         <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Mais de um arquivo encontrado para {0}</target>
+        <target state="translated">NETSDK1021: {0} で複数のファイルが見つかりました。</target>
         <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: este projeto utiliza uma biblioteca que tem como destino o .NET Standard 1.5 ou superior, e o projeto tem como destino uma versão do .NET Framework que não tem suporte interno para essa versão do .NET Standard. Visite o site https://aka.ms/net-standard-known-issues para ter acesso a uma variedade de problemas conhecidos. Considere alterar o destino para o .NET Framework 4.7.2.</target>
+        <target state="translated">NETSDK1069: このプロジェクトは .NET Standard 1.5 以上をターゲットとするライブラリを使用します。また、このプロジェクトは、そのバージョンの .NET Standard に対するサポートが組み込まれていない .NET Framework のバージョンをターゲットとしています。一連の既知の問題について、https://aka.ms/net-standard-known-issues をご覧ください。.NET Framework 4.7.2 への再ターゲットを検討してください。</target>
         <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkWithoutUsingNETSdkDefaults">
         <source>NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</source>
-        <target state="translated">NETSDK1115: o SDK do .NET atual não dá suporte ao .NET Framework sem o uso de Padrões do SDK do .NET. O motivo é provavelmente uma incompatibilidade entre a propriedade CLRSupport do projeto C++/CLI e a TargetFramework.</target>
+        <target state="translated">NETSDK1115: 現在の .NET SDK では、.NET SDK の既定値を使用せずに .NET Framework をサポートすることはできません。これは、C++/CLI プロジェクトの CLRSupport プロパティと TargetFramework の間の不一致が原因と考えられます。</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="translated">NETSDK1084: não há nenhum host do aplicativo disponível para o RuntimeIdentifier especificado '{0}'.</target>
+        <target state="translated">NETSDK1084: 指定された RuntimeIdentifier '{0}' で利用できるアプリケーション ホストはありません。</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
       <trans-unit id="NoBuildRequested">
         <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
-        <target state="translated">NETSDK1085: a propriedade 'NoBuild' foi definida como true, mas o destino 'Build' foi invocado.</target>
+        <target state="translated">NETSDK1085: 'NoBuild' プロパティが true に設定されていますが、'Build' ターゲットが呼び出されました。</target>
         <note>{StrBegin="NETSDK1085: "}</note>
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: O projeto '{0}' é direcionado a '{2}'. Ele não pode ser referenciado por um projeto direcionado a '{1}'.</target>
+        <target state="translated">NETSDK1002: プロジェクト '{0}' は、'{2}' を対象としています。'{1}' を対象とするプロジェクトは、これを参照できません。</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackAvailable">
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="translated">NETSDK1082: não havia nenhum pacote de tempo de execução de {0} disponível para o RuntimeIdentifier especificado '{1}'.</target>
+        <target state="translated">NETSDK1082: 指定された RuntimeIdentifier '{1}' で利用できる {0} のランタイム パックがありませんでした。</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackInformation">
         <source>NETSDK1132: No runtime pack information was available for {0}.</source>
-        <target state="translated">NETSDK1132: não havia nenhuma informação do pacote de runtime disponível para {0}.</target>
+        <target state="translated">NETSDK1132: {0} で使用可能なランタイム パックの情報がありません。</target>
         <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
-        <target state="translated">NETSDK1128: a hospedagem de COM não dá suporte a implantações independentes.</target>
+        <target state="translated">NETSDK1128: COM ホスティングは自己完結型の配置をサポートしていません。</target>
         <note>{StrBegin="NETSDK1128: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
-        <target state="translated">NETSDK1119: os projetos C++/CLI direcionados ao .NET Core não podem usar EnableComHosting = true.</target>
+        <target state="translated">NETSDK1119: .NET Core をターゲットとする C++/CLI プロジェクトでは EnableComHosting=true を使用できません。</target>
         <note>{StrBegin="NETSDK1119: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppNonDynamicLibraryDotnetCore">
         <source>NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</source>
-        <target state="translated">NETSDK1116: os projetos C++/CLI direcionados ao .NET Core precisam ser bibliotecas dinâmicas.</target>
+        <target state="translated">NETSDK1116: .NET Core をターゲットとする C++/CLI プロジェクトは、ダイナミック ライブラリである必要があります。</target>
         <note>{StrBegin="NETSDK1116: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPackDotnetCore">
         <source>NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</source>
-        <target state="translated">NETSDK1118: os projetos C++/CLI direcionados ao .NET Core não podem ser empacotados.</target>
+        <target state="translated">NETSDK1118: .NET Core をターゲットとする C++/CLI プロジェクトはパックできません。</target>
         <note>{StrBegin="NETSDK1118: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPublishDotnetCore">
         <source>NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</source>
-        <target state="translated">NETSDK1117: não dá suporte à publicação do projeto C++/CLI direcionado ao dotnet core.</target>
+        <target state="translated">NETSDK1117: .NET Core をターゲットとする C++/CLI プロジェクトの発行をサポートしていません。</target>
         <note>{StrBegin="NETSDK1117: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppSelfContained">
         <source>NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</source>
-        <target state="translated">NETSDK1121: os projetos C++/CLI direcionados ao .NET Core não podem usar SelfContained=true.</target>
+        <target state="translated">NETSDK1121: .NET Core をターゲットとする C++/CLI プロジェクトでは SelfContained=true を使用できません。</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
       <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
         <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</source>
-        <target state="needs-review-translation">NETSDK1151: O projeto referenciado '{0}' é um executável autossuficiente.  Um executável autossuficiente não pode ser referenciado por um executável não autossuficiente.</target>
+        <target state="needs-review-translation">NETSDK1151: 参照先プロジェクト '{0}'  は自己完結型実行可能ファイルです。 自己完結型の実行可能ファイルは、自己完結型以外の実行可能ファイルでは参照できません。</target>
         <note>{StrBegin="NETSDK1151: "}</note>
       </trans-unit>
       <trans-unit id="PDBGeneratorInputExecutableNotFound">
@@ -627,27 +622,27 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: O pacote como ferramenta não é compatível com a opção autossuficiente.</target>
+        <target state="translated">NETSDK1053: Pack As ツールは自己完結型をサポートしていません。</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
         <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
-        <target state="translated">NETSDK1146: PackAsTool não oferece suporte a TargetPlatformIdentifier definido. Por exemplo, TargetFramework não pode ser net5.0-windows, somente net5.0. PackAsTool também não suporta UseWPF ou UseWindowsForms ao direcionar para o .NET 5 e superior.</target>
+        <target state="translated">NETSDK1146: PackAsTool は、設定されている TargetPlatformIdentifier をサポートしていません。たとえば、TargetFramework には net5.0-windows は指定できず、net 5.0 のみ使用できます。また PackAsTool は、.NET 5 以降を対象としている場合には、UseWPF や UseWindowsForms もサポートしていません。</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="translated">NETSDK1064: O pacote {0}, versão {1}, não foi encontrado. Ele pode ter sido excluído desde a restauração do NuGet. Caso contrário, a restauração do NuGet pode ter sido concluída apenas parcialmente, o que pode ter ocorrido devido a restrições de comprimento máximo do caminho.</target>
+        <target state="translated">NETSDK1064: パッケージ {0}、バージョン {1} が見つかりませんでした。NuGet の復元により、削除された可能性があります。それ以外の場合、NuGet の復元が最大パス長の制限のために一部分しか完了していない可能性があります。</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceOverrideWarning">
         <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Uma PackageReference para '{0}' foi incluída no projeto. Esse pacote é referenciado implicitamente pelo SKD do .NET e, geralmente, não é necessário referenciá-lo no seu projeto. Para obter mais informações, confira {1}</target>
+        <target state="translated">NETSDK1023: '{0}' の PackageReference がプロジェクトに含められました。このパッケージは .NET SDK によって暗黙的に参照されるため、通常はプロジェクトから参照する必要がありません。詳細については、{1} をご覧ください。</target>
         <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceVersionNotRecommended">
         <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: uma PackageReference para '{0}' especificou uma Versão de '{1}'. Não é recomendado especificar a versão deste pacote. Para obter mais informações, consulte https://aka.ms/sdkimplicitrefs</target>
+        <target state="translated">NETSDK1071: '{0}' への PackageReference は '{1}' のバージョンを指定しました。このパッケージのバージョンを指定することは推奨されません。詳細については、https://aka.ms/sdkimplicitrefs を参照してください</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
@@ -657,87 +652,87 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Os ativos são consumidos de um projeto '{0}', mas não foi encontrado nenhum caminho de projeto do MSBuild correspondente em '{1}'.</target>
+        <target state="translated">NETSDK1011: プロジェクト '{0}' の資産が使用されますが、対応する MSBuild プロジェクト パスが '{1}' で見つかりませんでした。</target>
         <note>{StrBegin="NETSDK1011: "}</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
         <source>NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: a ferramenta '{0}' agora está incluída no SDK do .NET. Informações sobre como resolver este aviso estão disponíveis em (https://aka.ms/dotnetclitools-in-box).</target>
+        <target state="translated">NETSDK1059: ツール '{0}' は .NET SDK に含まれるようになりました。この警告の解決に関する情報は、(https://aka.ms/dotnetclitools-in-box) で入手できます。</target>
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
         <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: as ferramentas do projeto (DotnetCliTool) dão suporte somente para o direcionamento ao .NET Core 2.2 e inferior.</target>
+        <target state="translated">NETSDK1093: プロジェクト ツール (DotnetCliTool) は、ターゲットが .NET Core 2.2 以下の場合のみサポートされます。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1122: a compilação de ReadyToRun será ignorada porque ela é compatível apenas com o .NET Core 3.0 ou superior.</target>
+        <target state="translated">NETSDK1122: ReadyToRun コンパイルは、.NET Core 3.0 以降でのみサポートされているため、スキップされます。</target>
         <note>{StrBegin="NETSDK1122: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1123: a publicação de um aplicativo em um único arquivo exige o .NET Core 3.0 ou superior.</target>
+        <target state="translated">NETSDK1123: アプリケーションを 1 つのファイルに発行するには、.NET Core 3.0 以降が必要です。</target>
         <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="PublishTrimmedRequiresVersion30">
         <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1124: o corte de assemblies exige o .NET Core 3.0 ou superior.</target>
+        <target state="translated">NETSDK1124: アセンブリをトリミングするには、.NET Core 3.0 以降が必要です。</target>
         <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="PublishUnsupportedWithoutTargetFramework">
         <source>NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</source>
-        <target state="translated">NETSDK1129: não há suporte para o destino 'Publish' sem especificar uma estrutura de destino. O projeto atual se destina a várias estruturas. Você precisa especificar a estrutura do aplicativo publicado.</target>
+        <target state="translated">NETSDK1129: ターゲット フレームワークを指定しないと、'Publish' ターゲットはサポートされません。現在のプロジェクトは複数のフレームワークを対象としています。発行するアプリケーションのフレームワークを指定する必要があります。</target>
         <note>{StrBegin="NETSDK1129: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>
-        <target state="translated">NETSDK1096: falha ao otimizar assemblies para desempenho. Você pode impedir que os assemblies com falha sejam otimizados ou definir a propriedade PublishReadyToRun como false.</target>
+        <target state="translated">NETSDK1096: アセンブリのパフォーマンスの最適化が失敗しました。失敗したアセンブリを最適化の対象から除外するか、PublishReadyToRun プロパティを false に設定してください。</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
         <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
-        <target state="translated">Algumas compilações do ReadyToRun emitiram avisos, indicando possíveis dependências ausentes. Dependências ausentes podem causar falhas em tempo de execução. Para mostrar os avisos, defina a propriedade PublishReadyToRunShowWarnings como true.</target>
+        <target state="translated">一部の ReadyToRun コンパイルで警告が発生しました。これは、依存関係が見つからないことを示している可能性があります。依存関係が見つからないと、ランタイム エラーが発生する場合があります。警告を表示するには、PublishReadyToRunShowWarnings プロパティを true に設定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
-        <target state="translated">NETSDK1094: não é possível otimizar assemblies para desempenho: não foi encontrado um pacote válido do tempo de execução. Defina a propriedade PublishReadyToRun como false ou use um identificador de tempo de execução compatível durante a publicação.</target>
+        <target state="translated">NETSDK1094: アセンブリのパフォーマンスを最適化できません。有効なランタイム パッケージが見つかりませんでした。PublishReadyToRun プロパティを false に設定するか、公開するときに、サポートされているランタイム識別子を使用してください。</target>
         <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunTargetNotSupportedError">
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
-        <target state="translated">NETSDK1095: não há suporte para otimizar assemblies para desempenho na arquitetura ou plataforma de destino selecionada. Verifique se você está usando um identificador de tempo de execução com suporte ou defina a propriedade PublishReadyToRun como false.</target>
+        <target state="translated">NETSDK1095: アセンブリのパフォーマンスの最適化は、選択されたターゲット プラットフォームまたはアーキテクチャに対してはサポートされていません。サポートされているランタイム識別子を使用していることを確認するか、PublishReadyToRun プロパティを false に設定してください。</target>
         <note>{StrBegin="NETSDK1095: "}</note>
       </trans-unit>
       <trans-unit id="RollForwardRequiresVersion30">
         <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1103: só há suporte para a configuração RollForward no .NET Core 3.0 ou superior.</target>
+        <target state="translated">NETSDK1103: ロールフォワードの設定は、.NET Core 3.0 以降でのみサポートされています。</target>
         <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="translated">NETSDK1083: o RuntimeIdentifier especificado '{0}' não foi reconhecido.</target>
+        <target state="translated">NETSDK1083: 指定された RuntimeIdentifier '{0}' は認識されていません。</target>
         <note>{StrBegin="NETSDK1083: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Especifique um RuntimeIdentifier</target>
+        <target state="translated">NETSDK1028: RuntimeIdentifier の指定</target>
         <note>{StrBegin="NETSDK1028: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeListNotFound">
         <source>NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="translated">NETSDK1109: o arquivo da lista de runtime '{0}' não foi encontrado. Relate esse erro à equipe do .NET aqui: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="translated">NETSDK1109: ランタイム リスト ファイル '{0}' が見つかりませんでした。https://aka.ms/dotnet-sdk-issue で、このエラーを .NET チームに報告してください。</target>
         <note>{StrBegin="NETSDK1109: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotDownloaded">
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
-        <target state="translated">NETSDK1112: o pacote de tempo de execução para {0} não foi baixado. Tente executar uma restauração do NuGet com o RuntimeIdentifier '{1}'.</target>
+        <target state="translated">NETSDK1112: {0} のランタイム パックがダウンロードされませんでした。RuntimeIdentifier '{1}' で NuGet 復元を実行してみてください。</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
-        <target state="needs-review-translation">NETSDK1150: O projeto referenciado '{0}' é um executável não autossuficiente.  Um executável não autossuficiente não pode ser referenciado por um executável autossuficiente.</target>
+        <target state="needs-review-translation">NETSDK1150: 参照先プロジェクト'{0}'は、自己完結型以外の実行可能ファイルです。は、自己完結型以外の実行可能ファイルは自己完結型の実行可能ファイルでは参照できません。</target>
         <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionShouldBeUsedWithRuntime">
@@ -752,27 +747,27 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Os 'AdditionalProbingPaths' foram especificados para os GenerateRuntimeConfigurationFiles, mas estão sendo ignorados porque 'RuntimeConfigDevPath' está vazio.</target>
+        <target state="translated">NETSDK1048: 'AdditionalProbingPaths' が GenerateRuntimeConfigurationFiles に指定されましたが、'RuntimeConfigDevPath' が空であるためスキップされます。</target>
         <note>{StrBegin="NETSDK1048: "}</note>
       </trans-unit>
       <trans-unit id="TargetFrameworkIsEol">
         <source>NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
-        <target state="translated">NETSDK1138: não há mais suporte para a estrutura de destino '{0}' e ela não receberá atualizações de segurança no futuro. Confira {1} para obter mais informações sobre a política de suporte.</target>
+        <target state="translated">NETSDK1138: ターゲット フレームワーク '{0}' はサポートされていません。今後、セキュリティ更新プログラムを受け取ることはありません。サポート ポリシーの詳細については、{1} をご覧ください。</target>
         <note>{StrBegin="NETSDK1138: "}</note>
       </trans-unit>
       <trans-unit id="TargetFrameworkWithSemicolon">
         <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: O valor '{0}' do TargetFramework não é válido. Para vários destinos, use a propriedade 'TargetFrameworks'.</target>
+        <target state="translated">NETSDK1046: TargetFramework 値 '{0}' が無効です。複数をターゲットとするには、代わりに 'TargetFrameworks' プロパティを使用してください。</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
       <trans-unit id="TargetingApphostPackMissingCannotRestore">
         <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
-        <target state="translated">NETSDK1145: o pacote do {0} não está instalado e não há suporte para a restauração do pacote NuGet. Atualize o Visual Studio, remova global.json se ele especificar uma determinada versão do SDK e desinstale o SDK mais recente. Para obter mais opções, visite https://aka.ms/targeting-apphost-pack-missing  Tipo de Pacote: {0}, Diretório de pacotes: {1}, targetframework: {2}, PackageId do Pacote: {3}, Versão do Pacote: {4}</target>
+        <target state="translated">NETSDK1145: {0} パックはインストールされておらず、NuGet パッケージの復元はサポートされていません。Visual Studio をアップグレードして、global.json を削除し (特定の SDK バージョンがそれに指定されている場合)、より新しい SDK をアンインストールします。その他のオプションについては、https://aka.ms/targeting-apphost-pack-missing にアクセスしてください。パックの種類: {0}、パック ディレクトリ: {1}、targetframework: {2}、パックの PackageId: {3}、パック パッケージ バージョン: {4}</target>
         <note>{StrBegin="NETSDK1145: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
-        <target state="translated">NETSDK1127: o pacote de direcionamento do {0} não está instalado. Restaure e tente novamente.</target>
+        <target state="translated">NETSDK1127: ターゲット パック {0} がインストールされていません。復元して、もう一度お試しください。</target>
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -792,107 +787,107 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Não foi possível localizar o caminho resolvido para '{0}'.</target>
+        <target state="translated">NETSDK1016: 解決された '{0}' のパスが見つかりません。</target>
         <note>{StrBegin="NETSDK1016: "}</note>
       </trans-unit>
       <trans-unit id="UnableToUsePackageAssetsCache_Info">
         <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">Não é possível usar o cache de ativos do pacote por causa de um erro de E/S. Isso pode ocorrer quando o mesmo projeto é compilado mais de uma vez em paralelo. O desempenho poderá ser degradado, mas o resultado do build não será afetado.</target>
+        <target state="translated">I/O エラーのため、パッケージ資産のキャッシュを使用できません。これは、同じプロジェクトが同時に複数回ビルドされるときに発生することがあります。パフォーマンスが低下する可能性がありますが、ビルドの結果には影響はありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedFileType">
         <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Tipo de arquivo inesperado para '{0}'. O tipo é '{1}' e '{2}'.</target>
+        <target state="translated">NETSDK1012: '{0}' のファイルの種類が正しくありません。種類は '{1}' と '{2}' の両方です。</target>
         <note>{StrBegin="NETSDK1012: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference">
         <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: o FrameworkReference '{0}' não foi reconhecido</target>
+        <target state="translated">NETSDK1073: FrameworkReference '{0}' は認識されませんでした</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
-        <target state="translated">NETSDK1137: não é mais necessário usar o SDK do Microsoft.NET.Sdk.WindowsDesktop. Considere alterar o atributo SDK do elemento de Projeto raiz para 'Microsoft.NET.Sdk'.</target>
+        <target state="translated">NETSDK1137: Microsoft.NET.Sdk.WindowsDesktop SDK を使用する必要はなくなりました。ルート プロジェクト要素の SDK 属性を 'Microsoft.NET.Sdk' に変更することをご検討ください。</target>
         <note>{StrBegin="NETSDK1137: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Token de pré-processador não reconhecido '{0}' em '{1}'.</target>
+        <target state="translated">NETSDK1009: 認識されないプリプロセッサ トークン '{0}' が '{1}' に存在します。</target>
         <note>{StrBegin="NETSDK1009: "}</note>
       </trans-unit>
       <trans-unit id="UnresolvedTargetingPack">
         <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="translated">NETSDK1081: o pacote de direcionamento de {0} não foi encontrado. Você poderá resolver isso executando uma restauração do NuGet no projeto.</target>
+        <target state="translated">NETSDK1081: {0} の Targeting Pack が見つかりませんでした。プロジェクトで NuGet の復元を実行することにより、この問題を解決できる場合があります。</target>
         <note>{StrBegin="NETSDK1081: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} é uma estrutura sem suporte.</target>
+        <target state="translated">NETSDK1019: {0} は、サポートされていないフレームワークです。</target>
         <note>{StrBegin="NETSDK1019: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: O projeto é direcionado ao runtime '{0}', mas não resolveu nenhum pacote específico do runtime. Esse runtime pode não ser compatível com a estrutura de destino.</target>
+        <target state="translated">NETSDK1056: プロジェクトはランタイム '{0}' をターゲットとしていますが、ランタイム固有のパッケージを解決しませんでした。このランタイムはターゲットのフレームワークでサポートされていない可能性があります。</target>
         <note>{StrBegin="NETSDK1056: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">
         <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: A versão do Microsoft.NET.Sdk usada por este projeto é insuficiente para dar suporte às referências a bibliotecas direcionadas ao .NET Standard 1.5 ou superior. Instale a versão 2.0 ou superior do SDK do .NET Core.</target>
+        <target state="translated">NETSDK1050: このプロジェクトで使用される Microsoft.NET.Sdk のバージョンは、.NET Standard 1.5 以上を対象とするライブラリへの参照をサポートするには不十分です。.NET Core SDK のバージョン 2.0 以上をインストールしてください。</target>
         <note>{StrBegin="NETSDK1050: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetFrameworkVersion">
         <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: O SDK do .NET atual não dá suporte para direcionar a {0} {1}. Direcione a {0} {2} ou inferior, ou use uma versão do SDK do .NET compatível com  {0} {1}.</target>
+        <target state="translated">NETSDK1045: 現在の .NET SDK は、ターゲットとする {0} {1} をサポートしていません。{0} {2} 以下をターゲットとするか、{0} {1} をサポートする .NET SDK のバージョンを使用してください。</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifier">
         <source>NETSDK1139: The target platform identifier {0} was not recognized.</source>
-        <target state="translated">NETSDK1139: o identificador de plataforma de destino {0} não foi reconhecido.</target>
+        <target state="translated">NETSDK1139: ターゲット プラットフォーム識別子 {0} は認識されませんでした。</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
-        <target state="translated">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop é necessário para compilar aplicativos da área de trabalho do Windows. Não há suporte para 'UseWpf' e 'UseWindowsForms' no SDK atual.</target>
+        <target state="translated">NETSDK1107: Windows デスクトップ アプリケーションを作成するには、Microsoft.NET.Sdk.WindowsDesktop が必要です。現在の SDK では、'UseWpf' と 'UseWindowsForms' はサポートされていません。</target>
         <note>{StrBegin="NETSDK1107: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdk_Info">
         <source>You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">Você está usando uma versão prévia do .NET. Confira: https://aka.ms/dotnet-core-preview</target>
+        <target state="translated">プレビュー版の .NET を使用しています。https://aka.ms/dotnet-core-preview をご覧ください</target>
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
-        <target state="translated">NETSDK1131: não há suporte para a produção de um componente de Metadados do Windows gerenciado com o WinMDExp ao direcionar ao {0}.</target>
+        <target state="translated">NETSDK1131: {0} をターゲットにする場合、WinMDExp を使用したマネージド Windows メタデータ コンポーネント生成はサポートされていません。</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
         <source>NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</source>
-        <target state="translated">NETSDK1130: {1} não pode ser referenciada. Não é suportada a referência a um componente de Metadados do Windows diretamente quando direcionado ao .NET 5 ou superior. Para obter mais informações, consulte https://aka.ms/netsdk1130</target>
+        <target state="translated">NETSDK1130: {1} 参照できません。.NET 5 以上のターゲットを設定する場合、Windows Metadata コンポーネントを直接参照することはできません。詳細については、 「https://aka.ms/netsdk1130」をご参照ください。</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WinMDTransitiveReferenceNotSupported">
         <source>NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</source>
-        <target state="translated">NETSDK1149: {0} não pode ser referenciado porque utiliza suporte integrado para WinRT, que não é mais suportado em .NET 5 ou superior.  É necessária uma versão atualizada do componente que suporta o .NET 5. Para mais informações, consulte https://aka.ms/netsdk1149</target>
+        <target state="translated">NETSDK1149: NET 5 以上でサポートされなくなった WinRT に組み込みのサポートが使用されている可能性があり、{0}は参照できません。.NET 5 をサポートしているコンポーネントの更新バージョンが必要です。詳細については、「 https://aka.ms/netsdk1149」をご参照ください。</target>
         <note>{StrBegin="NETSDK1149: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
-        <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop exige 'UseWpf' ou 'UseWindowsForms' para ser definido como 'true'</target>
+        <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop では、'UseWpf' または 'UseWindowsForms' を 'true' に設定する必要があります</target>
         <note>{StrBegin="NETSDK1106: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
         <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1105: só há suporte para aplicativos de área de trabalho do Windows no .NET Core 3.0 ou superior.</target>
+        <target state="translated">NETSDK1105: Windows デスクトップ アプリケーションは、.NET Core 3.0 以降でのみサポートされています。</target>
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: o Windows é necessário para compilar aplicativos da área de trabalho do Windows.</target>
+        <target state="translated">NETSDK1100: Windows デスクトップ アプリケーションを構築するには Windows が必要です。</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">
         <source>NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</source>
-        <target state="translated">NETSDK1136: a plataforma de destino precisa ser definida como Windows (geralmente incluindo '-windows' na propriedade TargetFramework) ao usar o Windows Forms ou o WPF ou referenciando projetos ou pacotes que façam isso.</target>
+        <target state="translated">NETSDK1136: Windows フォームまたは WPF を使用しているとき、またはそのようなプロジェクトまたはパッケージを参照しているときには、ターゲット プラットフォームを Windows に設定する必要があります (通常は TargetFramework プロパティに '-windows' を含めることによる)。</target>
         <note>{StrBegin="NETSDK1136: "}</note>
       </trans-unit>
       <trans-unit id="WindowsSDKVersionConflicts">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -264,6 +264,11 @@
         <target state="translated">'{0}'이(가) 어셈블리가 아니기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: PlatformManifest가 존재하지 않기 때문에 '{0}'에서 로드할 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -264,6 +264,11 @@
         <target state="translated">Nie można określić wyniku, ponieważ element „{0}” nie jest zestawem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: Nie można załadować elementu PlatformManifest z lokalizacji „{0}”, ponieważ ta lokalizacja nie istnieje.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -264,6 +264,11 @@
         <target state="translated">Не удалось определить победителя, так как "{0}" не является сборкой.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: не удалось загрузить манифест PlatformManifest из "{0}", так как его не существует.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -264,6 +264,11 @@
         <target state="translated">'{0}' bütünleştirilmiş kod olmadığından kazanan belirlenemedi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: '{0}' mevcut olmadığından buradan PlatformManifest yüklenemedi.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -264,6 +264,11 @@
         <target state="translated">“{0}”不是程序集，因此无法确定优胜者。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: 无法从“{0}”中加载 PlatformManifest，因为它不存在。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -264,6 +264,11 @@
         <target state="translated">因為 '{0}' 並非組件，所以無法判斷成功者。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
+        <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <note>{StrBegin="NETSDK1181: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
         <target state="translated">NETSDK1042: 無法從 '{0}' 載入 PlatformManifest，因為它並不存在。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -77,6 +77,7 @@
     <Compile Include="..\Common\**\*.cs" LinkBase="Common" />
     <Compile Include="..\..\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\**\*.cs" LinkBase="WorkloadManifestReader" />
     <Compile Include="..\..\Resolvers\Microsoft.DotNet.MSBuildSdkResolver\FXVersion.cs" LinkBase="WorkloadManifestReader"/>
+    <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Cli;
 using Newtonsoft.Json;
 using NuGet.Frameworks;
 
@@ -622,7 +623,7 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     yield return TargetingPackRoot;
                 }
-                var packRootEnvironmentVariable = Environment.GetEnvironmentVariable("DOTNETSDK_WORKLOAD_PACK_ROOTS");
+                var packRootEnvironmentVariable = Environment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_PACK_ROOTS);
                 if (!string.IsNullOrEmpty(packRootEnvironmentVariable))
                 {
                     foreach (var packRoot in packRootEnvironmentVariable.Split(Path.PathSeparator))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -665,7 +665,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private string GetResolvedPackVersion(string packID, string packVersion)
         {
-            if (!packVersion.Equals("**FromWorload**", StringComparison.OrdinalIgnoreCase))
+            if (!packVersion.Equals("**FromWorkload**", StringComparison.OrdinalIgnoreCase))
             {
                 return packVersion;
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -107,7 +107,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 EnableTargetingPackDownload="$(EnableTargetingPackDownload)"
                                 EnableRuntimePackDownload="$(EnableRuntimePackDownload)"
                                 KnownCrossgen2Packs="@(KnownCrossgen2Pack)"
-                                NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)">
+                                NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
+                                NetCoreRoot="$(NetCoreRoot)"
+                                NETCoreSdkVersion="$(NETCoreSdkVersion)">
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackageToDownload" />
       <Output TaskParameter="RuntimeFrameworks" ItemName="RuntimeFramework" />

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.TestFramework;
@@ -219,7 +220,7 @@ namespace Microsoft.NET.Build.Tests
 
             //  Now build the original test project with the packs folder with the runtime packs we just downloaded
             var buildCommand = new BuildCommand(testAsset)
-                .WithEnvironmentVariable("DOTNETSDK_WORKLOAD_PACK_ROOTS", Path.Combine(packageDownloadAsset.TestRoot, packageDownloadProject.Name));
+                .WithEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_PACK_ROOTS, Path.Combine(packageDownloadAsset.TestRoot, packageDownloadProject.Name));
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -269,10 +269,10 @@ namespace Microsoft.NET.Build.Tests
     <KnownFrameworkReference Include='Microsoft.NETCore.App.Test'
                           TargetFramework='net6.0'
                           RuntimeFrameworkName='Microsoft.NETCore.App.Test'
-                          DefaultRuntimeFrameworkVersion='**FromWorload**'
-                          LatestRuntimeFrameworkVersion='**FromWorload**'
+                          DefaultRuntimeFrameworkVersion='**FromWorkload**'
+                          LatestRuntimeFrameworkVersion='**FromWorkload**'
                           TargetingPackName='Microsoft.NETCore.App.Test.Ref'
-                          TargetingPackVersion='**FromWorload**'
+                          TargetingPackVersion='**FromWorkload**'
                           RuntimePackNamePatterns='Microsoft.NETCore.App.Test.RuntimePack'
                           RuntimePackRuntimeIdentifiers='any'
                               />

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -154,7 +154,7 @@ namespace Microsoft.NET.Build.Tests
 				.HaveStdOutContaining("Hello World!");
 		}
 
-        [Fact]
+        [RequiresMSBuildVersionFact("17.0.0.32901")]
         public void It_resolves_runtimepack_from_packs_folder()
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateImplicitNamespaceImports_DotNet.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateImplicitNamespaceImports_DotNet.cs
@@ -72,7 +72,7 @@ global using global::System.Threading.Tasks;
         {
             var tfm = "net6.0";
             var testProject = CreateTestProject(tfm);
-            testProject.AdditionalItems["Import"] = new Dictionary<string, string> { ["Remove"] = "System.IO" };
+            testProject.AddItem("Import", "Remove", "System.IO");
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             var importFileName = $"{testAsset.TestProject.Name}.ImplicitNamespaceImports.cs";
 
@@ -104,7 +104,7 @@ global using global::System.Threading.Tasks;
             var tfm = "net6.0";
             var testProject = CreateTestProject(tfm);
             testProject.AdditionalProperties["DisableImplicitNamespaceImports_DotNet"] = "true";
-            testProject.AdditionalItems["Import"] = new Dictionary<string, string> { ["Include"] = "CustomNamespace" };
+            testProject.AddItem("Import", "Include", "CustomNamespace");
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             var importFileName = $"{testAsset.TestProject.Name}.ImplicitNamespaceImports.cs";
 
@@ -130,7 +130,7 @@ global using global::CustomNamespace;
             var tfm = "net6.0";
             var testProject = CreateTestProject(tfm);
             testProject.AdditionalProperties["DisableImplicitNamespaceImports_DotNet"] = "true";
-            testProject.AdditionalItems["Import"] = new Dictionary<string, string> { ["Include"] = "CustomNamespace;CustomNamespace" };
+            testProject.AddItem("Import", "Include", "CustomNamespace;CustomNamespace");
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             var importFileName = $"{testAsset.TestProject.Name}.ImplicitNamespaceImports.cs";
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateImplicitNamespaceImports_Worker.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateImplicitNamespaceImports_Worker.cs
@@ -90,10 +90,8 @@ global using global::System.Threading.Tasks;
                 TargetFrameworks = tfm,
                 ProjectSdk = "Microsoft.NET.Sdk.Worker"
             };
-            testProject.AdditionalItems["PackageReference"] = new Dictionary<string, string> { 
-                ["Include"] = "Microsoft.Extensions.Hosting", 
-                ["Version"] = "6.0.0-preview.5.21301.5"
-            };
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.Extensions.Hosting", "6.0.0-preview.5.21301.5"));
+
             testProject.SourceFiles["Program.cs"] = @"
 namespace WorkerApp
 {

--- a/src/Tests/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -39,6 +39,8 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
+
+    <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -65,7 +65,7 @@ namespace Microsoft.NET.Publish.Tests
                 "ClassLib");
 
             testProject.AdditionalProperties["PublishReadyToRun"] = "True";
-            testProject.AdditionalItems["PublishReadyToRunExclude"] = new Dictionary<string, string> { ["Include"] = "Classlib.dll" };
+            testProject.AddItem("PublishReadyToRunExclude", "Include", "Classlib.dll");
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -252,7 +252,7 @@ namespace Microsoft.NET.Publish.Tests
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
-            testProject.AdditionalItems["TrimmableAssembly"] = new Dictionary<string, string> { ["Include"] = referenceProjectName };
+            testProject.AddItem("TrimmableAssembly", "Include", referenceProjectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
             var publishCommand = new PublishCommand(testAsset);
@@ -1492,11 +1492,11 @@ namespace Microsoft.NET.Publish.Tests
   </assembly>
 </linker>
 ";
-
-            testProject.AdditionalItems["EmbeddedResource"] = new Dictionary<string, string> {
+            
+            testProject.AddItem("EmbeddedResource", new Dictionary<string, string> {
                 ["Include"] = substitutionsFilename,
                 ["LogicalName"] = substitutionsFilename
-            };
+            });
         }
 
         private void AddRuntimeConfigOption(XDocument project, bool trim)

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 
 using FluentAssertions;
-
+using Microsoft.DotNet.Cli;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using Microsoft.NET.TestFramework;
 
@@ -114,7 +114,7 @@ namespace ManifestReaderTests
             Directory.CreateDirectory(additionalManifestDirectory);
 
             var environmentMock = new EnvironmentMock();
-            environmentMock.Add("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", additionalManifestDirectory);
+            environmentMock.Add(EnvironmentVariableNames.WORKLOAD_MANIFEST_ROOTS, additionalManifestDirectory);
 
             //  Manifest in test hook directory
             Directory.CreateDirectory(Path.Combine(additionalManifestDirectory, sdkVersion, "Android"));
@@ -144,7 +144,7 @@ namespace ManifestReaderTests
             Directory.CreateDirectory(additionalManifestDirectory);
 
             var environmentMock = new EnvironmentMock();
-            environmentMock.Add("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", additionalManifestDirectory);
+            environmentMock.Add(EnvironmentVariableNames.WORKLOAD_MANIFEST_ROOTS, additionalManifestDirectory);
 
             //  Manifest in test hook directory
             Directory.CreateDirectory(Path.Combine(additionalManifestDirectory, sdkVersion, "Android"));
@@ -176,7 +176,7 @@ namespace ManifestReaderTests
             Directory.CreateDirectory(additionalManifestDirectory2);
 
             var environmentMock = new EnvironmentMock();
-            environmentMock.Add("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", additionalManifestDirectory1 + Path.PathSeparator + additionalManifestDirectory2);
+            environmentMock.Add(EnvironmentVariableNames.WORKLOAD_MANIFEST_ROOTS, additionalManifestDirectory1 + Path.PathSeparator + additionalManifestDirectory2);
 
 
             //  Manifests in default directory
@@ -214,7 +214,7 @@ namespace ManifestReaderTests
             var additionalManifestDirectory = Path.Combine(_testDirectory, "AdditionalManifests");
                 
             var environmentMock = new EnvironmentMock();
-            environmentMock.Add("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", additionalManifestDirectory);
+            environmentMock.Add(EnvironmentVariableNames.WORKLOAD_MANIFEST_ROOTS, additionalManifestDirectory);
 
             //  Manifest in default directory
             Directory.CreateDirectory(Path.Combine(_manifestDirectory, "Android"));

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public Dictionary<string, string> AdditionalProperties { get; } = new Dictionary<string, string>();
 
-        public Dictionary<string, Dictionary<string, string>> AdditionalItems { get; } = new Dictionary<string, Dictionary<string, string>>();
+        public List<KeyValuePair<string, Dictionary<string, string>>> AdditionalItems { get; } = new ();
 
         public List<Action<XDocument>> ProjectChanges { get; } = new List<Action<XDocument>>();
 
@@ -389,6 +389,16 @@ namespace {this.Name}
             {
                 File.WriteAllText(Path.Combine(targetFolder, kvp.Key), kvp.Value);
             }
+        }
+
+        public void AddItem(string itemName, string attributeName, string attributeValue)
+        {
+            AddItem(itemName, new Dictionary<string, string>() { { attributeName, attributeValue } } );
+        }
+
+        public void AddItem(string itemName, Dictionary<string, string> attributes)
+        {
+            AdditionalItems.Add(new(itemName, attributes));
         }
 
         public static bool ReferenceAssembliesAreInstalled(TargetDotNetFrameworkVersion targetFrameworkVersion)

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         [Fact]
         public void GivenAdvertisingManifestUpdateItUpdatesWhenDue()
         {
-            Func<string, string> getEnvironmentVariable = (envVar) => envVar.Equals("DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS") ? "0" : string.Empty;
+            Func<string, string> getEnvironmentVariable = (envVar) => envVar.Equals(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS) ? "0" : string.Empty;
             (var manifestUpdater, var nugetDownloader, var testDir) = GetTestUpdater(getEnvironmentVariable: getEnvironmentVariable);
 
             var sentinalPath = Path.Combine(testDir, ".dotnet", _manifestSentinalFileName);
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         [Fact]
         public void GivenAdvertisingManifestUpdateItHonorsDisablingEnvVar()
         {
-            Func<string, string> getEnvironmentVariable = (envVar) => envVar.Equals("DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE") ? "true" :  string.Empty;
+            Func<string, string> getEnvironmentVariable = (envVar) => envVar.Equals(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_DISABLE) ? "true" :  string.Empty;
             (var manifestUpdater, var nugetDownloader, _) = GetTestUpdater(getEnvironmentVariable: getEnvironmentVariable);
 
             manifestUpdater.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync().Wait();

--- a/src/Tests/dotnet.Tests/GivenThatICareAboutVBApps.cs
+++ b/src/Tests/dotnet.Tests/GivenThatICareAboutVBApps.cs
@@ -36,7 +36,7 @@ Module Program
     End Sub
 End Module
 ";
-            testProject.AdditionalItems["Import"] = new Dictionary<string, string> { ["Remove"] = "System" };
+            testProject.AddItem("Import", "Remove", "System");
             var testInstance = _testAssetsManager.CreateTestProject(testProject);
 
             new BuildCommand(testInstance)

--- a/src/Tests/dotnet.Tests/dotnet.Tests.csproj
+++ b/src/Tests/dotnet.Tests/dotnet.Tests.csproj
@@ -52,7 +52,6 @@
     <Compile Include="..\Microsoft.DotNet.CommandFactory.Tests\**\*.cs" LinkBase="CommandFactory" />
     <Compile Include="..\Microsoft.DotNet.Configurer.UnitTests\**\*.cs" LinkBase="Configurer" />
     <Compile Include="..\Microsoft.DotNet.ShellShim.Tests\**\*.cs" LinkBase="ShellShim" />
-    
 
     <None Include="..\Microsoft.DotNet.ShellShim.Tests\WpfBinaryTestAsssets\testwpf.dll" LinkBase="WpfBinaryTestAsssets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Fixes #14044
Fixes #18064

- Resolves runtime packs from packs directory if present
- Supports using DOTNETSDK_WORKLOAD_PACK_ROOTS environment variable to set additional packs folders for targeting and runtime packs
  - The packs should be under a `packs` subfolder of the directory specified by the environment variable
- Supports resolving targeting or runtime pack versions from workload manifest
  - To use this, the version in the `KnownFrameworkReference` or `KnownRuntimePack` item should be set to `**FromWorkload**`