### PR TITLE
Follow up to global usings changes

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-rc.1.21379.2",
+    "dotnet": "6.0.100-rc.1.21417.19",
     "runtimes": {
       "dotnet": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)"

--- a/src/Assets/TestProjects/BlazorHostedRID/blazorhosted/blazorhosted-rid.csproj
+++ b/src/Assets/TestProjects/BlazorHostedRID/blazorhosted/blazorhosted-rid.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(AspNetTestTfm)</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
-    <!-- Removing implicit namespace imports for web since AspNetCore.App is removed -->
-    <DisableImplicitNamespaceImports_Web>true</DisableImplicitNamespaceImports_Web>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Assets/TestProjects/HelloWorld/HelloWorld.csproj
+++ b/src/Assets/TestProjects/HelloWorld/HelloWorld.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
 </Project>

--- a/src/Assets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
+++ b/src/Assets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BlazorWasmSdk/Sdk/Sdk.props
+++ b/src/BlazorWasmSdk/Sdk/Sdk.props
@@ -20,7 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="$(_BlazorWebAssemblyPropsFile)" />
 
-  <ItemGroup Condition="'$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable'">
+  <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
     <Using Include="Microsoft.Extensions.Configuration" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
     <Using Include="Microsoft.Extensions.Logging" />

--- a/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.Tools.Internal;

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -4,6 +4,8 @@
 #nullable enable
 
 using System;
+using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Graph;

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -3,6 +3,8 @@
 
 #nullable enable
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Graph;
 using Microsoft.DotNet.Watcher.Internal;

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -3,7 +3,11 @@
 
 #nullable disable
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.IO.Pipes;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/src/Cli/dotnet/Installer/Windows/UpgradeAttributes.cs
+++ b/src/Cli/dotnet/Installer/Windows/UpgradeAttributes.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.DotNet.Installer.Windows
 {
     /// <summary>

--- a/src/Layout/toolset-tasks/toolset-tasks.csproj
+++ b/src/Layout/toolset-tasks/toolset-tasks.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>$(SdkTargetFramework);net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(SdkTargetFramework)</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -10,6 +10,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DisableImplicitNamespaceImports Condition="'$(DisableImplicitNamespaceImports)'==''">$(DisableImplicitFrameworkReferences)</DisableImplicitNamespaceImports>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(DisableImplicitNamespaceImports)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <!-- These namespaces are present in 2.0 Framework assemblies -->
     <Import Include="Microsoft.VisualBasic" />

--- a/src/Tests/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
+++ b/src/Tests/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         {
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "Unskipping tracked by https://github.com/dotnet/sdk/issues/19696")]
+        [RequiresMSBuildVersionFact("17.0.0.32901")]
         public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
             string projectDirectory = _testAssetsManager.CreateTestDirectory().Path;

--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/SampleGlobalTool/consoledemo.csproj
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/SampleGlobalTool/consoledemo.csproj
@@ -10,5 +10,6 @@
      <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
      <EnableSourceLink>false</EnableSourceLink>
      <DeterministicSourcePaths>false</DeterministicSourcePaths>
+     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/SampleGlobalToolWithDifferentCasing/ConsoleDemoWithCasing.csproj
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/SampleGlobalToolWithDifferentCasing/ConsoleDemoWithCasing.csproj
@@ -10,5 +10,6 @@
      <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
      <EnableSourceLink>false</EnableSourceLink>
      <DeterministicSourcePaths>false</DeterministicSourcePaths>
+     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/SampleGlobalToolWithPreview/consoledemo.csproj
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/SampleGlobalToolWithPreview/consoledemo.csproj
@@ -10,5 +10,6 @@
      <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
      <EnableSourceLink>false</EnableSourceLink>
      <DeterministicSourcePaths>false</DeterministicSourcePaths>
+     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/SampleGlobalToolWithShim/consoledemo.csproj
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/SampleGlobalToolWithShim/consoledemo.csproj
@@ -10,5 +10,6 @@
      <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
      <EnableSourceLink>false</EnableSourceLink>
      <DeterministicSourcePaths>false</DeterministicSourcePaths>
