### PR TITLE
Check that SDK and app archs match before setting `DOTNET_ROOT` when using `dotnet run`

### DIFF
--- a/src/Assets/TestProjects/TestAppEchoDotnetRoot/Program.cs
+++ b/src/Assets/TestProjects/TestAppEchoDotnetRoot/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace ConsoleApplication
 {
@@ -9,8 +10,10 @@ namespace ConsoleApplication
     {
         public static void Main(string[] args)
         {
+            var processArchitecture = $"DOTNET_ROOT_{RuntimeInformation.ProcessArchitecture.ToString().ToUpper()}";
             Console.WriteLine($"DOTNET_ROOT='{Environment.GetEnvironmentVariable("DOTNET_ROOT", EnvironmentVariableTarget.Process)}';" +
-                $"DOTNET_ROOT(x86)='{Environment.GetEnvironmentVariable("DOTNET_ROOT(x86)", EnvironmentVariableTarget.Process)}'");
+                $"DOTNET_ROOT(x86)='{Environment.GetEnvironmentVariable("DOTNET_ROOT(x86)", EnvironmentVariableTarget.Process)}';" +
+                $"DOTNET_ROOT_{processArchitecture}='{Environment.GetEnvironmentVariable(processArchitecture)}'");
         }
     }
 }

--- a/src/Assets/TestProjects/TestAppEchoDotnetRoot/Program.cs
+++ b/src/Assets/TestProjects/TestAppEchoDotnetRoot/Program.cs
@@ -10,7 +10,7 @@ namespace ConsoleApplication
     {
         public static void Main(string[] args)
         {
-            var processArchitecture = $"DOTNET_ROOT_{RuntimeInformation.ProcessArchitecture.ToString().ToUpper()}";
+            var processArchitecture = $"DOTNET_ROOT_{Enum.GetName(typeof(Architecture), RuntimeInformation.ProcessArchitecture)}";
             Console.WriteLine($"DOTNET_ROOT='{Environment.GetEnvironmentVariable("DOTNET_ROOT", EnvironmentVariableTarget.Process)}';" +
                 $"DOTNET_ROOT(x86)='{Environment.GetEnvironmentVariable("DOTNET_ROOT(x86)", EnvironmentVariableTarget.Process)}';" +
                 $"{processArchitecture}='{Environment.GetEnvironmentVariable(processArchitecture)}'");

--- a/src/Assets/TestProjects/TestAppEchoDotnetRoot/Program.cs
+++ b/src/Assets/TestProjects/TestAppEchoDotnetRoot/Program.cs
@@ -13,7 +13,7 @@ namespace ConsoleApplication
             var processArchitecture = $"DOTNET_ROOT_{RuntimeInformation.ProcessArchitecture.ToString().ToUpper()}";
             Console.WriteLine($"DOTNET_ROOT='{Environment.GetEnvironmentVariable("DOTNET_ROOT", EnvironmentVariableTarget.Process)}';" +
                 $"DOTNET_ROOT(x86)='{Environment.GetEnvironmentVariable("DOTNET_ROOT(x86)", EnvironmentVariableTarget.Process)}';" +
-                $"DOTNET_ROOT_{processArchitecture}='{Environment.GetEnvironmentVariable(processArchitecture)}'");
+                $"{processArchitecture}='{Environment.GetEnvironmentVariable(processArchitecture)}'");
         }
     }
 }

--- a/src/Assets/TestProjects/TestAppEchoDotnetRoot/TestAppEchoDotnetRoot.csproj
+++ b/src/Assets/TestProjects/TestAppEchoDotnetRoot/TestAppEchoDotnetRoot.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -255,7 +255,8 @@ namespace Microsoft.DotNet.Tools.Run
             var command = CommandFactoryUsingResolver.Create(commandSpec)
                 .WorkingDirectory(runWorkingDirectory);
 
