### PR TITLE
[release/6.0.1xx-rc2] BlazorWasm: Fix including the target assembly

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -114,7 +114,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GatherWasmFilesToBuild">
     <ItemGroup>
       <WasmAssembliesToBundle Remove="@(WasmAssembliesToBundle)" />
-      <WasmAssembliesToBundle Include="@(ReferenceCopyLocalPaths);@(MainAssembly)" Condition="'%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+      <WasmAssembliesToBundle Include="@(IntermediateAssembly)" />
+      <WasmAssembliesToBundle Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
       <WasmAssembliesToBundle Condition="'%(WasmAssembliesToBundle.FileName)' == 'Microsoft.JSInterop.WebAssembly'" AOT_InternalForceToInterpret="true" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Use `$(IntermediateAssembly)` when gathering files for wasm build.

Fixes https://github.com/dotnet/runtime/issues/59255 .