### PR TITLE
remove unused env var: `DOTNET_SKIP_FIRST_TIME_EXPERIENCE`

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -157,9 +157,6 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
   # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
   $env:DOTNET_MULTILEVEL_LOOKUP=0
 
-  # Disable first run since we do not need all ASP.NET packages restored.
-  $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-
   # Disable telemetry on CI.
   if ($ci) {
     $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
@@ -231,7 +228,6 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
   Write-PipelinePrependPath -Path $dotnetRoot
 
   Write-PipelineSetVariable -Name 'DOTNET_MULTILEVEL_LOOKUP' -Value '0'
-  Write-PipelineSetVariable -Name 'DOTNET_SKIP_FIRST_TIME_EXPERIENCE' -Value '1'
 
   return $global:_DotNetInstallDir = $dotnetRoot
 }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -111,9 +111,6 @@ function InitializeDotNetCli {
   # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
   export DOTNET_MULTILEVEL_LOOKUP=0
 
-  # Disable first run since we want to control all package sources
-  export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-
   # Disable telemetry on CI
   if [[ $ci == true ]]; then
     export DOTNET_CLI_TELEMETRY_OPTOUT=1
@@ -165,7 +162,6 @@ function InitializeDotNetCli {
   Write-PipelinePrependPath -path "$dotnet_root"
 
   Write-PipelineSetVariable -name "DOTNET_MULTILEVEL_LOOKUP" -value "0"
-  Write-PipelineSetVariable -name "DOTNET_SKIP_FIRST_TIME_EXPERIENCE" -value "1"
 
   # return value
   _InitializeDotNetCli="$dotnet_root"

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -43,7 +43,6 @@ function CreateBuildEnvScript()
   $scriptContents = @"
 @echo off
 title SDK Build ($RepoRoot)
-set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 set DOTNET_MULTILEVEL_LOOKUP=0
 
 set DOTNET_ROOT=$env:DOTNET_INSTALL_DIR

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -57,7 +57,6 @@ function CreateBuildEnvScript {
   scriptPath="$artifacts_dir/sdk-build-env.sh"
   scriptContents="
 #!/bin/bash
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0
 
 export DOTNET_ROOT=$DOTNET_INSTALL_DIR

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -61,8 +61,6 @@ namespace Microsoft.NET.TestFramework
             //  Set NUGET_PACKAGES environment variable to match value from build.ps1
             command.Environment["NUGET_PACKAGES"] = NuGetCachePath;
 
-            command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1";
-
             command.Environment["GenerateResourceMSBuildArchitecture"] = "CurrentArchitecture";
             command.Environment["GenerateResourceMSBuildRuntime"] = "CurrentRuntime";
 

--- a/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
+++ b/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
@@ -51,7 +51,6 @@ namespace Microsoft.DotNet.Watcher.Tools
             var processStartInfo = _spec.GetProcessStartInfo();
             processStartInfo.RedirectStandardOutput = true;
             processStartInfo.RedirectStandardError = true;
-            processStartInfo.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "true";
 
             _process = new Process
             {

--- a/src/WebSdk/Publish/Tasks/Tasks/GenerateEFSQLScripts.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/GenerateEFSQLScripts.cs
@@ -76,13 +76,10 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
         private int _processExitCode;
         private StringBuilder _standardOut = new StringBuilder();
         private StringBuilder _standardError = new StringBuilder();
-        private const string SkipFirstTimeEnvironmentVariable = "DOTNET_SKIP_FIRST_TIME_EXPERIENCE";
         private const string AspNetCoreEnvironment = "ASPNETCORE_ENVIRONMENT";
         private bool GenerateSQLScript(string sqlFileFullPath, string dbContextName, bool isLoggingEnabled = true)
         {
-            string previousSkipValue = Environment.GetEnvironmentVariable(SkipFirstTimeEnvironmentVariable);
             string previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable(AspNetCoreEnvironment); 
-            Environment.SetEnvironmentVariable(SkipFirstTimeEnvironmentVariable, "true");
             Environment.SetEnvironmentVariable(AspNetCoreEnvironment, "Development");
             ProcessStartInfo psi = new ProcessStartInfo("dotnet", $@"ef migrations script --no-build --idempotent --configuration {Configuration} --output ""{sqlFileFullPath}"" --context {dbContextName} {EFMigrationsAdditionalArgs}")
             {
@@ -128,7 +125,6 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
                 isProcessExited = proc.WaitForExit(300000);
             }
 
-            Environment.SetEnvironmentVariable(SkipFirstTimeEnvironmentVariable, previousSkipValue);
             Environment.SetEnvironmentVariable(AspNetCoreEnvironment, previousAspNetCoreEnvironment);
             if (!isProcessExited || _processExitCode != 0)
             {


### PR DESCRIPTION
Resolves: https://github.com/dotnet/sdk/issues/10195 (In combination with https://github.com/dotnet/installer/pull/11971)

https://github.com/dotnet/sdk/issues/9945 indicates this env var is no longer used.
I couldn't find usages in the SDK.