### PR TITLE
Add platform descriminator to workload records

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallRecords/RegistryWorkloadInstallationRecordRepository.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallRecords/RegistryWorkloadInstallationRecordRepository.cs
@@ -3,14 +3,13 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using Microsoft.DotNet.Installer.Windows;
-using Microsoft.Win32;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.Win32;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install.InstallRecord
 {
@@ -26,13 +25,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Install.InstallRecord
         /// <summary>
         /// The base path of workload installation records in the registry.
         /// </summary>
-        internal readonly string BasePath = @"SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone";
+        internal readonly string BasePath = @$"SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone\{HostArchitecture}";
 
         /// <summary>
         /// The base key to use when reading/writing records.
         /// </summary>
         private RegistryKey _baseKey = Registry.LocalMachine;
-
 
         internal RegistryWorkloadInstallationRecordRepository(InstallElevationContextBase elevationContext, ISetupLogger logger)
             : base(elevationContext, logger)
@@ -45,7 +43,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install.InstallRecord
         /// </summary>
         /// <param name="baseKey">The base key to use, e.g. <see cref="Registry.CurrentUser"/>.</param>
         internal RegistryWorkloadInstallationRecordRepository(InstallElevationContextBase elevationContext, ISetupLogger logger,
-            RegistryKey baseKey, string basePath) 
+            RegistryKey baseKey, string basePath)
             : this(elevationContext, logger)
         {
             _baseKey = baseKey;


### PR DESCRIPTION
**Description**: Workload records currently do not account for potential mixed installations, e.g. x64 on arm64. This ensures that we don't have records overwriting each other in SxS installs and not having to deal with legacy code going into RC2 and GA.

**Testing**: Automated

**Regression**: No

**Risk**: Low

**Workaround**: None

**Packaging change**: None