### PR TITLE
Always reference .NET Framework reference assembly packages if using static GraphWithoutRuntimeDependencies

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -396,12 +396,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="IncludeTargetingPackReference" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CheckForImplicitPackageReferenceOverrides"
           Condition="'$(TargetFrameworkMoniker)' != '' and '$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(AutomaticallyUseReferenceAssemblyPackages)' == 'true'">
+    
+    <!-- Skip this task if is using static graph, because in that case we don't want the NuGet packages referenced to change based on machine state, so we should always
+         reference the reference assembly package. -->
     <GetReferenceAssemblyPaths
         TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
         RootPath="$(TargetFrameworkRootPath)"
         TargetFrameworkFallbackSearchPaths="$(TargetFrameworkFallbackSearchPaths)"
         BypassFrameworkInstallChecks="true"
-        SuppressNotFoundError="true">
+        SuppressNotFoundError="true"
+        Condition="'$(IsGraphBuild)' != 'true'"
+        >
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="_FullFrameworkReferenceAssemblyPaths"/>
     </GetReferenceAssemblyPaths>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
@@ -30,13 +30,13 @@ namespace Microsoft.NET.Build.Tests
             BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new []{"/p:DisableTransitiveProjectReferences=true"});
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/13081")]
+        [Fact]
         public void It_builds_the_project_successfully_with_static_graph_and_isolation()
         {
             BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new []{"/graph"});
         }
         
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/13081")]
+        [Fact]
         public void It_cleans_the_project_successfully_with_static_graph_and_isolation()
         {
             var (testAsset, outputDirectories) = BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new []{"/graph"});

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
@@ -112,7 +112,7 @@ namespace Microsoft.NET.Build.Tests
                             "HelloWorld.exe.config",
                             "HelloWorld.pdb"
                         };
-                    if (TestProject.ReferenceAssembliesAreInstalled(TargetDotNetFrameworkVersion.Version471))
+                    if (TestProject.ReferenceAssembliesAreInstalled("4.7.1"))
                     {
                         return (VBRuntime.Default, files);
                     }

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -401,9 +401,14 @@ namespace {this.Name}
             AdditionalItems.Add(new(itemName, attributes));
         }
 
-        public static bool ReferenceAssembliesAreInstalled(TargetDotNetFrameworkVersion targetFrameworkVersion)
+        public static bool ReferenceAssembliesAreInstalled(string netFrameworkVersion)
         {
-            var referenceAssemblies = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(targetFrameworkVersion);
+            if (!Enum.TryParse<TargetDotNetFrameworkVersion>("Version" + string.Join("", netFrameworkVersion.Split('.')), out var enumVersion))
+            {
+                throw new ArgumentException("No TargetDotNetFrameworkVersion enum defined for .NET Framework " + netFrameworkVersion);
+            }
+
+            var referenceAssemblies = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(enumVersion);
             return referenceAssemblies != null;
         }
     }


### PR DESCRIPTION
Fixes #19506

@jeffkl @cdmihai for review.  There's not a good way to test the end-to-end scenario here, as it involves creating a static graph on one machine, and building on another, where one of the machines has the targeting pack installed and the other doesn't.  So in the test I added, I just search for a version of .NET Framework where the targeting pack is installed, and verify that it's still referenced when doing a static graph build.