### PR TITLE
Fix path issue when elevating from Program Files

### DIFF
--- a/src/Cli/dotnet/Installer/Windows/WindowsUtils.cs
+++ b/src/Cli/dotnet/Installer/Windows/WindowsUtils.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
 
 using System;
 using System.Runtime.Versioning;
@@ -25,7 +24,10 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <returns>A string containing the pipe name.</returns>
         public static string CreatePipeName(int processId, params string[] values)
         {
-            return Uuid.Create($"{processId};{Environment.ProcessPath};{Sha256Hasher.Hash(MacAddressGetter.GetMacAddress())};{string.Join(";", values)}")
+            // Reinvoking the host can cause differences between the original path, e.g.,
+            // "C:\Program Files" and "c:\Program Files". This will generate different UUID values and cause
+            // deadlock when the client and server are trying to connect, so always use the lower invariant of the process.
+            return Uuid.Create($"{processId};{Environment.ProcessPath.ToLowerInvariant()};{Sha256Hasher.Hash(MacAddressGetter.GetMacAddress())};{string.Join(";", values)}")
                 .ToString("B");
         }
 


### PR DESCRIPTION
- When invoking the host during elevation, the full path to dotnet.dll is specified. When residing under Program Files it must be quoted, otherwise the commandline parsing breaks.
- Ensure that the lower invariant of the process path is used to make the input value for the named pipes stable, otherwise we could end up with values such as ```C:\Program Files\dotnet``` and ```c:\Program Files\dotnet```. This will lead to generating different pipe names, resulting in deadlock when the client/server are trying to connect.

