### PR TITLE
Vary the cache key for TagHelpersFromReferences on SuppressRazorSourceGenerator

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -92,6 +92,10 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>2bfff7b9348e779628a06b86af04b5239d3a926d</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.0-4.21458.2">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>2bfff7b9348e779628a06b86af04b5239d3a926d</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.0-4.21458.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>2bfff7b9348e779628a06b86af04b5239d3a926d</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -126,6 +126,7 @@
     <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.21412.9</MicrosoftCodeAnalysisPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-4.21458.2</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-4.21458.2</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.0.0-4.21458.2</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-4.21458.2</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/RazorSdk/Razor.slnf
+++ b/src/RazorSdk/Razor.slnf
@@ -10,6 +10,7 @@
       "src\\RazorSdk\\Tool\\Microsoft.NET.Sdk.Razor.Tool.csproj",
       "src\\Resolvers\\Microsoft.DotNet.NativeWrapper\\Microsoft.DotNet.NativeWrapper.csproj",
       "src\\Tests\\Microsoft.NET.Sdk.BlazorWebAssembly.Tests\\Microsoft.NET.Sdk.BlazorWebAssembly.Tests.csproj",
+      "src\\Tests\\Microsoft.NET.Sdk.Razor.SourceGenerators.Tests\\Microsoft.NET.Sdk.Razor.SourceGenerators.Tests.csproj",
       "src\\Tests\\Microsoft.NET.Sdk.Razor.Tests\\Microsoft.NET.Sdk.Razor.Tests.csproj",
       "src\\Tests\\Microsoft.NET.Sdk.Razor.Tool.Tests\\Microsoft.NET.Sdk.Razor.Tool.Tests.csproj",
       "src\\Tests\\Microsoft.NET.TestFramework\\Microsoft.NET.TestFramework.csproj"

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -101,7 +101,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
             var tagHelpersFromReferences = context.CompilationProvider
                 .Combine(razorSourceGeneratorOptions)
