### PR TITLE
Fix cross-os symbol generation

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -66,6 +66,30 @@ namespace Microsoft.NET.Build.Tasks
         private List<ITaskItem> _r2rCompositeReferences = new List<ITaskItem>();
         private List<ITaskItem> _r2rCompositeInput = new List<ITaskItem>();
 
+        private bool IsTargetWindows
+        {
+            get
+            {
+                // Crossgen2 V6 and above always has TargetOS metadata available
+                if (ReadyToRunUseCrossgen2 && !string.IsNullOrEmpty(Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS))) 
+                    return Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "windows";
+                else
+                    return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            }
+        }
+
+        private bool IsTargetLinux
+        {
+            get
+            {
+                // Crossgen2 V6 and above always has TargetOS metadata available
+                if (ReadyToRunUseCrossgen2 && !string.IsNullOrEmpty(Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS))) 
+                    return Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "linux";
+                else
+                    return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+        }
+
         protected override void ExecuteCore()
         {
             if (ReadyToRunUseCrossgen2)
@@ -140,13 +164,13 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (EmitSymbols)
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && hasValidDiaSymReaderLib)
+                    if (IsTargetWindows && hasValidDiaSymReaderLib)
                     {
                         outputPDBImage = Path.ChangeExtension(outputR2RImage, "ni.pdb");
                         outputPDBImageRelativePath = Path.ChangeExtension(outputR2RImageRelativePath, "ni.pdb");
                         crossgen1CreatePDBCommand = $"/CreatePDB \"{Path.GetDirectoryName(outputPDBImage)}\"";
                     }
-                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    else if (IsTargetLinux)
                     {
                         string perfmapExtension;
                         if (ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5 && _perfmapFormatVersion >= 1)
@@ -246,12 +270,12 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     string compositePDBImage = null;
                     string compositePDBRelativePath = null;
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && hasValidDiaSymReaderLib)
+                    if (IsTargetWindows && hasValidDiaSymReaderLib)
                     {
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.pdb");
                         compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
                     }
-                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    else if (IsTargetLinux)
                     {
                         string perfmapExtension = (_perfmapFormatVersion >= 1 ? ".ni.r2rmap" : ".ni.{composite}.map");
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, perfmapExtension);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -318,7 +318,7 @@ namespace Microsoft.NET.Build.Tasks
             // 5.0 Crossgen2 doesn't support PDB generation.
             if (!Crossgen2IsVersion5 && _emitSymbols)
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "windows")
                 {
                     result.AppendLine("--pdb");
                     result.AppendLine($"--pdb-path:{Path.GetDirectoryName(_outputPDBImage)}");

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -451,7 +451,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework, runtimeIdentifier: RuntimeInformation.RuntimeIdentifier);
             var mainProjectDll = Path.Combine(intermediateDirectory.FullName, $"{TestProjectName}.dll");
-            var niPdbFile = GivenThatWeWantToPublishReadyToRun.GetPDBFileName(mainProjectDll, framework);
+            var niPdbFile = GivenThatWeWantToPublishReadyToRun.GetPDBFileName(mainProjectDll, framework, RuntimeInformation.RuntimeIdentifier);
 
             string[] expectedFiles = { SingleFile, PdbFile, niPdbFile };
             GetPublishDirectory(publishCommand)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -113,7 +113,7 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData("net6.0")]
         public void It_supports_framework_dependent_publishing(string targetFramework)
         {
-            TestProjectPublishing_Internal("FrameworkDependent", targetFramework, isSelfContained: false, emitNativeSymbols:true, identifier: targetFramework);
+            TestProjectPublishing_Internal("FrameworkDependent", targetFramework, isSelfContained: false, composite: false, emitNativeSymbols:true, identifier: targetFramework);
         }
 
         [Theory]
