### PR TITLE
Use GenerateComputedBuildStaticWebAssets to regenerate scoped css

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         public HotReload(ProcessRunner processRunner, IReporter reporter)
         {
             _staticFileHandler = new StaticFileHandler(reporter);
-            _scopedCssFileHandler = new ScopedCssFileHandler(processRunner, reporter);
+            _scopedCssFileHandler = new ScopedCssFileHandler(reporter);
             _compilationHandler = new CompilationHandler(reporter);
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.IO;
-using System.Threading;
+#nullable enable
+
 using System.Threading.Tasks;
+using Microsoft.Build.Graph;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.Tools.Internal;
 
@@ -12,13 +12,10 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     internal sealed class ScopedCssFileHandler
     {
-        private static readonly string _muxerPath = DotnetMuxer.MuxerPath;
-        private readonly ProcessRunner _processRunner;
         private readonly IReporter _reporter;
 
-        public ScopedCssFileHandler(ProcessRunner processRunner, IReporter reporter)
+        public ScopedCssFileHandler(IReporter reporter)
         {
-            _processRunner = processRunner;
             _reporter = reporter;
         }
 
@@ -33,7 +30,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             }
 
             _reporter.Verbose($"Handling file change event for scoped css file {file.FilePath}.");
-            if (!await RebuildScopedCss(file.ProjectPath, cancellationToken))
+            if (!RebuildScopedCss(context.ProjectGraph!, file.ProjectPath))
             {
                 HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.ScopedCssHandler);
                 return false;
@@ -44,20 +41,26 @@ namespace Microsoft.DotNet.Watcher.Tools
             return true;
         }
 
-        private async ValueTask<bool> RebuildScopedCss(string projectPath, CancellationToken cancellationToken)
+        private bool RebuildScopedCss(ProjectGraph projectGraph, string projectPath)
         {
-            var build = new ProcessSpec
+            var project = projectGraph.ProjectNodesTopologicallySorted.FirstOrDefault(f => string.Equals(f.ProjectInstance.FullPath, projectPath, StringComparison.OrdinalIgnoreCase));
+            if (project is null)
             {
-                Executable = _muxerPath,
-                Arguments = new[] { "msbuild", "/nologo", "/t:_PrepareForScopedCss", projectPath, }
-            };
+                return false;
+            }
 
-            var result = await _processRunner.RunAsync(build, cancellationToken);
-            return result == 0;
+            var projectInstance = project.ProjectInstance.DeepCopy();
+            var logger = _reporter.IsVerbose ? new[] { new Build.Logging.ConsoleLogger() } : null;
+            return projectInstance.Build("GenerateComputedBuildStaticWebAssets", logger);
         }
 
-        private static async Task HandleBrowserRefresh(BrowserRefreshServer browserRefreshServer, FileItem fileItem, CancellationToken cancellationToken)
+        private static async Task HandleBrowserRefresh(BrowserRefreshServer? browserRefreshServer, FileItem fileItem, CancellationToken cancellationToken)
         {
+            if (browserRefreshServer is null)
+            {
+                return;
+            }
+
             // We'd like an accurate scoped css path, but this needs a lot of work to wire-up now.
             // We'll handle this as part of https://github.com/dotnet/aspnetcore/issues/31217.
             // For now, we'll make it look like some css file which would cause JS to update a

--- a/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Tools.Internal
     /// </summary>
     public interface IReporter
     {
+        public bool IsVerbose => false;
         void Verbose(string message);
         void Output(string message);
         void Warn(string message);


### PR DESCRIPTION
* React to changes to the Razor SDK to use the new target
* Updates the ScopedCssFileHandler to use the in-memory project evaluation rather than shelling out to disk
* Nullability fixes


Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/824