### PR TITLE
Allow the app to rebuild when a new scoped css file is added

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Watcher
                     {
                         // Now wait for a file to change before restarting process
                         _reporter.Warn("Waiting for a file to change before restarting dotnet...");
-                        await fileSetWatcher.GetChangedFileAsync(cancellationToken);
+                        await fileSetWatcher.GetChangedFileAsync(cancellationToken, forceWaitForNewUpdate: true);
                     }
                     else
                     {
@@ -240,6 +240,11 @@ namespace Microsoft.DotNet.Watcher
                     // For cshtml files, runtime compilation can opt out of watching cshtml files.
                     // Obviously this does not work if a user explicitly removed files out of the watch list,
                     // but we could wait for someone to report it before we think about ways to address it.
+                    return file;
+                }
+
+                if (filePath.EndsWith(".razor.css", StringComparison.Ordinal) || filePath.EndsWith(".cshtml.css", StringComparison.Ordinal))
+                {
                     return file;
                 }
             }

--- a/src/BuiltInTools/dotnet-watch/Internal/HotReloadFileSetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/HotReloadFileSetWatcher.cs
@@ -98,12 +98,12 @@ namespace Microsoft.DotNet.Watcher.Internal
             }
         }
 
-        public Task<FileItem[]?> GetChangedFileAsync(CancellationToken cancellationToken)
+        public Task<FileItem[]?> GetChangedFileAsync(CancellationToken cancellationToken, bool forceWaitForNewUpdate = false)
         {
             EnsureInitialized();
 
             var tcs = _tcs;
-            if (tcs is not null)
+            if (!forceWaitForNewUpdate && tcs is not null)
             {
                 return tcs.Task;
             }


### PR DESCRIPTION
* Add .razor.css and .cshtml.css to the list of new files that trigger a rebuild.
* Fix a bug where dotnet-watch will cycle in a loop after the initial launch fails.

Fixes https://github.com/dotnet/aspnetcore/issues/33569