### PR TITLE
[port to release/6.0.1xx] Fix cross-os symbol generation (#20481)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -66,6 +66,30 @@ namespace Microsoft.NET.Build.Tasks
         private List<ITaskItem> _r2rCompositeReferences = new List<ITaskItem>();
         private List<ITaskItem> _r2rCompositeInput = new List<ITaskItem>();
 
+        private bool IsTargetWindows
+        {
+            get
+            {
+                // Crossgen2 V6 and above always has TargetOS metadata available
+                if (ReadyToRunUseCrossgen2 && !string.IsNullOrEmpty(Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS))) 
+                    return Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "windows";
+                else
+                    return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            }
+        }
+
+        private bool IsTargetLinux
+        {
+            get
+            {
+                // Crossgen2 V6 and above always has TargetOS metadata available
+                if (ReadyToRunUseCrossgen2 && !string.IsNullOrEmpty(Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS))) 
+                    return Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "linux";
+                else
+                    return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+        }
+
         protected override void ExecuteCore()
         {
             if (ReadyToRunUseCrossgen2)
@@ -140,13 +164,13 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (EmitSymbols)
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && hasValidDiaSymReaderLib)
+                    if (IsTargetWindows && hasValidDiaSymReaderLib)
                     {
                         outputPDBImage = Path.ChangeExtension(outputR2RImage, "ni.pdb");
                         outputPDBImageRelativePath = Path.ChangeExtension(outputR2RImageRelativePath, "ni.pdb");
                         crossgen1CreatePDBCommand = $"/CreatePDB \"{Path.GetDirectoryName(outputPDBImage)}\"";
                     }
-                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    else if (IsTargetLinux)
                     {
                         string perfmapExtension;
                         if (ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5 && _perfmapFormatVersion >= 1)
@@ -246,12 +270,12 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     string compositePDBImage = null;
                     string compositePDBRelativePath = null;
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && hasValidDiaSymReaderLib)
+                    if (IsTargetWindows && hasValidDiaSymReaderLib)
                     {
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.pdb");
                         compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
                     }
-                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    else if (IsTargetLinux)
                     {
                         string perfmapExtension = (_perfmapFormatVersion >= 1 ? ".ni.r2rmap" : ".ni.{composite}.map");
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, perfmapExtension);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -318,7 +318,7 @@ namespace Microsoft.NET.Build.Tasks
             // 5.0 Crossgen2 doesn't support PDB generation.
             if (!Crossgen2IsVersion5 && _emitSymbols)
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "windows")
                 {
                     result.AppendLine("--pdb");
                     result.AppendLine($"--pdb-path:{Path.GetDirectoryName(_outputPDBImage)}");

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -451,7 +451,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework, runtimeIdentifier: RuntimeInformation.RuntimeIdentifier);
             var mainProjectDll = Path.Combine(intermediateDirectory.FullName, $"{TestProjectName}.dll");
-            var niPdbFile = GivenThatWeWantToPublishReadyToRun.GetPDBFileName(mainProjectDll, framework);
+            var niPdbFile = GivenThatWeWantToPublishReadyToRun.GetPDBFileName(mainProjectDll, framework, RuntimeInformation.RuntimeIdentifier);
 
             string[] expectedFiles = { SingleFile, PdbFile, niPdbFile };
             GetPublishDirectory(publishCommand)


### PR DESCRIPTION
* Fix cross-os symbol generation
- Use the target os to determine the symbol type, not the sdk os
- Add tests for cross os/cross arch crossgen compilation

* Fix tests to specify composite accurately to TestProjectPublishing_Internal, as the new test logic demands correctness