### PR TITLE
Remove WinExe OutputType inference

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -242,9 +242,4 @@ Copyright (c) .NET Foundation. All rights reserved.
     <OutputPath>$(OutputPath)$(TargetFramework.ToLowerInvariant())\</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <DisableWinExeOutputInference Condition="'$(DisableWinExeOutputInference)' == '' and ('$(TargetFrameworkIdentifier)' != '.NETCoreApp' or $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '5.0')))">true</DisableWinExeOutputInference>
-    <OutputType Condition="'$(DisableWinExeOutputInference)' != 'true' and '$(OutputType)' == 'Exe' and ('$(UseWindowsForms)' == 'true' or '$(UseWPF)' == 'true')">WinExe</OutputType>
-  </PropertyGroup>
-
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -97,37 +97,6 @@ namespace Microsoft.NET.Build.Tests
                 .HaveStdOutContaining(Strings.WindowsDesktopFrameworkRequiresWindows);
         }
 
-        [WindowsOnlyTheory]
-        [InlineData("net5.0", "TargetPlatformIdentifier", "Windows", "Exe")]
-        [InlineData("net5.0", "UseWindowsForms", "true", "WinExe")]
-        [InlineData("netcoreapp3.1", "UseWindowsForms", "true", "Exe")]
-        [InlineData("net5.0", "UseWPF", "true", "WinExe")]
-        [InlineData("netcoreapp3.1", "UseWPF", "true", "Exe")]
-        [InlineData("net5.0", "UseWPF", "false", "Exe")]
-        [InlineData("netcoreapp3.1", "UseWPF", "false", "Exe")]
-        public void It_infers_WinExe_output_type(string targetFramework, string propName, string propValue, string expectedOutputType)
-        {
-            var testProject = new TestProject()
-            {
-                Name = "WinExeOutput",
-                TargetFrameworks = targetFramework,
-                IsExe = true,
-            };
-            testProject.AdditionalProperties[propName] = propValue;
-
-            var asset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework +  propName +  propValue);
-
-            var getValuesCommand = new GetValuesCommand(asset, "OutputType");
-            getValuesCommand
-                .Execute()
-                .Should()
-                .Pass();
-
-            var values = getValuesCommand.GetValues();
-            values.Count.Should().Be(1);
-            values.First().Should().Be(expectedOutputType);
-        }
-
         [WindowsOnlyRequiresMSBuildVersionFact("16.8.0")]
         public void It_builds_on_windows_with_the_windows_desktop_sdk_5_0_with_ProjectSdk_set()
         {


### PR DESCRIPTION
In .NET 5, we [automatically converted](https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/5.0/automatically-infer-winexe-output-type) an `OutputType` of `Exe` to `WinExe` for WPF and Windows forms apps.  This was intended to simplify .NET MAUI apps (so that the OutputType wouldn't need to be conditioned on the TargetFramework).

However:

- This broke user expectations and frustrated some folks.  See #16563 and other linked issues
- .NET MAUI apps are going to by default use WinUI, not Windows Forms or WPF, so this logic won't even apply to them

So this PR reverts the previous automatic `OutputType` conversion.

@mattleibow @jonathanpeppers @Redth The .NET MAUI targets for Windows should probably do something similar to the logic being removed here, ie change the `OutputType` from `Exe` to `WinExe` when targeting Windows.