### PR TITLE
[Razor] Fixes packing on multitargeting projects

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.ScopedCss.5_0.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.ScopedCss.5_0.targets
@@ -294,6 +294,12 @@ Integration with static web assets:
 
 </Target>
 
+<Target Name="_RemoveApplicationBundleForPack" BeforeTargets="_CreateStaticWebAssetsCustomPropsCacheFile" Condition="'$(DisableScopedCssBundling)' != 'true'">
+  <ItemGroup>
+    <StaticWebAsset Remove="@(_AppBundleStaticWebAsset)" />
+  </ItemGroup>
+</Target>
+
 <!-- This target runs as part of ResolveStaticWebAssetInputs and collects all the generated scoped css files. When bundling is enabled
      these files are removed from the list of static web assets by '_AddScopedCssBundles' -->
 

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.5_0.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.5_0.targets
@@ -80,7 +80,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(ResolveStaticWebAssetsInputsDependsOn)
     </ResolveStaticWebAssetsInputsDependsOn>
 
-    <ResolveReferencedProjectsStaticWebAssetsDependsOn Condition="$(TargetFramework) != ''">
+    <ResolveReferencedProjectsStaticWebAssetsDependsOn Condition="'$(TargetFramework)' != ''">
       PrepareProjectReferences;
       $(ResolveReferencedProjectsStaticWebAssetsDependsOn)
     </ResolveReferencedProjectsStaticWebAssetsDependsOn>

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.5_0.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.5_0.targets
@@ -80,7 +80,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(ResolveStaticWebAssetsInputsDependsOn)
     </ResolveStaticWebAssetsInputsDependsOn>
 
-    <ResolveReferencedProjectsStaticWebAssetsDependsOn>
+    <ResolveReferencedProjectsStaticWebAssetsDependsOn Condition="$(TargetFramework) != ''">
       PrepareProjectReferences;
       $(ResolveReferencedProjectsStaticWebAssetsDependsOn)
     </ResolveReferencedProjectsStaticWebAssetsDependsOn>
@@ -139,6 +139,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">_content/$(PackageId)</StaticWebAssetBasePath>
     </PropertyGroup>
+
   </Target>
 
   <!--
@@ -434,6 +435,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
+  <Target Name="_DeleteSentinelFile" BeforeTargets="_GetTargetFrameworksOutput">
+    <!-- We use this to detect when we are packing in a multitarget scenario, the first pack task to run creates the sentinel and
+    the other ones no-op when they see it. -->
+    <Delete Files="$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel" Condition="Exists('$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel')" />
+  </Target>
+
   <Target
     Name="_CreateStaticWebAssetsCustomPropsCacheFile"
     DependsOnTargets="_PrepareForStaticWebAssets">
@@ -487,7 +494,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_CurrentProjectHasStaticWebAssets Condition="'@(_CurrentProjectStaticWebAsset->Count())' != '0'">true</_CurrentProjectHasStaticWebAssets>
+      <!-- When multitargeting, nuget will call many times with each target framework to pack. We must include our assets only once.
+        For that reason, we will emit a sentinel file the first time we run to make sure other target frameworks don't try to
+        include the pack content again. -->
+      <_AlreadyIncludedByAnotherTfm Condition="Exists('$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel')">true</_AlreadyIncludedByAnotherTfm>
     </PropertyGroup>
+
+    <WriteLinesToFile 
+      Condition="'$(_AlreadyIncludedByAnotherTfm)' != 'true'"
+      File="$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel"
+      Lines="1.0"
+      WriteOnlyWhenDifferent="true" />
 
     <!-- Validate that there are no path conflicts between the assets we are about to pack. -->
     <ValidateStaticWebAssetsUniquePaths Condition="'$(_CurrentProjectHasStaticWebAssets)' == 'true'"
@@ -500,6 +517,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateStaticWebAsssetsPropsFile
       Condition="'$(_CurrentProjectHasStaticWebAssets)' == 'true'"
       StaticWebAssets="@(_CurrentProjectStaticWebAsset)"
+      AllowEmptySourceType="true"
       TargetPropsFilePath="$(_GeneratedStaticWebAssetsPropsFile)" />
 
     <!-- Generates a props file the goes in build\$(PackageId).props and that simply imports
