### PR TITLE
Update ValidateExecutableReferences with new schema

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 
@@ -19,6 +17,8 @@ namespace Microsoft.NET.Build.Tasks
         public bool IsExecutable { get; set; }
 
         public ITaskItem[] ReferencedProjects { get; set; } = Array.Empty<ITaskItem>();
+
+        public string MSBuildVersion { get; set; }
 
         protected override void ExecuteCore()
         {
@@ -40,7 +40,10 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 var additionalPropertiesXml = XElement.Parse(project.GetMetadata("AdditionalPropertiesFromProject"));
-                XElement targetFrameworkElement = additionalPropertiesXml.Elements().Where(el => el.HasAttributes && el.FirstAttribute.Value.Equals(nearestTargetFramework)).Single();
+                bool msbuild17OrLater = Version.TryParse(MSBuildVersion, out Version v) && v >= Version.Parse("17.0");
+                XElement targetFrameworkElement = msbuild17OrLater ?
+                    additionalPropertiesXml.Elements().Where(el => el.HasAttributes && el.FirstAttribute.Value.Equals(nearestTargetFramework)).Single() :
+                    additionalPropertiesXml.Element(nearestTargetFramework);
                 Dictionary<string, string> projectAdditionalProperties = new(StringComparer.OrdinalIgnoreCase);
                 foreach (XElement propertyElement in targetFrameworkElement.Elements())
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NET.Build.Tasks
                 return;
             }
 
-            foreach (var project in ReferencedProjects)
+            foreach (ITaskItem project in ReferencedProjects)
             {
                 string nearestTargetFramework = project.GetMetadata("NearestTargetFramework");
 
@@ -40,16 +40,22 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 var additionalPropertiesXml = XElement.Parse(project.GetMetadata("AdditionalPropertiesFromProject"));
-                var targetFrameworkElement = additionalPropertiesXml.Element(nearestTargetFramework);
+                XElement targetFrameworkElement = additionalPropertiesXml.Element("TargetFramework");
+                if (!targetFrameworkElement.HasAttributes || !targetFrameworkElement.FirstAttribute.Value.Equals(nearestTargetFramework))
+                {
+                    // The TargetFramework did not match.
+                    continue;
+                }
+
                 Dictionary<string, string> projectAdditionalProperties = new(StringComparer.OrdinalIgnoreCase);
-                foreach (var propertyElement in targetFrameworkElement.Elements())
+                foreach (XElement propertyElement in targetFrameworkElement.Elements())
                 {
                     projectAdditionalProperties[propertyElement.Name.LocalName] = propertyElement.Value;
                 }
 
-                var shouldBeValidatedAsExecutableReference = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["ShouldBeValidatedAsExecutableReference"], true);
-                var referencedProjectIsExecutable = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["_IsExecutable"]);
-                var referencedProjectIsSelfContained = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["SelfContained"]);
+                bool shouldBeValidatedAsExecutableReference = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["ShouldBeValidatedAsExecutableReference"], true);
+                bool referencedProjectIsExecutable = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["_IsExecutable"]);
+                bool referencedProjectIsSelfContained = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["SelfContained"]);
 
                 if (referencedProjectIsExecutable && shouldBeValidatedAsExecutableReference)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -40,13 +40,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 var additionalPropertiesXml = XElement.Parse(project.GetMetadata("AdditionalPropertiesFromProject"));
-                XElement targetFrameworkElement = additionalPropertiesXml.Element("TargetFramework");
-                if (!targetFrameworkElement.HasAttributes || !targetFrameworkElement.FirstAttribute.Value.Equals(nearestTargetFramework))
-                {
-                    // The TargetFramework did not match.
-                    continue;
-                }
-
+                XElement targetFrameworkElement = additionalPropertiesXml.Elements().Where(el => el.HasAttributes && el.FirstAttribute.Value.Equals(nearestTargetFramework)).Single();
                 Dictionary<string, string> projectAdditionalProperties = new(StringComparer.OrdinalIgnoreCase);
                 foreach (XElement propertyElement in targetFrameworkElement.Elements())
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public ITaskItem[] ReferencedProjects { get; set; } = Array.Empty<ITaskItem>();
 
-        public string MSBuildVersion { get; set; }
+        public bool UseAttributeForTargetFrameworkInfoPropertyNames { get; set; }
 
         protected override void ExecuteCore()
         {
@@ -40,8 +40,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 var additionalPropertiesXml = XElement.Parse(project.GetMetadata("AdditionalPropertiesFromProject"));
-                bool msbuild17OrLater = Version.TryParse(MSBuildVersion, out Version v) && v >= Version.Parse("17.0");
-                XElement targetFrameworkElement = msbuild17OrLater ?
+                XElement targetFrameworkElement = UseAttributeForTargetFrameworkInfoPropertyNames ?
                     additionalPropertiesXml.Elements().Where(el => el.HasAttributes && el.FirstAttribute.Value.Equals(nearestTargetFramework)).Single() :
                     additionalPropertiesXml.Element(nearestTargetFramework);
                 Dictionary<string, string> projectAdditionalProperties = new(StringComparer.OrdinalIgnoreCase);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1082,7 +1082,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="ValidateExecutableReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <PropertyGroup>
-    <_UseAttributeForTargetFrameworkInfoPropertyNames>true</_UseAttributeForTargetFrameworkInfoPropertyNames>
+    <_UseAttributeForTargetFrameworkInfoPropertyNames Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), '17.0'))">true</_UseAttributeForTargetFrameworkInfoPropertyNames>
   </PropertyGroup>
 
   <Target Name="ValidateExecutableReferences"
@@ -1093,6 +1093,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       SelfContained="$(SelfContained)"
       IsExecutable="$(_IsExecutable)"
       ReferencedProjects="@(_MSBuildProjectReferenceExistent)"
+      MSBuildVersion="$(MSBuildVersion)"
       />
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1093,7 +1093,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       SelfContained="$(SelfContained)"
       IsExecutable="$(_IsExecutable)"
       ReferencedProjects="@(_MSBuildProjectReferenceExistent)"
-      MSBuildVersion="$(MSBuildVersion)"
+      UseAttributeForTargetFrameworkInfoPropertyNames="$(_UseAttributeForTargetFrameworkInfoPropertyNames)"
       />
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1081,6 +1081,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="ValidateExecutableReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
+  <PropertyGroup>
+    <_UseAttributeForTargetFrameworkInfoPropertyNames>true</_UseAttributeForTargetFrameworkInfoPropertyNames>
+  </PropertyGroup>
+
   <Target Name="ValidateExecutableReferences"
           AfterTargets="_GetProjectReferenceTargetFrameworkProperties"
           Condition="'$(ValidateExecutableReferencesMatchSelfContained)' != 'false'">


### PR DESCRIPTION
Opts into using the new schema and looks for a TF with its first attribute equal to nearestTargetFramework.

There are multiple ways to do this, so I'm open to suggested improvements 🙂