### PR TITLE
Add a static cache for GetAssemblyVersion

### DIFF
--- a/src/Tasks/Common/FileUtilities.MetadataReader.cs
+++ b/src/Tasks/Common/FileUtilities.MetadataReader.cs
@@ -36,10 +36,7 @@ namespace Microsoft.NET.Build.Tasks
 
             Version version = GetAssemblyVersionFromFile(sourcePath);
 
-            if (version is not null)
-            {
-                s_versionCache[sourcePath] = (lastWriteTimeUtc, version);
-            }
+            s_versionCache[sourcePath] = (lastWriteTimeUtc, version);
 
             // When introducing this cache, we decided that the cached
             // data was small and likely to be basically finite for

--- a/src/Tasks/Common/FileUtilities.MetadataReader.cs
+++ b/src/Tasks/Common/FileUtilities.MetadataReader.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;

--- a/src/Tasks/Common/FileUtilities.MetadataReader.cs
+++ b/src/Tasks/Common/FileUtilities.MetadataReader.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks
             DateTime lastWriteTimeUtc = File.GetLastWriteTimeUtc(sourcePath);
 
             if (s_versionCache.TryGetValue(sourcePath, out var cacheEntry) 
-                && lastWriteTimeUtc < cacheEntry.LastKnownWriteTimeUtc)
+                && lastWriteTimeUtc == cacheEntry.LastKnownWriteTimeUtc)
             {
                 return cacheEntry.Version;
             }

--- a/src/Tasks/Common/FileUtilities.MetadataReader.cs
+++ b/src/Tasks/Common/FileUtilities.MetadataReader.cs
@@ -26,8 +26,6 @@ namespace Microsoft.NET.Build.Tasks
 
         private static Version GetAssemblyVersion(string sourcePath)
         {
-            // TODO: is there a way to assert that it's a full path?
-
             DateTime lastWriteTimeUtc = File.GetLastWriteTimeUtc(sourcePath);
 
             if (s_versionCache.TryGetValue(sourcePath, out var cacheEntry) 
@@ -43,7 +41,12 @@ namespace Microsoft.NET.Build.Tasks
                 s_versionCache[sourcePath] = (lastWriteTimeUtc, version);
             }
 
-            // TODO: clear or prune cache sometimes?
+            // When introducing this cache, we decided that the cached
+            // data was small and likely to be basically finite for
+            // any given MSBuild process lifetime, so we did not implement
+            // a cache lifetime. If you're here because those assumptions
+            // don't hold, there's no reason the cache must be static
+            // and monotonically growing.
 
             return version;
 


### PR DESCRIPTION
In real-world projects like OrchardCore, ResolvePackageFileConflicts can
run on many files. Since it doesn't cache at all today, that can result
in reading assembly metadata out of the files many, many times.

Instead, cache the results of the call within GetAssemblyVersion and
check only the timestamp of the file on subsequent reads. Even that is
probably too conservative--we could consider caching files in the .NET
SDK directory "forever" (the lifetime of the MSBuild node), and possibly
expanding that to the NuGet packages directory as well, since its
contents should be immutable (but users do occasionally change them).

For this point in the release cycle I chose to be conservative and do
the timestamp check.