### PR TITLE
Add CodeSignAppHost Task

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/CodeSignAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CodeSignAppHost.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Sign the app binary using codesign with an anonymous certificate.
+    /// </summary>
+    public class CodeSignAppHost : TaskBase
+    {
+        private const string CodeSignPath = @"/usr/bin/codesign";
+
+        [Required]
+        public string AppHostPath { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
+            if (!File.Exists(AppHostPath))
+            {
+                return;
+            }
+
+            var psi = new ProcessStartInfo()
+            {
+                Arguments = $"-s - \"{AppHostPath}\"",
+                FileName = CodeSignPath,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using (var p = Process.Start(psi))
+            {
+                p.WaitForExit();
+                if (p.ExitCode != 0)
+                {
+                    throw new BuildErrorException(Strings.AppHostSigningFailed, p.StandardError.ReadToEnd(), p.ExitCode.ToString());
+                }
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
@@ -47,8 +47,6 @@ namespace Microsoft.NET.Build.Tasks
 
         public int RetryDelayMilliseconds { get; set; } = DefaultRetryDelayMilliseconds;
 
-        public bool EnableMacOSCodeSign { get; set; } = false;
-
         protected override void ExecuteCore()
         {
             try
@@ -77,8 +75,7 @@ namespace Microsoft.NET.Build.Tasks
                                                 appHostDestinationFilePath: AppHostDestinationPath,
                                                 appBinaryFilePath: AppBinaryName,
                                                 windowsGraphicalUserInterface: isGUI,
-                                                assemblyToCopyResorcesFrom: resourcesAssembly,
-                                                enableMacOSCodeSign: EnableMacOSCodeSign);
+                                                assemblyToCopyResorcesFrom: resourcesAssembly);
                         return;
                     }
                     catch (Exception ex) when (ex is IOException ||
@@ -113,10 +110,6 @@ namespace Microsoft.NET.Build.Tasks
             catch (AppNameTooLongException ex)
             {
                 throw new BuildErrorException(Strings.FileNameIsTooLong, ex.LongName);
-            }
-            catch (AppHostSigningException ex)
-            {
-                throw new BuildErrorException(Strings.AppHostSigningFailed, ex.Message, ex.ExitCode.ToString());
             }
             catch (PlaceHolderNotFoundInAppHostException ex)
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -915,6 +915,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <UsingTask TaskName="CodeSignAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="_CodeSignSingleFileHost"
+          AfterTargets="GenerateSingleFileBundle"
+          Condition="$([MSBuild]::IsOSPlatform(`OSX`)) and Exists('/usr/bin/codesign') and $(RuntimeIdentifier.StartsWith('osx'))">
+    <CodeSignAppHost AppHostPath="$(PublishedSingleFileName)" />
+  </Target>
+
   <!--
     ============================================================
     _GeneratePublishDependencyFile

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -543,8 +543,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                      Exists('$(AppHostSourcePath)')">
     <PropertyGroup>
       <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
-      <_EnableMacOSCodeSign Condition="'$(_EnableMacOSCodeSign)' == '' and $([MSBuild]::IsOSPlatform(`OSX`)) and Exists('/usr/bin/codesign') and
-                                      ($(RuntimeIdentifier.StartsWith('osx')) or $(AppHostRuntimeIdentifier.StartsWith('osx')))">true</_EnableMacOSCodeSign>
     </PropertyGroup>
 
     <CreateAppHost AppHostSourcePath="$(AppHostSourcePath)"
@@ -554,8 +552,15 @@ Copyright (c) .NET Foundation. All rights reserved.
                    WindowsGraphicalUserInterface="$(_UseWindowsGraphicalUserInterface)"
                    Retries="$(CopyRetryCount)"
                    RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-                   EnableMacOSCodeSign="$(_EnableMacOSCodeSign)"
                    />
+  </Target>
+
+  <UsingTask TaskName="CodeSignAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="_CodeSignAppHost"
+          AfterTargets="_CreateAppHost"
+          Condition="$([MSBuild]::IsOSPlatform(`OSX`)) and Exists('/usr/bin/codesign') and
+                    ($(RuntimeIdentifier.StartsWith('osx')) or $(AppHostRuntimeIdentifier.StartsWith('osx')))">
+    <CodeSignAppHost AppHostPath="$(AppHostIntermediatePath)" />
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -558,7 +558,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="CodeSignAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_CodeSignAppHost"
           AfterTargets="_CreateAppHost"
-          Condition="$([MSBuild]::IsOSPlatform(`OSX`)) and Exists('/usr/bin/codesign') and
+          Condition="$([MSBuild]::IsOSPlatform(`OSX`)) and Exists('/usr/bin/codesign') and '$(PublishSingleFile)' != 'true' and
                     ($(RuntimeIdentifier.StartsWith('osx')) or $(AppHostRuntimeIdentifier.StartsWith('osx')))">
     <CodeSignAppHost AppHostPath="$(AppHostIntermediatePath)" />
   </Target>


### PR DESCRIPTION
Add a task with the codesigning logic that currently lives on the `HostModel`. For single-file publish, we make sure that we sign the binary only after we've completed generating the bundle and not on apphost creation; otherwise, we'd end up having a malformed binary, since codesigning affects the binary format.