### PR TITLE
Add toolset zip as source build intermediate

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -11,4 +11,14 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="GetSdkCategorizedIntermediateNupkgContents"
+          BeforeTargets="GetCategorizedIntermediateNupkgContents">
+    <ItemGroup>
+      <!--
+        Add the internal toolset zip required by dotnet/installer.
+      -->
+      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)NonShipping\dotnet-toolset-internal-*.zip" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
This PR backports an sdk patch required by the installer repo - see https://github.com/dotnet/installer/pull/11483 for details.