### PR TITLE
Avoid assuming RSG in non-C# projects

### DIFF
--- a/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
+++ b/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
@@ -49,9 +49,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_TargetingNETCoreApp30OrLater>true</_TargetingNETCoreApp30OrLater>
         <_TargetingNET50OrLater>true</_TargetingNET50OrLater>
         <_TargetingNET60OrLater>true</_TargetingNET60OrLater>
-        <UseRazorSourceGenerator Condition="'$(UseRazorSourceGenerator)' == '' ">true</UseRazorSourceGenerator>
-        <!-- Required to support incremental source generator -->
-        <LangVersion Condition="'$(UseRazorSourceGenerator)' != '' ">preview</LangVersion>
+        <UseRazorSourceGenerator Condition="'$(Language)' == 'C#' AND '$(UseRazorSourceGenerator)' == '' ">true</UseRazorSourceGenerator>
         <RazorLangVersion Condition="'$(RazorLangVersion)' == '' ">6.0</RazorLangVersion>
       </PropertyGroup>
     </When>
@@ -101,7 +99,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <StaticWebAssetsEnabled Condition="'$(StaticWebAssetsEnabled)' == ''">$(_Targeting30OrNewerRazorLangVersion)</StaticWebAssetsEnabled>
 
     <UseStaticWebAssetsV2>$(_TargetingNET60OrLater)</UseStaticWebAssetsV2>
-     
+
     <!-- Controls whether or not the scoped css feature is enabled. By default is enabled for net6.0 applications and RazorLangVersion 5 or above -->
     <ScopedCssEnabled Condition="'$(ScopedCssEnabled)' == '' and '$(StaticWebAssetsEnabled)' == 'true'">$(_Targeting30OrNewerRazorLangVersion)</ScopedCssEnabled>
 

--- a/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
+++ b/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
@@ -50,6 +50,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_TargetingNET50OrLater>true</_TargetingNET50OrLater>
         <_TargetingNET60OrLater>true</_TargetingNET60OrLater>
         <UseRazorSourceGenerator Condition="'$(Language)' == 'C#' AND '$(UseRazorSourceGenerator)' == '' ">true</UseRazorSourceGenerator>
+        <!-- Required to support incremental source generator -->
+        <LangVersion Condition="'$(UseRazorSourceGenerator)'  == 'true'">preview</LangVersion>
         <RazorLangVersion Condition="'$(RazorLangVersion)' == '' ">6.0</RazorLangVersion>
       </PropertyGroup>
     </When>


### PR DESCRIPTION
* [x] While it's generally no-op to define it, we can be correct and only configure UseRazorSourceGenerator for C# projects where they're supported.

