### PR TITLE
Switch to 1ES Servicing pools in 3.1.1xx

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -31,11 +31,11 @@ stages:
       agentOs: Windows_NT
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.server.amd64.vs2019.open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals build.server.amd64.vs2019.open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2017
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2017
       strategy:
         matrix:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -60,8 +60,8 @@ stages:
       parameters:
         agentOs: Windows_NT_FullFramework
         pool:
-          name: NetCorePublic-Pool
-          queue: buildpool.server.amd64.vs2019.open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals build.server.amd64.vs2019.open
         strategy:
           matrix:
             Build_Debug:
@@ -77,8 +77,8 @@ stages:
       parameters:
         agentOs: Windows_NT_TestAsTools
         pool:
-          name: NetCorePublic-Pool
-          queue: buildpool.server.amd64.vs2019.open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals build.server.amd64.vs2019.open
         strategy:
           matrix:
             Build_Debug:
@@ -90,8 +90,8 @@ stages:
       parameters:
         agentOs: Ubuntu_16_04
         pool:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Ubuntu.1604.Amd64.Open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals build.Ubuntu.1604.Amd64.Open
         strategy:
           matrix:
             Build_Debug:


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/core-eng/issues/14276