### PR TITLE
Update Microsoft.SourceBuild.Intermediate.source-build reference

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -260,7 +260,7 @@
       <Sha>bd9c63c9e74681617fccf2e371cd90f00d01cef7</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21318.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21460.1">
       <Uri>https://github.com/dotnet/source-build</Uri>
       <Sha>3fb25b8db3bec654e37e71a5b2b7fde14444bc2f</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />


### PR DESCRIPTION
Porting https://github.com/dotnet/installer/pull/11965 to the SDK.  This is needed as the sdk version flows to installer - see https://github.com/dotnet/installer/pull/11969/files#r707020189