### PR TITLE
Change dotnet-new output encoding to utf8

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -51,6 +51,7 @@ namespace Microsoft.DotNet.Tools.New
                 RestoreProject = RestoreProject
             };
 
+            Console.OutputEncoding = Encoding.Utf8;
             var disableSdkTemplates = args.Contains("--debug:disable-sdk-templates");
 
             return New3Command.Run(CommandName, CreateHost(disableSdkTemplates), logger, callbacks, args, null);

--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tools.New
                 RestoreProject = RestoreProject
             };
 
-            Console.OutputEncoding = Encoding.Utf8;
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
             var disableSdkTemplates = args.Contains("--debug:disable-sdk-templates");
 
             return New3Command.Run(CommandName, CreateHost(disableSdkTemplates), logger, callbacks, args, null);


### PR DESCRIPTION
Partly fixes https://github.com/dotnet/templating/issues/3288
Rest of this fix is here https://github.com/dotnet/templating/pull/3630
Without the encoding set, some characters are displayed as question marks. This becomes a problem when rendering tables where the original character would have occupied 2 spaces, but the question mark occupies only one.