### PR TITLE
[release/6.0.1xx]  Arch-independent support for `dotnet run`

### DIFF
--- a/src/Assets/TestProjects/TestAppEchoDotnetRoot/Program.cs
+++ b/src/Assets/TestProjects/TestAppEchoDotnetRoot/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace ConsoleApplication
 {
@@ -9,8 +10,10 @@ namespace ConsoleApplication
     {
         public static void Main(string[] args)
         {
+            var processArchitecture = $"DOTNET_ROOT_{Enum.GetName(typeof(Architecture), RuntimeInformation.ProcessArchitecture)}";
             Console.WriteLine($"DOTNET_ROOT='{Environment.GetEnvironmentVariable("DOTNET_ROOT", EnvironmentVariableTarget.Process)}';" +
-                $"DOTNET_ROOT(x86)='{Environment.GetEnvironmentVariable("DOTNET_ROOT(x86)", EnvironmentVariableTarget.Process)}'");
+                $"DOTNET_ROOT(x86)='{Environment.GetEnvironmentVariable("DOTNET_ROOT(x86)", EnvironmentVariableTarget.Process)}';" +
+                $"{processArchitecture}='{Environment.GetEnvironmentVariable(processArchitecture)}'");
         }
     }
 }

--- a/src/Assets/TestProjects/TestAppEchoDotnetRoot/TestAppEchoDotnetRoot.csproj
+++ b/src/Assets/TestProjects/TestAppEchoDotnetRoot/TestAppEchoDotnetRoot.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -15,17 +15,21 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 {
     public class GivenDotnetRootEnv : SdkTest
     {
+        private static Version Version6_0 = new Version(6, 0);
+
         public GivenDotnetRootEnv(ITestOutputHelper log) : base(log)
         {
         }
 
-        [Fact]
-        public void ItShouldSetDotnetRootToDirectoryOfMuxer()
+        [Theory]
+        [InlineData("net5.0")]
+        [InlineData("net6.0")]
+        public void ItShouldSetDotnetRootToDirectoryOfMuxer(string targetFramework)
         {
             string expectDotnetRoot = TestContext.Current.ToolsetUnderTest.DotNetRoot;
-            string expectOutput = GetExpectOutput(expectDotnetRoot);
+            string expectOutput = GetExpectOutput(expectDotnetRoot, targetFramework);
 
-            var projectRoot = SetupDotnetRootEchoProject();
+            var projectRoot = SetupDotnetRootEchoProject(null, targetFramework);
 
             var runCommand = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(projectRoot);
@@ -65,31 +69,37 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .And.HaveStdOutContaining(GetExpectOutput(expectDotnetRoot));
         }
 
-        private string SetupDotnetRootEchoProject([CallerMemberName] string callingMethod = null)
+        private string SetupDotnetRootEchoProject([CallerMemberName] string callingMethod = null, string targetFramework = null)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("TestAppEchoDotnetRoot", callingMethod)
+                .CopyTestAsset("TestAppEchoDotnetRoot", callingMethod, allowCopyIfPresent: true)
                 .WithSource()
+                .WithTargetFrameworkOrFrameworks(targetFramework ?? null, false)
                 .Restore(Log);
 
             new BuildCommand(testAsset)
-                .Execute()
+                .Execute($"{(!string.IsNullOrEmpty(targetFramework) ? "/p:TargetFramework=" + targetFramework : string.Empty)}")
                 .Should()
                 .Pass();
 
             return testAsset.Path;
         }
 
-        private static string GetExpectOutput(string expectDotnetRoot)
+        private static string GetExpectOutput(string expectDotnetRoot, string targetFramework = null)
         {
             string expectOutput;
-            if (Environment.Is64BitProcess)
+            string processArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToUpperInvariant();
+            if (!string.IsNullOrEmpty(targetFramework) && Version.Parse(targetFramework.AsSpan(3)) >= Version6_0)
             {
-                expectOutput = @$"DOTNET_ROOT='{expectDotnetRoot}';DOTNET_ROOT(x86)=''";
+                expectOutput = $"DOTNET_ROOT='';DOTNET_ROOT(x86)='';DOTNET_ROOT_{processArchitecture}='{expectDotnetRoot}'";
+            }
+            else if (Environment.Is64BitProcess)
+            {
+                expectOutput = @$"DOTNET_ROOT='{expectDotnetRoot}';DOTNET_ROOT(x86)='';DOTNET_ROOT_{processArchitecture}=''";
             }
             else
             {
-                expectOutput = @$"DOTNET_ROOT='';DOTNET_ROOT(x86)='{expectDotnetRoot}'";
+                expectOutput = @$"DOTNET_ROOT='';DOTNET_ROOT(x86)='{expectDotnetRoot}';DOTNET_ROOT_{processArchitecture}=''";
             }
 
             return expectOutput;


### PR DESCRIPTION
Backport of #19860

# Description

`dotnet run` sets DOTNET_ROOT, but it needs to pick the appropriate location based on the target architecture

# Testing

Unit tests, manual verification

# Risk

Low