### PR TITLE
[6.0.1xx-rc1] Fix PlatformNotSupportedException for Windows (arm64)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,22 +79,22 @@
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>727a4ec856a56e39e1dea812107b876199865e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.12">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.13">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>2aaa031e2dfac954e6c0934453c5a300f054362d</Sha>
+      <Sha>6e712935e202b768bef8b9099a90089c37150c20</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.12">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.13">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>2aaa031e2dfac954e6c0934453c5a300f054362d</Sha>
+      <Sha>6e712935e202b768bef8b9099a90089c37150c20</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.12">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.13">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>2aaa031e2dfac954e6c0934453c5a300f054362d</Sha>
+      <Sha>6e712935e202b768bef8b9099a90089c37150c20</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.12">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.13">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>2aaa031e2dfac954e6c0934453c5a300f054362d</Sha>
+      <Sha>6e712935e202b768bef8b9099a90089c37150c20</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21430.26">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,22 +79,22 @@
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>727a4ec856a56e39e1dea812107b876199865e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.15">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.20">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>e98d13dd31cf25bb66cdccd83d928b44fa21a295</Sha>
+      <Sha>86952a3a120b6b5be6a44514629040b3ff21b58e</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.15">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.20">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>e98d13dd31cf25bb66cdccd83d928b44fa21a295</Sha>
+      <Sha>86952a3a120b6b5be6a44514629040b3ff21b58e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.15">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.20">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>e98d13dd31cf25bb66cdccd83d928b44fa21a295</Sha>
+      <Sha>86952a3a120b6b5be6a44514629040b3ff21b58e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.15">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.20">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>e98d13dd31cf25bb66cdccd83d928b44fa21a295</Sha>
+      <Sha>86952a3a120b6b5be6a44514629040b3ff21b58e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21430.26">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,22 +79,22 @@
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>727a4ec856a56e39e1dea812107b876199865e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-5.21451.20">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-5.21451.31">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>bad140860fe3aca9cb50dc573641371fb5bb9332</Sha>
+      <Sha>1865b5c2f536d711d7525cbaa69fdb323956a114</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-5.21451.20">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-5.21451.31">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>bad140860fe3aca9cb50dc573641371fb5bb9332</Sha>
+      <Sha>1865b5c2f536d711d7525cbaa69fdb323956a114</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-5.21451.20">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-5.21451.31">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>bad140860fe3aca9cb50dc573641371fb5bb9332</Sha>
+      <Sha>1865b5c2f536d711d7525cbaa69fdb323956a114</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-5.21451.20">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-5.21451.31">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>bad140860fe3aca9cb50dc573641371fb5bb9332</Sha>
+      <Sha>1865b5c2f536d711d7525cbaa69fdb323956a114</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,22 +79,22 @@
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>727a4ec856a56e39e1dea812107b876199865e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.26">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-5.21451.5">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>a8b10ae673b6c5fc4b72b42e85ad1bf42cd16749</Sha>
+      <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.26">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-5.21451.5">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>a8b10ae673b6c5fc4b72b42e85ad1bf42cd16749</Sha>
+      <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.26">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-5.21451.5">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>a8b10ae673b6c5fc4b72b42e85ad1bf42cd16749</Sha>
+      <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.26">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-5.21451.5">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>a8b10ae673b6c5fc4b72b42e85ad1bf42cd16749</Sha>
+      <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21430.26">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -137,21 +137,21 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-rc.1.21451.2">
+    <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-rc.1.21451.3">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
-      <Sha>c5e73d70337bb142c7c986579ad04e312cff26bb</Sha>
+      <Sha>f7325d55937fbfcd28a1b61fcbea420f2fc79c72</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.WindowsDesktop.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21451.2">
+    <Dependency Name="VS.Redist.Common.WindowsDesktop.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21451.3">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
-      <Sha>c5e73d70337bb142c7c986579ad04e312cff26bb</Sha>
+      <Sha>f7325d55937fbfcd28a1b61fcbea420f2fc79c72</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="6.0.0-rc.1.21451.2">
+    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="6.0.0-rc.1.21451.3">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
-      <Sha>c5e73d70337bb142c7c986579ad04e312cff26bb</Sha>
+      <Sha>f7325d55937fbfcd28a1b61fcbea420f2fc79c72</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="6.0.0-rc.1.21451.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Ref">
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="6.0.0-rc.1.21451.4" CoherentParentDependency="Microsoft.WindowsDesktop.App.Ref">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>1dc7216102edb876af4793d41d15aac81d2c9b44</Sha>
+      <Sha>d62caf8a5fb9bc507457b6925cbf621720e268c7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -58,13 +58,13 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21430-03">
+    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21431-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>e65d1aeab4692586b220ee295b91ffb42c253248</Sha>
+      <Sha>bd6797fc88ffbb2a0ffd3cbe0b67c93831cbcb9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.0.0-preview-21430-03">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.0.0-preview-21431-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>e65d1aeab4692586b220ee295b91ffb42c253248</Sha>
+      <Sha>bd6797fc88ffbb2a0ffd3cbe0b67c93831cbcb9f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.0-beta.21431.3">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,22 +79,22 @@
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>727a4ec856a56e39e1dea812107b876199865e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21430.4">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.12">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>4cda89e2dddc3e34ffa211c6c3ffb143e5433f0b</Sha>
+      <Sha>2aaa031e2dfac954e6c0934453c5a300f054362d</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21430.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.12">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>4cda89e2dddc3e34ffa211c6c3ffb143e5433f0b</Sha>
+      <Sha>2aaa031e2dfac954e6c0934453c5a300f054362d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21430.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.12">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>4cda89e2dddc3e34ffa211c6c3ffb143e5433f0b</Sha>
+      <Sha>2aaa031e2dfac954e6c0934453c5a300f054362d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21430.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.12">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>4cda89e2dddc3e34ffa211c6c3ffb143e5433f0b</Sha>
+      <Sha>2aaa031e2dfac954e6c0934453c5a300f054362d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21430.26">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -96,13 +96,13 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="6.0.0-preview.4.221">
       <Uri>https://github.com/nuget/nuget.client</Uri>
