### PR TITLE
[Release/6.0.1xx-rc1] Dispose Open handle on the produced package

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/NupkgParser.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/NupkgParser.cs
@@ -23,10 +23,12 @@ namespace Microsoft.DotNet.PackageValidation
         /// <returns>The package object.</returns>
         public static Package CreatePackage(string packagePath, RuntimeGraph runtimeGraph)
         {
-            PackageArchiveReader packageReader = new PackageArchiveReader(packagePath);
-            Package package = CreatePackage(packageReader, runtimeGraph);
-            package.PackagePath = packagePath;
-            return package;
+            using (PackageArchiveReader packageReader = new PackageArchiveReader(packagePath))
+            {
+                Package package = CreatePackage(packageReader, runtimeGraph);
+                package.PackagePath = packagePath;
+                return package;
+            }
         }
 
         private static Package CreatePackage(PackageArchiveReader packageReader, RuntimeGraph runtimeGraph)


### PR DESCRIPTION
## Description

Package validation task uses nuget apis to load the package in memory
We were not disposing one of the handles to the nuget package. This opened handle didnt allow the users to do any operations on packages even after the pack task has been completed. 

In this change we add the using statement to dispose off the handle after the loading the package in memory.

## Customer Impact

Some customers might start getting file contention issues when they are moving or editing the nuget packages. we hit this while enabling the package validation feature in dotnet/aspnetcore 

## Regression?
- [ ] Yes
- [X] No

## Risk

- [X] Low

This whole feature is an opt-in feature.

## Verification
- [X] Ran a build of dotnet/aspnetcore with the change and verified that the build is successful with this change. Aspnetcore edits the packages after the pack task