### PR TITLE
Warn when Targeting net6.0 with 16.11 and the 6.0 SDK

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -832,4 +832,8 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</value>
     <comment>{StrBegin="NETSDK1181: "}</comment>
   </data>
+  <data name="Net6NotCompatibleWithDev16" xml:space="preserve">
+    <value>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</value>
+    <comment>{StrBegin="NETSDK1182: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -833,7 +833,7 @@ You may need to build the project on another operating system or architecture, o
     <comment>{StrBegin="NETSDK1181: "}</comment>
   </data>
   <data name="Net6NotCompatibleWithDev16" xml:space="preserve">
-    <value>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</value>
+    <value>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</value>
     <comment>{StrBegin="NETSDK1182: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: Aktuální sada .NET SDK nepodporuje .NET Framework bez použití výchozích nastavení .NET SDK. Pravděpodobně došlo k neshodě mezi vlastnostmi CLRSupport projektu C++/CLI a TargetFramework.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: Pro zadaný identifikátor RuntimeIdentifier {0} není k dispozici žádný hostitel aplikace.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: Das aktuelle .NET SDK unterstützt das .NET Framework nur, wenn .NET SDK-Standardwerte verwendet werden. Wahrscheinlich liegt ein Konflikt zwischen der CLRSupport-Eigenschaft des C++-/CLI-Projekts und TargetFramework vor.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: Für den angegebenen RuntimeIdentifier "{0}" ist kein Anwendungshost verfügbar.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: Le SDK .NET actuel ne prend pas en charge le .NET Framework avec des valeurs du SDK .NET autres que celles par défaut. Cela est probablement dû à une incompatibilité entre la propriété CLRSupport du projet C++/CLI et TargetFramework.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: il n'existe aucun d'hôte d'application disponible pour le RuntimeIdentifier spécifié '{0}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: l'istanza corrente di .NET SDK non supporta .NET Framework senza usare le impostazioni predefinite di .NET SDK. Il problema dipende probabilmente da una mancata corrispondenza tra la proprietà CLRSupport del progetto C++/CLI e TargetFramework.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: non è disponibile alcun host applicazione per l'elemento RuntimeIdentifier specificato '{0}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: 現在の .NET SDK では、.NET SDK の既定値を使用せずに .NET Framework をサポートすることはできません。これは、C++/CLI プロジェクトの CLRSupport プロパティと TargetFramework の間の不一致が原因と考えられます。</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: 指定された RuntimeIdentifier '{0}' で利用できるアプリケーション ホストはありません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: 현재 .NET SDK는 .NET SDK 기본값을 사용하지 않는 .NET Framework를 지원하지 않습니다. C++/CLI 프로젝트 CLRSupport 속성과 TargetFramework 사이의 불일치 때문일 수 있습니다.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: 지정된 RuntimeIdentifier '{0}'에 사용할 수 있는 애플리케이션 호스트가 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: Bieżący zestaw .NET SDK nie obsługuje programu .NET Framework bez użycia wartości domyślnych zestawu .NET SDK. Prawdopodobna przyczyna to niezgodność między właściwością CLRSupport projektu C++/CLI i elementu TargetFramework.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: Brak dostępnej aplikacji hosta dla określonego elementu RuntimeIdentifier „{0}”.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: o SDK do .NET atual não dá suporte ao .NET Framework sem o uso de Padrões do SDK do .NET. O motivo é provavelmente uma incompatibilidade entre a propriedade CLRSupport do projeto C++/CLI e a TargetFramework.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: não há nenhum host do aplicativo disponível para o RuntimeIdentifier especificado '{0}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: текущий пакет SDK для .NET не поддерживает .NET Framework без использования значений SDK для .NET по умолчанию. Причиной, скорее всего, является несоответствие TargetFramework и свойства CLRSupport в проекте C++/CLI.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: нет узла приложения для указанного RuntimeIdentifier "{0}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: Geçerli .NET SDK, .NET SDK Varsayılanlarını kullanmadan .NET Framework'ü desteklemiyor. C++/CLI projesi CLRSupport özelliği ve TargetFramework arasındaki uyuşmazlık bu duruma neden olabilir.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: Belirtilen RuntimeIdentifier '{0}' için kullanılabilecek bir uygulama konağı yok.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: 未使用 .NET SDK 默认设置的情况下，当前 .NET SDK 不支持 .NET Framework。很可能是因为 C++/CLI 项目的 CLRSupport 属性和 TargetFramework 之间存在不匹配情况。</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: 没有应用程序主机可用于指定的 RuntimeIdentifier“{0}”。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -560,6 +560,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1115: 目前的 .NET SDK 不支援在不使用 .NET SDK 預設的情形下使用 .NET Framework。這可能是因為 C++/CLI 專案 CLRSupport 屬性與 TargetFramework 不相符所致。</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
+      <trans-unit id="Net6NotCompatibleWithDev16">
+        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
+        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
+      </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
         <target state="translated">NETSDK1084: 對指定的 RuntimeIdentifier '{0}'，無法使用任何應用程式主機。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -561,8 +561,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
-        <source>NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</source>
-        <target state="new">NETSDK1182: Using .NET 6.0 in Visual Studio 2019 is not a supported scenario.</target>
+        <source>NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</source>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -128,6 +128,12 @@ Copyright (c) .NET Foundation. All rights reserved.
                  FormatArguments="$(SdkResolverGlobalJsonPath)" />
   </Target>
 
+  <Target Name="_WarnWhenUsingNET6WithVS1611"
+        BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+        Condition="'$(BuildingInsideVisualStudio)' == 'true' and $(VisualStudioVersion.StartsWith('16'))">
+    <NetSdkWarning ResourceName="Net6NotCompatibleWithDev16"/>
+  </Target>
+
   <Target Name="_CheckForInvalidWindowsDesktopTargetingConfiguration"
         BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
         Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0')) and ('$(UseWindowsForms)' == 'true' or '$(UseWPF)' == 'true')">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -128,9 +128,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                  FormatArguments="$(SdkResolverGlobalJsonPath)" />
   </Target>
 
-  <Target Name="_WarnWhenUsingNET6WithVS1611"
+  <Target Name="_WarnWhenUsingNET6AndVSPriorTo17"
         BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-        Condition="'$(BuildingInsideVisualStudio)' == 'true' and $(VisualStudioVersion.StartsWith('16'))">
+        Condition="$([MSBuild]::VersionLessThan($(VisualStudioVersion), '17.0'))">
     <NetSdkWarning ResourceName="Net6NotCompatibleWithDev16"/>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -130,7 +130,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_WarnWhenUsingNET6AndVSPriorTo17"
         BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-        Condition="$([MSBuild]::VersionLessThan($(VisualStudioVersion), '17.0'))">
+        Condition="$([MSBuild]::VersionLessThan($(VisualStudioVersion), '17.0')) and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
     <NetSdkWarning ResourceName="Net6NotCompatibleWithDev16"/>
   </Target>
 

--- a/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
+++ b/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Clean.Tests
         {
         }
 
-        [Fact]
+        [RequiresMSBuildVersionFact("17.0.0")]
         public void It_cleans_without_logging_assets_message()
         {
             var testAsset = _testAssetsManager


### PR DESCRIPTION
`NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.`