### PR TITLE
Restore preferred packages functionality

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -369,6 +369,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </ResolveTargetingPackAssets>
 
+    <PropertyGroup>
+      <!-- Unescape this semicolon-delimited ordered list so that it's passed as a list to targets
+           that consume it. -->
+      <PackageConflictPreferredPackages>$([MSBuild]::Unescape($(PackageConflictPreferredPackages)))</PackageConflictPreferredPackages>
+    </PropertyGroup>
+
     <ItemGroup Condition="'$(RuntimeIdentifier)' == '' or '$(SelfContained)' != 'true'">
       <PackageConflictPlatformManifests Include="@(PlatformManifestsFromTargetingPacks)" />
     </ItemGroup>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -1061,5 +1061,29 @@ namespace ProjectNameWithSpaces
                 .And
                 .HaveStdOutContaining("NETSDK1148");
         }
+
+        [Fact]
+        public void It_Has_Unescaped_PackageConflictPreferredPackages_Values()
+        {
+            string targetFramework = ToolsetInfo.CurrentTargetFramework;
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary", identifier: targetFramework)
+                .WithSource()
+                .WithTargetFramework(targetFramework, "TestLibrary");
+
+            var getValuesCommand = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, "TestLibrary"), targetFramework, "PackageConflictPreferredPackages");
+            getValuesCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            List<string> preferredPackages = getValuesCommand.GetValues();
+            preferredPackages.Should().NotBeEmpty();
+            preferredPackages.Count.Should().BeGreaterThan(1);
+
+            preferredPackages.Should().NotContain(packageName => packageName.Contains(';'),
+                because: "No package name should have a semicolon in it--PackageConflictPreferredPackages should be a semicolon delimited list of package names");
+        }
     }
 }


### PR DESCRIPTION
The MSBuild engine automatically escapes strings returned from tasks,
which was causing problems because the later task
`ResolvePackageFileConflicts` was expecting to be passed an array of
strings, rather than an array consisting of a single string with a bunch
of semicolons in it.

Before:

```
                   Task "ResolvePackageFileConflicts" (TaskId:404)
                   Using "ResolvePackageFileConflicts" task from assembly "C:\Program Files\dotnet\sdk\6.0.100-preview.7.21379.14\Sdks\Microsoft.NET.Sdk\targets\..\tools\net6.0\Microsoft.NET.Build.Tasks.dll".
                   Task "ResolvePackageFileConflicts" (TaskId:405)
                     Task Parameter:PreferredPackages=Microsoft.NETCore.App.Ref;Microsoft.NETCore.App.Runtime.Mono.linux-arm;Microsoft.NETCore.App.Runtime.Mono.linux-arm64;Microsoft.NETCore.App.Runtime.Mono.linux-musl-arm64;Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64;Microsoft.NETCore.App.Runtime.Mono.linux-x64;Microsoft.NETCore.App.Runtime.Mono.osx-x64;Microsoft.NETCore.App.Runtime.Mono.rhel.6-x64;Microsoft.NETCore.App.Runtime.Mono.win-arm;Microsoft.NETCore.App.Runtime.Mono.win-arm64;Microsoft.NETCore.App.Runtime.Mono.win-x64;Microsoft.NETCore.App.Runtime.Mono.win-x86;Microsoft.NETCore.App.Runtime.Mono.linux-musl-arm;Microsoft.NETCore.App.Runtime.Mono.osx-arm64;Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64;Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64;Microsoft.NETCore.App.Runtime.Mono.browser-wasm;Microsoft.NETCore.App.Runtime.Mono.ios-arm64;Microsoft.NETCore.App.Runtime.Mono.ios-arm;Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64;Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64;Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86;Microsoft.NETCore.App.Runtime.Mono.tvos-arm64;Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64;Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64;Microsoft.NETCore.App.Runtime.Mono.android-arm64;Microsoft.NETCore.App.Runtime.Mono.android-arm;Microsoft.NETCore.App.Runtime.Mono.android-x64;Microsoft.NETCore.App.Runtime.Mono.android-x86 (TaskId:405)
...
                     Encountered conflict between 'Analyzer:C:\Users\raines\.nuget\packages\system.text.json\6.0.0-preview.7.21377.19\analyzers\dotnet\cs\System.Text.Json.SourceGeneration.dll' and 'Analyzer:C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.0-preview.7.21377.19\analyzers/dotnet/cs/System.Text.Json.SourceGeneration.dll'. Could not determine winner due to equal file and assembly versions. (TaskId:405)
```

After:

```
                   Task "ResolvePackageFileConflicts" (TaskId:406)
                   Using "ResolvePackageFileConflicts" task from assembly "S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\6.0.100-dev\Sdks\Microsoft.NET.Sdk\targets\..\tools\net6.0\Microsoft.NET.Build.Tasks.dll".
                   Task "ResolvePackageFileConflicts" (TaskId:407)
                     Task Parameter:
                         PreferredPackages=
                             Microsoft.NETCore.App.Ref
                             Microsoft.NETCore.App.Runtime.Mono.linux-arm
                             Microsoft.NETCore.App.Runtime.Mono.linux-arm64
                             Microsoft.NETCore.App.Runtime.Mono.linux-musl-arm64
                             Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64
                             Microsoft.NETCore.App.Runtime.Mono.linux-x64
                             Microsoft.NETCore.App.Runtime.Mono.osx-x64
                             Microsoft.NETCore.App.Runtime.Mono.rhel.6-x64
                             Microsoft.NETCore.App.Runtime.Mono.win-arm
                             Microsoft.NETCore.App.Runtime.Mono.win-arm64
                             Microsoft.NETCore.App.Runtime.Mono.win-x64
                             Microsoft.NETCore.App.Runtime.Mono.win-x86
                             Microsoft.NETCore.App.Runtime.Mono.linux-musl-arm
                             Microsoft.NETCore.App.Runtime.Mono.osx-arm64
                             Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64
                             Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64
                             Microsoft.NETCore.App.Runtime.Mono.browser-wasm
                             Microsoft.NETCore.App.Runtime.Mono.ios-arm64
                             Microsoft.NETCore.App.Runtime.Mono.ios-arm
                             Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64
                             Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64
                             Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86
                             Microsoft.NETCore.App.Runtime.Mono.tvos-arm64
                             Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64
                             Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64
                             Microsoft.NETCore.App.Runtime.Mono.android-arm64
                             Microsoft.NETCore.App.Runtime.Mono.android-arm
                             Microsoft.NETCore.App.Runtime.Mono.android-x64
                             Microsoft.NETCore.App.Runtime.Mono.android-x86]) (TaskId:407)
...
                     Encountered conflict between 'Analyzer:C:\Users\raines\.nuget\packages\system.text.json\6.0.0-rc.1.21418.7\analyzers\dotnet\cs\System.Text.Json.SourceGeneration.dll' and 'Analyzer:C:\Users\raines\.nuget\packages\microsoft.netcore.app.ref\6.0.0-rc.1.21418.7\analyzers/dotnet/cs/System.Text.Json.SourceGeneration.dll'. Choosing 'Analyzer:C:\Users\raines\.nuget\packages\microsoft.netcore.app.ref\6.0.0-rc.1.21418.7\analyzers/dotnet/cs/System.Text.Json.SourceGeneration.dll' because it comes from a package that is preferred. (TaskId:407)
```

Fixes #19834