@@ -535,7 +553,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- All files that go into the nuget package -->
-    <ItemGroup Condition="'$(_CurrentProjectHasStaticWebAssets)' == 'true'">
+    <ItemGroup Condition="'$(_CurrentProjectHasStaticWebAssets)' == 'true' and '$(_AlreadyIncludedByAnotherTfm)' != 'true'">
 
       <!-- MSBuild prop files -->
 
@@ -571,7 +589,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
   </Target>
-
 
   <!--
     ============================================================

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -425,9 +425,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       ManifestPath="$(StaticWebAssetDevelopmentManifestPath)">
     </GenerateStaticWebAssetsDevelopmentManifest>
 
+    <WriteLinesToFile File="$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel" Lines="2.0" WriteOnlyWhenDifferent="true" />
+
     <ItemGroup>
       <FileWrites Include="$(StaticWebAssetBuildManifestPath)" />
       <FileWrites Include="$(StaticWebAssetDevelopmentManifestPath)" />
+      <FileWrites Include="$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel" />
     </ItemGroup>
     
   </Target>
@@ -858,6 +861,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'%(StaticWebAsset.SourceType)' == ''"
         Remove="@(StaticWebAsset->'wwwroot\%(RelativePath)')"  />
     </ItemGroup>
+  </Target>
+
+  <Target Name="_DeleteSentinelFile" BeforeTargets="_GetTargetFrameworksOutput">
+    <!-- We use this to detect when we are packing in a multitarget scenario, the first pack task to run creates the sentinel and
+    the other ones no-op when they see it. -->
+    <Delete Files="$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel" Condition="Exists('$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel')" />
   </Target>
 
   <!-- This target makes sure that all static web assets for the current project get included

--- a/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
+++ b/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
@@ -100,8 +100,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <UseStaticWebAssetsV2>$(_TargetingNET60OrLater)</UseStaticWebAssetsV2>
 
-    <!-- Controls whether or not the scoped css feature is enabled. By default is enabled for net6.0 applications and RazorLangVersion 5 or above -->
-    <ScopedCssEnabled Condition="'$(ScopedCssEnabled)' == '' and '$(StaticWebAssetsEnabled)' == 'true'">$(_Targeting30OrNewerRazorLangVersion)</ScopedCssEnabled>
+    <!-- Controls whether or not the scoped css feature is enabled. By default is enabled for net5.0 applications and RazorLangVersion 5 or above -->
+    <ScopedCssEnabled Condition="'$(ScopedCssEnabled)' == '' and '$(StaticWebAssetsEnabled)' == 'true'">$(_TargetingNET50OrLater)</ScopedCssEnabled>
 
     <JSModulesEnabled Condition="'$(JSModulesEnabled)' == '' and '$(StaticWebAssetsEnabled)' == 'true'">$(_TargetingNET60OrLater)</JSModulesEnabled>
   </PropertyGroup>

--- a/src/RazorSdk/Tasks/GenerateStaticWebAsssetsPropsFile.cs
+++ b/src/RazorSdk/Tasks/GenerateStaticWebAsssetsPropsFile.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         public string PackagePathPrefix { get; set; } = "staticwebassets";
         
