### PR TITLE
Do not clear DOTNET_MODIFIABLE_ASSEMBLIES in startup hook

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -38,7 +38,6 @@ internal sealed class StartupHook
         // Workaround for https://github.com/dotnet/runtime/issues/58000
         // Clear any hot-reload specific environment variables. This should prevent child processes from being
         // affected by the current app's hot reload settings.
-        setEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES", null);
         const string StartupHooksEnvironment = "DOTNET_STARTUP_HOOKS";
         var environment = getEnvironmentVariable(StartupHooksEnvironment);
         setEnvironmentVariable(StartupHooksEnvironment, RemoveCurrentAssembly(environment));

--- a/src/Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests/StartupHookTests.cs
+++ b/src/Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests/StartupHookTests.cs
@@ -10,25 +10,6 @@ namespace Microsoft.Extensions.DotNetDeltaApplier
     public class StartupHookTests
     {
         [Fact]
-        public void ClearHotReloadEnvironmentVariables_ClearsDotnetModifiableAssemblies()
-        {
-            // Arrange
-            var environmentVariables = new Dictionary<string, string?>
-            {
-                ["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug",
-                ["DOTNET_STARTUP_HOOKS"] = null
-            };
-
-            // Act
-            StartupHook.ClearHotReloadEnvironmentVariables(
-                (name) => environmentVariables[name],
-                (name, value) => environmentVariables[name] = value);
-
-            // Assert
-            Assert.Null(environmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"]);
-        }
-
-        [Fact]
         public void ClearHotReloadEnvironmentVariables_ClearsStartupHook()
         {
             // Arrange


### PR DESCRIPTION
Blazor WebAssembly relies on the environment variable to be read inside the app -
https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs#L54-L57
Removing this variable prevents hot reload for hosted app from functioning correctly.