+     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.NET.Build.Tests
             //  .HaveStdOutContaining("android");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/sdk/issues/19866")]
         public void It_should_fail_to_build_without_workload_when_multitargeted()
         {
             var testProject = new TestProject()
@@ -238,7 +238,7 @@ namespace Microsoft.NET.Build.Tests
                 .BeEquivalentTo("true");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/sdk/issues/19866")]
         public void It_should_get_suggested_workload_by_GetRequiredWorkloads_target()
         {
             var mainProject = new TestProject()
@@ -266,7 +266,7 @@ namespace Microsoft.NET.Build.Tests
                 .BeEquivalentTo("microsoft-android-sdk-full");
         }
 
-        [Theory]
+        [Theory(Skip = "https://github.com/dotnet/sdk/issues/19866")]
         [InlineData("net6.0-android;net6.0-ios", "net6.0-android;net6.0-ios", "microsoft-android-sdk-full;microsoft-ios-sdk-full")]
         [InlineData("net6.0", "net6.0;net6.0-android;net6.0-ios", "microsoft-android-sdk-full;microsoft-ios-sdk-full")]
         [InlineData("net6.0;net6.0-ios", "net6.0;net6.0-android", "microsoft-android-sdk-full;microsoft-ios-sdk-full")]

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmBaselineTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmBaselineTests.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Tasks;
 using Microsoft.NET.Sdk.Razor.Tests;
 using Microsoft.NET.TestFramework;
@@ -22,7 +25,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             {
                 return null;
             }
-            
+
             if (asset.RelatedAsset == originalValue)
             {
                 return null;

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Razor.Tasks;
 using Microsoft.NET.TestFramework.Assertions;

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmJsModulesIntegrationTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmJsModulesIntegrationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.IO;
 using System.Text.Json;
 using System.Xml.Linq;
@@ -213,7 +214,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
   </BlazorPublishExtension>
   <FileWrites Include=""$(IntermediateOutputPath)publish.extension.txt"" />
   </ItemGroup>
-  
+
   <WriteLinesToFile
     Lines=""@(_BlazorBootFilesToUpdate->'%(FullPath)')""
     File=""$(IntermediateOutputPath)publish.extension.txt""
@@ -290,7 +291,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
   </BlazorPublishExtension>
   <FileWrites Include=""$(IntermediateOutputPath)publish.extension.txt"" />
   </ItemGroup>
-  
+
   <WriteLinesToFile
     Lines=""@(_BlazorBootFilesToUpdate->'%(FullPath)')""
     File=""$(IntermediateOutputPath)publish.extension.txt""

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.Tasks;
 using Microsoft.Build.Framework;
@@ -101,8 +105,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] 
-                { 
+                Assets = new[]
+                {
                     CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
                     CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All")
                 },
@@ -365,7 +369,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 
             result.ApplyDefaults();
             result.Normalize();
-            
+
             return result.ToTaskItem();
         }
 

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeStaticWebAssetsForCurrentProjectTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeStaticWebAssetsForCurrentProjectTest.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.Tasks;
 using Microsoft.Build.Framework;
@@ -48,8 +51,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] 
-                { 
+                Assets = new[]
+                {
                     CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
                     CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All")
                 },
@@ -303,7 +306,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 
             result.ApplyDefaults();
             result.Normalize();
-            
+
             return result.ToTaskItem();
         }
 

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -284,7 +284,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             // Assert
             result.Should().Be(false);
             errorMessages.Count.Should().Be(1);
