### PR TITLE
Do not fail design time builds when there are missing workload packs

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
@@ -28,9 +28,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ShowMissingWorkloads>
   </Target>
 
+  <!-- Skip this target for design time builds when there are missing workload packs.
+       This will prevent design time builds from failing and therefore allow
+       Visual Studio to collect the workloads from the GetSuggestedWorkloads target -->
   <Target Name="_CheckForMissingWorkload"
         BeforeTargets="_CheckForInvalidConfigurationAndPlatform;_CheckForUnsupportedTargetPlatformIdentifier"
-        Condition="'@(MissingWorkloadPack)' != ''">
+        Condition="'@(MissingWorkloadPack)' != '' And '$(DesignTimeBuild)' != 'true'">
 
     <ShowMissingWorkloads MissingWorkloadPacks="@(MissingWorkloadPack)"
                           NetCoreRoot="$(NetCoreRoot)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -98,9 +98,12 @@ Copyright (c) .NET Foundation. All rights reserved.
                  FormatArguments="$([MSBuild]::Escape('$(TargetFramework)'))" />
   </Target>
 
+  <!-- Skip this target for design time builds when there are missing workload packs.
+       This will prevent design time builds from failing and therefore allow
+       Visual Studio to collect the workloads from the GetSuggestedWorkloads target -->
   <Target Name="_CheckForUnsupportedTargetPlatformIdentifier"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform;RunResolvePackageDependencies;GetFrameworkPaths;GetReferenceAssemblyPaths;CollectPackageReferences"
-          Condition="'$(TargetPlatformIdentifier)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))" >
+          Condition="'$(TargetPlatformIdentifier)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) And ('$(DesignTimeBuild)' != 'true' Or '@(MissingWorkloadPack)' == '')" >
 
     <PropertyGroup>
       <TargetPlatformSupported Condition="'$(TargetPlatformIdentifier)' == 'Windows'">true</TargetPlatformSupported>


### PR DESCRIPTION
### Description
Design-time builds for projects with missing workloads should still succeed. This enables Visual Studio to gather the SuggestedWorkloads and present the user with a list of components to install to build and use the projects successfully.

This is needed by https://github.com/dotnet/project-system/pull/7432

### Regression
No

### Tests
[x] Manually tested with changes from https://github.com/dotnet/project-system/pull/7432

### Risk
Low. Changes design-time behavior to reduce number of already failing design-time builds.

### Packaging changes
None