### PR TITLE
Test driven RazorSourceGenerator incrementality

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -92,6 +92,10 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>8893e64d4a9f4ba78aae83e6c87f302ab14a60e9</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.0-4.21424.5">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>8893e64d4a9f4ba78aae83e6c87f302ab14a60e9</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21424.5">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>8893e64d4a9f4ba78aae83e6c87f302ab14a60e9</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -126,6 +126,7 @@
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21424.5</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21424.5</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.0.0-4.21424.5</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21424.5</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/RazorSdk/Razor.slnf
+++ b/src/RazorSdk/Razor.slnf
@@ -5,11 +5,13 @@
       "src\\BlazorWasmSdk\\Tasks\\Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.csproj",
       "src\\BlazorWasmSdk\\Tool\\Microsoft.NET.Sdk.BlazorWebAssembly.Tool.csproj",
       "src\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj",
+      "src\\Cli\\Microsoft.DotNet.InternalAbstractions\\Microsoft.DotNet.InternalAbstractions.csproj",
       "src\\RazorSdk\\SourceGenerators\\Microsoft.NET.Sdk.Razor.SourceGenerators.csproj",
       "src\\RazorSdk\\Tasks\\Microsoft.NET.Sdk.Razor.Tasks.csproj",
       "src\\RazorSdk\\Tool\\Microsoft.NET.Sdk.Razor.Tool.csproj",
       "src\\Resolvers\\Microsoft.DotNet.NativeWrapper\\Microsoft.DotNet.NativeWrapper.csproj",
       "src\\Tests\\Microsoft.NET.Sdk.BlazorWebAssembly.Tests\\Microsoft.NET.Sdk.BlazorWebAssembly.Tests.csproj",
+      "src\\Tests\\Microsoft.NET.Sdk.Razor.SourceGenerators.Tests\\Microsoft.NET.Sdk.Razor.SourceGenerators.Tests.csproj",
       "src\\Tests\\Microsoft.NET.Sdk.Razor.Tests\\Microsoft.NET.Sdk.Razor.Tests.csproj",
       "src\\Tests\\Microsoft.NET.Sdk.Razor.Tool.Tests\\Microsoft.NET.Sdk.Razor.Tool.Tests.csproj",
       "src\\Tests\\Microsoft.NET.TestFramework\\Microsoft.NET.TestFramework.csproj"

--- a/src/RazorSdk/SourceGenerators/IncrementalValueProviderExtensions.cs
+++ b/src/RazorSdk/SourceGenerators/IncrementalValueProviderExtensions.cs
@@ -16,6 +16,12 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             return source.WithComparer(comparer);
         }
 
