### PR TITLE
Remove MMI dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,7 +39,6 @@
     <DeploymentReleasesVersion>1.0.0-preview1.1.21112.1</DeploymentReleasesVersion>
     <SystemManagementPackageVersion>4.6.0</SystemManagementPackageVersion>
     <SystemCommandLineVersion>2.0.0-beta1.21417.2</SystemCommandLineVersion>
-    <MicrosoftManagementInfrastructurePackageVersion>2.0.0</MicrosoftManagementInfrastructurePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.Versioning;
-using Microsoft.Management.Infrastructure;
+using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -36,27 +33,19 @@ namespace Microsoft.DotNet.Cli.Utils
         /// </summary>
         /// <param name="process">The process component.</param>
         /// <returns>The process ID of the parent process, or -1 if the parent process could not be found.</returns>
-        public static int GetParentProcessId(this Process process)
+        public unsafe static int GetParentProcessId(this Process process)
         {
-            CimSession cimSession = CimSession.Create(null);
-            IEnumerable<CimInstance> results = cimSession.QueryInstances(@"root\cimv2", "WQL",
-                $"SELECT ParentProcessId FROM Win32_Process WHERE ProcessId='{process.Id}'");
+            using SafeProcessHandle handle = new(process.Handle, ownsHandle: false);
 
-            return results.Any() ? Convert.ToInt32(results.First().CimInstanceProperties["ParentProcessId"].Value) : -1;
-        }
+            NativeMethods.Windows.PROCESS_BASIC_INFORMATION info;
 
-        /// <summary>
-        /// Returns the command line of this process by querying the Win32_Process class.
-        /// </summary>
-        /// <param name="process">The process component.</param>
-        /// <returns>The command line of the process or <see langword="null"/> if it could not be retrieved.</returns>
-        public static string GetCommandLine(this Process process)
-        {
-            CimSession cimSession = CimSession.Create(null);
-            IEnumerable<CimInstance> results = cimSession.QueryInstances(@"root\cimv2", "WQL",
-                $"SELECT CommandLine FROM Win32_Process WHERE ProcessId='{process.Id}'");
+            if (NativeMethods.Windows.NtQueryInformationProcess(handle, NativeMethods.Windows.ProcessBasicInformation,
+                &info, (uint)sizeof(NativeMethods.Windows.PROCESS_BASIC_INFORMATION), out _) != 0)
+            {
+                return -1;
+            }
 
-            return results.Any() ? Convert.ToString(results.First().CimInstanceProperties["CommandLine"].Value) : null;
+            return (int)info.InheritedFromUniqueProcessId;
         }
 #pragma warning restore CA1416
     }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
@@ -35,8 +35,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// <returns>The process ID of the parent process, or -1 if the parent process could not be found.</returns>
         public unsafe static int GetParentProcessId(this Process process)
         {
-            using SafeProcessHandle handle = new(process.Handle, ownsHandle: false);
-
+            SafeProcessHandle handle = process.SafeHandle;
             NativeMethods.Windows.PROCESS_BASIC_INFORMATION info;
 
             if (NativeMethods.Windows.NtQueryInformationProcess(handle, NativeMethods.Windows.ProcessBasicInformation,

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -43,7 +43,6 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
-    <PackageReference Include="Microsoft.Management.Infrastructure" Version="$(MicrosoftManagementInfrastructurePackageVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />  
   </ItemGroup>
 </Project>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/NativeMethods.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/NativeMethods.cs
@@ -55,6 +55,19 @@ namespace Microsoft.DotNet.Cli.Utils
                 public UIntPtr PeakJobMemoryUsed;
             }
 
+            internal const int ProcessBasicInformation = 0;
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct PROCESS_BASIC_INFORMATION
+            {
+                public uint ExitStatus;
+                public IntPtr PebBaseAddress;
+                public UIntPtr AffinityMask;
+                public int BasePriority;
+                public UIntPtr UniqueProcessId;
+                public UIntPtr InheritedFromUniqueProcessId;
+            }
+
             [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
             internal static extern SafeWaitHandle CreateJobObjectW(IntPtr lpJobAttributes, string lpName);
 
@@ -63,6 +76,14 @@ namespace Microsoft.DotNet.Cli.Utils
 
             [DllImport("kernel32.dll", SetLastError = true)]
             internal static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+            [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            internal static extern IntPtr GetCommandLine();
+
+            [DllImport("ntdll.dll", SetLastError = true)]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            internal static extern unsafe uint NtQueryInformationProcess(SafeProcessHandle ProcessHandle, int ProcessInformationClass, void* ProcessInformation, uint ProcessInformationLength, out uint ReturnLength);
         }
 
         internal static class Posix

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Windows.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Windows.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Principal;
 using System.Threading;
@@ -49,6 +50,15 @@ namespace Microsoft.DotNet.Cli.Utils
         public static bool RebootRequired()
         {
             return new SystemInformationClass().RebootRequired;
+        }
+
+        /// <summary>
+        /// Returns the commandline of the currently executing process.
+        /// </summary>
+        /// <returns>The commandline of the current process.</returns>
+        public static string GetProcessCommandLine()
+        {
+            return Marshal.PtrToStringAuto(NativeMethods.Windows.GetCommandLine());
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             AppDomain.CurrentDomain.ProcessExit += new EventHandler(OnProcessExit);
 
-            Log?.LogMessage($"Executing: {CurrentProcess.GetCommandLine()}, PID: {CurrentProcess.Id}, PPID: {ParentProcess.Id}");
+            Log?.LogMessage($"Executing: {Windows.GetProcessCommandLine()}, PID: {CurrentProcess.Id}, PPID: {ParentProcess.Id}");
             Log?.LogMessage($"{nameof(IsElevated)}: {IsElevated}");
             Log?.LogMessage($"{nameof(Is64BitProcess)}: {Is64BitProcess}");
             Log?.LogMessage($"{nameof(RebootPending)}: {RebootPending}");

--- a/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
+++ b/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
 
 using System.Diagnostics;
 using System.Runtime.Versioning;


### PR DESCRIPTION
MMI links in a large set of native dependencies and was only used to work around System.Management being unsupported on Windows (arm64).

This change removes that dependency and instead directly call the native APIs providing similar information.