### PR TITLE
Preserve environment variable previously configured on ProcessStartInfo

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshServer.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshServer.cs
@@ -121,7 +121,11 @@ namespace Microsoft.DotNet.Watcher.Tools
             await _terminateWebSocket.Task;
         }
 
-        public Task WaitForClientConnectionAsync(CancellationToken cancellationToken) => _clientConnected.Task.WaitAsync(cancellationToken);
+        public async Task WaitForClientConnectionAsync(CancellationToken cancellationToken)
+        {
+            _reporter.Verbose("Waiting for a browser to connect");
+            await _clientConnected.Task.WaitAsync(cancellationToken);
+        }
 
         public ValueTask SendJsonSerlialized<TValue>(TValue value, CancellationToken cancellationToken = default)
         {

--- a/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.Tools.Internal;

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -3,6 +3,10 @@
 
 #nullable enable
 
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Graph;
 using Microsoft.DotNet.Watcher.Internal;

--- a/src/Tests/dotnet-watch.Tests/Internal/ProcessRunnerTest.cs
+++ b/src/Tests/dotnet-watch.Tests/Internal/ProcessRunnerTest.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace Microsoft.DotNet.Watcher.Internal
+{
+    public class ProcessRunnerTest
+    {
+        [Fact]
+        public void SetEnvironmentVariable_SetsSpecifiedValue()
+        {
+            // Arrange
+            var processStartInfo = new ProcessStartInfo();
+
+           // Act
+           ProcessRunner.SetEnvironmentVariable(processStartInfo, "Test", new () { "value1" }, ';', _ => null);
+
+            // Assert
+            Assert.Equal("value1", processStartInfo.Environment["Test"]);
+        }
+
+        [Fact]
+        public void SetEnvironmentVariable_ConcatenatesMultipleValues()
+        {
+            // Arrange
+            var processStartInfo = new ProcessStartInfo();
+
+            // Act
+            ProcessRunner.SetEnvironmentVariable(processStartInfo, "Test", new() { "value1", "value2" }, ';', _ => null);
+
+            // Assert
+            Assert.Equal("value1;value2", processStartInfo.Environment["Test"]);
+        }
+
+        [Fact]
+        public void SetEnvironmentVariable_Concatenates_WithEnvironmentVariable()
+        {
+            // Arrange
+            var processStartInfo = new ProcessStartInfo();
+
+            // Act
+            ProcessRunner.SetEnvironmentVariable(processStartInfo, "Test", new() { "value1", "value2" }, ';', _ => "value3");
+
+            // Assert
+            Assert.Equal("value3;value1;value2", processStartInfo.Environment["Test"]);
+        }
+
+        [Fact]
+        public void SetEnvironmentVariable_Concatenates_WithEnvironmentVariableAndPreviouslyConfiguredValue()
+        {
+            // Arrange
+            var processStartInfo = new ProcessStartInfo
+            {
+                Environment = { ["Test"] = "value4" },
+            };
+            
+            // Act
+            ProcessRunner.SetEnvironmentVariable(processStartInfo, "Test", new() { "value1", "value2" }, ';', _ => "value3");
+
+            // Assert
+            Assert.Equal("value3;value4;value1;value2", processStartInfo.Environment["Test"]);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void SetEnvironmentVariable_IgnoresNullOrEmptyEnvironment(string value)
+        {
+            // Arrange
+            var processStartInfo = new ProcessStartInfo
+            {
+                Environment = { ["Test"] = "value4" },
+            };
+
+            // Act
+            ProcessRunner.SetEnvironmentVariable(processStartInfo, "Test", new() { "value1", "value2" }, ';', _ => value);
+
+            // Assert
+            Assert.Equal("value4;value1;value2", processStartInfo.Environment["Test"]);
+        }
+    }
+}


### PR DESCRIPTION
* dotnet-watch concats values from Environment, but ignores environment values configured on ProcessStartInfo
typically configured by launchSettings.json.

* Print a message that says we're waiting for a browser connection.

Fixes https://github.com/dotnet/aspnetcore/issues/35410
Fixes https://github.com/dotnet/aspnetcore/issues/35427