+        internal static IncrementalValuesProvider<T> WithLambdaComparer<T>(this IncrementalValuesProvider<T> source, Func<T, T, bool> equal, Func<T, int> getHashCode)
+        {
+            var comparer = new LambdaComparer<T>(equal, getHashCode);
+            return source.WithComparer(comparer);
+        }
+
         internal static IncrementalValuesProvider<TSource> ReportDiagnostics<TSource>(this IncrementalValuesProvider<(TSource?, Diagnostic?)> source, IncrementalGeneratorInitializationContext context)
         {
             context.RegisterSourceOutput(source, (spc, source) =>

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -34,13 +34,15 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         }
 
         private static RazorProjectEngine GetDeclarationProjectEngine(
-            IEnumerable<SourceGeneratorProjectItem> items,
+            SourceGeneratorProjectItem item,
+            IEnumerable<SourceGeneratorProjectItem> imports,
             RazorSourceGenerationOptions razorSourceGeneratorOptions)
         {
             var fileSystem = new VirtualRazorProjectFileSystem();
-            foreach (var item in items)
+            fileSystem.Add(item);
+            foreach (var import in imports)
             {
-                fileSystem.Add(item);
+                fileSystem.Add(import);
             }
 
             var discoveryProjectEngine = RazorProjectEngine.Create(razorSourceGeneratorOptions.Configuration, fileSystem, b =>

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
@@ -16,6 +16,8 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
     {
         private static (RazorSourceGenerationOptions?, Diagnostic?) ComputeRazorSourceGeneratorOptions((AnalyzerConfigOptionsProvider, ParseOptions) pair, CancellationToken ct)
         {
+            Log.ComputeRazorSourceGeneratorOptions();
+
             var (options, parseOptions) = pair;
             var globalOptions = options.GlobalOptions;
 

--- a/src/RazorSdk/SourceGenerators/RazorSourceGeneratorEventSource.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGeneratorEventSource.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Tracing;
 
 namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
-    [EventSource(Name = "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator")]
+    [EventSource(Name = "Microsoft-DotNet-SDK-Razor-SourceGenerator")]
     internal sealed class RazorSourceGeneratorEventSource : EventSource
     {
         public static readonly RazorSourceGeneratorEventSource Log = new();
@@ -13,125 +13,51 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         private RazorSourceGeneratorEventSource() { }
 
         private const int ComputeRazorSourceGeneratorOptionsId = 1;
-
         [Event(ComputeRazorSourceGeneratorOptionsId, Level = EventLevel.Informational)]
-        public void ComputeRazorSourceGeneratorOptions()
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(ComputeRazorSourceGeneratorOptionsId);
-            }
-        }
+        public void ComputeRazorSourceGeneratorOptions() => WriteEvent(ComputeRazorSourceGeneratorOptionsId);
 
         private const int GenerateDeclarationCodeStartId = 2;
-
         [Event(GenerateDeclarationCodeStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
-        public void GenerateDeclarationCodeStart(string filePath)
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(GenerateDeclarationCodeStartId, filePath);
-            }
-        }
+        public void GenerateDeclarationCodeStart(string filePath) => WriteEvent(GenerateDeclarationCodeStartId, filePath);
 
         private const int GenerateDeclarationCodeStopId = 4;
         [Event(GenerateDeclarationCodeStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
-        public void GenerateDeclarationCodeStop(string filePath)
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(GenerateDeclarationCodeStopId, filePath);
-            }
-        }
+        public void GenerateDeclarationCodeStop(string filePath) => WriteEvent(GenerateDeclarationCodeStopId, filePath);
 
         private const int DiscoverTagHelpersFromCompilationStartId = 6;
         [Event(DiscoverTagHelpersFromCompilationStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
-        public void DiscoverTagHelpersFromCompilationStart()
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(DiscoverTagHelpersFromCompilationStartId);
-            }
-        }
+        public void DiscoverTagHelpersFromCompilationStart() => WriteEvent(DiscoverTagHelpersFromCompilationStartId);
 
         private const int DiscoverTagHelpersFromCompilationStopId = 7;
         [Event(DiscoverTagHelpersFromCompilationStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
-        public void DiscoverTagHelpersFromCompilationStop()
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(DiscoverTagHelpersFromCompilationStopId);
-            }
-        }
+        public void DiscoverTagHelpersFromCompilationStop() => WriteEvent(DiscoverTagHelpersFromCompilationStopId);
 
         private const int DiscoverTagHelpersFromReferencesStartId = 8;
         [Event(DiscoverTagHelpersFromReferencesStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
-        public void DiscoverTagHelpersFromReferencesStart()
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(DiscoverTagHelpersFromReferencesStartId);
-            }
-        }
+        public void DiscoverTagHelpersFromReferencesStart() => WriteEvent(DiscoverTagHelpersFromReferencesStartId);
 
         private const int DiscoverTagHelpersFromReferencesStopId = 9;
         [Event(DiscoverTagHelpersFromReferencesStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
-        public void DiscoverTagHelpersFromReferencesStop()
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(DiscoverTagHelpersFromReferencesStopId);
-            }
-        }
+        public void DiscoverTagHelpersFromReferencesStop() => WriteEvent(DiscoverTagHelpersFromReferencesStopId);
 
         private const int RazorCodeGenerateStartId = 10;
         [Event(RazorCodeGenerateStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
-        public void RazorCodeGenerateStart(string file)
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(RazorCodeGenerateStartId, file);
-            }
-        }
+        public void RazorCodeGenerateStart(string file) => WriteEvent(RazorCodeGenerateStartId, file);
 
         private const int RazorCodeGenerateStopId = 11;
         [Event(RazorCodeGenerateStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
-        public void RazorCodeGenerateStop(string file)
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(RazorCodeGenerateStopId, file);
-            }
-        }
+        public void RazorCodeGenerateStop(string file) => WriteEvent(RazorCodeGenerateStopId, file);
 
         private const int AddSyntaxTreesId = 12;
         [Event(AddSyntaxTreesId, Level = EventLevel.Informational)]
-        public void AddSyntaxTrees(string file)
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(AddSyntaxTreesId, file);
-            }
-        }
+        public void AddSyntaxTrees(string file) => WriteEvent(AddSyntaxTreesId, file);
 
         private const int GenerateDeclarationSyntaxTreeStartId = 13;
         [Event(GenerateDeclarationSyntaxTreeStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
-        public void GenerateDeclarationSyntaxTreeStart()
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(GenerateDeclarationSyntaxTreeStartId);
-            }
-        }
+        public void GenerateDeclarationSyntaxTreeStart() => WriteEvent(GenerateDeclarationSyntaxTreeStartId);
 
         private const int GenerateDeclarationSyntaxTreeStopId = 14;
         [Event(GenerateDeclarationSyntaxTreeStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
-        public void GenerateDeclarationSyntaxTreeStop()
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(GenerateDeclarationSyntaxTreeStopId);
-            }
-        }
+        public void GenerateDeclarationSyntaxTreeStop() => WriteEvent(GenerateDeclarationSyntaxTreeStopId);
     }
 }