@@ -153,78 +153,78 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>1dc7216102edb876af4793d41d15aac81d2c9b44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
       <SourceBuild RepoName="aspnetcore" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="dotnet-dev-certs" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="dotnet-user-secrets" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Analyzers" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.Analyzers" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Analyzers" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Analyzers" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Razor" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.CodeAnalysis.Razor" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Razor.Language" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.Razor.Language" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Razor.Internal.SourceGenerator.Transport" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.Razor.Internal.SourceGenerator.Transport" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="6.0.0-rc.1.21430.26">
+    <Dependency Name="Microsoft.JSInterop" Version="6.0.0-rc.1.21451.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
+      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Web.Xdt" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/xdt</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,22 +79,22 @@
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>727a4ec856a56e39e1dea812107b876199865e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.22">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.26">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ef43e6320233f2e8355134e6f3e28a11dc1cbd07</Sha>
+      <Sha>a8b10ae673b6c5fc4b72b42e85ad1bf42cd16749</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.22">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.26">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ef43e6320233f2e8355134e6f3e28a11dc1cbd07</Sha>
+      <Sha>a8b10ae673b6c5fc4b72b42e85ad1bf42cd16749</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.22">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.26">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ef43e6320233f2e8355134e6f3e28a11dc1cbd07</Sha>
+      <Sha>a8b10ae673b6c5fc4b72b42e85ad1bf42cd16749</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.22">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.26">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ef43e6320233f2e8355134e6f3e28a11dc1cbd07</Sha>
+      <Sha>a8b10ae673b6c5fc4b72b42e85ad1bf42cd16749</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21430.26">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,22 +79,22 @@
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>727a4ec856a56e39e1dea812107b876199865e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.13">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.15">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>6e712935e202b768bef8b9099a90089c37150c20</Sha>
+      <Sha>e98d13dd31cf25bb66cdccd83d928b44fa21a295</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.13">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.15">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>6e712935e202b768bef8b9099a90089c37150c20</Sha>
+      <Sha>e98d13dd31cf25bb66cdccd83d928b44fa21a295</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.13">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.15">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>6e712935e202b768bef8b9099a90089c37150c20</Sha>
+      <Sha>e98d13dd31cf25bb66cdccd83d928b44fa21a295</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.13">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.15">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>6e712935e202b768bef8b9099a90089c37150c20</Sha>
+      <Sha>e98d13dd31cf25bb66cdccd83d928b44fa21a295</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21430.26">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,22 +79,22 @@
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>727a4ec856a56e39e1dea812107b876199865e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-5.21451.5">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-5.21451.20">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
+      <Sha>bad140860fe3aca9cb50dc573641371fb5bb9332</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-5.21451.5">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-5.21451.20">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
+      <Sha>bad140860fe3aca9cb50dc573641371fb5bb9332</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-5.21451.5">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-5.21451.20">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
+      <Sha>bad140860fe3aca9cb50dc573641371fb5bb9332</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-5.21451.5">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-5.21451.20">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
+      <Sha>bad140860fe3aca9cb50dc573641371fb5bb9332</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -104,9 +104,9 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>be284fb9ec8ad3e0ef4efc3425be412a4233aab9</Sha>
     </Dependency>
