### PR TITLE
[Blazor] Fix duplicate entries in blazor.boot.json manifest extensions

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -542,6 +542,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         Include="@(StaticWebAsset)"
         Condition="'%(StaticWebAsset.AssetTraitName)' == 'JSModule' and '%(StaticWebAsset.AssetTraitValue)' == 'JSLibraryModule' and '%(AssetKind)' != 'Build'" />
 
+      <!-- We remove the extensions since they are added to the list of static web assets but we need to compute the target path for them -->
+      <_BlazorPublishAsset Remove="@(_BlazorExtensionsCandidatesForPublish)" />
+
     </ItemGroup>
 
     <ComputeStaticWebAssetsTargetPaths

--- a/src/BlazorWasmSdk/Tasks/GenerateBlazorWebAssemblyBootJson.cs
+++ b/src/BlazorWasmSdk/Tasks/GenerateBlazorWebAssemblyBootJson.cs
@@ -1,8 +1,10 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -155,7 +157,9 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                         Log.LogMessage("Candidate '{0}' is defined as a library initializer resource.", resource.ItemSpec);
                         resourceData.libraryInitializers ??= new();
                         resourceList = resourceData.libraryInitializers;
-                        AddResourceToList(resource, resourceList, resource.GetMetadata("TargetPath"));
+                        var targetPath = resource.GetMetadata("TargetPath");
+                        Debug.Assert(!string.IsNullOrEmpty(targetPath), "Target path for '{0}' must exist.", resource.ItemSpec);
+                        AddResourceToList(resource, resourceList, targetPath);
                         continue;
                     }
                     else if (string.Equals("BlazorWebAssemblyResource", assetTraitName, StringComparison.OrdinalIgnoreCase) &&
@@ -169,7 +173,9 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                             resourceList = new();
                             resourceData.extensions[extensionName] = resourceList;
                         }
-                        AddResourceToList(resource, resourceList, resource.GetMetadata("TargetPath"));
+                        var targetPath = resource.GetMetadata("TargetPath");
+                        Debug.Assert(!string.IsNullOrEmpty(targetPath), "Target path for '{0}' must exist.", resource.ItemSpec);
+                        AddResourceToList(resource, resourceList, targetPath);
                         continue;
                     }
                     else

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/GenerateBlazorBootJsonTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/GenerateBlazorBootJsonTest.cs
@@ -1,13 +1,11 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.Serialization.Json;
-using Microsoft.Build.Framework;
-using Microsoft.NET.Sdk.BlazorWebAssembly;
 using FluentAssertions;
+using Microsoft.Build.Framework;
 using Moq;
 using Xunit;
 
@@ -166,7 +164,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Arrange
             var taskInstance = new GenerateBlazorWebAssemblyBootJson { DebugBuild = flagValue };
             taskInstance.BuildEngine = Mock.Of<IBuildEngine>();
-            
+
             using var stream = new MemoryStream();
 
             // Act


### PR DESCRIPTION
When we are generating the extension it gets included into two ItemGroups that go into GenerateBlazorBootJson, so it creates an entry with an empty string `""` on the extension section in the manifest.

* The fix removes the item from the item group it should not be in, avoiding the duplicate.
* It adds a debug.assert to ensure that we don't make a mistake like adding an empty entry to the manifest.
* It improves the integration tests to check specifically that there is only one entry in the manifest