-            errorMessages[0].Should().Be($@"Two assets found targeting the same path with incompatible asset kinds:
+            errorMessages[0].Should().Be($@"Two assets found targeting the same path with incompatible asset kinds: 
 '{Path.GetFullPath(Path.Combine("wwwroot", "candidate.js"))}' with kind '{firstKind}'
 '{Path.GetFullPath(Path.Combine("wwwroot", "candidate.publish.js"))}' with kind '{secondKind}'
 for path 'candidate.js'");

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.Tasks;
 using Microsoft.Build.Framework;
@@ -281,7 +284,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             // Assert
             result.Should().Be(false);
             errorMessages.Count.Should().Be(1);
-            errorMessages[0].Should().Be($@"Two assets found targeting the same path with incompatible asset kinds: 
+            errorMessages[0].Should().Be($@"Two assets found targeting the same path with incompatible asset kinds:
 '{Path.GetFullPath(Path.Combine("wwwroot", "candidate.js"))}' with kind '{firstKind}'
 '{Path.GetFullPath(Path.Combine("wwwroot", "candidate.publish.js"))}' with kind '{secondKind}'
 for path 'candidate.js'");
@@ -393,10 +396,10 @@ for path 'candidate.js'");
             {
                 ["RelativePath"] = relativePath ?? "",
                 ["TargetPath"] = targetPath ?? "",
-                ["Link"] = link ?? "",                
+                ["Link"] = link ?? "",
                 ["CopyToOutputDirectory"] = copyToOutputDirectory ?? "",
                 ["CopyToPublishDirectory"] = copyToPublishDirectory ?? ""
-            });            
+            });
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestTest.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.Tasks;
 using Microsoft.Build.Framework;
@@ -76,7 +80,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var task = new GenerateStaticWebAssetsManifest
             {
                 BuildEngine = buildEngine.Object,
-                Assets = new[] 
+                Assets = new[]
                 {
                     asset.ToTaskItem()
                 },
@@ -101,7 +105,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             newAsset.Should().Be(asset);
         }
 
-        public static TheoryData<Action<StaticWebAsset>> GeneratesManifestFailsWhenInvalidAssetsAreProvidedData 
+        public static TheoryData<Action<StaticWebAsset>> GeneratesManifestFailsWhenInvalidAssetsAreProvidedData
         {
             get
             {

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/MergeConfigurationPropertiesTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/MergeConfigurationPropertiesTest.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.Tasks;
 using Microsoft.Build.Framework;

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Security.Principal;
 using System.Text.Json;
 using FluentAssertions;
@@ -270,7 +273,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             task.ReferencedProjectsConfiguration.Should().BeEmpty();
             task.Assets.Should().BeEmpty();
             var discoveryPattern = task.DiscoveryPatterns[0];
-            
+
             discoveryPattern.ItemSpec.ShouldBeEquivalentTo(Path.Combine("AnotherClassLib", "wwwroot"));
             discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.Source)).ShouldBeEquivalentTo("AnotherClassLib");
             discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.ContentRoot)).ShouldBeEquivalentTo($"{contentRoot}");

--- a/src/Tests/dotnet-pack.Tests/PackTests.cs
+++ b/src/Tests/dotnet-pack.Tests/PackTests.cs
@@ -262,7 +262,6 @@ namespace Microsoft.DotNet.Pack.Tests
 
             new DotnetPackCommand(Log)
                 .WithWorkingDirectory(rootPath)
-                .WithEnvironmentVariable("ImplicitUsings", "enable") // Removing tracked as part of https://github.com/dotnet/sdk/issues/19696
                 .Execute("--no-restore")
                 .Should()
                 .Pass();

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -247,7 +247,6 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 
             new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(rootPath)
-                .WithEnvironmentVariable("ImplicitUsings", "enable") // Removing tracked as part of https://github.com/dotnet/sdk/issues/19696
                 .Execute("--no-restore")
                 .Should().Pass()
                          .And.HaveStdOutContaining("Hello, World");

--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -58,7 +58,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable'">
+  <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
     <Using Include="System.Net.Http.Json" />
     <Using Include="Microsoft.AspNetCore.Builder" />
     <Using Include="Microsoft.AspNetCore.Hosting" />

--- a/src/WebSdk/Worker/Targets/Microsoft.NET.Sdk.Worker.props
+++ b/src/WebSdk/Worker/Targets/Microsoft.NET.Sdk.Worker.props
@@ -38,7 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_ContentIncludedByDefault Include="@(Content)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable'">
+  <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
     <Using Include="Microsoft.Extensions.Configuration" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
     <Using Include="Microsoft.Extensions.Hosting" />


### PR DESCRIPTION
Port https://github.com/dotnet/sdk/pull/19840 to 6.0-rc1

* When reverting changes to the VisualBasic.targets file, a property initialization was missed. This would have introduced
a regression for users upgrading to the 6.0 SDK when they had global imports disabled in their apps.
* Only add implicitly enabled imports for C# projects.
* Update the stage 0 SDK and re-enable skipped / altered tests

Fixes https://github.com/dotnet/sdk/issues/19793
Fixes https://github.com/dotnet/sdk/issues/19696

------ 


## Description
Ports fixes and enhancements to ImplictUsings feature that were added in rc1. 

a) While undoing some of the changes we made to this feature while making it opt-in, we missed undoing a change to the VB targets. This affects all tfms, so we'd like to get this in.
b) We had a last minute feature request to only define implicitly defined usings for C# projects based on user feedback. This PR adds that change.

## Regression?
- [x] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

## Verification
- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses [issue number]
Fixes https://github.com/dotnet/sdk/issues/19793
Fixes https://github.com/dotnet/sdk/issues/19696

