### PR TITLE
Fix null ref and client shutdown

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/DependencyProvider.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/DependencyProvider.cs
@@ -177,8 +177,7 @@ namespace Microsoft.DotNet.Cli.Utils
         private string GetProductCode()
         {
             using RegistryKey providerKey = BaseKey.OpenSubKey(ProviderKeyPath);
-
-            return providerKey.GetValue(null) as string;
+            return providerKey?.GetValue(null) as string ?? null;
         }
     }
 }

--- a/src/Cli/dotnet/Installer/Windows/InstallerBase.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallerBase.cs
@@ -199,7 +199,8 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <param name="exception">The exception to log.</param>
         protected void LogException(Exception exception)
         {
-            Log?.LogMessage($"{exception.Message} HResult: 0x{exception.HResult:x8}.");
+            Log?.LogMessage($"Exception: {exception.Message}, HResult: 0x{exception.HResult:x8}.");
+            Log?.LogMessage($"{exception.StackTrace}");
         }
 
         static InstallerBase()

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -32,6 +32,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         private IWorkloadResolver _workloadResolver;
 
+        private bool _shutdown;
+
         private readonly PackageSourceLocation _packageSourceLocation;
 
         private readonly string _dependent;
@@ -451,6 +453,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             Log?.LogMessage("Shutdown completed.");
             Log?.LogMessage($"Restart required: {Restart}");
+            _shutdown = true;
         }
 
         private void LogPackInfo(PackInfo packInfo)
@@ -865,7 +868,19 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         private void OnProcessExit(object sender, EventArgs e)
         {
-            Shutdown();
+            if (!_shutdown)
+            {
+                try
+                {
+                    Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    // Don't rethrow. We'll call ShutDown during abnormal termination when control is passing back to the host
+                    // so there's nothing in the CLI that will catch the exception.
+                    Log?.LogMessage($"OnProcessExit: Shutdown failed, {ex.Message}");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Description**: MSI payload packages can be missing from the package feeds, e.g. Maui doesn't push regular updates, When a manifest update breaks because of this and a rollback is triggered to perform a downgrade of a package that wasn't installed correctly, the missing registry key can result in a null reference, A side effect of this results in attempting to shutdown the elevated service which runs after the command has completed, causing the exception to be raised by dotnet.exe instead.

**Fixes**: https://github.com/dotnet/sdk/issues/20143

**Risk**: Low

**Validation**: Manual and automated

**Regression**: No, new feature for RC1