@@ -200,7 +200,7 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData("net6.0")]
         public void It_can_publish_readytorun_for_library_projects(string targetFramework)
         {
-            TestProjectPublishing_Internal("LibraryProject1", targetFramework, isSelfContained: false, makeExeProject: false, identifier: targetFramework);
+            TestProjectPublishing_Internal("LibraryProject1", targetFramework, isSelfContained: false, composite: false, makeExeProject: false, identifier: targetFramework);
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
@@ -209,7 +209,7 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData("net6.0")]
         public void It_can_publish_readytorun_for_selfcontained_library_projects(string targetFramework)
         {
-            TestProjectPublishing_Internal("LibraryProject2", targetFramework, isSelfContained:true, makeExeProject: false, identifier: targetFramework);
+            TestProjectPublishing_Internal("LibraryProject2", targetFramework, isSelfContained:true, composite: true, makeExeProject: false, identifier: targetFramework);
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -274,7 +274,7 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData("net6.0", "win-x86", "windows", "X86,X64,Arm64,Arm", "nonComposite", "nonselfcontained")]
         public void It_supports_crossos_arch_compilation(string targetFramework, string runtimeIdentifier, string sdkSupportedOs, string sdkSupportedArch, string composite, string selfcontained)
         {
-            var projectName = $"FrameworkDependentUsingCrossArchTest";// {targetFramework}{runtimeIdentifier.Replace("-",".")}{composite}{selfcontained}";
+            var projectName = $"FrameworkDependentUsingCrossArchTest{targetFramework}{runtimeIdentifier.Replace("-",".")}{composite}{selfcontained}";
             string sdkOs = "NOTHING";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
@@ -309,7 +309,7 @@ namespace Microsoft.NET.Publish.Tests
 
         private static bool IsTargetOsOsX(string runtimeIdentifier)
         {
-            if (runtimeIdentifier.Contains("osx") || runtimeIdentifier.Contains("macOs"))
+            if (runtimeIdentifier.Contains("osx"))
             {
                 return true;
             }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
@@ -86,8 +87,8 @@ namespace Microsoft.NET.Publish.Tests
                 NuGetFramework framework = NuGetFramework.Parse(targetFramework);
 
                 publishDirectory.Should().NotHaveFiles(new[] {
-                    GetPDBFileName(mainProjectDll, framework),
-                    GetPDBFileName(classLibDll, framework),
+                    GetPDBFileName(mainProjectDll, framework, testProject.RuntimeIdentifier),
+                    GetPDBFileName(classLibDll, framework, testProject.RuntimeIdentifier),
                 });
             }
 
@@ -264,6 +265,67 @@ namespace Microsoft.NET.Publish.Tests
             publishCommand.Execute().Should().Pass();
         }
 
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData("net6.0", "linux-x64", "windows,linux,osx", "X64,Arm64", "nonComposite", "nonselfcontained")]
+        [InlineData("net6.0", "linux-x64", "windows,linux,osx", "X64,Arm64", "composite", "selfcontained")] // Composite in .NET 6.0 is only supported for self-contained builds
+        [InlineData("net6.0", "win-x64", "windows", "X64,Arm64", "composite", "selfcontained")] // Composite in .NET 6.0 is only supported for self-contained builds
+        [InlineData("net6.0", "osx-arm64", "windows,linux,osx", "X64,Arm64", "nonComposite", "nonselfcontained")]
+        // In .NET 6.0 building targetting Windows doesn't support emitting native symbols.
+        [InlineData("net6.0", "win-x86", "windows", "X86,X64,Arm64,Arm", "nonComposite", "nonselfcontained")]
+        public void It_supports_crossos_arch_compilation(string targetFramework, string runtimeIdentifier, string sdkSupportedOs, string sdkSupportedArch, string composite, string selfcontained)
+        {
+            var projectName = $"FrameworkDependentUsingCrossArchTest";// {targetFramework}{runtimeIdentifier.Replace("-",".")}{composite}{selfcontained}";
+            string sdkOs = "NOTHING";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                sdkOs = "linux";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                sdkOs = "windows";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                sdkOs = "osx";
+            }
+
+            Assert.NotEqual("NOTHING", sdkOs); // We should know which OS we are running on
+            if (!sdkSupportedOs.Contains(sdkOs))
+            {
+                // Running test on OS that doesn't support this cross platform build
+                return;
+            }
+
+            string sdkArch = RuntimeInformation.ProcessArchitecture.ToString();
+            Assert.Contains(sdkArch, new string[]{"Arm", "Arm64", "X64", "X86"}); // Assert that the Architecture in use is a known architecture
+            if (!sdkSupportedArch.Split(',').Contains(sdkArch))
+            {
+                // Running test on processor architecture that doesn't support this cross platform build
+                return;
+            }
+
+            TestProjectPublishing_Internal(projectName, targetFramework, isSelfContained: selfcontained == "selfcontained", emitNativeSymbols: true, useCrossgen2: true, composite: composite == "composite", identifier: targetFramework, runtimeIdentifier: runtimeIdentifier);
+        }
+
+        private static bool IsTargetOsOsX(string runtimeIdentifier)
+        {
+            if (runtimeIdentifier.Contains("osx") || runtimeIdentifier.Contains("macOs"))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private static bool IsTargetOsWindows(string runtimeIdentifier)
+        {
+            return runtimeIdentifier.Contains("win");
+        }
+
+        private static bool IsTargetOsLinux(string runtimeIdentifier)
+        {
+            return runtimeIdentifier.Contains("linux");
+        }
+
         private void TestProjectPublishing_Internal(string projectName,
             string targetFramework,
             bool makeExeProject = true,
@@ -272,13 +334,15 @@ namespace Microsoft.NET.Publish.Tests
             bool useCrossgen2 = false,
             bool composite = true,
             [CallerMemberName] string callingMethod = "",
-            string identifier = null)
+            string identifier = null,
+            string runtimeIdentifier = null)
         {
             var testProject = CreateTestProjectForR2RTesting(
                 targetFramework,
                 projectName,
                 "ClassLib",
-                isExeProject: makeExeProject);
+                isExeProject: makeExeProject,
+                runtimeIdentifier: runtimeIdentifier);
 
             testProject.AdditionalProperties["PublishReadyToRun"] = "True";
             testProject.AdditionalProperties["PublishReadyToRunEmitSymbols"] = emitNativeSymbols ? "True" : "False";
