### PR TITLE
Turn off publishing for Debug configurations on PR

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -84,6 +84,7 @@ stages:
           matrix:
             Build_Debug:
               _BuildConfig: Debug
+              _PublishArgs: ''
               _SignType: test
               _Test: -test
             Build_Release:


### PR DESCRIPTION
Turning off publishing for Debug configurations on PR builds to avoid publishing multiple artifacts to the same blob