### PR TITLE
[Razor] Ensure the manifest is not generated when there are no assets or discovery patterns

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -393,7 +393,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="AddStaticWebAssetsManifest" DependsOnTargets="ResolveStaticWebAssetsConfiguration">
     <ItemGroup>
-      <ContentWithTargetPath Condition="@(StaticWebAsset) != ''"
+      <ContentWithTargetPath Condition="Exists('$(StaticWebAssetDevelopmentManifestPath)')"
         Include="$(StaticWebAssetDevelopmentManifestPath)"
         TargetPath="$(TargetName).staticwebassets.runtime.json"
         CopyToOutputDirectory="PreserveNewest"

--- a/src/RazorSdk/Tasks/StaticWebAssets/GenerateStaticWebAssetsDevelopmentManifest.cs
+++ b/src/RazorSdk/Tasks/StaticWebAssets/GenerateStaticWebAssetsDevelopmentManifest.cs
@@ -39,6 +39,12 @@ namespace Microsoft.AspNetCore.Razor.Tasks
         {
             try
             {
+                if (Assets.Length == 0 && DiscoveryPatterns.Length == 0)
+                {
+                    Log.LogMessage("Skipping manifest generation because no assets nor discovery patterns were found.");
+                    return true;
+                }
+
                 var manifest = ComputeDevelopmentManifest(
                     Assets.Select(a => StaticWebAsset.FromTaskItem(a)),
                     DiscoveryPatterns.Select(StaticWebAssetsManifest.DiscoveryPattern.FromTaskItem));


### PR DESCRIPTION
Improves the condition we check