### PR TITLE
Reorder the EmbedProjectAssetsFile condition to skip probing the file …

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -62,7 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Embed all project.assets.json files into the binary log when building with /bl -->
   <ItemGroup>
-    <EmbedInBinlog Include="$(ProjectAssetsFile)" Condition="Exists('$(ProjectAssetsFile)') AND $(EmbedProjectAssetsFile) != false" />
+    <EmbedInBinlog Include="$(ProjectAssetsFile)" Condition="$(EmbedProjectAssetsFile) != false AND Exists('$(ProjectAssetsFile)')" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
…if the property is false.