### PR TITLE
Opt into the RAR precomputed cache

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,5 +27,9 @@
     <!-- <TestRunnerAdditionalArguments>-parallel none</TestRunnerAdditionalArguments> -->
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AssemblyInformationCachePaths Condition="Exists('$(NetCoreRoot)sdk\$(NetCoreSdkVersion)\SdkPrecomputedAssemblyReferences.cache')">$(AssemblyInformationCachePaths);$(NetCoreRoot)sdk\$(NetCoreSdkVersion)\SDKPrecomputedAssemblyReferences.cache</AssemblyInformationCachePaths>
+  </PropertyGroup>
+
   <Import Project="build/GenerateResxSource.targets" />
 </Project>


### PR DESCRIPTION
Adding it to MSBuild seems like it was probably roughly a push from a performance perspective. It could be better or worse here, but this should give us a better idea of whether we should add it elsewhere.