### PR TITLE
Remove explicitly configured LangVersion from RazorSDK

### DIFF
--- a/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
+++ b/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
@@ -50,8 +50,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_TargetingNET50OrLater>true</_TargetingNET50OrLater>
         <_TargetingNET60OrLater>true</_TargetingNET60OrLater>
         <UseRazorSourceGenerator Condition="'$(UseRazorSourceGenerator)' == '' ">true</UseRazorSourceGenerator>
-        <!-- Required to support incremental source generator -->
-        <LangVersion Condition="'$(UseRazorSourceGenerator)' != '' ">preview</LangVersion>
         <RazorLangVersion Condition="'$(RazorLangVersion)' == '' ">6.0</RazorLangVersion>
       </PropertyGroup>
     </When>
@@ -101,7 +99,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <StaticWebAssetsEnabled Condition="'$(StaticWebAssetsEnabled)' == ''">$(_Targeting30OrNewerRazorLangVersion)</StaticWebAssetsEnabled>
 
     <UseStaticWebAssetsV2>$(_TargetingNET60OrLater)</UseStaticWebAssetsV2>
-     
+
     <!-- Controls whether or not the scoped css feature is enabled. By default is enabled for net6.0 applications and RazorLangVersion 5 or above -->
     <ScopedCssEnabled Condition="'$(ScopedCssEnabled)' == '' and '$(StaticWebAssetsEnabled)' == 'true'">$(_Targeting30OrNewerRazorLangVersion)</ScopedCssEnabled>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/33848
Fixes https://github.com/dotnet/sdk/issues/19879

### Description

Until recently incremental source generators required the LangVersion to be set to Preview. To support this, the RazorSDK unconditionally configured the `LangVersion` MSBuild property for all 6.0 or newer projects. Unfortunately this setting also applied to 6.0 VB and F# projects. We've had reports of this affecting VB developers updating to the preview7 SDK: https://developercommunity.visualstudio.com/t/the-value-preview-is-invalid-for-optio/1504419. 

This change removes the explicitly configured LangVersion

### Regression
Yes - This was regressed in .NET 6 preview 7 SDK

### Tests

[x] Manually tested on a .NET 6 VB targeting the WebSDK. Manually tested projects with razor assets continue building
[x] Automated tests

### Risk
Low. The compiler's targets correctly configures LangVersion.

### Packaging changes
None