### PR TITLE
Fix failure when manifest that is expected to exist isn't found

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -140,7 +140,10 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 foreach (var missingManifestId in missingManifestIds)
                 {
                     var manifestDir = FallbackForMissingManifest(missingManifestId);
-                    manifestIdsToDirectories.Add(missingManifestId, manifestDir);
+                    if (!string.IsNullOrEmpty(manifestDir))
+                    {
+                        manifestIdsToDirectories.Add(missingManifestId, manifestDir);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes the fallback code which is supposed to find workload manifests from previous versions.  It was not correctly handling the case where the manifest it expects to find isn't found.  It ended up returning an empty string and adding that to the list of manifest directories, which later on caused the manifest reader to look for WorkloadManifest.json in whatever the current directory is, causing the workload resolver to fail when it couldn't find that file.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1409464 (though separately it may still be a problem that the IncludedWorkloadManifests.txt file lists manifests that aren't installed by VS).

@sfoslund Can you advise on whether there's an easy way to add test coverage for this?