### PR TITLE
Set the EnableDynamicLoading property before importing Microsoft.PackageDependencyResolution.targets

### DIFF
--- a/src/Assets/TestProjects/ComServerWithDependencies/ComServer.cs
+++ b/src/Assets/TestProjects/ComServerWithDependencies/ComServer.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace COMServer
+{
+    [ComVisible(true)]
+    [Guid("17B6329E-B025-4FC7-A854-97D34600C5A6")]
+    public class Class1
+    {
+        public bool IsValidJson(string json)
+        {
+            try
+            {
+                JObject.Parse(json);
+                return true;
+            }
+            catch (JsonReaderException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Assets/TestProjects/ComServerWithDependencies/ComServerWithDependencies.csproj
+++ b/src/Assets/TestProjects/ComServerWithDependencies/ComServerWithDependencies.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>42.43.44.45-alpha</Version>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <EnableComHosting>true</EnableComHosting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -11,6 +11,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="Microsoft.NET.Sdk.Common.targets" />
 
+  <PropertyGroup>
+    <EnableDynamicLoading Condition="'$(EnableDynamicLoading)' == '' and '$(EnableComHosting)' == 'true'">true</EnableDynamicLoading>
+  </PropertyGroup>
+  
   <ImportGroup>
     <Import Project="$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolution.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolution.targets') and ('$(Language)' != 'C++' or '$(_EnablePackageReferencesInVCProjects)' == 'true')" />
     <Import Project="$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolutionStubs.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolutionStubs.targets') and ('$(Language)' == 'C++' and '$(_EnablePackageReferencesInVCProjects)' != 'true')" />
@@ -30,7 +34,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <EnableDynamicLoading Condition="'$(EnableDynamicLoading)' == '' and '$(EnableComHosting)' == 'true'">true</EnableDynamicLoading>
     <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and ('$(HasRuntimeOutput)' == 'true' or '$(EnableComHosting)' == 'true' or '$(EnableDynamicLoading)' == 'true') ">true</GenerateRuntimeConfigurationFiles>
     <AlwaysIncludeCoreFrameworkInRuntimeConfig Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0'))">false</AlwaysIncludeCoreFrameworkInRuntimeConfig>
     <AlwaysIncludeCoreFrameworkInRuntimeConfig Condition="'$(AlwaysIncludeCoreFrameworkInRuntimeConfig)' == ''">true</AlwaysIncludeCoreFrameworkInRuntimeConfig>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
@@ -333,13 +333,13 @@ namespace Microsoft.NET.Build.Tests
             var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp3.1");
 
             outputDirectory.Should().OnlyHaveFiles(new[] {
-                "ComServer.dll",
-                "ComServer.pdb",
-                "ComServer.deps.json",
-                "ComServer.comhost.dll",
-                "ComServer.runtimeconfig.json",
-                "ComServer.runtimeconfig.dev.json",
-                "Newstonsoft.Json.dll"
+                "ComServerWithDependencies.dll",
+                "ComServerWithDependencies.pdb",
+                "ComServerWithDependencies.deps.json",
+                "ComServerWithDependencies.comhost.dll",
+                "ComServerWithDependencies.runtimeconfig.json",
+                "ComServerWithDependencies.runtimeconfig.dev.json",
+                "Newtonsoft.Json.dll"
             });
         }
     }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
@@ -316,5 +316,31 @@ namespace Microsoft.NET.Build.Tests
                 .And
                 .HaveStdOutContaining("NETSDK1173: ");
         }
+
+        [WindowsOnlyFact]
+        public void It_copies_nuget_package_dependencies()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("ComServerWithDependencies")
+                .WithSource();
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp3.1");
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "ComServer.dll",
+                "ComServer.pdb",
+                "ComServer.deps.json",
+                "ComServer.comhost.dll",
+                "ComServer.runtimeconfig.json",
+                "ComServer.runtimeconfig.dev.json",
+                "Newstonsoft.Json.dll"
+            });
+        }
     }
 }


### PR DESCRIPTION
The condition for `CopyLocalLockFileAssemblies` in Microsoft.Package.DependencyResolution.targets depends on the `EnableDynamicLoading` property and should be true in the `EnableComHosting` case.

This issue was discovered when working on https://github.com/dotnet/winforms/pull/4685

cc: @ericstj @RussKie