--- a/src/RazorSdk/SourceGenerators/RazorSourceGeneratorEventSource.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGeneratorEventSource.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    [EventSource(Name = "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator")]
+    internal sealed class RazorSourceGeneratorEventSource : EventSource
+    {
+        public static readonly RazorSourceGeneratorEventSource Log = new();
+
+        private RazorSourceGeneratorEventSource() { }
+
+        private const int ComputeRazorSourceGeneratorOptionsId = 1;
+
+        [Event(ComputeRazorSourceGeneratorOptionsId, Level = EventLevel.Informational)]
+        public void ComputeRazorSourceGeneratorOptions()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ComputeRazorSourceGeneratorOptionsId);
+            }
+        }
+
+        private const int GenerateDeclarationCodeStartId = 2;
+
+        [Event(GenerateDeclarationCodeStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
+        public void GenerateDeclarationCodeStart(string filePath)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(GenerateDeclarationCodeStartId, filePath);
+            }
+        }
+
+        private const int GenerateDeclarationCodeStopId = 4;
+        [Event(GenerateDeclarationCodeStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
+        public void GenerateDeclarationCodeStop(string filePath)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(GenerateDeclarationCodeStopId, filePath);
+            }
+        }
+
+        private const int DiscoverTagHelpersFromCompilationStartId = 6;
+        [Event(DiscoverTagHelpersFromCompilationStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
+        public void DiscoverTagHelpersFromCompilationStart()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(DiscoverTagHelpersFromCompilationStartId);
+            }
+        }
+
+        private const int DiscoverTagHelpersFromCompilationStopId = 7;
+        [Event(DiscoverTagHelpersFromCompilationStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
+        public void DiscoverTagHelpersFromCompilationStop()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(DiscoverTagHelpersFromCompilationStopId);
+            }
+        }
+
+        private const int DiscoverTagHelpersFromReferencesStartId = 8;
+        [Event(DiscoverTagHelpersFromReferencesStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
+        public void DiscoverTagHelpersFromReferencesStart()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(DiscoverTagHelpersFromReferencesStartId);
+            }
+        }
+
+        private const int DiscoverTagHelpersFromReferencesStopId = 9;
+        [Event(DiscoverTagHelpersFromReferencesStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
+        public void DiscoverTagHelpersFromReferencesStop()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(DiscoverTagHelpersFromReferencesStopId);
+            }
+        }
+
+        private const int RazorCodeGenerateStartId = 10;
+        [Event(RazorCodeGenerateStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
+        public void RazorCodeGenerateStart(string file)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(RazorCodeGenerateStartId, file);
+            }
+        }
+
+        private const int RazorCodeGenerateStopId = 11;
+        [Event(RazorCodeGenerateStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
+        public void RazorCodeGenerateStop(string file)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(RazorCodeGenerateStopId, file);
+            }
+        }
+
+        private const int AddSyntaxTreesId = 12;
+        [Event(AddSyntaxTreesId, Level = EventLevel.Informational)]
+        public void AddSyntaxTrees(string file)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(AddSyntaxTreesId, file);
+            }
+        }
+
+        private const int GenerateDeclarationSyntaxTreeStartId = 13;
+        [Event(GenerateDeclarationSyntaxTreeStartId, Level = EventLevel.Informational, Opcode = EventOpcode.Start)]
+        public void GenerateDeclarationSyntaxTreeStart()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(GenerateDeclarationSyntaxTreeStartId);
+            }
+        }
+
+        private const int GenerateDeclarationSyntaxTreeStopId = 14;
+        [Event(GenerateDeclarationSyntaxTreeStopId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop)]
+        public void GenerateDeclarationSyntaxTreeStop()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(GenerateDeclarationSyntaxTreeStopId);
+            }
+        }
+    }
+}

