### PR TITLE
[Razor] Reenables the ability to set a custom application part factory for an assembly.

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -18,6 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_RazorSdkSourceGeneratorDirectoryRoot>$(RazorSdkDirectoryRoot)\source-generators\</_RazorSdkSourceGeneratorDirectoryRoot>
+      <ProvideApplicationPartFactoryAttributeTypeName Condition="'$(ProvideApplicationPartFactoryAttributeTypeName)' == ''">Microsoft.AspNetCore.Mvc.ApplicationParts.ConsolidatedAssemblyApplicationPartFactory, Microsoft.AspNetCore.Mvc.Razor</ProvideApplicationPartFactoryAttributeTypeName>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -73,7 +74,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup Condition="@(_RazorAdditionalFile->WithMetadataValue('Extension', '.cshtml')->Count()) > 0" >
       <_RazorAssemblyAttribute Include="Microsoft.AspNetCore.Mvc.ApplicationParts.ProvideApplicationPartFactoryAttribute">
-        <_Parameter1>Microsoft.AspNetCore.Mvc.ApplicationParts.ConsolidatedAssemblyApplicationPartFactory, Microsoft.AspNetCore.Mvc.Razor</_Parameter1>
+        <_Parameter1>$(ProvideApplicationPartFactoryAttributeTypeName)</_Parameter1>
       </_RazorAssemblyAttribute>
     </ItemGroup>
 


### PR DESCRIPTION
As part of the move to use source generators this feature regressed