### PR TITLE
Evaluate the FileSetFactory after performing build

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.Tools.Internal;
@@ -11,21 +10,22 @@ namespace Microsoft.DotNet.Watcher.Tools
     public class DotNetBuildFilter : IWatchFilter
     {
         private readonly string _muxer = DotnetMuxer.MuxerPath;
+        private readonly IFileSetFactory _fileSetFactory;
         private readonly ProcessRunner _processRunner;
         private readonly IReporter _reporter;
 
-        public DotNetBuildFilter(ProcessRunner processRunner, IReporter reporter)
+        public DotNetBuildFilter(IFileSetFactory fileSetFactory, ProcessRunner processRunner, IReporter reporter)
         {
+            _fileSetFactory = fileSetFactory;
             _processRunner = processRunner;
             _reporter = reporter;
         }
 
         public async ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
-            using var fileSetWatcher = new FileSetWatcher(context.FileSet, _reporter);
             while (!cancellationToken.IsCancellationRequested)
             {
-                var arguments = context.RequiresMSBuildRevaluation ?
+                var arguments = context.Iteration == 0 || (context.ChangedFile?.FilePath is string changedFile && changedFile.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)) ?
                    new[] { "msbuild", "/t:Build", "/restore", "/nologo" } :
                    new[] { "msbuild", "/t:Build", "/nologo" };
 
@@ -38,12 +38,14 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                 _reporter.Output("Building...");
                 var exitCode = await _processRunner.RunAsync(processSpec, cancellationToken);
+                context.FileSet = await _fileSetFactory.CreateAsync(cancellationToken);
                 if (exitCode == 0)
                 {
                     return;
                 }
 
                 // If the build fails, we'll retry until we have a successful build.
+                using var fileSetWatcher = new FileSetWatcher(context.FileSet, _reporter);
                 await fileSetWatcher.GetChangedFileAsync(cancellationToken, () => _reporter.Warn("Waiting for a file to change before restarting dotnet..."));
             }
         }


### PR DESCRIPTION
Under hot reload, watch performs dotnet-build. However the RunCommand is evaluated
prior to this which means any imports from restore are ignored.

This change removes the dependency on MSBuildEvaluationFilter and instead performs the evaluation as part of the DotnetBuildFilter
after the build has completed.

Fixes https://github.com/dotnet/aspnetcore/issues/34500