### PR TITLE
Adding issue templates for repo [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.md
@@ -1,0 +1,33 @@
+---
+name: 🐞 Bug report
+about: Create a report about something that is not working
+---
+
+<!--
+Please keep in mind that the GitHub issue tracker is not intended as a general support forum, but for reporting **non-security** bugs and feature requests.
+
+If you believe you have an issue that affects the SECURITY of the platform, please do NOT create an issue and instead email your issue details to secure@microsoft.com. Your report may be eligible for our [bug bounty](https://www.microsoft.com/en-us/msrc/bounty-dot-net-core) but ONLY if it is reported through email.
+For other types of questions, consider using [StackOverflow](https://stackoverflow.com).
+
+-->
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### To Reproduce
+<!--
+We ❤ code! Point us to a minimalistic repro project hosted in a GitHub repo, Gist snippet, or other means to see the isolated behavior.
+
+We may close this issue if:
+- the repro project you share with us is complex. We can't investigate custom projects, so don't point us to such, please.
+- if we will not be able to repro the behavior you're reporting
+-->
+
+### Exceptions (if any)
+<!-- 
+Include the exception you get when facing this issue
+-->
+
+### Further technical details
+- Include the output of `dotnet --info`
+- The IDE (VS / VS Code/ VS4Mac) you're running on, and its version

--- a/.github/ISSUE_TEMPLATE/20_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/20_feature_request.md
@@ -1,0 +1,14 @@
+---
+name: 💡 Feature request
+about: Suggest an idea for this project
+---
+
+### Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is.
+Example: I am trying to do [...] but [...]
+
+### Describe the solution you'd like
+A clear and concise description of what you want to happen. Include any alternative solutions you've considered.
+
+### Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+
+blank_issues_enabled: true
+contact_links:
+  - name: Issue with ASP.NET Core
+    url: https://github.com/dotnet/aspnetcore/issues/new/choose
+    about: Please open issues related to the ASP.NET Core runtime in dotnet/aspnetcore
+  - name: Issue with .NET runtime or core .NET libraries
+    url:  https://github.com/dotnet/runtime/issues/new/choose
+    about: Please open issues relating to the .NET runtime or core .NET libraries in dotnet/runtime.
+  - name: Issue with .NET SDK
+    url:  https://github.com/dotnet/sdk/issues/new/choose
+    about: Please open issues relating to the .NET SDK itself in dotnet/sdk.
+  - name: Issue with Entity Framework Core
+    url:  https://github.com/dotnet/efcore/issues/new/choose
+    about: Please open issues relating to Entity Framework Core in dotnet/efcore.
+  - name: Issue with Roslyn compiler
+    url:  https://github.com/dotnet/roslyn/issues/new/choose
+    about: Please open issues relating to the Roslyn .NET compiler in dotnet/roslyn.


### PR DESCRIPTION
PM team has been guiding more people to engage on the repo for issues and such. This repo doesn't have the simple templates like the other .NET repos have...adding for consistency and helpers on those logging new issues/feature requests.

Repo documentation only -- no product changes.