### PR TITLE
Update Microsoft.NET.EolTargetFrameworks.targets to add 2.1

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
@@ -20,7 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     receive servicing updates and security fixes.
   -->
   <ItemGroup>
-    <_EolNetCoreTargetFrameworkVersions Include="1.0;1.1;2.0;2.2;3.0" />
+    <_EolNetCoreTargetFrameworkVersions Include="1.0;1.1;2.0;2.1;2.2;3.0" />
   </ItemGroup>
 
   <Target Name="_CheckForEolTargetFrameworks" AfterTargets="_CheckForUnsupportedNETCoreVersion"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetEolFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetEolFrameworks.cs
@@ -22,6 +22,7 @@ namespace Microsoft.NET.Build.Tests
         [Theory]
         [InlineData("netcoreapp1.0")]
         [InlineData("netcoreapp3.0")]
+        [InlineData("netcoreapp2.1")]
         public void It_warns_that_framework_is_out_of_support(string targetFrameworks)
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
+++ b/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
@@ -47,7 +47,7 @@ namespace Microsoft.NET.Clean.Tests
             var cleanCommand = new CleanCommand(Log, testAsset.TestRoot);
 
             cleanCommand
-                .Execute()
+                .Execute("/p:CheckEolTargetFramework=false")
                 .Should()
                 .Pass()
                 .And


### PR DESCRIPTION
## Description
The 2.1 runtime is going out of support later this month. Adding it to the list of OOS runtimes so customers get a build warning.

C:\Program Files\dotnet\sdk\6.0.100-preview.7.21377.35\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'netcoreapp2.1' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [C:\test\bug\bug.csproj]

## Regression?
No

## Risk
Low.

## Verification
[X] Manual (required)
[x] Automated