### PR TITLE
Make ICUDataMode less prone to accidental breakage

### DIFF
--- a/src/BlazorWasmSdk/Tasks/BootJsonData.cs
+++ b/src/BlazorWasmSdk/Tasks/BootJsonData.cs
@@ -100,22 +100,24 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
         public Dictionary<string, ResourceHashesByNameDictionary> extensions { get; set; }
     }
 
-    public enum ICUDataMode
+    public enum ICUDataMode : int
     {
+        // Note that the numeric values are serialized and used in JS code, so don't change them without also updating the JS code
+    
         /// <summary>
         /// Load optimized icu data file based on the user's locale
         /// </summary>
-        Sharded,
+        Sharded = 0,
 
         /// <summary>
         /// Use the combined icudt.dat file
         /// </summary>
-        All,
+        All = 1,
 
         /// <summary>
         /// Do not load any icu data files.
         /// </summary>
-        Invariant,
+        Invariant = 2,
     }
 #pragma warning restore IDE1006 // Naming Styles
 }


### PR DESCRIPTION
Currently, the enum `ICUDataMode` relies on compiler-generated numeric values. This is not a great move because we serialize these values and check for specific ones in the JS-side code. Anybody who updates this enum, for example inserting a new value in the middle, would risk breaking applications in subtle ways.

We should use explicit values to make breakage less likely.