-    <Dependency Name="NuGet.Build.Tasks" Version="6.0.0-preview.4.220">
+    <Dependency Name="NuGet.Build.Tasks" Version="6.0.0-preview.4.221">
       <Uri>https://github.com/nuget/nuget.client</Uri>
-      <Sha>0a66a9486c69f95ddd5ea57158c86dfb2c9e877f</Sha>
+      <Sha>048c1f435952666c470d85724b3d4ea1e100c168</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.0.0-preview-20210817-02">
       <Uri>https://github.com/microsoft/vstest</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="6.0.100-rc.1.21430.6">
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="6.0.100-rc.1.21451.20">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>aabbcb08ca25bffa17c6f67dc6f66bbc011f7f9a</Sha>
+      <Sha>4cfbd3b0e453224565f25e7a6ca9adf1a62e4af5</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="6.0.100-rc.1.21430.6">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="6.0.100-rc.1.21451.20">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>aabbcb08ca25bffa17c6f67dc6f66bbc011f7f9a</Sha>
+      <Sha>4cfbd3b0e453224565f25e7a6ca9adf1a62e4af5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="6.0.100-rc.1.21430.6">
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="6.0.100-rc.1.21451.20">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>aabbcb08ca25bffa17c6f67dc6f66bbc011f7f9a</Sha>
+      <Sha>4cfbd3b0e453224565f25e7a6ca9adf1a62e4af5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="6.0.100-rc.1.21430.6">
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="6.0.100-rc.1.21451.20">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>aabbcb08ca25bffa17c6f67dc6f66bbc011f7f9a</Sha>
+      <Sha>4cfbd3b0e453224565f25e7a6ca9adf1a62e4af5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.Common" Version="6.0.100-rc.1.21430.6">
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="6.0.100-rc.1.21451.20">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>aabbcb08ca25bffa17c6f67dc6f66bbc011f7f9a</Sha>
+      <Sha>4cfbd3b0e453224565f25e7a6ca9adf1a62e4af5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.100-rc.1.21430.6">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.100-rc.1.21451.20">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>aabbcb08ca25bffa17c6f67dc6f66bbc011f7f9a</Sha>
+      <Sha>4cfbd3b0e453224565f25e7a6ca9adf1a62e4af5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -58,13 +58,13 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21431-01">
+    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21431-03">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>bd6797fc88ffbb2a0ffd3cbe0b67c93831cbcb9f</Sha>
+      <Sha>f6cf1185647f4cd520ef4267b1bac1f879fa2e3b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.0.0-preview-21431-01">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.0.0-preview-21431-03">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>bd6797fc88ffbb2a0ffd3cbe0b67c93831cbcb9f</Sha>
+      <Sha>f6cf1185647f4cd520ef4267b1bac1f879fa2e3b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.0-beta.21431.3">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -58,13 +58,13 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21431-03">
+    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21451-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>f6cf1185647f4cd520ef4267b1bac1f879fa2e3b</Sha>
+      <Sha>596f08dcfe629084c9f69e8a929deffad73a8ed9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.0.0-preview-21431-03">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.0.0-preview-21451-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>f6cf1185647f4cd520ef4267b1bac1f879fa2e3b</Sha>
+      <Sha>596f08dcfe629084c9f69e8a929deffad73a8ed9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.0-beta.21431.3">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,37 +26,37 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>aabbcb08ca25bffa17c6f67dc6f66bbc011f7f9a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21451-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
@@ -121,21 +121,21 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>a1f528d854ee057290682490a74e59a809fe453f</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="System.CodeDom" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="System.Resources.Extensions" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-rc.1.21430.5">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
@@ -267,9 +267,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>ac8b7514ca8bcac1d071a16b7a92cb52f7058871</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-rc.1.21430.11">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-rc.1.21451.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0ab2741bdcf5c05c6c4f986d6c4eb0df573bc549</Sha>
+      <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21417.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,22 +79,22 @@
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>727a4ec856a56e39e1dea812107b876199865e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.20">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21431.22">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>86952a3a120b6b5be6a44514629040b3ff21b58e</Sha>
+      <Sha>ef43e6320233f2e8355134e6f3e28a11dc1cbd07</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.20">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.21431.22">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>86952a3a120b6b5be6a44514629040b3ff21b58e</Sha>
+      <Sha>ef43e6320233f2e8355134e6f3e28a11dc1cbd07</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.20">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.0-4.21431.22">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>86952a3a120b6b5be6a44514629040b3ff21b58e</Sha>
+      <Sha>ef43e6320233f2e8355134e6f3e28a11dc1cbd07</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.20">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21431.22">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>86952a3a120b6b5be6a44514629040b3ff21b58e</Sha>
+      <Sha>ef43e6320233f2e8355134e6f3e28a11dc1cbd07</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21430.26">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -58,13 +58,13 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21451-01">
+    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21451-03">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>596f08dcfe629084c9f69e8a929deffad73a8ed9</Sha>
+      <Sha>864047de115b74992485b08c5d2eaa43ca95ee68</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.0.0-preview-21451-01">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.0.0-preview-21451-03">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>596f08dcfe629084c9f69e8a929deffad73a8ed9</Sha>
+      <Sha>864047de115b74992485b08c5d2eaa43ca95ee68</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.0-beta.21431.3">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -96,13 +96,13 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>e8bd12286b725b1c67a5a5ba5292536904eccf55</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="6.0.0-preview.4.221">
       <Uri>https://github.com/nuget/nuget.client</Uri>
