### PR TITLE
[RC1] port [Package Validation] resolve references when running API Compat

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/IDiagnostic.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/IDiagnostic.cs
@@ -17,5 +17,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// String representing the ID for the object that the diagnostic was created for.
         /// </summary>
         string ReferenceId { get; }
+
+        /// <summary>
+        /// String describing the diagnostic.
+        /// </summary>
+        string Message { get; }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ComparingSettings.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ComparingSettings.cs
@@ -30,16 +30,22 @@ namespace Microsoft.DotNet.ApiCompatibility
         public IEqualityComparer<ISymbol> EqualityComparer { get; }
 
         /// <summary>
+        /// Indicates if we are running with a full set of references for left and right.
+        /// </summary>
+        public bool RunningWithReferences { get; }
+
+        /// <summary>
         /// Instantiate an object with the desired settings.
         /// </summary>
         /// <param name="ruleRunnerFactory">The factory to create a <see cref="IRuleRunner"/></param>
         /// <param name="filter">The symbol filter.</param>
         /// <param name="equalityComparer">The comparer to map metadata.</param>
-        public ComparingSettings(RuleRunnerFactory ruleRunnerFactory = null, ISymbolFilter filter = null, IEqualityComparer<ISymbol> equalityComparer = null, bool includeInternalSymbols = false, bool strictMode = false, string leftName = null, string[] rightNames = null)
+        public ComparingSettings(RuleRunnerFactory ruleRunnerFactory = null, ISymbolFilter filter = null, IEqualityComparer<ISymbol> equalityComparer = null, bool includeInternalSymbols = false, bool strictMode = false, bool withReferences = false, string leftName = null, string[] rightNames = null)
         {
             Filter = filter ?? new SymbolAccessibilityBasedFilter(includeInternalSymbols: includeInternalSymbols);
             EqualityComparer = equalityComparer ?? new DefaultSymbolsEqualityComparer();
-            RuleRunnerFactory = ruleRunnerFactory ?? new RuleRunnerFactory(leftName, rightNames, EqualityComparer, includeInternalSymbols, strictMode);
+            RuleRunnerFactory = ruleRunnerFactory ?? new RuleRunnerFactory(leftName, rightNames, EqualityComparer, includeInternalSymbols, strictMode, withReferences);
+            RunningWithReferences = withReferences;
         }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DefaultSymbolsEqualityComparer.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DefaultSymbolsEqualityComparer.cs
@@ -16,6 +16,19 @@ namespace Microsoft.DotNet.ApiCompatibility
         public int GetHashCode(ISymbol obj) =>
             GetKey(obj).GetHashCode();
 
-        private static string GetKey(ISymbol symbol) => symbol.ToComparisonDisplayString();
+        private static string GetKey(ISymbol symbol)
+        {
+            if (symbol is IMethodSymbol method)
+            {
+                // The display string for event add and remove varies
+                // depending if we have references or not.
+                // As these can't have different overrides we don't care
+                // about the full display string.
+                if (method.IsEventAdderOrRemover())
+                    return method.Name;
+            }
+
+            return symbol.ToComparisonDisplayString();
+        }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
@@ -17,5 +17,10 @@ namespace Microsoft.DotNet.ApiCompatibility
         public const string CannotRemoveBaseType = "CP0007";
         public const string CannotRemoveBaseInterface = "CP0008";
         public const string CannotSealType = "CP0009";
+
+        // Assembly loading ids
+        public const string AssemblyNotFound = "CP1001";
+        public const string AssemblyReferenceNotFound = "CP1002";
+        public const string SearchDirectoriesNotFoundForTfm = "CP1003";
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Extensions/SymbolExtensions.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Extensions/SymbolExtensions.cs
@@ -18,7 +18,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Extensions
 
             // Remove ? annotations from reference types as we want to map the APIs without nullable annotations
             // and have a special rule to catch those differences.