-            if (TryGetTargetArchitecture(project.GetPropertyValue("DefaultAppHostRuntimeIdentifier"), out var targetArchitecture) &&
+            if ((TryGetTargetArchitecture(project.GetPropertyValue("RuntimeIdentifier"), out var targetArchitecture) ||
+                TryGetTargetArchitecture(project.GetPropertyValue("DefaultAppHostRuntimeIdentifier"), out targetArchitecture)) &&
                 targetArchitecture == RuntimeInformation.ProcessArchitecture)
             {
                 var rootVariableName = Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)";

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -262,10 +262,9 @@ namespace Microsoft.DotNet.Tools.Run
             {
                 var rootVariableName = Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)";
                 string targetFrameworkVersion = project.GetPropertyValue("TargetFrameworkVersion");
-                if (!string.IsNullOrEmpty(targetFrameworkVersion) && Version.Parse(targetFrameworkVersion.AsSpan(1)) >= Version6_0 &&
-                    Enum.GetName(typeof(Architecture), RuntimeInformation.ProcessArchitecture) is string processArchitecture)
+                if (!string.IsNullOrEmpty(targetFrameworkVersion) && Version.Parse(targetFrameworkVersion.AsSpan(1)) >= Version6_0)
                 {
-                    rootVariableName = $"DOTNET_ROOT_{processArchitecture}";
+                    rootVariableName = $"DOTNET_ROOT_{targetArchitecture.ToString().ToUpperInvariant()}";
                 }
 
                 if (Environment.GetEnvironmentVariable(rootVariableName) == null)

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -256,15 +256,16 @@ namespace Microsoft.DotNet.Tools.Run
             var command = CommandFactoryUsingResolver.Create(commandSpec)
                 .WorkingDirectory(runWorkingDirectory);
 
-            if ((TryGetTargetArchitecture(project.GetPropertyValue("RuntimeIdentifier"), out var targetArchitecture) ||
+            if (((TryGetTargetArchitecture(project.GetPropertyValue("RuntimeIdentifier"), out var targetArchitecture) ||
                 TryGetTargetArchitecture(project.GetPropertyValue("DefaultAppHostRuntimeIdentifier"), out targetArchitecture)) &&
-                targetArchitecture == RuntimeInformation.ProcessArchitecture)
+                targetArchitecture == RuntimeInformation.ProcessArchitecture) || targetArchitecture == null)
             {
                 var rootVariableName = Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)";
                 string targetFrameworkVersion = project.GetPropertyValue("TargetFrameworkVersion");
-                if (!string.IsNullOrEmpty(targetFrameworkVersion) && Version.Parse(targetFrameworkVersion.AsSpan(1)) >= Version6_0)
+                if (!string.IsNullOrEmpty(targetFrameworkVersion) && Version.Parse(targetFrameworkVersion.AsSpan(1)) >= Version6_0 &&
+                    Enum.GetName(typeof(Architecture), RuntimeInformation.ProcessArchitecture) is string processArchitecture)
                 {
-                    rootVariableName = $"DOTNET_ROOT_{targetArchitecture.ToString().ToUpper()}";
+                    rootVariableName = $"DOTNET_ROOT_{processArchitecture}";
                 }
 
                 if (Environment.GetEnvironmentVariable(rootVariableName) == null)

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -264,7 +264,7 @@ namespace Microsoft.DotNet.Tools.Run
                 string targetFrameworkVersion = project.GetPropertyValue("TargetFrameworkVersion");
                 if (!string.IsNullOrEmpty(targetFrameworkVersion) && Version.Parse(targetFrameworkVersion.AsSpan(1)) >= Version6_0)
                 {
-                    rootVariableName = $"DOTNET_ROOT_{targetArchitecture.ToString().ToUpperInvariant()}";
+                    rootVariableName = $"DOTNET_ROOT_{RuntimeInformation.ProcessArchitecture.ToString().ToUpperInvariant()}";
                 }
 
                 if (Environment.GetEnvironmentVariable(rootVariableName) == null)

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.Tools.Run
         public bool Interactive { get; private set; }
         public IEnumerable<string> RestoreArgs { get; private set; }
 
+        private Version Version6_0 = new Version(6, 0);
         private bool ShouldBuild => !NoBuild;
         private bool HasQuietVerbosity =>
             RestoreArgs.All(arg => !arg.StartsWith("-verbosity:", StringComparison.Ordinal) ||
@@ -260,6 +261,12 @@ namespace Microsoft.DotNet.Tools.Run
                 targetArchitecture == RuntimeInformation.ProcessArchitecture)
             {
                 var rootVariableName = Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)";
+                string targetFrameworkVersion = project.GetPropertyValue("TargetFrameworkVersion");
+                if (!string.IsNullOrEmpty(targetFrameworkVersion) && Version.Parse(targetFrameworkVersion.AsSpan(1)) >= Version6_0)
+                {
+                    rootVariableName = $"DOTNET_ROOT_{targetArchitecture.ToString().ToUpper()}";
+                }
+
                 if (Environment.GetEnvironmentVariable(rootVariableName) == null)
                 {
                     command.EnvironmentVariable(rootVariableName, Path.GetDirectoryName(new Muxer().MuxerPath));

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -15,17 +15,21 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 {
     public class GivenDotnetRootEnv : SdkTest
     {
+        private static Version Version6_0 = new Version(6, 0);
+
         public GivenDotnetRootEnv(ITestOutputHelper log) : base(log)
         {
         }
 
-        [Fact]
-        public void ItShouldSetDotnetRootToDirectoryOfMuxer()
+        [Theory]
+        [InlineData("net5.0")]
+        [InlineData("net6.0")]
+        public void ItShouldSetDotnetRootToDirectoryOfMuxer(string targetFramework)
         {
             string expectDotnetRoot = TestContext.Current.ToolsetUnderTest.DotNetRoot;
-            string expectOutput = GetExpectOutput(expectDotnetRoot);
+            string expectOutput = GetExpectOutput(expectDotnetRoot, targetFramework);
 
-            var projectRoot = SetupDotnetRootEchoProject();
+            var projectRoot = SetupDotnetRootEchoProject(null, targetFramework);
 
             var runCommand = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(projectRoot);
@@ -65,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .And.HaveStdOutContaining(GetExpectOutput(expectDotnetRoot));
         }
 
-        private string SetupDotnetRootEchoProject([CallerMemberName] string callingMethod = null)
+        private string SetupDotnetRootEchoProject([CallerMemberName] string callingMethod = null, string targetFramework = null)
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("TestAppEchoDotnetRoot", callingMethod)
@@ -73,23 +77,28 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Restore(Log);
 
             new BuildCommand(testAsset)
-                .Execute()
+                .Execute($"{(!string.IsNullOrEmpty(targetFramework) ? "/p:TargetFramework = " + targetFramework : string.Empty)}")
                 .Should()
                 .Pass();
 
             return testAsset.Path;
         }
 
-        private static string GetExpectOutput(string expectDotnetRoot)
+        private static string GetExpectOutput(string expectDotnetRoot, string targetFramework = null)
         {
             string expectOutput;
-            if (Environment.Is64BitProcess)
+            string processArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToUpper();
+            if (!string.IsNullOrEmpty(targetFramework) && Version.Parse(targetFramework.AsSpan(3)) >= Version6_0)
             {
-                expectOutput = @$"DOTNET_ROOT='{expectDotnetRoot}';DOTNET_ROOT(x86)=''";
+                expectOutput = $"DOTNET_ROOT='';DOTNET_ROOT(x86)='';DOTNET_ROOT_{processArchitecture}={expectDotnetRoot}";
+            }
+            else if (Environment.Is64BitProcess)
+            {
+                expectOutput = @$"DOTNET_ROOT='{expectDotnetRoot}';DOTNET_ROOT(x86)='';DOTNET_ROOT_{processArchitecture}=''";
             }
             else
             {
-                expectOutput = @$"DOTNET_ROOT='';DOTNET_ROOT(x86)='{expectDotnetRoot}'";
+                expectOutput = @$"DOTNET_ROOT='';DOTNET_ROOT(x86)='{expectDotnetRoot}';DOTNET_ROOT_{processArchitecture}=''";
             }
 
             return expectOutput;

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         private static string GetExpectOutput(string expectDotnetRoot, string targetFramework = null)
         {
             string expectOutput;
-            string processArchitecture = Enum.GetName(typeof(Architecture), RuntimeInformation.ProcessArchitecture);
+            string processArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToUpperInvariant();
             if (!string.IsNullOrEmpty(targetFramework) && Version.Parse(targetFramework.AsSpan(3)) >= Version6_0)
             {
                 expectOutput = $"DOTNET_ROOT='';DOTNET_ROOT(x86)='';DOTNET_ROOT_{processArchitecture}='{expectDotnetRoot}'";

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
@@ -72,12 +72,12 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         private string SetupDotnetRootEchoProject([CallerMemberName] string callingMethod = null, string targetFramework = null)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("TestAppEchoDotnetRoot", callingMethod)
+                .CopyTestAsset("TestAppEchoDotnetRoot", callingMethod, allowCopyIfPresent: true)
                 .WithSource()
                 .Restore(Log);
 
             new BuildCommand(testAsset)
-                .Execute($"{(!string.IsNullOrEmpty(targetFramework) ? "/p:TargetFramework = " + targetFramework : string.Empty)}")
+                .Execute($"{(!string.IsNullOrEmpty(targetFramework) ? "/p:TargetFramework=" + targetFramework : string.Empty)}")
                 .Should()
                 .Pass();
 

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
@@ -74,6 +74,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             var testAsset = _testAssetsManager
                 .CopyTestAsset("TestAppEchoDotnetRoot", callingMethod, allowCopyIfPresent: true)
                 .WithSource()
+                .WithTargetFrameworkOrFrameworks(targetFramework ?? null, false)
                 .Restore(Log);
 
             new BuildCommand(testAsset)
@@ -90,7 +91,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             string processArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToUpper();
             if (!string.IsNullOrEmpty(targetFramework) && Version.Parse(targetFramework.AsSpan(3)) >= Version6_0)
             {
-                expectOutput = $"DOTNET_ROOT='';DOTNET_ROOT(x86)='';DOTNET_ROOT_{processArchitecture}={expectDotnetRoot}";
+                expectOutput = $"DOTNET_ROOT='';DOTNET_ROOT(x86)='';DOTNET_ROOT_{processArchitecture}='{expectDotnetRoot}'";
             }
             else if (Environment.Is64BitProcess)
             {

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         private static string GetExpectOutput(string expectDotnetRoot, string targetFramework = null)
         {
             string expectOutput;
-            string processArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToUpper();
+            string processArchitecture = Enum.GetName(typeof(Architecture), RuntimeInformation.ProcessArchitecture);
             if (!string.IsNullOrEmpty(targetFramework) && Version.Parse(targetFramework.AsSpan(3)) >= Version6_0)
             {
                 expectOutput = $"DOTNET_ROOT='';DOTNET_ROOT(x86)='';DOTNET_ROOT_{processArchitecture}='{expectDotnetRoot}'";


### PR DESCRIPTION
Fixes #19743. I tested this locally. The steps for reproing the fix are already in the above issue. For checking the app's architecture, this first checks for the `RuntimeIdentifier` property of the project to run, if not set, it'll grab the architecture from the `DefaultAppHostRuntimeIdentifier` prop.