### PR TITLE
[release/6.0.1xx-rc1] Avoid signing and generating unnecessary packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,8 @@
     <LangVersion>Latest</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
+    <!-- Default to all packages generating a corresponding symbol package -->
+    <IncludeSymbols>true</IncludeSymbols>
     <IsShippingPackage>false</IsShippingPackage>
     <SdkTargetFramework>net6.0</SdkTargetFramework>
     <ToolsetTargetFramework>$(SdkTargetFramework)</ToolsetTargetFramework>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -3,6 +3,8 @@
 <Project>
   <PropertyGroup>
     <PublishingVersion>3</PublishingVersion>
+    <!-- This repo does its own symbol package generation to avoid generating symbols for a bunch of unrelated test packages. -->
+    <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -53,6 +53,11 @@
     <FileSignInfo Include="xunit.performance.metrics.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
+  <!-- Filter out any test packages from ItemsToSign -->
+  <ItemGroup>
+    <ItemsToSignPostBuild Remove="*tests*.nupkg" />
+  </ItemGroup>
+
   <PropertyGroup>
     <UseDotNetCertificate>true</UseDotNetCertificate>
   </PropertyGroup>

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -19,6 +19,9 @@
     <GenerateProgramFile>false</GenerateProgramFile>
     
     <DebugType>embedded</DebugType>
+
+    <!-- Don't generate separate symbol packages for the test packages -->
+    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Remove *tests*.nupkg from items to sign post build. These are only used in downstream repos.
- Generate symbol packages selectively. Exclude tests packages. Today symbol packages are generated for every package by default, and also included for post-build signing. This is unnecessary and also causes problems if odd files (like tamperd.msi) exist in them. Note that this does not mean that symbols will not be available, just that a separate symbol package will not be generated.