### PR TITLE
Pass in position to .GetSuggestions()

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-complete/CompleteCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-complete/CompleteCommand.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Cli
 
             var result = Parser.Instance.Parse(input);
 
-            return result.GetSuggestions()
+            return result.GetSuggestions(position)
                 .Distinct()
                 .ToArray();
         }

--- a/src/Cli/dotnet/commands/dotnet-complete/CompleteCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-complete/CompleteCommand.cs
@@ -49,9 +49,9 @@ namespace Microsoft.DotNet.Cli
 
         private static string[] Suggestions(ParseResult complete)
         {
-            var input = complete.ValueForArgument<string>(CompleteCommandParser.PathArgument) ?? string.Empty;
+            var input = complete.ValueForArgument(CompleteCommandParser.PathArgument) ?? string.Empty;
 
-            var position = complete.ValueForOption<int>(CompleteCommandParser.PositionOption);
+            var position = complete.ValueForOption(CompleteCommandParser.PositionOption);
 
             if (position > input.Length)
             {

--- a/src/Cli/dotnet/commands/dotnet-complete/CompleteCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-complete/CompleteCommandParser.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli
     {
         public static readonly Argument<string> PathArgument = new Argument<string>("path");
 
-        public static readonly Option<int> PositionOption = new Option<int>("--position")
+        public static readonly Option<int?> PositionOption = new Option<int?>("--position")
         {
             ArgumentHelpName = "command"
         };

--- a/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Cli;
@@ -306,6 +307,45 @@ namespace Microsoft.DotNet.Tests.Commands
             var reporter = new BufferedReporter();
             CompleteCommand.RunWithReporter(new[] { "dotnet nuget sign " }, reporter).Should().Be(0);
             reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
+        }
+
+        [Fact]
+        public void GivenDotnetAddPackWithPosition()
+        {
+            var expected = new[] {
+                "package"
+            };
+
+            var reporter = new BufferedReporter();
+            CompleteCommand.RunWithReporter(GetArguments("dotnet add pack$ abc"), reporter).Should().Be(0);
+            reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
+        }
+
+        [Fact]
+        public void GivenDotnetToolInWithPosition()
+        {
+            var expected = new[] {
+                "install",
+                "uninstall",
+                "--info"
+            };
+
+            var reporter = new BufferedReporter();
+            CompleteCommand.RunWithReporter(GetArguments("dotnet tool in$ abc"), reporter).Should().Be(0);
+            reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
+        }
+
+        /// <summary>
+        /// Converts command annotated with dollar sign($) into string array with "--position" option pointing at dollar sign location.
+        /// </summary>
+        private string[] GetArguments(string command)
+        {
+            var indexOfDollar = command.IndexOf("$");
+            if (indexOfDollar == -1)
+            {
+                throw new ArgumentException("Does not contain $", nameof(command));
+            }
+            return new[] { command.Replace("$", ""), "--position", indexOfDollar.ToString() };
         }
     }
 }


### PR DESCRIPTION
This means user can get completion also when caret is not at end of command line.
For example `dotnet tool inst$ abc` if caret position is where I placed `$` it will now correctly suggest `install`.