### PR TITLE
Only throw missing reference path error when running with references

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.PackageValidation
                 resolvedReferences = true;
                 loader.AddReferenceSearchDirectories(referencePathForTFM);
             }
-            else if (!_isBaselineSuppression && _referencePaths != null && ShouldLogDiagnosticId(ApiCompatibility.DiagnosticIds.SearchDirectoriesNotFoundForTfm))
+            else if (!_isBaselineSuppression && _referencePaths.Count != 0 && ShouldLogDiagnosticId(ApiCompatibility.DiagnosticIds.SearchDirectoriesNotFoundForTfm))
             {
                 _log.LogWarning(
                     new Suppression()

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.PackageValidation
 
             // In order to enable reference support for baseline suppression we need a better way
             // to resolve references for the baseline package. Let's not enable it for now.
-            bool shouldResolveReferences = !_isBaselineSuppression && _referencePaths != null &&
+            bool shouldResolveReferences = !_isBaselineSuppression &&
                 _referencePaths.TryGetValue(assemblyInformation.TargetFramework, out referencePathForTFM);
 
             AssemblySymbolLoader loader = new(resolveAssemblyReferences: shouldResolveReferences);


### PR DESCRIPTION
Today, when running package validation (that is not against a package baseline), we resolve references of the assets being compared. We also then provide an optional switch you can set (set `RunPackageValidationWithoutReferences` to true) in order to not use references if you prefer just compare the two assemblies in question without looking at the references. There is an issue with the code since if you decide to run with out references today, you would get a warning similar to this:

```
CP1003 Could not find a reference directory in the provided directories for TargetFramework Foo when loading 'lib/Foo/Bar.dll'. For more information see: https://aka.ms/dotnetpackagevalidation
```

This is because we are not funneling through the value of that property correctly to the analysis, so we are not making it aware that we actually don't care about references. These changes are fixing that bug, as well as adding test coverage for it.

cc: @Anipik @ericstj 