@@ -153,78 +153,78 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>d62caf8a5fb9bc507457b6925cbf621720e268c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
       <SourceBuild RepoName="aspnetcore" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="dotnet-dev-certs" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="dotnet-user-secrets" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Analyzers" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.Analyzers" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Analyzers" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Analyzers" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Razor" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.CodeAnalysis.Razor" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Razor.Language" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.Razor.Language" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Razor.Internal.SourceGenerator.Transport" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.Razor.Internal.SourceGenerator.Transport" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="6.0.0-rc.1.21451.22">
+    <Dependency Name="Microsoft.JSInterop" Version="6.0.0-rc.1.21451.36">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a27dcac09efa52e4eec07d86537db37b53fef3fb</Sha>
+      <Sha>516f7ba4cb94c600ddce4aa4bc7088f6366ef066</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Web.Xdt" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/xdt</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -137,21 +137,21 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d7619cd4b165c13430484e381042f055d4c5a9c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-rc.1.21430.5">
+    <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-rc.1.21451.2">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
-      <Sha>1149d2dcf8d5faf7fd0fc77a19ceb1bcd55dc16f</Sha>
+      <Sha>c5e73d70337bb142c7c986579ad04e312cff26bb</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.WindowsDesktop.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21430.5">
+    <Dependency Name="VS.Redist.Common.WindowsDesktop.SharedFramework.x64.6.0" Version="6.0.0-rc.1.21451.2">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
-      <Sha>1149d2dcf8d5faf7fd0fc77a19ceb1bcd55dc16f</Sha>
+      <Sha>c5e73d70337bb142c7c986579ad04e312cff26bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="6.0.0-rc.1.21430.5">
+    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="6.0.0-rc.1.21451.2">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
-      <Sha>1149d2dcf8d5faf7fd0fc77a19ceb1bcd55dc16f</Sha>
+      <Sha>c5e73d70337bb142c7c986579ad04e312cff26bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="6.0.0-rc.1.21430.6" CoherentParentDependency="Microsoft.WindowsDesktop.App.Ref">
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="6.0.0-rc.1.21451.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Ref">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>d26acd0cf4ebdd75304a111e2ce6dac41b7b0add</Sha>
+      <Sha>1dc7216102edb876af4793d41d15aac81d2c9b44</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-rc.1.21430.26">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.15</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.20</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.15</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.15</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.15</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.20</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.20</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.20</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -96,10 +96,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.0.0-preview-21451-01</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.0.0-preview-21451-03</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.0.0-preview-21451-01</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.0.0-preview-21451-03</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -130,16 +130,16 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreMvcAnalyzersPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreMvcAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreAnalyzersPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreTestHostPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreRazorLanguageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreRazorLanguageVersion>
-    <MicrosoftCodeAnalysisRazorVersion>6.0.0-rc.1.21451.22</MicrosoftCodeAnalysisRazorVersion>
-    <MicrosoftAspNetCoreRazorInternalSourceGeneratorTransportPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreRazorInternalSourceGeneratorTransportPackageVersion>
+    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>6.0.0-rc.1.21451.36</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>6.0.0-rc.1.21451.36</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreMvcAnalyzersPackageVersion>6.0.0-rc.1.21451.36</MicrosoftAspNetCoreMvcAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>6.0.0-rc.1.21451.36</MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreAnalyzersPackageVersion>6.0.0-rc.1.21451.36</MicrosoftAspNetCoreAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>6.0.0-rc.1.21451.36</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>6.0.0-rc.1.21451.36</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreRazorLanguageVersion>6.0.0-rc.1.21451.36</MicrosoftAspNetCoreRazorLanguageVersion>
+    <MicrosoftCodeAnalysisRazorVersion>6.0.0-rc.1.21451.36</MicrosoftCodeAnalysisRazorVersion>
+    <MicrosoftAspNetCoreRazorInternalSourceGeneratorTransportPackageVersion>6.0.0-rc.1.21451.36</MicrosoftAspNetCoreRazorInternalSourceGeneratorTransportPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/wpf -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.26</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-5.21451.5</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.26</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.26</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.26</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-5.21451.5</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-5.21451.5</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-5.21451.5</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -96,10 +96,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.0.0-preview-21430-03</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.0.0-preview-21431-01</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.0.0-preview-21430-03</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.0.0-preview-21431-01</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.22</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.26</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.22</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.22</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.22</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.26</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.26</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.26</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -143,11 +143,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/wpf -->
-    <MicrosoftNETSdkWindowsDesktopPackageVersion>6.0.0-rc.1.21451.1</MicrosoftNETSdkWindowsDesktopPackageVersion>
+    <MicrosoftNETSdkWindowsDesktopPackageVersion>6.0.0-rc.1.21451.4</MicrosoftNETSdkWindowsDesktopPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/windowsdesktop -->
-    <VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>6.0.0-rc.1.21451.2</VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>
+    <VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>6.0.0-rc.1.21451.3</VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manually updated">
     <!-- Dependencies from https://github.com/microsoft/MSBuildLocator -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.13</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.15</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.13</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.13</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.13</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.15</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.15</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.15</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21430.4</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.12</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21430.4</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21430.4</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21430.4</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.12</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.12</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.12</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -96,10 +96,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.0.0-preview-21431-01</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.0.0-preview-21431-03</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.0.0-preview-21431-01</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.0.0-preview-21431-03</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-5.21451.5</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-5.21451.20</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-5.21451.5</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-5.21451.5</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-5.21451.5</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-5.21451.20</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-5.21451.20</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-5.21451.20</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -110,11 +110,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>6.0.100-rc.1.21430.6</MicrosoftTemplateEngineCliPackageVersion>
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>6.0.100-rc.1.21430.6</MicrosoftTemplateEngineAbstractionsPackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>6.0.100-rc.1.21430.6</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>6.0.100-rc.1.21430.6</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>6.0.100-rc.1.21430.6</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>6.0.100-rc.1.21451.20</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>6.0.100-rc.1.21451.20</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>6.0.100-rc.1.21451.20</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>6.0.100-rc.1.21451.20</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>6.0.100-rc.1.21451.20</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -130,16 +130,16 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>6.0.0-rc.1.21430.26</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>6.0.0-rc.1.21430.26</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreMvcAnalyzersPackageVersion>6.0.0-rc.1.21430.26</MicrosoftAspNetCoreMvcAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>6.0.0-rc.1.21430.26</MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreAnalyzersPackageVersion>6.0.0-rc.1.21430.26</MicrosoftAspNetCoreAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>6.0.0-rc.1.21430.26</MicrosoftAspNetCoreTestHostPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>6.0.0-rc.1.21430.26</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreRazorLanguageVersion>6.0.0-rc.1.21430.26</MicrosoftAspNetCoreRazorLanguageVersion>
-    <MicrosoftCodeAnalysisRazorVersion>6.0.0-rc.1.21430.26</MicrosoftCodeAnalysisRazorVersion>
-    <MicrosoftAspNetCoreRazorInternalSourceGeneratorTransportPackageVersion>6.0.0-rc.1.21430.26</MicrosoftAspNetCoreRazorInternalSourceGeneratorTransportPackageVersion>
+    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreMvcAnalyzersPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreMvcAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreAnalyzersPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreRazorLanguageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreRazorLanguageVersion>
+    <MicrosoftCodeAnalysisRazorVersion>6.0.0-rc.1.21451.22</MicrosoftCodeAnalysisRazorVersion>
+    <MicrosoftAspNetCoreRazorInternalSourceGeneratorTransportPackageVersion>6.0.0-rc.1.21451.22</MicrosoftAspNetCoreRazorInternalSourceGeneratorTransportPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/wpf -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.20</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.22</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.20</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.20</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.20</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.22</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.22</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.22</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,25 +30,25 @@
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.21418.12</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-rc.1.21430.11</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-rc.1.21451.13</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
     <SystemTextJsonVersion>5.0.2</SystemTextJsonVersion>
