### PR TITLE
Make PackageValidation uses the right roslyn when the Microsoft.Net.Compilers.Toolset is used 

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
@@ -8,6 +8,8 @@
 
     <PropertyGroup Condition="'$(RoslynAssembliesPath)' == ''">
       <RoslynAssembliesPath>$(RoslynTargetsPath)</RoslynAssembliesPath>
+      <RoslynAssembliesPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$([System.IO.Path]::GetDirectoryName($(CSharpCoreTargetsPath)))</RoslynAssembliesPath>
+      <RoslynAssembliesPath Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$([System.IO.Path]::GetDirectoryName($(VisualBasicCoreTargetsPath)))</RoslynAssembliesPath>
       <RoslynAssembliesPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$([System.IO.Path]::Combine('$(RoslynAssembliesPath)', bincore))</RoslynAssembliesPath>
     </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/19615
depends on https://github.com/dotnet/roslyn/pull/55552