--- a/src/RazorSdk/SourceGenerators/SourceGeneratorProjectItem.cs
+++ b/src/RazorSdk/SourceGenerators/SourceGeneratorProjectItem.cs
@@ -2,14 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text;
 using System.IO;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
-    internal class SourceGeneratorProjectItem : RazorProjectItem
+    internal class SourceGeneratorProjectItem : RazorProjectItem, IEquatable<SourceGeneratorProjectItem>
     {
         private readonly string _fileKind;
 
@@ -47,5 +46,11 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         public override Stream Read() 
             => throw new NotSupportedException("This API should not be invoked. We should instead be relying on " +
                 "the RazorSourceDocument associated with this item instead.");
+
+        public bool Equals(SourceGeneratorProjectItem other) => AdditionalText == other.AdditionalText;
+
+        public override int GetHashCode() => AdditionalText.GetHashCode();
+
+        public override bool Equals(object obj) => obj is SourceGeneratorProjectItem projectItem && Equals(projectItem);
     }
 }

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
@@ -6,11 +6,9 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackageId>testSdkRSG</PackageId>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +20,9 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
+
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorEventListener.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorEventListener.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics.Tracing;
+using System.Linq;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    public class RazorEventListener : EventListener
+    {
+        protected override void OnEventSourceCreated(EventSource source)
+        {
+            if (source.Name.Equals("Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator"))
+            {
+                EnableEvents(source, EventLevel.Informational);
+            }
+        }
+
+        public ConcurrentQueue<RazorEvent> Events { get; } = new();
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            var @event = new RazorEvent
+            {
+                EventId = eventData.EventId,
+                EventName = eventData.EventName,
+                Payload = eventData.Payload.ToArray(),
+            };
+
+            Events.Enqueue(@event);
+        }
+
+        public sealed class RazorEvent
+        {
+            public int EventId { get; init; }
+
+            public string EventName { get; init; }
+
+            public object[] Payload { get; init; }
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorEventListener.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorEventListener.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
     {
         protected override void OnEventSourceCreated(EventSource source)
         {
-            if (source.Name.Equals("Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator"))
+            if (source.Name == "Microsoft-DotNet-SDK-Razor-SourceGenerator")
             {
                 EnableEvents(source, EventLevel.Informational);
             }

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
@@ -1,0 +1,1075 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.Extensions.DependencyModel.Resolution;
+using Xunit;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    public class RazorSourceGeneratorTests
+    {
+        private static readonly Project _baseProject = CreateBaseProject();
+
+        [Fact]
+        public async Task SourceGenerator_RazorFiles_Works()
+        {
+            // Arrange
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+            });
+
+            var compilation = await project.GetCompilationAsync();
+            var driver = await GetDriverAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Single(result.GeneratedSources);
+        }
+
+        [Fact]
+        public async Task SourceGeneratorEvents_RazorFiles_Works()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] = "<h1>Counter</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var driver = await GetDriverAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+                e => Assert.Equal("ComputeRazorSourceGeneratorOptions", e.EventName),
+                e =>
+                {
+                    Assert.Equal("GenerateDeclarationCodeStart", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Index.razor", file);
+                },
+                e =>
+                {
+                    Assert.Equal("GenerateDeclarationCodeStop", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Index.razor", file);
+                },
+                e =>
+                {
+                    Assert.Equal("GenerateDeclarationCodeStart", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Counter.razor", file);
+                },
+                e =>
+                {
+                    Assert.Equal("GenerateDeclarationCodeStop", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Counter.razor", file);
+                },
+                e => Assert.Equal("DiscoverTagHelpersFromCompilationStart", e.EventName),
+                e => Assert.Equal("DiscoverTagHelpersFromCompilationStop", e.EventName),
+                e => Assert.Equal("DiscoverTagHelpersFromReferencesStart", e.EventName),
+                e => Assert.Equal("DiscoverTagHelpersFromReferencesStop", e.EventName),
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Index.razor", file);
+                },
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Index.razor", file);
+                },
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Counter.razor", file);
+                },
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Counter.razor", file);
+                },
+                e =>
+                {
+                    Assert.Equal("AddSyntaxTrees", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("Pages_Index_razor.g.cs", file);
+                },
+                e =>
+                {
+                    Assert.Equal("AddSyntaxTrees", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("Pages_Counter_razor.g.cs", file);
+                });
+        }
+
+        [Fact]
+        public async Task IncrementalCompilation_DoesNotReexecuteSteps_WhenRazorFilesAreUnchanged()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] = "<h1>Counter</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var driver = await GetDriverAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Empty(eventListener.Events);
+        }
+
+        [Fact]
+        public async Task IncrementalCompilation_WhenRazorFileMarkupChanges()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] = "<h1>Counter</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Empty(eventListener.Events);
+
+            var updatedText = new TestAdditionalText("Pages/Counter.razor", SourceText.From("<h2>Counter</h2>", Encoding.UTF8));
+            driver = driver.ReplaceAdditionalText(additionalTexts.First(f => f.Path == updatedText.Path), updatedText);
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+               e =>
+               {
+                   Assert.Equal("GenerateDeclarationCodeStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("GenerateDeclarationCodeStop", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("AddSyntaxTrees", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("Pages_Counter_razor.g.cs", file);
+               });
+        }
+
+        [Fact]
+        public async Task IncrementalCompilation_RazorFiles_WhenNewTypeIsAdded()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] = "<h1>Counter</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            project = project.AddDocument("Person.cs", SourceText.From(@"
+public class Person
+{
+    public string Name { get; set; }
+}", Encoding.UTF8)).Project;
+            compilation = await project.GetCompilationAsync();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStart", e.EventName),
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStop", e.EventName));
+        }
+
+        [Fact]
+        public async Task IncrementalCompilation_RazorFiles_WhenCSharpTypeChanges()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] = "<h1>Counter</h1>",
+            },
+            new()
+            {
+                ["Person.cs"] = @"
+public class Person
+{
+    public string Name { get; set; }
+}"
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            project = project.Documents.First().WithText(SourceText.From(@"
+public class Person
+{
+    public string Name { get; set; }
+    public int Age { get; set; }
+}", Encoding.UTF8)).Project;
+            compilation = await project.GetCompilationAsync();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStart", e.EventName),
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStop", e.EventName));
+        }
+
+        [Fact]
+        public async Task IncrementalCompilation_RazorFiles_WhenChildComponentsAreAdded()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] = "<h1>Counter</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Empty(eventListener.Events);
+
+            var updatedText = new TestAdditionalText("Pages/Counter.razor", SourceText.From(@"
+<h2>Counter</h2>
+<h3>Current count: @count</h3>
+<button @onclick=""Click"">Click me</button>
+
+@code
+{
+    private int count;
+    
+    public void Click() => count++;
+}
+
+", Encoding.UTF8));
+            driver = driver.ReplaceAdditionalText(additionalTexts.First(f => f.Path == updatedText.Path), updatedText);
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+               e =>
+               {
+                   Assert.Equal("GenerateDeclarationCodeStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("GenerateDeclarationCodeStop", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStart", e.EventName),
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStop", e.EventName),
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("AddSyntaxTrees", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("Pages_Counter_razor.g.cs", file);
+               });
+        }
+
+        [Fact]
+        public async Task IncrementalCompilation_RazorFiles_WhenNewComponentParameterIsAdded()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] = "<h1>Counter</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Empty(eventListener.Events);
+
+            var updatedText = new TestAdditionalText("Pages/Counter.razor", SourceText.From(@"
+<h2>Counter</h2>
+<h3>Current count: @count</h3>
+<button @onclick=""Click"">Click me</button>
+
+@code
+{
+    private int count;
+    
+    public void Click() => count++;
+
+    [Parameter] public int IncrementAmount { get; set; }
+}
+
+", Encoding.UTF8));
+            driver = driver.ReplaceAdditionalText(additionalTexts.First(f => f.Path == updatedText.Path), updatedText);
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+               e =>
+               {
+                   Assert.Equal("GenerateDeclarationCodeStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("GenerateDeclarationCodeStop", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStart", e.EventName),
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStop", e.EventName),
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Index.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Index.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("AddSyntaxTrees", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("Pages_Counter_razor.g.cs", file);
+               });
+        }
+
+        [Fact]
+        public async Task IncrementalCompilation_RazorFiles_WhenProjectReferencesChange()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] =
+@"
+@using SurveyPromptRootNamspace;
+<h1>Hello world</h1>
+<SurveyPrompt />
+",
+                ["Pages/Counter.razor"] = "<h1>Counter</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            var diagnostic = Assert.Single(result.Diagnostics);
+            Assert.Equal("RZ10012", diagnostic.Id);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+            
+            var surveryPromptAssembly = GetSurveyPromptMetadataReference(compilation!);
+            compilation = compilation!.AddReferences(surveryPromptAssembly);
+
+            result = RunGenerator(compilation, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStart", e.EventName),
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStop", e.EventName),
+               e => Assert.Equal("DiscoverTagHelpersFromReferencesStart", e.EventName),
+               e => Assert.Equal("DiscoverTagHelpersFromReferencesStop", e.EventName),
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Index.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Index.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Counter.razor", file);
+               },
+               e =>
+               {
+                   Assert.Equal("AddSyntaxTrees", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("Pages_Index_razor.g.cs", file);
+               });
+
+            // Verify caching
+            eventListener.Events.Clear();
+            result = RunGenerator(compilation, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+            Assert.Empty(eventListener.Events);
+
+            static MetadataReference GetSurveyPromptMetadataReference(Compilation currentCompilation)
+            {
+                var updatedCompilation = currentCompilation.RemoveAllSyntaxTrees()
+                    .WithAssemblyName("SurveyPromptAssembly")
+                    .AddSyntaxTrees(CSharpSyntaxTree.ParseText(@"
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+namespace SurveyPromptRootNamspace;
+public class SurveyPrompt : ComponentBase
+{
+    protected override void BuildRenderTree(RenderTreeBuilder builder) {}
+}"));
+                var stream = new MemoryStream();
+                var emitResult = updatedCompilation.Emit(stream);
+                Assert.True(emitResult.Success);
+
+                stream.Position = 0;
+                return MetadataReference.CreateFromStream(stream);
+            }
+        }
+
+
+        [Fact]
+        public async Task SourceGenerator_CshtmlFiles_Works()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.cshtml"] = "<h1>Hello world</h1>",
+                ["Views/Shared/_Layout.cshtml"] = "<h1>Layout</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var driver = await GetDriverAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+                e => Assert.Equal("ComputeRazorSourceGeneratorOptions", e.EventName),
+                e => Assert.Equal("DiscoverTagHelpersFromCompilationStart", e.EventName),
+                e => Assert.Equal("DiscoverTagHelpersFromCompilationStop", e.EventName),
+                e => Assert.Equal("DiscoverTagHelpersFromReferencesStart", e.EventName),
+                e => Assert.Equal("DiscoverTagHelpersFromReferencesStop", e.EventName),
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Index.cshtml", file);
+                },
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Index.cshtml", file);
+                },
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Views/Shared/_Layout.cshtml", file);
+                },
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Views/Shared/_Layout.cshtml", file);
+                },
+                e =>
+                {
+                    Assert.Equal("AddSyntaxTrees", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("Pages_Index_cshtml.g.cs", file);
+                },
+                e =>
+                {
+                    Assert.Equal("AddSyntaxTrees", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("Views_Shared__Layout_cshtml.g.cs", file);
+                });
+        }
+
+        [Fact]
+        public async Task SourceGenerator_CshtmlFiles_WhenMarkupChanges()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.cshtml"] = "<h1>Hello world</h1>",
+                ["Views/Shared/_Layout.cshtml"] = "<h1>Layout</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Empty(eventListener.Events);
+
+            var updatedText = new TestAdditionalText("Views/Shared/_Layout.cshtml", SourceText.From("<h2>Updated Layout</h2>", Encoding.UTF8));
+            driver = driver.ReplaceAdditionalText(additionalTexts.First(f => f.Path == updatedText.Path), updatedText);
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Views/Shared/_Layout.cshtml", file);
+               },
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Views/Shared/_Layout.cshtml", file);
+                },
+                e =>
+                {
+                    Assert.Equal("AddSyntaxTrees", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("Views_Shared__Layout_cshtml.g.cs", file);
+                });
+        }
+
+        [Fact]
+        public async Task SourceGenerator_CshtmlFiles_CSharpTypeChanges()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.cshtml"] = "<h1>Hello world</h1>",
+                ["Views/Shared/_Layout.cshtml"] = "<h1>Layout</h1>",
+            },
+            new()
+            {
+                ["Person.cs"] = @"
+public class Person
+{
+    public string Name { get; set; }
+}"
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            project = project.Documents.First().WithText(SourceText.From(@"
+public class Person
+{
+    public string Name { get; set; }
+    public int Age { get; set; }
+}", Encoding.UTF8)).Project;
+            compilation = await project.GetCompilationAsync();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStart", e.EventName),
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStop", e.EventName));
+        }
+
+        [Fact]
+        public async Task SourceGenerator_CshtmlFiles_NewTagHelper()
+        {
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.cshtml"] =
+@"
+@addTagHelper *, TestProject
+<h2>Hello world</h2>",
+                ["Views/Shared/_Layout.cshtml"] = "<h1>Layout</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            eventListener.Events.Clear();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            project = project.AddDocument("HeaderTagHelper.cs", SourceText.From(@"
+using Microsoft.AspNetCore.Razor.TagHelpers;
+namespace MyApp;
+
+[HtmlTargetElement(""h2"")]
+public class HeaderTagHelper : TagHelper
+{
+    public override int Order => 0;
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.Attributes.Add(""role"", ""heading"");
+    }
+}", Encoding.UTF8)).Project;
+            compilation = await project.GetCompilationAsync();
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            Assert.Collection(eventListener.Events,
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStart", e.EventName),
+               e => Assert.Equal("DiscoverTagHelpersFromCompilationStop", e.EventName),
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Pages/Index.cshtml", file);
+               },
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Pages/Index.cshtml", file);
+                },
+               e =>
+               {
+                   Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                   var file = Assert.Single(e.Payload);
+                   Assert.Equal("/Views/Shared/_Layout.cshtml", file);
+               },
+                e =>
+                {
+                    Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("/Views/Shared/_Layout.cshtml", file);
+                },
+                e =>
+                {
+                    Assert.Equal("AddSyntaxTrees", e.EventName);
+                    var file = Assert.Single(e.Payload);
+                    Assert.Equal("Pages_Index_cshtml.g.cs", file);
+                });
+        }
+
+        [Fact]
+        public async Task SourceGenerator_CshtmlFiles_RazorDiagnostics_Fixed()
+        {
+            // Arrange
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.cshtml"] =
+@"
+@{
+<h1>Malformed h1
+}
+</h1>",
+                ["Views/Shared/_Layout.cshtml"] = "<h1>Layout</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            var diagnostic = Assert.Single(result.Diagnostics);
+            Assert.Equal("RZ1006", diagnostic.Id);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            var updatedText = new TestAdditionalText("Pages/Index.cshtml", SourceText.From("<h1>Fixed header</h1>", Encoding.UTF8));
+            driver = driver.ReplaceAdditionalText(additionalTexts.First(f => f.Path == updatedText.Path), updatedText);
+
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+        }
+
+        [Fact]
+        public async Task SourceGenerator_CshtmlFiles_RazorDiagnostics_Introduced()
+        {
+            // Arrange
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.cshtml"] = "<h1>Valid h1</h1>",
+                ["Views/Shared/_Layout.cshtml"] = "<h1>Layout</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            var updatedText = new TestAdditionalText("Pages/Index.cshtml", SourceText.From(@"
+@{
+<h1>Malformed h1
+}
+</h1>", Encoding.UTF8));
+            driver = driver.ReplaceAdditionalText(additionalTexts.First(f => f.Path == updatedText.Path), updatedText);
+
+            result = RunGenerator(compilation!, ref driver);
+
+            var diagnostic = Assert.Single(result.Diagnostics);
+            Assert.Equal("RZ1006", diagnostic.Id);
+            Assert.Equal(2, result.GeneratedSources.Length);
+        }
+
+        private static async ValueTask<GeneratorDriver> GetDriverAsync(Project project)
+        {
+            var (driver, _) = await GetDriverWithAdditionalTextAsync(project);
+            return driver;
+        }
+
+        private static async ValueTask<(GeneratorDriver, ImmutableArray<AdditionalText>)> GetDriverWithAdditionalTextAsync(Project project)
+        {
+            var razorSourceGenerator = new RazorSourceGenerator().AsSourceGenerator();
+            var driver = (GeneratorDriver)CSharpGeneratorDriver.Create(new[] { razorSourceGenerator }, parseOptions: (CSharpParseOptions)project.ParseOptions!);
+
+            var optionsProvider = new TestAnalyzerConfigOptionsProvider();
+            optionsProvider.TestGlobalOptions["build_property.RazorConfiguration"] = "Default";
+            optionsProvider.TestGlobalOptions["build_property.RootNamespace"] = "MyApp";
+            optionsProvider.TestGlobalOptions["build_property.RazorLangVersion"] = "Latest";
+
+            var additionalTexts = ImmutableArray<AdditionalText>.Empty;
+
+            foreach (var document in project.AdditionalDocuments)
+            {
+                var additionalText = new TestAdditionalText(document.Name, await document.GetTextAsync());
+                additionalTexts = additionalTexts.Add(additionalText);
+
+                var additionalTextOptions = new TestAnalyzerConfigOptions
+                {
+                    ["build_metadata.AdditionalFiles.TargetPath"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(additionalText.Path)),
+                };
+
+                optionsProvider.AdditionalTextOptions[additionalText.Path] = additionalTextOptions;
+            }
+
+            driver = driver
+                .AddAdditionalTexts(additionalTexts)
+                .WithUpdatedAnalyzerConfigOptions(optionsProvider);
+
+            return (driver, additionalTexts);
+        }
+
+        private static GeneratorRunResult RunGenerator(Compilation compilation, ref GeneratorDriver driver)
+        {
+            driver = driver.RunGenerators(compilation);
+
+            var result = driver.RunGenerators(compilation).GetRunResult();
+            return result.Results[0];
+        }
+
+        private static Project CreateTestProject(
+            Dictionary<string, string> additonalSources,
+            Dictionary<string, string>? sources = null)
+        {
+            var project = _baseProject;
+
+            if (sources is not null)
+            {
+                foreach (var (name, source) in sources)
+                {
+                    project = project.AddDocument(name, source).Project;
+                }
+            }
+
+            foreach (var (name, source) in additonalSources)
+            {
+                project = project.AddAdditionalDocument(name, source).Project;
+            }
+
+            return project;
+        }
+
+        private class AppLocalResolver : ICompilationAssemblyResolver
+        {
+            public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
+            {
+                foreach (var assembly in library.Assemblies)
+                {
+                    var dll = Path.Combine(Directory.GetCurrentDirectory(), "refs", Path.GetFileName(assembly));
+                    if (File.Exists(dll))
+                    {
+                        assemblies.Add(dll);
+                        return true;
+                    }
+
+                    dll = Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileName(assembly));
+                    if (File.Exists(dll))
+                    {
+                        assemblies.Add(dll);
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        private static Project CreateBaseProject()
+        {
+            var projectId = ProjectId.CreateNewId(debugName: "TestProject");
+
+            var solution = new AdhocWorkspace()
+               .CurrentSolution
+               .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp);
+
+            var project = solution.Projects.Single()
+                .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+
+            project = project.WithParseOptions(((CSharpParseOptions)project.ParseOptions!).WithLanguageVersion(LanguageVersion.Preview));
+
+
+            foreach (var defaultCompileLibrary in DependencyContext.Load(typeof(RazorSourceGeneratorTests).Assembly).CompileLibraries)
+            {
+                foreach (var resolveReferencePath in defaultCompileLibrary.ResolveReferencePaths(new AppLocalResolver()))
+                {
+                    project = project.AddMetadataReference(MetadataReference.CreateFromFile(resolveReferencePath));
+                }
+            }
+
+            // The deps file in the project is incorrect and does not contain "compile" nodes for some references.
+            // However these binaries are always present in the bin output. As a "temporary" workaround, we'll add
+            // every dll file that's present in the test's build output as a metadatareference.
+            foreach (var assembly in Directory.EnumerateFiles(AppContext.BaseDirectory, "*.dll"))
+            {
+                if (!project.MetadataReferences.Any(c => string.Equals(Path.GetFileNameWithoutExtension(c.Display), Path.GetFileNameWithoutExtension(assembly), StringComparison.OrdinalIgnoreCase)))
+                {
+                    project = project.AddMetadataReference(MetadataReference.CreateFromFile(assembly));
+                }
+            }
+
+            return project;
+        }
+
+        private class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+        {
+            public override AnalyzerConfigOptions GlobalOptions => TestGlobalOptions;
+
+            public TestAnalyzerConfigOptions TestGlobalOptions { get; } = new TestAnalyzerConfigOptions();
+
+            public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => throw new NotImplementedException();
+
+            public Dictionary<string, TestAnalyzerConfigOptions> AdditionalTextOptions { get; } = new();
+
+            public override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
+            {
+                return AdditionalTextOptions.TryGetValue(textFile.Path, out var options) ? options : new TestAnalyzerConfigOptions();
+            }
+        }
+
+        private class TestAnalyzerConfigOptions : AnalyzerConfigOptions
+        {
+            public Dictionary<string, string> Options { get; } = new();
+
+            public string this[string name]
+            {
+                get => Options[name];
+                set => Options[name] = value;
+            }
+
+            public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+                => Options.TryGetValue(key, out value);
+        }
+    }
+}


### PR DESCRIPTION
* Add some instrumentation and tests to validate RazorSourceGenerator's incrementality
* Do not codegen declaration for .cshtml files.
* Update the declaration caching to be more granular, and also cache SyntaxTrees
* Cache tag helpers from compilation correctly