-    <SystemReflectionMetadataLoadContextVersion>6.0.0-rc.1.21430.11</SystemReflectionMetadataLoadContextVersion>
+    <SystemReflectionMetadataLoadContextVersion>6.0.0-rc.1.21451.13</SystemReflectionMetadataLoadContextVersion>
     <DeploymentReleasesVersion>1.0.0-preview1.1.21112.1</DeploymentReleasesVersion>
     <SystemManagementPackageVersion>4.6.0</SystemManagementPackageVersion>
     <SystemCommandLineVersion>2.0.0-beta1.21416.6</SystemCommandLineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-rc.1.21430.11</MicrosoftNETCoreAppRefPackageVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-rc.1.21430.11</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-rc.1.21430.11</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-rc.1.21451.13</MicrosoftNETCoreAppRefPackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-rc.1.21451.13</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-rc.1.21451.13</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-rc.1.21430.11</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-rc.1.21430.11</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>6.0.0-rc.1.21430.11</MicrosoftNETHostModelVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-rc.1.21451.13</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-rc.1.21451.13</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>6.0.0-rc.1.21451.13</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>6.0.0-preview.7.21363.9</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
   </PropertyGroup>
@@ -81,10 +81,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <SystemCodeDomPackageVersion>6.0.0-rc.1.21430.11</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>6.0.0-rc.1.21430.11</SystemTextEncodingCodePagesPackageVersion>
+    <SystemCodeDomPackageVersion>6.0.0-rc.1.21451.13</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>6.0.0-rc.1.21451.13</SystemTextEncodingCodePagesPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20364.11</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>6.0.0-rc.1.21430.11</SystemResourcesExtensionsPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>6.0.0-rc.1.21451.13</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/format -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-5.21451.20</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-5.21451.31</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-5.21451.20</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-5.21451.20</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-5.21451.20</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-5.21451.31</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-5.21451.31</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-5.21451.31</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,7 +34,7 @@
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
-    <SystemTextJsonVersion>4.7.2</SystemTextJsonVersion>
+    <SystemTextJsonVersion>5.0.2</SystemTextJsonVersion>
     <SystemReflectionMetadataLoadContextVersion>6.0.0-rc.1.21430.11</SystemReflectionMetadataLoadContextVersion>
     <DeploymentReleasesVersion>1.0.0-preview1.1.21112.1</DeploymentReleasesVersion>
     <SystemManagementPackageVersion>4.6.0</SystemManagementPackageVersion>
