### PR TITLE
Fix PlatformNotSupportedException for Windows (arm64)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,6 +39,7 @@
     <DeploymentReleasesVersion>1.0.0-preview1.1.21112.1</DeploymentReleasesVersion>
     <SystemManagementPackageVersion>4.6.0</SystemManagementPackageVersion>
     <SystemCommandLineVersion>2.0.0-beta1.21417.2</SystemCommandLineVersion>
+    <MicrosoftManagementInfrastructurePackageVersion>2.0.0</MicrosoftManagementInfrastructurePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
-    <PackageReference Include="System.Management" Version="$(SystemManagementPackageVersion)" />  
+    <PackageReference Include="Microsoft.Management.Infrastructure" Version="$(MicrosoftManagementInfrastructurePackageVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />  
   </ItemGroup>
 </Project>

--- a/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
+++ b/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
@@ -3,11 +3,15 @@
 //
 
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Microsoft.NET.TestFramework;
 using Xunit;
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+#if NET
+    [SupportedOSPlatform("windows")]
+#endif
     public class ProcessExtensionsTests
     {
         [WindowsOnlyFact]


### PR DESCRIPTION
Description: Workload admin installs rely on some WMI queries to obtain data from Win32_Process. This is not supported on Windows (arm64). We can retain the queries by switching to Microsoft.Management.Infrastructure instead of System.Management. Without this, all workload commands will fail with System.PlatformNotSupportedException: Could not find an installation of .NET Framework v4.0.30319. System.Management requires native modules from the .NET Framework to operate.

Risk: Low

Testing: Automated and manual

Packaging change: None

Workaround: None