### PR TITLE
Support platform discriminator for workload pack records

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
@@ -116,9 +116,9 @@ namespace Microsoft.DotNet.Installer.Windows
         /// </summary>
         private IReadOnlyDictionary<string, List<WorkloadPackRecord>> GetWorkloadPackRecords()
         {
-            Log?.LogMessage("Detecting installed workload packs.");
+            Log?.LogMessage($"Detecting installed workload packs for {HostArchitecture}.");
             Dictionary<string, List<WorkloadPackRecord>> workloadPackRecords = new Dictionary<string, List<WorkloadPackRecord>>();
-            using RegistryKey installedPacksKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\dotnet\InstalledPacks");
+            using RegistryKey installedPacksKey = Registry.LocalMachine.OpenSubKey(@$"SOFTWARE\Microsoft\dotnet\InstalledPacks\{HostArchitecture}");
 
             if (installedPacksKey != null)
             {


### PR DESCRIPTION
SDK change related to #20202. This allows us to handle scenarios for x64 on arm64 since both will write to the same hive.

Also depends on https://github.com/dotnet/arcade/pull/7803 since we require workload packs produced with the modified registry path.