### PR TITLE
Do not specify a protocol if server does not require secrets

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -223,7 +223,7 @@ setTimeout(async function () {
   function getWebSocket(url) {
     return new Promise((resolve, reject) => {
       const encryptedSecret = sharedSecret && sharedSecret.encryptedSharedSecret;
-      const protocol = encryptedSecret ? encodeURIComponent(encryptedSecret) : null;
+      const protocol = encryptedSecret ? encodeURIComponent(encryptedSecret) : [];
       const webSocket = new WebSocket(url, protocol);
       let opened = false;
 


### PR DESCRIPTION
As part of the hot reload work, we wanted to optionally include a WS (sub)protocol if a value was specified. It was designed to be backwards compatible in that older servers (VS uses this) that did not anticipate a subprotocol would continue operating if this wasn't specified.

The second parameter to `WebSockets` is an array of values which [defaults to an empty array](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket). Passing a `null` value causes it to translate it to an empty string and require that the server acknowledge it with an empty subProtocol. Using an empty array appears to fix the issue.