### PR TITLE
Turn off additional publishing conflicts

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -54,6 +54,7 @@ stages:
         matrix:
           Build_Release:
             _BuildConfig: Release
+            _PublishArgs: '-publish'
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               _SignType: test
               _Test: -test
@@ -128,6 +129,7 @@ stages:
           matrix:
             Build_Release:
               _BuildConfig: Release
+              _PublishArgs: ''
               _SignType: test
 
     - template: /eng/build.yml
@@ -143,6 +145,7 @@ stages:
           matrix:
             Build_Release:
               _BuildConfig: Release
+              _PublishArgs: ''
               _SignType: test
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -89,6 +89,7 @@ stages:
               _Test: -test
             Build_Release:
               _BuildConfig: Release
+              _PublishArgs: ''
               _SignType: test
               _Test: -test
 
@@ -106,6 +107,7 @@ stages:
           matrix:
             Build_Debug:
               _BuildConfig: Debug
+              _PublishArgs: ''
               _SignType: test
 
     - template: /eng/build.yml

--- a/eng/CIBuild.cmd
+++ b/eng/CIBuild.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" -restore -build -sign -pack -publish -ci %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" -restore -build -sign -pack -ci %*"


### PR DESCRIPTION
Fixing additional publishing conflicts when multiple legs try to write to the same blob location.

Example of build failure:  https://dev.azure.com/dnceng/public/_build/results?buildId=1298276&view=logs&j=ffcccca8-8d4a-5f1e-019c-64de63d1f0d8&t=b45037e0-dc32-5dd3-9457-1b637e753ec3&l=881