### PR TITLE
Revert "Ensure the server and client are valid when sending / receiving hot reload messages"

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BrowserScriptMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserScriptMiddleware.cs
@@ -45,20 +45,13 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         }
 
         internal static byte[] GetBrowserRefreshJS()
-        {
-            var endpoint = Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT")!;
-            var serverKey = Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_KEY") ?? string.Empty;
+            => GetWebSocketClientJavaScript(Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT")!);
 
-            return GetWebSocketClientJavaScript(endpoint, serverKey);
-        }
-
-        internal static byte[] GetWebSocketClientJavaScript(string hostString, string serverKey)
+        internal static byte[] GetWebSocketClientJavaScript(string hostString)
         {
             var jsFileName = "Microsoft.AspNetCore.Watch.BrowserRefresh.WebSocketScriptInjection.js";
             using var reader = new StreamReader(typeof(WebSocketScriptInjection).Assembly.GetManifestResourceStream(jsFileName)!);
-            var script = reader.ReadToEnd()
-                .Replace("{{hostString}}", hostString)
-                .Replace("{{ServerKey}}", serverKey);
+            var script = reader.ReadToEnd().Replace("{{hostString}}", hostString);
 
             return Encoding.UTF8.GetBytes(script);
         }

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -1,7 +1,6 @@
 setTimeout(async function () {
   // dotnet-watch browser reload script
   const webSocketUrls = '{{hostString}}'.split(',');
-  const sharedSecret = await getSecret('{{ServerKey}}');
   let connection;
   for (const url of webSocketUrls) {
     try {
@@ -36,7 +35,7 @@ setTimeout(async function () {
       const payload = JSON.parse(message.data);
       const action = {
         'UpdateStaticFile': () => updateStaticFile(payload.path),
-        'BlazorHotReloadDeltav1': () => applyBlazorDeltas(payload.sharedSecret, payload.deltas),
+        'BlazorHotReloadDeltav1': () => applyBlazorDeltas(payload.deltas),
         'HotReloadDiagnosticsv1': () => displayDiagnostics(payload.diagnostics),
         'BlazorRequestApplyUpdateCapabilities': getBlazorWasmApplyUpdateCapabilities,
         'AspNetCoreHotReloadApplied': () => aspnetCoreHotReloadApplied()
@@ -116,13 +115,7 @@ setTimeout(async function () {
     styleElement.parentNode.insertBefore(newElement, styleElement.nextSibling);
   }
 
-  function applyBlazorDeltas(serverSecret, deltas) {
-    if (sharedSecret && (serverSecret != sharedSecret.encodedSharedSecret)) {
-      // Validate the shared secret if it was specified. It might be unspecified in older versions of VS
-      // that do not support this feature as yet.
-      throw 'Unable to validate the server. Rejecting apply-update payload.';
-    }
-
+  function applyBlazorDeltas(deltas) {
     let applyFailed = false;
     deltas.forEach(d => {
       try {
@@ -194,37 +187,9 @@ setTimeout(async function () {
     connection.send(new Uint8Array([0]).buffer);
   }
 
-  async function getSecret(serverKeyString) {
-    if (!serverKeyString || !window.crypto || !window.crypto.subtle) {
-      return null;
-    }
-
-    const secretBytes = window.crypto.getRandomValues(new Uint8Array(32)); // 32-bytes of entropy
-
-    // Based on https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#subjectpublickeyinfo_import
-    const binaryServerKey = str2ab(atob(serverKeyString));
-    const serverKey = await window.crypto.subtle.importKey('spki', binaryServerKey, { name: "RSA-OAEP", hash: "SHA-256" }, false, ['encrypt']);
-    const encrypted = await window.crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, secretBytes);
-    return {
-      encryptedSharedSecret: btoa(String.fromCharCode(...new Uint8Array(encrypted))),
-      encodedSharedSecret: btoa(String.fromCharCode(...secretBytes)),
-    };
-
-    function str2ab(str) {
-      const buf = new ArrayBuffer(str.length);
-      const bufView = new Uint8Array(buf);
-      for (let i = 0, strLen = str.length; i < strLen; i++) {
-        bufView[i] = str.charCodeAt(i);
-      }
-      return buf;
-    }
-  }
-
   function getWebSocket(url) {
     return new Promise((resolve, reject) => {
-      const encryptedSecret = sharedSecret && sharedSecret.encryptedSharedSecret;
-      const protocol = encryptedSecret ? encodeURIComponent(encryptedSecret) : null;
-      const webSocket = new WebSocket(url, protocol);
+      const webSocket = new WebSocket(url);
       let opened = false;
 
       function onOpen() {

--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
@@ -54,7 +54,6 @@ namespace Microsoft.DotNet.Watcher.Tools
                 var serverUrls = string.Join(',', await _refreshServer.StartAsync(cancellationToken));
                 context.Reporter.Verbose($"Refresh server running at {serverUrls}.");
                 context.ProcessSpec.EnvironmentVariables["ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT"] = serverUrls;
-                context.ProcessSpec.EnvironmentVariables["ASPNETCORE_AUTO_RELOAD_WS_KEY"] = _refreshServer.ServerKey;
 
                 var pathToMiddleware = Path.Combine(AppContext.BaseDirectory, "middleware", "Microsoft.AspNetCore.Watch.BrowserRefresh.dll");
                 context.ProcessSpec.EnvironmentVariables.DotNetStartupHooks.Add(pathToMiddleware);

--- a/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserScriptMiddlewareTest.cs
+++ b/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserScriptMiddlewareTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             var context = new DefaultHttpContext();
             var stream = new MemoryStream();
             context.Response.Body = stream;
-            var middleware = new BrowserScriptMiddleware(_next, BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host", "test-key"));
+            var middleware = new BrowserScriptMiddleware(_next, BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host"));
 
             // Act
             await middleware.InvokeAsync(context);
@@ -31,7 +31,6 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             var script = Encoding.UTF8.GetString(stream.ToArray());
             Assert.Contains("// dotnet-watch browser reload script", script);
             Assert.Contains("'some-host'", script);
-            Assert.Contains("'test-key'", script);
         }
 
         [Fact]
@@ -40,7 +39,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             // Arrange
             var context = new DefaultHttpContext();
             context.Response.Body = new MemoryStream();
-            var middleware = new BrowserScriptMiddleware(_next, BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host", "test-key"));
+            var middleware = new BrowserScriptMiddleware(_next, BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host"));
 
             // Act
             await middleware.InvokeAsync(context);


### PR DESCRIPTION
## Description
We've discovered an issue, where installing the .NET 6 RC1 SDK breaks the WebSocket connection used by VS to auto refresh the browser during development. Unfortunately, this impacts even .NET 5 applications being developed with VS 2019 because VS2019 picks up newer components from the .NET 6 SDK.


## Customer Impact
Every VS 2019 user, who will be using Ctrl+F5 for their ASP.NET 5 projects will be impacted by this issue, if not addressed.


## Regression?
- [X] Yes: The browser auto-refresh used to work, and it doesn't now.
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [X] Low

Treating this as a low risk, as this used to work before the change.

## Verification
- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A


Reverts dotnet/sdk#18912