### PR TITLE
Rocky Linux support

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/RuntimeEnvironment.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/RuntimeEnvironment.cs
@@ -220,7 +220,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 lastVersionNumberSeparatorIndex = distroInfo.VersionId.IndexOf('.', lastVersionNumberSeparatorIndex + 1);
             }
 
-            if (lastVersionNumberSeparatorIndex != -1 && (distroInfo.Id == "rhel" || distroInfo.Id == "alpine"))
+            if (lastVersionNumberSeparatorIndex != -1 && (distroInfo.Id == "rhel" || distroInfo.Id == "alpine" || distroInfo.Id == "rocky"))
             {
                 distroInfo.VersionId = distroInfo.VersionId.Substring(0, lastVersionNumberSeparatorIndex);
             }

--- a/src/Layout/toolset-tasks/Enumerations/BuildPlatform.cs
+++ b/src/Layout/toolset-tasks/Enumerations/BuildPlatform.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         Debian = 8,
         Fedora = 9,
         OpenSuse = 10,
-        FreeBSD = 11
+        FreeBSD = 11,
+        Rocky = 12
     }
 }


### PR DESCRIPTION
Add Rocky Linux support

Changes based on those necessary for Rocky Linux downstream rebuild of RHEL source packages for dotnet 3.1 and dotnet 5.0.