+            // Also don't use keyword names for special types. This makes the comparison more accurate when no
+            // references are running or if one side has references and the other doesn't.
             format = format.WithMiscellaneousOptions(format.MiscellaneousOptions &
+                ~SymbolDisplayMiscellaneousOptions.UseSpecialTypes &
                 ~SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName &
                 ~SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
 
@@ -83,5 +86,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Extensions
             symbol.DeclaredAccessibility == Accessibility.Protected ||
             symbol.DeclaredAccessibility == Accessibility.ProtectedOrInternal ||
             (includeInternals && symbol.DeclaredAccessibility != Accessibility.Private);
+
+        internal static bool IsEventAdderOrRemover(this IMethodSymbol method) =>
+            method.MethodKind == MethodKind.EventAdd ||
+            method.MethodKind == MethodKind.EventRemove ||
+            method.Name.StartsWith("add_", StringComparison.Ordinal) ||
+            method.Name.StartsWith("remove_", StringComparison.Ordinal);
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/CannotRemoveBaseTypeOrInterface.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/CannotRemoveBaseTypeOrInterface.cs
@@ -41,6 +41,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             ITypeSymbol leftBaseType = left.BaseType;
             ITypeSymbol rightBaseType = right.BaseType;
 
+            if (leftBaseType == null)
+                return;
+
             while (rightBaseType != null)
             {
                 // If we found the immediate left base type on right we can assume

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -14,14 +14,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         private readonly RuleSettings _settings;
         private readonly string _leftName;
         private readonly string[] _rightNames;
-
         internal const string DEFAULT_LEFT_NAME = "left";
         internal const string DEFAULT_RIGHT_NAME = "right";
 
-        internal RuleRunner(string leftName, string[] rightNames, bool strictMode, IEqualityComparer<ISymbol> symbolComparer, bool includeInternalSymbols)
+        internal RuleRunner(string leftName, string[] rightNames, bool strictMode, IEqualityComparer<ISymbol> symbolComparer, bool includeInternalSymbols, bool withReferences)
         {
             _context = new RuleRunnerContext();
-            _settings = new RuleSettings(strictMode, symbolComparer, includeInternalSymbols);
+            _settings = new RuleSettings(strictMode, symbolComparer, includeInternalSymbols, withReferences);
             _leftName = leftName;
             _rightNames = rightNames;
             InitializeRules();

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerFactory.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerFactory.cs
@@ -15,11 +15,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         private readonly string[] _rightNames;
         private readonly IEqualityComparer<ISymbol> _equalityComparer;
         private readonly bool _includeInternalSymbols;
+        private readonly bool _withReferences;
         private RuleRunner _runner;
 
-        public RuleRunnerFactory(string leftName, string[] rightNames, IEqualityComparer<ISymbol> equalityComparer, bool includeInternalSymbols, bool strictMode)
+        public RuleRunnerFactory(string leftName, string[] rightNames, IEqualityComparer<ISymbol> equalityComparer, bool includeInternalSymbols, bool strictMode, bool withReferences)
         {
             _strictMode = strictMode;
+            _withReferences = withReferences;
             _equalityComparer = equalityComparer;
             _includeInternalSymbols = includeInternalSymbols;
             _leftName = string.IsNullOrEmpty(leftName) ? RuleRunner.DEFAULT_LEFT_NAME : leftName;
@@ -46,7 +48,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         public virtual IRuleRunner GetRuleRunner()
         {
             if (_runner == null)
-                _runner = new RuleRunner(_leftName, _rightNames, _strictMode, _equalityComparer, _includeInternalSymbols);
+                _runner = new RuleRunner(_leftName, _rightNames, _strictMode, _equalityComparer, _includeInternalSymbols, _withReferences);
 
             return _runner;
         }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
@@ -8,15 +8,17 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
     public class RuleSettings
     {
-        public RuleSettings(bool strictMode, IEqualityComparer<ISymbol> symbolComparer, bool includeInternalSymbols)
+        public RuleSettings(bool strictMode, IEqualityComparer<ISymbol> symbolComparer, bool includeInternalSymbols, bool withReferences)
         {
             StrictMode = strictMode;
             SymbolComparer = symbolComparer;
             IncludeInternalSymbols = includeInternalSymbols;
+            WithReferences = withReferences;
         }
 
         public bool StrictMode { get; }
         public IEqualityComparer<ISymbol> SymbolComparer { get; }
         public bool IncludeInternalSymbols { get; }
+        public bool WithReferences { get; }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.Compatibility/CompatibilityLogger.cs
+++ b/src/Compatibility/Microsoft.DotNet.Compatibility/CompatibilityLogger.cs
@@ -25,7 +25,13 @@ namespace Microsoft.DotNet.Compatibility
             _baselineAllErrors = baselineAllErrors;
         }
 
-        public void LogError(Suppression suppression, string code, string format, params string[] args)
+        public void LogError(Suppression suppression, string code, string format, params string[] args) =>
+            LogSuppressableMessage(MessageLevel.Error, suppression, code, format, args);
+
+        public void LogWarning(Suppression suppression, string code, string format, params string[] args) =>
+            LogSuppressableMessage(MessageLevel.Warning, suppression, code, format, args);
+
+        private void LogSuppressableMessage(MessageLevel messageLevel, Suppression suppression, string code, string format, params string[] args)
         {
             if (!_suppressionEngine.IsErrorSuppressed(suppression))
             {
@@ -35,14 +41,12 @@ namespace Microsoft.DotNet.Compatibility
                 }
                 else
                 {
-                    _log.LogNonSdkError(code, format, args);
+                    _log.Log(new Message(messageLevel, string.Format(format, args), code));
                 }
             }
         }
 
         public void LogMessage(MessageImportance importance, string format, params string[] args) => _log.LogMessage(importance, format, args);
-
-        public void LogErrorHeader(string message) => _log.LogNonSdkError(null, message);
 
         public void GenerateSuppressionsFile(string suppressionsFile)
         {

--- a/src/Compatibility/Microsoft.DotNet.Compatibility/ValidatePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.Compatibility/ValidatePackage.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using Microsoft.Build.Framework;
@@ -37,6 +39,8 @@ namespace Microsoft.DotNet.Compatibility
 
         public string CompatibilitySuppressionFilePath { get; set; }
 
+        public ITaskItem[] ReferencePaths { get; set; }
+
         public override bool Execute()
         {
             AppDomain.CurrentDomain.AssemblyResolve += ResolverForRoslyn;
@@ -58,16 +62,39 @@ namespace Microsoft.DotNet.Compatibility
                 runtimeGraph = JsonRuntimeFormat.ReadRuntimeGraph(RuntimeGraph);
             }
 
+            Dictionary<string, HashSet<string>> apiCompatReferences = new();
+            if (ReferencePaths != null)
+            {
+                foreach (ITaskItem taskItem in ReferencePaths)
+                {
+                    string tfm = taskItem.GetMetadata("TargetFramework");
+                    if (string.IsNullOrEmpty(tfm))
+                        continue;
+
+                    string referencePath = taskItem.GetMetadata("Identity");
+                    if (!File.Exists(referencePath))
+                        continue;
+
+                    if (!apiCompatReferences.TryGetValue(tfm, out HashSet<string> directories))
+                    {
+                        directories = new();
+                        apiCompatReferences.Add(tfm, directories);
+                    }
+
+                    directories.Add(referencePath);
+                }
+            }
+
             Package package = NupkgParser.CreatePackage(PackageTargetPath, runtimeGraph);
             CompatibilityLogger logger = new(Log, CompatibilitySuppressionFilePath, GenerateCompatibilitySuppressionFile);
 
-            new CompatibleTfmValidator(NoWarn, null, RunApiCompat, EnableStrictModeForCompatibleTfms, logger).Validate(package);
-            new CompatibleFrameworkInPackageValidator(NoWarn, null, EnableStrictModeForCompatibleFrameworksInPackage, logger).Validate(package);
+            new CompatibleTfmValidator(NoWarn, null, RunApiCompat, EnableStrictModeForCompatibleTfms, logger, apiCompatReferences).Validate(package);
+            new CompatibleFrameworkInPackageValidator(NoWarn, null, EnableStrictModeForCompatibleFrameworksInPackage, logger, apiCompatReferences).Validate(package);
 
             if (!DisablePackageBaselineValidation && !string.IsNullOrEmpty(BaselinePackageTargetPath))
             {
                 Package baselinePackage = NupkgParser.CreatePackage(BaselinePackageTargetPath, runtimeGraph);
-                new BaselinePackageValidator(baselinePackage, NoWarn, null, RunApiCompat, logger).Validate(package);
+                new BaselinePackageValidator(baselinePackage, NoWarn, null, RunApiCompat, logger, apiCompatReferences).Validate(package);
             }
 
             if (GenerateCompatibilitySuppressionFile)

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
@@ -21,17 +21,18 @@ namespace Microsoft.DotNet.PackageValidation
         internal Dictionary<MetadataInformation, List<(MetadataInformation rightAssembly, string header)>> _dict = new();
         private readonly ApiComparer _differ = new();
         private readonly ICompatibilityLogger _log;
-
+        private readonly Dictionary<string, HashSet<string>> _referencePaths;
         private bool _isBaselineSuppression = false;
         private string _leftPackagePath;
         private string _rightPackagePath;
 
-        public ApiCompatRunner(string noWarn, (string, string)[] ignoredDifferences, bool enableStrictMode, ICompatibilityLogger log)
+        public ApiCompatRunner(string noWarn, (string, string)[] ignoredDifferences, bool enableStrictMode, ICompatibilityLogger log, Dictionary<string, HashSet<string>> referencePaths)
         {
             _differ.NoWarn = noWarn;
             _differ.IgnoredDifferences = ignoredDifferences;
             _differ.StrictMode = enableStrictMode;
             _log = log;
+            _referencePaths = referencePaths ?? new();
         }
 
         /// <summary>
@@ -42,10 +43,12 @@ namespace Microsoft.DotNet.PackageValidation
             foreach (MetadataInformation left in _dict.Keys)
             {
                 IAssemblySymbol leftSymbols;
+                bool runWithReferences = false;
                 using(Stream leftAssemblyStream = GetFileStreamFromPackage(_leftPackagePath, left.AssemblyId))
                 {
-                    leftSymbols = new AssemblySymbolLoader().LoadAssembly(left.AssemblyName, leftAssemblyStream);
+                    leftSymbols = GetAssemblySymbolFromStream(leftAssemblyStream, left, out runWithReferences);
                 }
+
                 ElementContainer<IAssemblySymbol> leftContainer = new(leftSymbols, left);
 
                 List<ElementContainer<IAssemblySymbol>> rightContainerList = new();
@@ -54,8 +57,10 @@ namespace Microsoft.DotNet.PackageValidation
                     IAssemblySymbol rightSymbols;
                     using (Stream rightAssemblyStream = GetFileStreamFromPackage(_rightPackagePath, rightTuple.rightAssembly.AssemblyId))
                     {
-                        rightSymbols = new AssemblySymbolLoader().LoadAssembly(rightTuple.rightAssembly.AssemblyName, rightAssemblyStream);
+                        rightSymbols = GetAssemblySymbolFromStream(rightAssemblyStream, rightTuple.rightAssembly, out bool resolvedReferences);
+                        runWithReferences &= resolvedReferences;
                     }
+
                     rightContainerList.Add(new ElementContainer<IAssemblySymbol>(rightSymbols, rightTuple.rightAssembly));
                 }
 
@@ -66,10 +71,16 @@ namespace Microsoft.DotNet.PackageValidation
                 foreach ((MetadataInformation, MetadataInformation, IEnumerable<CompatDifference> differences) diff in differences)
                 {
                     (MetadataInformation rightAssembly, string header) rightTuple = _dict[left][counter++];
-                    _log.LogMessage(MessageImportance.Low, rightTuple.header);
 
+                    bool logHeaderMessage = true;
                     foreach (CompatDifference difference in diff.differences)
                     {
+                        if (logHeaderMessage)
+                        {
+                            _log.LogMessage(MessageImportance.Low, rightTuple.header);
+                            logHeaderMessage = false;
+                        }
+
                         _log.LogError(
                             new Suppression
                             {
@@ -85,6 +96,61 @@ namespace Microsoft.DotNet.PackageValidation
                 }
             }
             _dict.Clear();
+        }
+
+        private IAssemblySymbol GetAssemblySymbolFromStream(Stream assemblyStream, MetadataInformation assemblyInformation, out bool resolvedReferences)
+        {
+            resolvedReferences = false;
+            HashSet<string> referencePathForTFM = null;
+
+            // In order to enable reference support for baseline suppression we need a better way
+            // to resolve references for the baseline package. Let's not enable it for now.
+            bool shouldResolveReferences = !_isBaselineSuppression && _referencePaths != null &&
+                _referencePaths.TryGetValue(assemblyInformation.TargetFramework, out referencePathForTFM);
+
+            AssemblySymbolLoader loader = new(resolveAssemblyReferences: shouldResolveReferences);
+            if (shouldResolveReferences)
+            {
+                resolvedReferences = true;
+                loader.AddReferenceSearchDirectories(referencePathForTFM);
+            }
+            else if (!_isBaselineSuppression && _referencePaths != null && ShouldLogDiagnosticId(ApiCompatibility.DiagnosticIds.SearchDirectoriesNotFoundForTfm))
+            {
+                _log.LogWarning(
+                    new Suppression()
+                    {
+                        DiagnosticId = ApiCompatibility.DiagnosticIds.SearchDirectoriesNotFoundForTfm,
+                        Target = assemblyInformation.DisplayString
+                    },
+                    ApiCompatibility.DiagnosticIds.SearchDirectoriesNotFoundForTfm,
+                    Resources.MissingSearchDirectory,
+                    assemblyInformation.TargetFramework, assemblyInformation.DisplayString);
+            }
+
+            IAssemblySymbol symbol = loader.LoadAssembly(assemblyInformation.AssemblyName, assemblyStream);
+
+            if (loader.HasLoadWarnings(out IEnumerable<AssemblyLoadWarning> warnings))
+            {
+                resolvedReferences = false;
+                foreach (AssemblyLoadWarning warning in warnings)
+                {
+                    if (ShouldLogDiagnosticId(warning.DiagnosticId))
+                    {
+                        _log.LogWarning(
+                            new Suppression()
+                            {
+                                DiagnosticId = warning.DiagnosticId,
+                                Target = warning.ReferenceId
+                            },
+                            warning.DiagnosticId,
+                            Resources.AssemblyLoadWarning,
+                            assemblyInformation.DisplayString,
+                            warning.Message);
+                    }
+                }
+            }
+
+            return symbol;
         }
 
         /// <summary>
@@ -133,6 +199,22 @@ namespace Microsoft.DotNet.PackageValidation
                 ms.Seek(0, SeekOrigin.Begin);
             }
             return ms;
+        }
+
+        private bool ShouldLogDiagnosticId(string diagnosticId)
+        {
+            if (!string.IsNullOrEmpty(_differ.NoWarn))
+            {
+                foreach (var noWarn in _differ.NoWarn.Split(';'))
+                {
+                    if (StringComparer.InvariantCultureIgnoreCase.Equals(noWarn, diagnosticId))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
@@ -24,12 +24,12 @@ namespace Microsoft.DotNet.PackageValidation
         private readonly ApiCompatRunner _apiCompatRunner;
         private readonly ICompatibilityLogger _log;
 
-        public BaselinePackageValidator(Package baselinePackage, string noWarn, (string, string)[] ignoredDifferences, bool runApiCompat, ICompatibilityLogger log)
+        public BaselinePackageValidator(Package baselinePackage, string noWarn, (string, string)[] ignoredDifferences, bool runApiCompat, ICompatibilityLogger log, Dictionary<string, HashSet<string>> apiCompatReferences)
         {
             _baselinePackage = baselinePackage;
             _runApiCompat = runApiCompat;
             _log = log;
-            _apiCompatRunner = new(noWarn, ignoredDifferences, false, _log);
+            _apiCompatRunner = new(noWarn, ignoredDifferences, false, _log, apiCompatReferences);
             _diagnosticBag = new(noWarn?.Split(';')?.Where(t => s_diagList.Contains(t)), ignoredDifferences);
         }
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
@@ -17,9 +17,9 @@ namespace Microsoft.DotNet.PackageValidation
     {
         private readonly ApiCompatRunner _apiCompatRunner;
 
-        public CompatibleFrameworkInPackageValidator(string noWarn, (string, string)[] ignoredDifferences, bool enableStrictMode, ICompatibilityLogger log)
+        public CompatibleFrameworkInPackageValidator(string noWarn, (string, string)[] ignoredDifferences, bool enableStrictMode, ICompatibilityLogger log, Dictionary<string, HashSet<string>> apiCompatReferences)
         {
-            _apiCompatRunner = new(noWarn, ignoredDifferences, enableStrictMode, log);
+            _apiCompatRunner = new(noWarn, ignoredDifferences, enableStrictMode, log, apiCompatReferences);
         }
 
         /// <summary>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
@@ -27,11 +27,11 @@ namespace Microsoft.DotNet.PackageValidation
         private readonly ApiCompatRunner _apiCompatRunner;
         private readonly ICompatibilityLogger _log;
 
-        public CompatibleTfmValidator(string noWarn, (string, string)[] ignoredDifferences, bool runApiCompat, bool enableStrictMode, ICompatibilityLogger log)
+        public CompatibleTfmValidator(string noWarn, (string, string)[] ignoredDifferences, bool runApiCompat, bool enableStrictMode, ICompatibilityLogger log, Dictionary<string, HashSet<string>> apiCompatReferences)
         {
             _runApiCompat = runApiCompat;
             _log = log;
-            _apiCompatRunner = new(noWarn, ignoredDifferences, enableStrictMode, _log);
+            _apiCompatRunner = new(noWarn, ignoredDifferences, enableStrictMode, _log, apiCompatReferences);
             _diagnosticBag = new(noWarn?.Split(';')?.Where(t => s_diagList.Contains(t)), ignoredDifferences);
         }
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ICompatibilityLogger.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ICompatibilityLogger.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.PackageValidation
     public interface ICompatibilityLogger
     {
         void LogError(Suppression suppression, string code, string format, params string[] args);
-        void LogErrorHeader(string message);
+        void LogWarning(Suppression suppression, string code, string format, params string[] args);
         void LogMessage(MessageImportance importance, string format, params string[] args);
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
@@ -150,4 +150,10 @@
   <data name="Baseline" xml:space="preserve">
     <value>[Baseline]</value>
   </data>
+  <data name="AssemblyLoadWarning" xml:space="preserve">
+    <value>When loading: '{0}': {1}</value>
+  </data>
+  <data name="MissingSearchDirectory" xml:space="preserve">
+    <value>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</value>
+  </data>
 </root>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyLoadWarning">
+        <source>When loading: '{0}': {1}</source>
+        <target state="new">When loading: '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Baseline">
         <source>[Baseline]</source>
         <target state="new">[Baseline]</target>
@@ -25,6 +30,11 @@
       <trans-unit id="InvalidPackagePath">
         <source>Package path '{0}' is invalid.</source>
         <target state="new">Package path '{0}' is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingSearchDirectory">
+        <source>Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</source>
+        <target state="new">Could not find a reference directory in the provided directories for TargetFramework '{0}' when loading '{1}'. For more information see: https://aka.ms/dotnetpackagevalidation</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTargetFramework">

--- a/src/Tasks/Common/Logger.cs
+++ b/src/Tasks/Common/Logger.cs
@@ -65,9 +65,6 @@ namespace Microsoft.NET.Build.Tasks
         public void LogError(string format, params string[] args)
             => Log(CreateMessage(MessageLevel.Error, format, args));
 
-        public void LogNonSdkError(string code, string format, params string[] args) 
-            => Log(new Message(MessageLevel.Error, string.Format(format, args), code));
-        
         public void Log(in Message message)
         {
             HasLoggedErrors |= message.Level == MessageLevel.Error;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
@@ -2,7 +2,13 @@
 <Project>
   <UsingTask TaskName="Microsoft.DotNet.Compatibility.ValidatePackage" AssemblyFile="$(DotNetCompatibilityAssembly)" />
 
+  <PropertyGroup>
+    <!--Add any custom targets that need to run before package validation to the following property-->
+    <RunPackageValidationDependsOn>_GetReferencePathFromInnerProjects;$(RunPackageValidationDependsOn)</RunPackageValidationDependsOn>
+  </PropertyGroup>
+
   <Target Name="RunPackageValidation"
+          DependsOnTargets="$(RunPackageValidationDependsOn)"
           AfterTargets="Pack"
           Condition="'$(IsPackable)' == 'true' and '$(EnablePackageValidation)' == 'true'">
 
@@ -34,6 +40,36 @@
       CompatibilitySuppressionFilePath="$(CompatibilitySuppressionFilePath)"
       BaselinePackageTargetPath="$(PackageValidationBaselinePath)"
       DisablePackageBaselineValidation="$(DisablePackageBaselineValidation)"
-      RoslynAssembliesPath="$(RoslynAssembliesPath)" />
+      RoslynAssembliesPath="$(RoslynAssembliesPath)"
+      ReferencePaths="@(PackageValidationReferencePath)" />
+  </Target>
+
+  <PropertyGroup>
+    <_GetReferencePathFromInnerProjectsDependsOn Condition="'$(IsCrossTargetingBuild)' != 'true'">_GetReferencePathForPackageValidation</_GetReferencePathFromInnerProjectsDependsOn>
+    <_GetReferencePathFromInnerProjectsDependsOn Condition="'$(IsCrossTargetingBuild)' == 'true'">_ComputeTargetFrameworkItems</_GetReferencePathFromInnerProjectsDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_GetReferencePathForPackageValidation"
+          DependsOnTargets="ResolveReferences"
+          Returns="@(_ReferencePathWithTargetFramework)">
+    <ItemGroup>
+      <_ReferencePathWithTargetFramework Include="@(ReferencePath)"  TargetFramework="$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_GetReferencePathFromInnerProjects"
+          DependsOnTargets="$(_GetReferencePathFromInnerProjectsDependsOn)"
+          Condition="'$(RunPackageValidationWithoutReferences)' != 'true'">
+
+    <MSBuild Projects="@(_InnerBuildProjects)"
+             Condition="'$(IsCrossTargetingBuild)' == 'true'"
+             Targets="_GetReferencePathForPackageValidation"
+             Properties="BuildProjectReferences=false">
+      <Output ItemName="PackageValidationReferencePath" TaskParameter="TargetOutputs" />
+    </MSBuild>
+
+    <ItemGroup Condition="'$(IsCrossTargetingBuild)' != 'true'">
+      <PackageValidationReferencePath Include="@(_ReferencePathWithTargetFramework)" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/AssemblySymbolLoaderTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/AssemblySymbolLoaderTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Cli.Utils;
@@ -144,14 +145,14 @@ namespace MyNamespace
             AssemblySymbolLoader loader = new();
             IEnumerable<IAssemblySymbol> symbols = loader.LoadMatchingAssemblies(new[] { assembly }, paths);
             Assert.Empty(symbols);
-            Assert.True(loader.HasLoadWarnings(out IEnumerable<string> warnings));
+            Assert.True(loader.HasLoadWarnings(out IEnumerable<AssemblyLoadWarning> warnings));
 
-            IEnumerable<string> expected = new[]
+            IEnumerable<AssemblyLoadWarning> expected = new[]
             {
-                $"Could not find matching assembly: '{assembly.Identity.GetDisplayName()}' in any of the search directories."
+                new AssemblyLoadWarning(DiagnosticIds.AssemblyNotFound, assembly.Identity.GetDisplayName(), $"Could not find matching assembly: '{assembly.Identity.GetDisplayName()}' in any of the search directories.")
             };
 
-            Assert.Equal(expected, warnings, StringComparer.Ordinal);
+            Assert.Equal(expected, warnings);
         }
 
         [Fact]
@@ -195,14 +196,14 @@ namespace MyNamespace
             if (validateIdentities)
             {
                 Assert.Empty(matchingAssemblies);
-                Assert.True(loader.HasLoadWarnings(out IEnumerable<string> warnings));
+                Assert.True(loader.HasLoadWarnings(out IEnumerable<AssemblyLoadWarning> warnings));
 
-                IEnumerable<string> expected = new[]
+                IEnumerable<AssemblyLoadWarning> expected = new[]
                 {
-                    $"Could not find matching assembly: '{fromAssembly.Identity.GetDisplayName()}' in any of the search directories."
+                    new AssemblyLoadWarning(DiagnosticIds.AssemblyNotFound, fromAssembly.Identity.GetDisplayName(), $"Could not find matching assembly: '{fromAssembly.Identity.GetDisplayName()}' in any of the search directories.")
                 };
 
-                Assert.Equal(expected, warnings, StringComparer.Ordinal);
+                Assert.Equal(expected, warnings);
             }
             else
             {
@@ -290,7 +291,7 @@ namespace MyNamespace
 
             if (resolveReferences)
             {
-                Assert.True(loader.HasLoadWarnings(out IEnumerable<string> warnings));
+                Assert.True(loader.HasLoadWarnings(out IEnumerable<AssemblyLoadWarning> warnings));
 
                 string expectedReference = "System.Runtime.dll";
 
@@ -299,16 +300,16 @@ namespace MyNamespace
                     expectedReference = "mscorlib.dll";
                 }
 
-                IEnumerable<string> expected = new[]
+                IEnumerable<AssemblyLoadWarning> expected = new List<AssemblyLoadWarning>
                 {
-                    $"Could not resolve reference '{expectedReference}' in any of the provided search directories."
+                    new AssemblyLoadWarning(DiagnosticIds.AssemblyReferenceNotFound, expectedReference, $"Could not resolve reference '{expectedReference}' in any of the provided search directories.")
                 };
 
-                Assert.Equal(expected, warnings, StringComparer.Ordinal);
+                Assert.Equal(expected, warnings);
             }
             else
             {
-                Assert.False(loader.HasLoadWarnings(out IEnumerable<string> warnings));
+                Assert.False(loader.HasLoadWarnings(out IEnumerable<AssemblyLoadWarning> warnings));
                 Assert.Empty(warnings);
             }
         }
@@ -318,11 +319,17 @@ namespace MyNamespace
         {
             var assetInfo = GetSimpleTestAsset();
             AssemblySymbolLoader loader = new(resolveAssemblyReferences: true);
+            // AddReferenceSearchDirectories should be able to handle directories as well as full path to assemblies.
             loader.AddReferenceSearchDirectories(Path.GetDirectoryName(typeof(string).Assembly.Location));
+            loader.AddReferenceSearchDirectories(Path.GetFullPath(typeof(string).Assembly.Location));
             loader.LoadAssembly(Path.Combine(assetInfo.OutputDirectory, assetInfo.TestAsset.TestProject.Name + ".dll"));
 
-            Assert.False(loader.HasLoadWarnings(out IEnumerable<string> warnings));
+            Assert.False(loader.HasLoadWarnings(out IEnumerable<AssemblyLoadWarning> warnings));
             Assert.Empty(warnings);
+
+            // Ensure we loaded more than one assembly since resolveReferences was set to true.
+            Dictionary<string, MetadataReference> loadedAssemblies = (Dictionary<string, MetadataReference>)typeof(AssemblySymbolLoader)?.GetField("_loadedAssemblies", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(loader);
+            Assert.True(loadedAssemblies != null && loadedAssemblies.Count > 1);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ApiCompatRunnerTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ApiCompatRunnerTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
         [Fact]
         public void NoDuplicateRightsForSpecificLeft()
         {
-            ApiCompatRunner acp = new(null, null, false, null);
+            ApiCompatRunner acp = new(null, null, false, null, null);
             MetadataInformation left = new(@"A.dll", "netstandard2.0", @"lib\netstandard2.0\A.dll");
             MetadataInformation right = new(@"A.dll", "net461", @"lib\net461\A.dll");
 

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/BaseLineVersionValidatorTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/BaseLineVersionValidatorTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "2.0.0", currentFilePaths, null, null);
-            new BaselinePackageValidator(previousPackage, string.Empty, null, false, _log).Validate(package);
+            new BaselinePackageValidator(previousPackage, string.Empty, null, false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
             Assert.Contains(DiagnosticIds.TargetFrameworkDropped + " " + string.Format(Resources.MissingTargetFramework, ".NETStandard,Version=v2.0"), _log.errors);
         }

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworkValidatorTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworkValidatorTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
             Assert.Single(_log.errors);
             Assert.Equal(DiagnosticIds.CompatibleRuntimeRidLessAsset + " " + string.Format(Resources.NoCompatibleRuntimeAsset, ".NETCoreApp,Version=v3.1"), _log.errors[0]);
         }
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package); ;
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package); ;
             Assert.NotEmpty(_log.errors);
             Assert.Contains(DiagnosticIds.CompatibleRuntimeRidLessAsset + " " + string.Format(Resources.NoCompatibleRuntimeAsset, ".NETStandard,Version=v2.0"), _log.errors);
         }
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
             Assert.Contains(DiagnosticIds.CompatibleRuntimeRidLessAsset + " " + string.Format(Resources.NoCompatibleRuntimeAsset, ".NETCoreApp,Version=v2.0"), _log.errors);
             Assert.Contains(DiagnosticIds.CompatibleRuntimeRidSpecificAsset + " " + string.Format(Resources.NoCompatibleRidSpecificRuntimeAsset, ".NETCoreApp,Version=v2.0", "win"), _log.errors);
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
 
             Assert.NotEmpty(_log.errors);
             Assert.Contains(DiagnosticIds.ApplicableCompileTimeAsset + " " + string.Format(Resources.NoCompatibleCompileTimeAsset, ".NETStandard,Version=v2.0"), _log.errors);
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
             Assert.Empty(_log.errors);
         }
 
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
             Assert.Contains(DiagnosticIds.ApplicableCompileTimeAsset + " " +string.Format(Resources.NoCompatibleCompileTimeAsset, ".NETStandard,Version=v2.0"), _log.errors);
         }
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
             Assert.Contains(DiagnosticIds.CompatibleRuntimeRidLessAsset +  " " + string.Format(Resources.NoCompatibleRuntimeAsset, ".NETCoreApp,Version=v3.0"), _log.errors);
         }
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
             Assert.Empty(_log.errors);
         }
 
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
             Assert.Contains(DiagnosticIds.ApplicableCompileTimeAsset + " " + string.Format(Resources.NoCompatibleCompileTimeAsset, ".NETStandard,Version=v2.0"), _log.errors);
         }
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
             Assert.Empty(_log.errors);
         }
 
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
 
             Package package = new("TestPackage", "1.0.0", filePaths, null, null);