@@ -96,10 +96,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.0.0-preview-21431-03</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.0.0-preview-21451-01</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.0.0-preview-21431-03</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.0.0-preview-21451-01</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -54,7 +54,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
-    <NuGetBuildTasksPackageVersion>6.0.0-preview.4.220</NuGetBuildTasksPackageVersion>
+    <NuGetBuildTasksPackageVersion>6.0.0-preview.4.221</NuGetBuildTasksPackageVersion>
     <NuGetBuildTasksConsolePackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksConsolePackageVersion>
     <NuGetBuildTasksPackPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksPackPackageVersion>
     <NuGetCommandLineXPlatPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetCommandLineXPlatPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.12</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-4.21431.13</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.12</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.12</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.12</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21431.13</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21431.13</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21431.13</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -143,11 +143,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/wpf -->
-    <MicrosoftNETSdkWindowsDesktopPackageVersion>6.0.0-rc.1.21430.6</MicrosoftNETSdkWindowsDesktopPackageVersion>
+    <MicrosoftNETSdkWindowsDesktopPackageVersion>6.0.0-rc.1.21451.1</MicrosoftNETSdkWindowsDesktopPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/windowsdesktop -->
-    <VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>6.0.0-rc.1.21430.5</VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>
+    <VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>6.0.0-rc.1.21451.2</VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manually updated">
     <!-- Dependencies from https://github.com/microsoft/MSBuildLocator -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,6 +39,7 @@
     <DeploymentReleasesVersion>1.0.0-preview1.1.21112.1</DeploymentReleasesVersion>
     <SystemManagementPackageVersion>4.6.0</SystemManagementPackageVersion>
     <SystemCommandLineVersion>2.0.0-beta1.21416.6</SystemCommandLineVersion>