@@ -307,18 +371,34 @@ namespace Microsoft.NET.Publish.Tests
             else
                 publishDirectory.Should().NotHaveFile("System.Private.CoreLib.dll");
 
-            if (emitNativeSymbols && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (emitNativeSymbols && !IsTargetOsOsX(testProject.RuntimeIdentifier))
             {
                 NuGetFramework framework = NuGetFramework.Parse(targetFramework);
+                Log.WriteLine("Checking for symbol files");
+                IEnumerable<string> pdbFiles;
 
-                publishDirectory.Should().HaveFiles(new[] {
-                    GetPDBFileName(mainProjectDll, framework),
-                    GetPDBFileName(classLibDll, framework),
-                });
+                if (composite)
+                {
+                    pdbFiles = new[] { GetPDBFileName(Path.ChangeExtension(mainProjectDll, "r2r.dll"), framework, testProject.RuntimeIdentifier) };
+                }
+                else
+                {
+                    pdbFiles = new[] {
+                        GetPDBFileName(mainProjectDll, framework, testProject.RuntimeIdentifier),
+                        GetPDBFileName(classLibDll, framework, testProject.RuntimeIdentifier),
+                    };
+                }
+
+                foreach (string s in pdbFiles)
+                {
+                    Log.WriteLine($"{publishDirectory.FullName} {s}");
+                }
+
+                publishDirectory.Should().HaveFiles(pdbFiles);
             }
         }
 
-        private TestProject CreateTestProjectForR2RTesting(string targetFramework, string mainProjectName, string referenceProjectName, bool isExeProject = true)
+        private TestProject CreateTestProjectForR2RTesting(string targetFramework, string mainProjectName, string referenceProjectName, bool isExeProject = true, string runtimeIdentifier = null)
         {
             var referenceProject = new TestProject()
             {
@@ -340,7 +420,7 @@ public class Classlib
                 Name = mainProjectName,
                 TargetFrameworks = targetFramework,
                 IsExe = isExeProject,
-                RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid(targetFramework),
+                RuntimeIdentifier = runtimeIdentifier ?? EnvironmentInfo.GetCompatibleRid(targetFramework),
                 ReferencedProjects = { referenceProject },
             };
             testProject.SourceFiles[$"{mainProjectName}.cs"] = @"
@@ -356,14 +436,14 @@ public class Program
             return testProject;
         }
 
-        public static string GetPDBFileName(string assemblyFile, NuGetFramework framework)
+        public static string GetPDBFileName(string assemblyFile, NuGetFramework framework, string runtimeIdentifier)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (IsTargetOsWindows(runtimeIdentifier))
             {
                 return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.pdb"));
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (IsTargetOsLinux(runtimeIdentifier))
             {
                 if (framework.Version.Major >= 6)
                 {


### PR DESCRIPTION
- Use the target os to determine the symbol type, not the sdk os
- Add tests for cross os/cross arch crossgen compilation