### PR TITLE
Require individual languages opt-in to Hot Reload

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
@@ -33,4 +33,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);$(VersionlessImplicitFrameworkDefine);$(ImplicitFrameworkDefine);$(BackwardsCompatFrameworkDefine)</DefineConstants>
   </PropertyGroup>
+
+  <!-- Enable hot reload in 6.0 and newer C# projects -->
+  <ItemGroup Condition="'$(SupportsHotReload)' != 'false' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">
+    <ProjectCapability Include="SupportsHotReload" />
+  </ItemGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -93,6 +93,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <FinalDefineConstants Condition="'$(MyType)' == ''">$(FinalDefineConstants),_MyType=&quot;Empty&quot;</FinalDefineConstants>
   </PropertyGroup>
 
+  <!-- Enable hot reload in 6.0 and newer VB projects -->
+  <ItemGroup Condition="'$(SupportsHotReload)' != 'false' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">
+    <ProjectCapability Include="SupportsHotReload" />
+  </ItemGroup>
+
   <!--
     NOTE: We must hook directly to CoreCompile for compatibility with two phase XAML
           build. We also must not pull in a dependency on ResolveAssemblyReferences

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1066,14 +1066,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Don't generate a NETSDK1151 error if a non self-contained Exe references a Blazor wasm Exe -->
     <ShouldBeValidatedAsExecutableReference>false</ShouldBeValidatedAsExecutableReference>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' And '$(ValidateExecutableReferencesMatchSelfContained)' == ''">
     <!-- Don't generate an error if a test project references a self-contained Exe.  Test projects
          use an OutputType of Exe but will usually call APIs in a referenced Exe rather than try
          to run it. -->
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <!-- Don't generate an error if an Exe project references a test project. -->
     <ShouldBeValidatedAsExecutableReference>false</ShouldBeValidatedAsExecutableReference>
@@ -1102,13 +1102,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="ValidateCommandLineProperties"
           AfterTargets="_CheckForInvalidConfigurationAndPlatform" >
-    
+
     <NETSdkWarning Condition="'$(_CommandLineDefinedSelfContained)' != 'true' and
                    '$(_CommandLineDefinedRuntimeIdentifier)' == 'true' and
                    '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))"
                ResourceName="SelfContainedOptionShouldBeUsedWithRuntime" />
-  
+
   </Target>
 
   <!--
@@ -1124,11 +1124,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Reference Manager capabilities -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ProjectCapability Remove="ReferenceManagerAssemblies" />
-  </ItemGroup>
-
-  <!-- Enable hot reload in 6.0 and newer apps by default -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">
-    <ProjectCapability Include="SupportsHotReload" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />


### PR DESCRIPTION
* Move capability to C# and VB project imports
* Add a feature switch to opt out of hot reload capability

Fixes https://github.com/dotnet/sdk/issues/19608