+    <MicrosoftManagementInfrastructurePackageVersion>2.0.0</MicrosoftManagementInfrastructurePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
@@ -2,14 +2,20 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
-using System.Management;
+using System.Linq;
+using System.Runtime.Versioning;
+using Microsoft.Management.Infrastructure;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
     /// <summary>
     /// Extensions methods for <see cref="Process"/> components.
     /// </summary>
+#if NET
+    [SupportedOSPlatform("windows")]
+#endif
     public static class ProcessExtensions
     {
         /// <summary>
@@ -31,11 +37,11 @@ namespace Microsoft.DotNet.Cli.Utils
         /// <returns>The process ID of the parent process, or -1 if the parent process could not be found.</returns>
         public static int GetParentProcessId(this Process process)
         {
-            ManagementObjectSearcher searcher = new($"SELECT ParentProcessId FROM Win32_Process WHERE ProcessId='{process.Id}'");
-            using ManagementObjectCollection result = searcher.Get();
-            ManagementObjectCollection.ManagementObjectEnumerator enumerator = result.GetEnumerator();
+            CimSession cimSession = CimSession.Create(null);
+            IEnumerable<CimInstance> results = cimSession.QueryInstances(@"root\cimv2", "WQL",
+                $"SELECT ParentProcessId FROM Win32_Process WHERE ProcessId='{process.Id}'");
 
-            return enumerator.MoveNext() ? Convert.ToInt32(enumerator.Current.GetPropertyValue("ParentProcessId")) : -1;
+            return results.Any() ? Convert.ToInt32(results.First().CimInstanceProperties["ParentProcessId"].Value) : -1;
         }
 
         /// <summary>
@@ -45,11 +51,11 @@ namespace Microsoft.DotNet.Cli.Utils
         /// <returns>The command line of the process or <see langword="null"/> if it could not be retrieved.</returns>
         public static string GetCommandLine(this Process process)
         {
-            ManagementObjectSearcher searcher = new($"SELECT CommandLine FROM Win32_Process WHERE ProcessId='{process.Id}'");
-            using ManagementObjectCollection result = searcher.Get();
-            ManagementObjectCollection.ManagementObjectEnumerator enumerator = result.GetEnumerator();
+            CimSession cimSession = CimSession.Create(null);
+            IEnumerable<CimInstance> results = cimSession.QueryInstances(@"root\cimv2", "WQL",
+                $"SELECT CommandLine FROM Win32_Process WHERE ProcessId='{process.Id}'");
 
-            return enumerator.MoveNext() ? Convert.ToString(enumerator.Current.GetPropertyValue("CommandLine")) : null;
+            return results.Any() ? Convert.ToString(results.First().CimInstanceProperties["CommandLine"].Value) : null;
         }
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
-    <PackageReference Include="System.Management" Version="$(SystemManagementPackageVersion)" />  
+    <PackageReference Include="Microsoft.Management.Infrastructure" Version="$(MicrosoftManagementInfrastructurePackageVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />  
   </ItemGroup>
 </Project>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallRecords/RegistryWorkloadInstallationRecordRepository.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallRecords/RegistryWorkloadInstallationRecordRepository.cs
@@ -3,14 +3,13 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using Microsoft.DotNet.Installer.Windows;
-using Microsoft.Win32;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.Win32;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install.InstallRecord
 {
@@ -26,13 +25,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Install.InstallRecord
         /// <summary>
         /// The base path of workload installation records in the registry.
         /// </summary>
-        internal readonly string BasePath = @"SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone";
+        internal readonly string BasePath = @$"SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone\{HostArchitecture}";
 
         /// <summary>
         /// The base key to use when reading/writing records.
         /// </summary>
         private RegistryKey _baseKey = Registry.LocalMachine;
-
 
         internal RegistryWorkloadInstallationRecordRepository(InstallElevationContextBase elevationContext, ISetupLogger logger)
             : base(elevationContext, logger)
@@ -45,7 +43,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install.InstallRecord
         /// </summary>
         /// <param name="baseKey">The base key to use, e.g. <see cref="Registry.CurrentUser"/>.</param>
         internal RegistryWorkloadInstallationRecordRepository(InstallElevationContextBase elevationContext, ISetupLogger logger,
-            RegistryKey baseKey, string basePath) 
+            RegistryKey baseKey, string basePath)
             : this(elevationContext, logger)
         {
             _baseKey = baseKey;

--- a/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
+++ b/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
@@ -3,11 +3,15 @@
 //
 
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Microsoft.NET.TestFramework;
 using Xunit;
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+#if NET
+    [SupportedOSPlatform("windows")]
+#endif
     public class ProcessExtensionsTests
     {
         [WindowsOnlyFact]


### PR DESCRIPTION
**Description**: Workload admin installs rely on some WMI queries to obtain data from ```Win32_Process```. This is not supported on Windows (arm64). We can retain the queries by switching to Microsoft.Management.Infrastructure instead of System.Management. Without this, all workload commands will fail with ```System.PlatformNotSupportedException: Could not find an installation of .NET Framework v4.0.30319. System.Management requires native modules from the .NET Framework to operate.```

**Risk**: Low

**Testing**: Automated and manual

**Packaging change**: None

**Workaround**: None

**Alternative**: Another option would be to pull out some of the P/Invoke code in runtime and copy that into the CLI, e.g. https://github.com/dotnet/runtime/blob/720279cc437cb05418155a407b5ac7a698de879d/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs#L350