### PR TITLE
Fix PerfmapFormatVersion in the Microsoft.NET.Publish.targets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -296,7 +296,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
                                 EmitSymbols="$(PublishReadyToRunEmitSymbols)"
-                                ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)">
+                                ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
+                                PerfmapFormatVersion="$(PublishReadyToRunPerfmapFormatVersion)">
 
       <Output TaskParameter="CrossgenTool" ItemName="CrossgenTool" />
       <Output TaskParameter="Crossgen2Tool" ItemName="Crossgen2Tool" />

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -10,6 +10,7 @@ using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework.ProjectConstruction;
 using System.Linq;
 using System.Xml.Linq;
+using NuGet.Frameworks;
 using Xunit;
 using Xunit.Abstractions;
 using System;
@@ -445,9 +446,12 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
 
-            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: "net5.0", runtimeIdentifier: RuntimeInformation.RuntimeIdentifier);
+            string targetFramework = "net5.0";
+            NuGetFramework framework = NuGetFramework.Parse(targetFramework);
+
+            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework, runtimeIdentifier: RuntimeInformation.RuntimeIdentifier);
             var mainProjectDll = Path.Combine(intermediateDirectory.FullName, $"{TestProjectName}.dll");
-            var niPdbFile = GivenThatWeWantToPublishReadyToRun.GetPDBFileName(mainProjectDll);
+            var niPdbFile = GivenThatWeWantToPublishReadyToRun.GetPDBFileName(mainProjectDll, framework);
 
             string[] expectedFiles = { SingleFile, PdbFile, niPdbFile };
             GetPublishDirectory(publishCommand)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -360,14 +360,7 @@ public class Program
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                using (FileStream fs = new FileStream(assemblyFile, FileMode.Open, FileAccess.Read))
-                {
-                    PEReader pereader = new PEReader(fs);
-                    MetadataReader mdReader = pereader.GetMetadataReader();
-                    Guid mvid = mdReader.GetGuid(mdReader.GetModuleDefinition().Mvid);
-
-                    return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.{" + mvid + "}.map"));
-                }
+                return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.r2rmap"));
             }
 
             return null;

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -11,6 +11,7 @@ using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.Frameworks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -82,9 +83,11 @@ namespace Microsoft.NET.Publish.Tests
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
+                NuGetFramework framework = NuGetFramework.Parse(targetFramework);
+
                 publishDirectory.Should().NotHaveFiles(new[] {
-                    GetPDBFileName(mainProjectDll),
-                    GetPDBFileName(classLibDll),
+                    GetPDBFileName(mainProjectDll, framework),
+                    GetPDBFileName(classLibDll, framework),
                 });
             }
 
@@ -306,9 +309,11 @@ namespace Microsoft.NET.Publish.Tests
 
             if (emitNativeSymbols && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
+                NuGetFramework framework = NuGetFramework.Parse(targetFramework);
+
                 publishDirectory.Should().HaveFiles(new[] {
-                    GetPDBFileName(mainProjectDll),
-                    GetPDBFileName(classLibDll),
+                    GetPDBFileName(mainProjectDll, framework),
+                    GetPDBFileName(classLibDll, framework),
                 });
             }
         }
@@ -351,7 +356,7 @@ public class Program
             return testProject;
         }
 
-        public static string GetPDBFileName(string assemblyFile)
+        public static string GetPDBFileName(string assemblyFile, NuGetFramework framework)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -360,7 +365,20 @@ public class Program
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.r2rmap"));
+                if (framework.Version.Major >= 6)
+                {
+                    return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.r2rmap"));
+                }
+
+                // Legacy perfmap file naming prior to .NET 6
+                using (FileStream fs = new FileStream(assemblyFile, FileMode.Open, FileAccess.Read))
+                {
+                    PEReader pereader = new PEReader(fs);
+                    MetadataReader mdReader = pereader.GetMetadataReader();
+                    Guid mvid = mdReader.GetGuid(mdReader.GetModuleDefinition().Mvid);
+
+                    return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.{" + mvid + "}.map"));
+                }
             }
 
             return null;


### PR DESCRIPTION
The two msbuild scripts Microsoft.NET.Crossgen.targets and
Microsoft.NET.Publish.targets both include the target
ResolveReadyToRunCompilers but in my previous fix I only added
the new PerfmapFormatVersion property to the version in
Microsoft.NET.Crossgen.targets; this fix puts both versions of
the target in sync.

Thanks

Tomas