### PR TITLE
Prevent null ref in RazorSourceGenerator

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -249,6 +249,12 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 })
                 .WithLambdaComparer(static (a, b) =>
                 {
+                    if (a.hintName is null)
+                    {
+                        // Source generator is suppressed.
+                        return false;
+                    }
+
                     if (a.csharpDocument.Diagnostics.Count > 0 || b.csharpDocument.Diagnostics.Count > 0)
                     {
                         // if there are any diagnostics, treat the documents as unequal and force RegisterSourceOutput to be called uncached.


### PR DESCRIPTION
We had an e2e test that verifies RSG worked correctly when suppressed, but missed
an incrementalism case. Added a test, and verified that hot reload works with this patch.

Fixes https://github.com/dotnet/aspnetcore/issues/36227

Port https://github.com/dotnet/sdk/pull/20719 to main