### PR TITLE
Fix Bash shebang for scripts to run under FreeBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export MicrosoftNETBuildExtensionsTargets=$HELIX_CORRELATION_PAYLOAD/ex/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.targets
 export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/d

--- a/build/sdktests.sh
+++ b/build/sdktests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 install=false
 uninstall=false

--- a/eng/dogfood.sh
+++ b/eng/dogfood.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -56,7 +56,7 @@ function CreateBuildEnvScript {
   mkdir -p $artifacts_dir
   scriptPath="$artifacts_dir/sdk-build-env.sh"
   scriptContents="
-#!/bin/bash
+#!/usr/bin/env bash
 export DOTNET_MULTILEVEL_LOOKUP=0
 
 export DOTNET_ROOT=$DOTNET_INSTALL_DIR

--- a/restore.sh
+++ b/restore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink


### PR DESCRIPTION
Not on all OS'es `bash` is placed under `/bin` (ex. FreeBSD). This small PR fixes those issues when running those scripts on such systems.