-        public bool AllowEmptySourceType { get; set; } = false;
+        public bool AllowEmptySourceType { get; set; }
 
         public override bool Execute()
         {

--- a/src/RazorSdk/Tasks/GenerateStaticWebAsssetsPropsFile.cs
+++ b/src/RazorSdk/Tasks/GenerateStaticWebAsssetsPropsFile.cs
@@ -1,7 +1,9 @@
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -37,6 +39,8 @@ namespace Microsoft.AspNetCore.Razor.Tasks
         public ITaskItem[] StaticWebAssets { get; set; }
 
         public string PackagePathPrefix { get; set; } = "staticwebassets";
+        
+        public bool AllowEmptySourceType { get; set; } = false;
 
         public override bool Execute()
         {
@@ -58,7 +62,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             var itemGroup = new XElement("ItemGroup");
             var orderedAssets = StaticWebAssets.OrderBy(e => e.GetMetadata(BasePath), StringComparer.OrdinalIgnoreCase)
                 .ThenBy(e => e.GetMetadata(RelativePath), StringComparer.OrdinalIgnoreCase);
-            foreach(var element in orderedAssets)
+            foreach (var element in orderedAssets)
             {
                 var fullPathExpression = @$"$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\{Normalize(PackagePathPrefix)}\{Normalize(element.GetMetadata(RelativePath))}))";
                 itemGroup.Add(new XElement("StaticWebAsset",
@@ -118,7 +122,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             {
                 var webAsset = StaticWebAssets[i];
                 if (!EnsureRequiredMetadata(webAsset, SourceId) ||
-                    !EnsureRequiredMetadata(webAsset, SourceType, allowEmpty: true) ||
+                    !EnsureRequiredMetadata(webAsset, SourceType, allowEmpty: AllowEmptySourceType) ||
                     !EnsureRequiredMetadata(webAsset, ContentRoot) ||
                     !EnsureRequiredMetadata(webAsset, BasePath) ||
                     !EnsureRequiredMetadata(webAsset, RelativePath))
@@ -133,7 +137,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 }
 
                 if (!ValidateMetadataMatches(firstAsset, webAsset, SourceId) ||
-                    !ValidateSourceType(webAsset))
+                    !ValidateSourceType(webAsset, allowEmpty: AllowEmptySourceType))
                 {
                     return false;
                 }
@@ -142,9 +146,14 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             return true;
         }
 
-        private bool ValidateSourceType(ITaskItem candidate)
+        private bool ValidateSourceType(ITaskItem candidate, bool allowEmpty)
         {
             var candidateMetadata = candidate.GetMetadata(SourceType);
+            if (allowEmpty && string.IsNullOrEmpty(candidateMetadata))
+            {
+                return true;
+            }
+
             if (!(string.Equals("Discovered", candidateMetadata, StringComparison.Ordinal) || string.Equals("Computed", candidateMetadata, StringComparison.Ordinal)))
             {
                 Log.LogError($"Static web asset '{candidate.ItemSpec}' has invalid source type '{candidateMetadata}'.");

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
@@ -450,13 +450,11 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 {
                     if (Path.GetFileName(project) == "AnotherClassLib.csproj")
                     {
-                        document.Descendants("TargetFramework").Single().ReplaceNodes("netcoreapp3.1");
-                        document.Descendants("PropertyGroup").First().Add(new XElement("RazorLangVersion", "3.0"));
+                        document.Descendants("TargetFramework").Single().ReplaceNodes("net5.0");
                     }
                     if (Path.GetFileName(project) == "ClassLibrary.csproj")
                     {
-                        document.Descendants("TargetFramework").Single().ReplaceNodes("netcoreapp3.0");
-                        document.Descendants("PropertyGroup").First().Add(new XElement("RazorLangVersion", "3.0"));
+                        document.Descendants("TargetFramework").Single().ReplaceNodes("net5.0");
                     }
                 });
 
@@ -495,13 +493,11 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 {
                     if (Path.GetFileName(project) == "AnotherClassLib.csproj")
                     {
-                        document.Descendants("TargetFramework").Single().ReplaceNodes("netcoreapp3.1");
-                        document.Descendants("PropertyGroup").First().Add(new XElement("RazorLangVersion", "3.0"));
+                        document.Descendants("TargetFramework").Single().ReplaceNodes("net5.0");
                     }
                     if (Path.GetFileName(project) == "ClassLibrary.csproj")
                     {
-                        document.Descendants("TargetFramework").Single().ReplaceNodes("netcoreapp3.0");
-                        document.Descendants("PropertyGroup").First().Add(new XElement("RazorLangVersion", "3.0"));
+                        document.Descendants("TargetFramework").Single().ReplaceNodes("net5.0");
                     }
                 });
 

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/ScopedCss_IsBackwardsCompatible_WithPreviousVersions.Build.staticwebassets.json
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/ScopedCss_IsBackwardsCompatible_WithPreviousVersions.Build.staticwebassets.json
@@ -98,10 +98,10 @@
       "OriginalItemSpec": "${ProjectRoot}\\AppWithPackageAndP2PReference\\obj\\Debug\\net6.0\\scopedcss\\bundle\\AppWithPackageAndP2PReference.styles.css"
     },
     {
-      "Identity": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\netcoreapp3.0\\scopedcss\\projectbundle\\ClassLibrary.bundle.scp.css",
+      "Identity": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\net5.0\\scopedcss\\projectbundle\\ClassLibrary.bundle.scp.css",
       "SourceId": "ClassLibrary",
       "SourceType": "Project",
-      "ContentRoot": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\netcoreapp3.0\\scopedcss\\projectbundle\\",
+      "ContentRoot": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\net5.0\\scopedcss\\projectbundle\\",
       "BasePath": "_content/ClassLibrary",
       "RelativePath": "ClassLibrary.bundle.scp.css",
       "AssetKind": "All",
@@ -112,7 +112,7 @@
       "AssetTraitValue": "ProjectBundle",
       "CopyToOutputDirectory": "Never",
       "CopyToPublishDirectory": "PreserveNewest",
-      "OriginalItemSpec": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\netcoreapp3.0\\scopedcss\\projectbundle\\ClassLibrary.bundle.scp.css"
+      "OriginalItemSpec": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\net5.0\\scopedcss\\projectbundle\\ClassLibrary.bundle.scp.css"
     },
     {
       "Identity": "${ProjectRoot}\\ClassLibrary\\wwwroot\\js\\project-transitive-dep.js",

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/ScopedCss_PublishIsBackwardsCompatible_WithPreviousVersions.Publish.staticwebassets.json
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/ScopedCss_PublishIsBackwardsCompatible_WithPreviousVersions.Publish.staticwebassets.json
@@ -98,10 +98,10 @@
       "OriginalItemSpec": "${ProjectRoot}\\AppWithPackageAndP2PReference\\obj\\Debug\\net6.0\\scopedcss\\bundle\\AppWithPackageAndP2PReference.styles.css"
     },
     {
-      "Identity": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\netcoreapp3.0\\scopedcss\\projectbundle\\ClassLibrary.bundle.scp.css",
+      "Identity": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\net5.0\\scopedcss\\projectbundle\\ClassLibrary.bundle.scp.css",
       "SourceId": "ClassLibrary",
       "SourceType": "Project",
-      "ContentRoot": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\netcoreapp3.0\\scopedcss\\projectbundle\\",
+      "ContentRoot": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\net5.0\\scopedcss\\projectbundle\\",
       "BasePath": "_content/ClassLibrary",
       "RelativePath": "ClassLibrary.bundle.scp.css",
       "AssetKind": "All",
@@ -112,7 +112,7 @@
       "AssetTraitValue": "ProjectBundle",
       "CopyToOutputDirectory": "Never",
       "CopyToPublishDirectory": "PreserveNewest",
-      "OriginalItemSpec": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\netcoreapp3.0\\scopedcss\\projectbundle\\ClassLibrary.bundle.scp.css"
+      "OriginalItemSpec": "${ProjectRoot}\\ClassLibrary\\obj\\Debug\\net5.0\\scopedcss\\projectbundle\\ClassLibrary.bundle.scp.css"
     },
     {
       "Identity": "${ProjectRoot}\\ClassLibrary\\wwwroot\\js\\project-transitive-dep.js",

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
@@ -1028,6 +1028,221 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         [Fact]
+        public void Pack_BeforeNet60_MultipleTargetFrameworks_WithScopedCss_IncludesAssetsAndProjectBundle()
+        {
+            var testAsset = "PackageLibraryTransitiveDependency";
+            var projectDirectory = CreateAspNetSdkTestAsset(testAsset, subdirectory: "TestPackages");
+
+            projectDirectory.WithProjectChanges(document =>
+            {
+                var parse = XDocument.Parse($@"<Project Sdk=""Microsoft.NET.Sdk.Razor"">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <RazorLangVersion>3.0</RazorLangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Condition=""'$(TargetFramework)' == 'net5.0'"" Include=""Microsoft.AspNetCore.Components.Web"" Version=""{DefaultPackageVersion}"" />
+    <PackageReference Condition=""'$(TargetFramework)' == 'netstandard2.0'"" Include=""Microsoft.AspNetCore.Components.Web"" Version=""3.1.0"" />
+  </ItemGroup>
+
+</Project>
+");
+                document.Root.ReplaceWith(parse.Root);
+            });
+
+            Directory.Delete(Path.Combine(projectDirectory.Path, "wwwroot"), recursive: true);
+
+            var componentText = @"<div class=""my-component"">
+    This component is defined in the <strong>razorclasslibrarypack</strong> library.
+</div>";
+
+            // This mimics the structure of our default template project
+            Directory.CreateDirectory(Path.Combine(projectDirectory.Path, "wwwroot"));
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "_Imports.razor"), "@using Microsoft.AspNetCore.Components.Web" + Environment.NewLine);
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "Component1.razor"), componentText);
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "Component1.razor.css"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "ExampleJsInterop.cs"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "wwwroot", "background.png"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "wwwroot", "exampleJsInterop.js"), "");
+
+            var pack = new MSBuildCommand(Log, "Pack", projectDirectory.Path);
+            pack.WithWorkingDirectory(projectDirectory.Path);
+            var result = pack.Execute("/bl");
+
+            result.Should().Pass();
+
+            var outputPath = pack.GetOutputDirectory("net5.0", "Debug").ToString();
+
+            new FileInfo(Path.Combine(outputPath, "PackageLibraryTransitiveDependency.dll")).Should().Exist();
+
+            var packagePath = Path.Combine(
+                projectDirectory.Path,
+                "bin",
+                "Debug",
+                "PackageLibraryTransitiveDependency.1.0.0.nupkg");
+
+            result.Should().NuPkgContain(
+                packagePath,
+                filePaths: new[]
+                {
+                    Path.Combine("staticwebassets", "exampleJsInterop.js"),
+                    Path.Combine("staticwebassets", "background.png"),
+                    Path.Combine("staticwebassets", "PackageLibraryTransitiveDependency.bundle.scp.css"),
+                    Path.Combine("build", "Microsoft.AspNetCore.StaticWebAssets.props"),
+                    Path.Combine("build", "PackageLibraryTransitiveDependency.props"),
+                    Path.Combine("buildMultiTargeting", "PackageLibraryTransitiveDependency.props"),
+                    Path.Combine("buildTransitive", "PackageLibraryTransitiveDependency.props")
+                });
+        }
+
+        [Fact]
+        public void Pack_MultipleTargetFrameworks_WithScopedCssAndJsModules_IncludesAssetsAndProjectBundle()
+        {
+            var testAsset = "PackageLibraryTransitiveDependency";
+            var projectDirectory = CreateAspNetSdkTestAsset(testAsset, subdirectory: "TestPackages");
+
+            projectDirectory.WithProjectChanges(document =>
+            {
+                var parse = XDocument.Parse($@"<Project Sdk=""Microsoft.NET.Sdk.Razor"">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SupportedPlatform Condition=""'$(TargetFramework)' == 'net6.0'"" Include=""browser"" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.AspNetCore.Components.Web"" Version=""{DefaultPackageVersion}"" />
+  </ItemGroup>
+
+</Project>
+");
+                document.Root.ReplaceWith(parse.Root);
+            });
+
+            Directory.Delete(Path.Combine(projectDirectory.Path, "wwwroot"), recursive: true);
+
+            var componentText = @"<div class=""my-component"">
+    This component is defined in the <strong>razorclasslibrarypack</strong> library.
+</div>";
+
+            // This mimics the structure of our default template project
+            Directory.CreateDirectory(Path.Combine(projectDirectory.Path, "wwwroot"));
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "_Imports.razor"), "@using Microsoft.AspNetCore.Components.Web" + Environment.NewLine);
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "Component1.razor"), componentText);
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "Component1.razor.css"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "Component1.razor.js"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "ExampleJsInterop.cs"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "wwwroot", "background.png"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "wwwroot", "PackageLibraryTransitiveDependency.lib.module.js"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "wwwroot", "exampleJsInterop.js"), "");
+
+            var pack = new MSBuildCommand(Log, "Pack", projectDirectory.Path);
+            pack.WithWorkingDirectory(projectDirectory.Path);
+            var result = pack.Execute("/bl");
+
+            result.Should().Pass();
+
+            var outputPath = pack.GetOutputDirectory(DefaultTfm, "Debug").ToString();
+
+            new FileInfo(Path.Combine(outputPath, "PackageLibraryTransitiveDependency.dll")).Should().Exist();
+
+            var packagePath = Path.Combine(
+                projectDirectory.Path,
+                "bin",
+                "Debug",
+                "PackageLibraryTransitiveDependency.1.0.0.nupkg");
+
+            result.Should().NuPkgContain(
+                packagePath,
+                filePaths: new[]
+                {
+                    Path.Combine("staticwebassets", "exampleJsInterop.js"),
+                    Path.Combine("staticwebassets", "background.png"),
+                    Path.Combine("staticwebassets", "Component1.razor.js"),
+                    Path.Combine("staticwebassets", "PackageLibraryTransitiveDependency.bundle.scp.css"),
+                    Path.Combine("staticwebassets", "PackageLibraryTransitiveDependency.lib.module.js"),
+                    Path.Combine("build", "Microsoft.AspNetCore.StaticWebAssets.props"),
+                    Path.Combine("build", "PackageLibraryTransitiveDependency.props"),
+                    Path.Combine("buildMultiTargeting", "PackageLibraryTransitiveDependency.props"),
+                    Path.Combine("buildTransitive", "PackageLibraryTransitiveDependency.props")
+                });
+        }
+
+        [Fact]
+        public void Pack_MultipleTargetFrameworks_WithScopedCssAndJsModules_DoesNotIncludeApplicationBundleNorModulesManifest()
+        {
+            var testAsset = "PackageLibraryTransitiveDependency";
+            var projectDirectory = CreateAspNetSdkTestAsset(testAsset, subdirectory: "TestPackages");
+
+            projectDirectory.WithProjectChanges(document =>
+            {
+                var parse = XDocument.Parse($@"<Project Sdk=""Microsoft.NET.Sdk.Razor"">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SupportedPlatform Condition=""'$(TargetFramework)' == 'net6.0'"" Include=""browser"" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.AspNetCore.Components.Web"" Version=""{DefaultPackageVersion}"" />
+  </ItemGroup>
+
+</Project>
+");
+                document.Root.ReplaceWith(parse.Root);
+            });
+
+            Directory.Delete(Path.Combine(projectDirectory.Path, "wwwroot"), recursive: true);
+
+            var componentText = @"<div class=""my-component"">
+    This component is defined in the <strong>razorclasslibrarypack</strong> library.
+</div>";
+
+            // This mimics the structure of our default template project
+            Directory.CreateDirectory(Path.Combine(projectDirectory.Path, "wwwroot"));
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "_Imports.razor"), "@using Microsoft.AspNetCore.Components.Web" + Environment.NewLine);
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "Component1.razor"), componentText);
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "Component1.razor.css"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "ExampleJsInterop.cs"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "wwwroot", "background.png"), "");
+            File.WriteAllText(Path.Combine(projectDirectory.Path, "wwwroot", "exampleJsInterop.js"), "");
+
+            var pack = new MSBuildCommand(Log, "Pack", projectDirectory.Path);
+            pack.WithWorkingDirectory(projectDirectory.Path);
+            var result = pack.Execute("/bl");
+
+            result.Should().Pass();
+
+            var outputPath = pack.GetOutputDirectory(DefaultTfm, "Debug").ToString();
+
+            new FileInfo(Path.Combine(outputPath, "PackageLibraryTransitiveDependency.dll")).Should().Exist();
+
+            var packagePath = Path.Combine(
+                projectDirectory.Path,
+                "bin",
+                "Debug",
+                "PackageLibraryTransitiveDependency.1.0.0.nupkg");
+
+            result.Should().NuPkgDoesNotContain(
+                packagePath,
+                filePaths: new[]
+                {
+                    Path.Combine("staticwebassets", "PackageLibraryTransitiveDependency.styles.css"),
+                    Path.Combine("staticwebassets", "PackageLibraryTransitiveDependency.modules.json"),
+                });
+        }
+
+        [Fact]
         public void Pack_MultipleTargetFrameworks_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryDirectDependency";


### PR DESCRIPTION
There are several issues involved in fixing this. It is not a scenario that worked well before for several reasons:
* Scoped css would include both files (project bundle and app bundle on the package)
* The static web asset targets get called multiple times, one time per target and that introduces issues.
* With the move to static web assets V2, when packaging assets on multi-targeting packages tries to use the V1 version of static web assets to do the packing.

The fixes are as follows:
* Make scoped CSS only work in 5.0 and onwards which is when the feature was originally introduced.
  * The feature is active on 3.1 however the convention is so specific that we didn't consider disabling it before.
* Remove the app bundle when we are packing assets using V1 (avoid packing app.styles.css)
* Make sure that the targets for packing assets only run once on multi-target builds
  * We achieve this by writing a sentinel file the first time the target to pack the asset runs.
  * On each build we remove the file if its present.
* Ensure that when there is at least a net6.0 target we use the V2 asset definition to do the packing.