### PR TITLE
Allow Razor code generation when using the Razor source generator

### DIFF
--- a/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
+++ b/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
@@ -384,7 +384,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- When targeting 3.x and later projects, we have to infer configuration by inspecting the project. -->
   <Import Project="Microsoft.NET.Sdk.Razor.Configuration.targets" Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true'" />
 
-  <Import Project="Microsoft.NET.Sdk.Razor.CodeGeneration.targets" Condition="'$(UseRazorSourceGenerator)' != 'true'" />
+  <Import Project="Microsoft.NET.Sdk.Razor.CodeGeneration.targets" />
 
   <Import Project="Microsoft.NET.Sdk.Razor.Component.targets" Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true' AND '$(UseRazorSourceGenerator)' != 'true'" />
 


### PR DESCRIPTION
### Summary
We are developing a sample project for Blazor that demonstrates how one could automatically generate Angular and React components that wrap Blazor components (https://github.com/dotnet/aspnetcore/issues/35112). Part of this sample requires reading build artifacts from Razor code generation.

The changes in this PR allow us to invoke the Razor code generator even when using the new Razor source generator.