-            new CompatibleTfmValidator(string.Empty, null, false, false, _log).Validate(package);
+            new CompatibleTfmValidator(string.Empty, null, false, false, _log, null).Validate(package);
             Assert.Empty(_log.errors);
         }
 

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
@@ -46,7 +46,7 @@ namespace PackageValidationTests
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
             Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
-            new CompatibleFrameworkInPackageValidator(string.Empty, null, false, _log).Validate(package);
+            new CompatibleFrameworkInPackageValidator(string.Empty, null, false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
             // TODO: add asserts for assembly and header metadata.
             string assemblyName = $"{asset.TestProject.Name}.dll";
@@ -84,7 +84,7 @@ namespace PackageValidationTests
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
             Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
-            new CompatibleFrameworkInPackageValidator(string.Empty, null, false, _log).Validate(package);
+            new CompatibleFrameworkInPackageValidator(string.Empty, null, false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
 
             string assemblyName = $"{asset.TestProject.Name}.dll";

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/TestLogger.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/TestLogger.cs
@@ -11,14 +11,14 @@ namespace Microsoft.DotNet.PackageValidation.Tests
     public class TestLogger : ICompatibilityLogger
     {
         public List<string> errors = new();
+        public List<string> warnings = new();
 
-        public void LogError(Suppression suppression, string code, string format, params string[] args)
-        {
+        public void LogError(Suppression suppression, string code, string format, params string[] args) =>
             errors.Add(code + " " + string.Format(format, args));
-        }
-
-        public void LogErrorHeader(string message) { }
 
         public void LogMessage(MessageImportance importance, string format, params string[] args) { }
+
+        public void LogWarning(Suppression suppression, string code, string format, params string[] args) =>
+            errors.Add(code + " " + string.Format(format, args));
     }
 }

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -122,6 +125,85 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;DisablePackageBaselineValidation=true;PackageValidationBaselinePath={nonExistentPackageBaselinePath}");
             Assert.Equal(0, result.ExitCode);
+        }
+
+        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        public void ValidatePackageWithReferences()
+        {
+            TestLogger log = new TestLogger();
+
+            string subDependencyName = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
+            TestProject testSubDependency = new()
+            {
+                Name = subDependencyName,
+                TargetFrameworks = "netstandard2.0"
+            };
+            string subDependencySourceCode = @"
+namespace PackageValidationTests
+{
+    public interface IBaseInterface { }
+}
+";
+            testSubDependency.SourceFiles.Add("IBaseInterface.cs", subDependencySourceCode);
+
+            string dependencyName = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
+            TestProject testDependency = new()
+            {
+                Name = dependencyName,
+                TargetFrameworks = "netstandard2.0;net5.0"
+            };
+            string dependencySourceCode = @"
+namespace PackageValidationTests
+{
+    public class ItermediateBaseClass
+#if NETSTANDARD2_0
+: IBaseInterface
+#endif
+    { }
+}
+";
+            testDependency.ReferencedProjects.Add(testSubDependency);
+            testDependency.SourceFiles.Add("ItermediateBaseClass.cs", dependencySourceCode);
+
+
+            string name = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
+            TestProject testProject = new()
+            {
+                Name = name,
+                TargetFrameworks = "netstandard2.0;net5.0",
+            };
+
+            string sourceCode = @"
+namespace PackageValidationTests
+{
+    public class First : ItermediateBaseClass { }
+}";
+
+            testProject.ReferencedProjects.Add(testDependency);
+            testProject.SourceFiles.Add("Hello.cs", sourceCode);
+            TestAsset asset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
+            PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
+            var result = packCommand.Execute();
+            Assert.Equal(string.Empty, result.StdErr);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+
+            // First we run without references. Without references, ApiCompat should not be able to see that class First
+            // removed an interface due to it's base class removing that implementation. We validate that APICompat doesn't
+            // log errors when not using references.
+            new CompatibleFrameworkInPackageValidator("CP1003", null, false, log, null).Validate(package);
+            Assert.Empty(log.errors);
+
+            // Now we do pass in references. With references, ApiCompat should now detect that an interface was removed in a
+            // dependent assembly, causing one of our types to stop implementing that assembly. We validate that a CP0008 is logged.
+            Dictionary<string, HashSet<string>> references = new()
+            {
+                { "netstandard2.0", new HashSet<string> { Path.Combine(asset.TestRoot, asset.TestProject.Name, "bin", "Debug", "netstandard2.0") } },
+                { "net5.0", new HashSet<string> { Path.Combine(asset.TestRoot, asset.TestProject.Name, "bin", "Debug", "net5.0") } }
+            };
+            new CompatibleFrameworkInPackageValidator("CP1002", null, false, log, references).Validate(package);
+            Assert.NotEmpty(log.errors);
+
+            Assert.Contains($"CP0008 Type 'PackageValidationTests.First' does not implement interface 'PackageValidationTests.IBaseInterface' on lib/net5.0/{asset.TestProject.Name}.dll but it does on lib/netstandard2.0/{asset.TestProject.Name}.dll" ,log.errors);
         }
     }
 }


### PR DESCRIPTION

Ports https://github.com/dotnet/sdk/pull/19771

## Description

Adds support to automatically resolve references when comparing compatible assemblies while checking for APICompat breaking changes during Package Validation. One of the big things that this will fix, is that it will finally be able to compare two assemblies if one of them uses type-forwards. Another benefit is that it will be able to analyze through the whole type-hirerarchy for removing base interfaces or base classes. We have tested these changes in dotnet/runtime, and greatly improve the results that we get and have also caught a few great breaking changes. The idea of getting this in to RC1, is so that we can get feedback from users that try it out so that we can react to it on the next RC.

## Customer Impact

Some customers might start getting more ApiCompat errors than they were in the past. All new ones should be actual breaking changes which the customer very likely is interested in finding out of.

## Regression?
- [ ] Yes
- [X] No

## Risk

- [X] Low

This is an opt-in new feature, and if anything, we expect it should only increase the value of the results that come back from running APICompat through your project to detect breaking changes.

## Verification
- [X] Automated tests
- [X] Ran a build of dotnet/runtime against the new changes and found a big improvement in the results from Apicompat.