-                .WithLambdaComparer(static (a, b) => a.Left.References.SequenceEqual(b.Left.References), static a => a.Left.References.GetHashCode())
+                .WithLambdaComparer(
+                    static (a, b) => a.Right.SuppressRazorSourceGenerator == b.Right.SuppressRazorSourceGenerator && a.Left.References.SequenceEqual(b.Left.References),
+                    static a => a.Left.References.GetHashCode())
                 .Select(static (pair, _) =>
                 {
                     var (compilation, razorSourceGeneratorOptions) = pair;

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
@@ -6,11 +6,9 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackageId>testSdkRSG</PackageId>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +20,9 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
+
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
@@ -1,0 +1,306 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.Extensions.DependencyModel.Resolution;
+using Xunit;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    public class RazorSourceGeneratorTests
+    {
+        private static readonly Project _baseProject = CreateBaseProject();
+
+        [Fact]
+        public async Task SourceGenerator_RazorFiles_Works()
+        {
+            // Arrange
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+            });
+
+            var compilation = await project.GetCompilationAsync();
+            var driver = await GetDriverAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Single(result.GeneratedSources);
+        }
+
+        [Fact]
+        public async Task SourceGenerator_DoesNotAddAnyGeneratedSources_WhenSourceGeneratorIsSuppressed()
+        {
+            // Regression test for https://github.com/dotnet/aspnetcore/issues/36227
+            // Arrange
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] = "<h1>Counter</h1>",
+            });
+
+            var compilation = await project.GetCompilationAsync();
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project, optionsProvider =>
+            {
+                optionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "true";
+            });
+
+            var result = RunGenerator(compilation!, ref driver);
+            Assert.Empty(result.Diagnostics);
+            Assert.Empty(result.GeneratedSources);
+
+            var updatedText = new TestAdditionalText("Pages/Index.razor", SourceText.From(@"<h1>Hello world 1</h1>", Encoding.UTF8));
+            driver = driver.ReplaceAdditionalText(additionalTexts.First(f => f.Path == updatedText.Path), updatedText);
+
+            // Now run the source generator again with updated text that should result in a cache miss
+            // and exercise comparers
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Empty(result.GeneratedSources);
+        }
+
+        [Fact]
+        public async Task SourceGenerator_CorrectlyGeneratesSourcesOnceSuppressRazorSourceGeneratorIsUnset()
+        {
+            // Regression test for https://github.com/dotnet/aspnetcore/issues/36227
+            // Arrange
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] =
+@"
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+<h1>Counter</h1>
+<button @onclick=""IncrementCount"">Click me</button>",
+            });
+
+            var compilation = await project.GetCompilationAsync();
+            TestAnalyzerConfigOptionsProvider? testOptionsProvider = null;
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project, optionsProvider =>
+            {
+                testOptionsProvider = optionsProvider;
+                optionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "true";
+            });
+
+            var result = RunGenerator(compilation!, ref driver);
+            Assert.Empty(result.Diagnostics);
+            Assert.Empty(result.GeneratedSources);
+
+
+            var updatedOptionsProvider = new TestAnalyzerConfigOptionsProvider();
+            foreach (var option in testOptionsProvider!.AdditionalTextOptions)
+            {
+                updatedOptionsProvider.AdditionalTextOptions[option.Key] = option.Value;
+            }
+
+            foreach (var option in testOptionsProvider!.TestGlobalOptions.Options)
+            {
+                updatedOptionsProvider.TestGlobalOptions[option.Key] = option.Value;
+            }
+
+            updatedOptionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "false";
+
+            driver = driver.WithUpdatedAnalyzerConfigOptions(updatedOptionsProvider);
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Collection(
+                result.GeneratedSources,
+                sourceResult =>
+                {
+                    Assert.Contains("public partial class Index", sourceResult.SourceText.ToString());
+                },
+                sourceResult =>
+                {
+                    var sourceText = sourceResult.SourceText.ToString();
+                    Assert.Contains("public partial class Counter", sourceText);
+                    // Regression test for https://github.com/dotnet/aspnetcore/issues/36116. Verify that @onclick is resolved as a component, and not as a regular attribute
+                    Assert.Contains("__builder.AddAttribute(2, \"onclick\", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this,", sourceText);
+                });
+        }
+
+        private static async ValueTask<GeneratorDriver> GetDriverAsync(Project project)
+        {
+            var (driver, _) = await GetDriverWithAdditionalTextAsync(project);
+            return driver;
+        }
+
+        private static async ValueTask<(GeneratorDriver, ImmutableArray<AdditionalText>)> GetDriverWithAdditionalTextAsync(Project project, Action<TestAnalyzerConfigOptionsProvider>? configureGlobalOptions = null)
+        {
+            var razorSourceGenerator = new RazorSourceGenerator().AsSourceGenerator();
+            var driver = (GeneratorDriver)CSharpGeneratorDriver.Create(new[] { razorSourceGenerator }, parseOptions: (CSharpParseOptions)project.ParseOptions!);
+
+            var optionsProvider = GetDefaultOptionsProvider();
+
+            configureGlobalOptions?.Invoke(optionsProvider);
+
+            var additionalTexts = ImmutableArray<AdditionalText>.Empty;
+
+            foreach (var document in project.AdditionalDocuments)
+            {
+                var additionalText = new TestAdditionalText(document.Name, await document.GetTextAsync());
+                additionalTexts = additionalTexts.Add(additionalText);
+
+                var additionalTextOptions = new TestAnalyzerConfigOptions
+                {
+                    ["build_metadata.AdditionalFiles.TargetPath"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(additionalText.Path)),
+                };
+
+                optionsProvider.AdditionalTextOptions[additionalText.Path] = additionalTextOptions;
+            }
+
+            driver = driver
+                .AddAdditionalTexts(additionalTexts)
+                .WithUpdatedAnalyzerConfigOptions(optionsProvider);
+
+            return (driver, additionalTexts);
+        }
+
+        private static TestAnalyzerConfigOptionsProvider GetDefaultOptionsProvider()
+        {
+            var optionsProvider = new TestAnalyzerConfigOptionsProvider();
+            optionsProvider.TestGlobalOptions["build_property.RazorConfiguration"] = "Default";
+            optionsProvider.TestGlobalOptions["build_property.RootNamespace"] = "MyApp";
+            optionsProvider.TestGlobalOptions["build_property.RazorLangVersion"] = "Latest";
+            return optionsProvider;
+        }
+
+        private static GeneratorRunResult RunGenerator(Compilation compilation, ref GeneratorDriver driver)
+        {
+            driver = driver.RunGenerators(compilation);
+
+            var result = driver.RunGenerators(compilation).GetRunResult();
+            return result.Results[0];
+        }
+
+        private static Project CreateTestProject(
+            Dictionary<string, string> additonalSources,
+            Dictionary<string, string>? sources = null)
+        {
+            var project = _baseProject;
+
+            if (sources is not null)
+            {
+                foreach (var (name, source) in sources)
+                {
+                    project = project.AddDocument(name, source).Project;
+                }
+            }
+
+            foreach (var (name, source) in additonalSources)
+            {
+                project = project.AddAdditionalDocument(name, source).Project;
+            }
+
+            return project;
+        }
+
+        private class AppLocalResolver : ICompilationAssemblyResolver
+        {
+            public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
+            {
+                foreach (var assembly in library.Assemblies)
+                {
+                    var dll = Path.Combine(Directory.GetCurrentDirectory(), "refs", Path.GetFileName(assembly));
+                    if (File.Exists(dll))
+                    {
+                        assemblies.Add(dll);
+                        return true;
+                    }
+
+                    dll = Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileName(assembly));
+                    if (File.Exists(dll))
+                    {
+                        assemblies.Add(dll);
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        private static Project CreateBaseProject()
+        {
+            var projectId = ProjectId.CreateNewId(debugName: "TestProject");
+
+            var solution = new AdhocWorkspace()
+               .CurrentSolution
+               .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp);
+
+            var project = solution.Projects.Single()
+                .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+
+            project = project.WithParseOptions(((CSharpParseOptions)project.ParseOptions!).WithLanguageVersion(LanguageVersion.Preview));
+
+
+            foreach (var defaultCompileLibrary in DependencyContext.Load(typeof(RazorSourceGeneratorTests).Assembly).CompileLibraries)
+            {
+                foreach (var resolveReferencePath in defaultCompileLibrary.ResolveReferencePaths(new AppLocalResolver()))
+                {
+                    project = project.AddMetadataReference(MetadataReference.CreateFromFile(resolveReferencePath));
+                }
+            }
+
+            // The deps file in the project is incorrect and does not contain "compile" nodes for some references.
+            // However these binaries are always present in the bin output. As a "temporary" workaround, we'll add
+            // every dll file that's present in the test's build output as a metadatareference.
+            foreach (var assembly in Directory.EnumerateFiles(AppContext.BaseDirectory, "*.dll"))
+            {
+                if (!project.MetadataReferences.Any(c => string.Equals(Path.GetFileNameWithoutExtension(c.Display), Path.GetFileNameWithoutExtension(assembly), StringComparison.OrdinalIgnoreCase)))
+                {
+                    project = project.AddMetadataReference(MetadataReference.CreateFromFile(assembly));
+                }
+            }
+
+            return project;
+        }
+
+        private class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+        {
+            public override AnalyzerConfigOptions GlobalOptions => TestGlobalOptions;
+
+            public TestAnalyzerConfigOptions TestGlobalOptions { get; } = new TestAnalyzerConfigOptions();
+
+            public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => throw new NotImplementedException();
+
+            public Dictionary<string, TestAnalyzerConfigOptions> AdditionalTextOptions { get; } = new();
+
+            public override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
+            {
+                return AdditionalTextOptions.TryGetValue(textFile.Path, out var options) ? options : new TestAnalyzerConfigOptions();
+            }
+        }
+
+        private class TestAnalyzerConfigOptions : AnalyzerConfigOptions
+        {
+            public Dictionary<string, string> Options { get; } = new();
+
+            public string this[string name]
+            {
+                get => Options[name];
+                set => Options[name] = value;
+            }
+
+            public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+                => Options.TryGetValue(key, out value);
+        }
+    }
+}


### PR DESCRIPTION
RSG is invoked with 2 sets of values for SuppressRazorSourceGenerator first with it being set, and once without.
When set, RSG, does not compute any tag helpers from references and produces an empty result. Prior to this change,
we were caching this value invariant of SuppressRazorSourceGenerator. Consequently the next time the RSG was invoked,
the source generator infrastructure would assume that the empty result is still valid and use it for codegen.

The result of the bug is that in a hot reload compilation, none of the tag helpers were resolved and razor would treat tag helpers
from references as markup text. We fix this scenario by varying TagHelpersFromReferences using SuppressRazorSourceGenerator. Additionally added a test to validate that we're generating the expected source.