### PR TITLE
Clean up client/server shutdown

### DIFF
--- a/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
@@ -62,20 +62,15 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <summary>
         /// Creates a new <see cref="TimestampedFileLogger"/> instance.
         /// </summary>
-        /// <param name="path"></param>
-        /// <param name="flushThreshold"></param>
-        /// <param name="logPipeNames"></param>
+        /// <param name="path">The path of the log file.</param>
+        /// <param name="flushThreshold">The number of writes to allow before flushing the underlying stream.</param>
+        /// <param name="logPipeNames">Additional named pipes that can be used to send log requests from other processes.</param>
         public TimestampedFileLogger(string path, int flushThreshold, params string[] logPipeNames)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(path));
             _stream = File.CreateText(path);
             LogPath = Path.GetFullPath(path);
             FlushThreshold = flushThreshold;
-
-            // Capture control events. While console applications do support the CancelKeyPres event, users can
-            // terminate a CLI command by simply closing the command window, rebooting or logging off.
-            //NativeMethods.Windows.SetConsoleCtrlHandler(CtrlHandler, true);
-            AppDomain.CurrentDomain.ProcessExit += OnExit;
 
             // Spin up additional threads to listen for log requests coming in from external processes.
             foreach (string logPipeName in logPipeNames)
@@ -93,7 +88,7 @@ namespace Microsoft.DotNet.Installer.Windows
         }
 
         /// <summary>
-        /// Starts a new thread to list for log requests messages from external processes.
+        /// Starts a new thread to listen for log requests messages from external processes.
         /// </summary>
         /// <param name="pipeName">The name of the pipe.</param>
         public void AddNamedPipe(string pipeName)
@@ -124,17 +119,6 @@ namespace Microsoft.DotNet.Installer.Windows
 
                 _disposed = true;
             }
-        }
-
-        /// <summary>
-        /// Event handler for when the current process terminates.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void OnExit(object sender, EventArgs e)
-        {
-            LogMessage($"Process is exiting");
-            Dispose();
         }
 
         /// <summary>
@@ -173,7 +157,7 @@ namespace Microsoft.DotNet.Installer.Windows
             int writeCount = 0;
             int threshold = (int)flushThreshold;
 
-            foreach (var message in _messageQueue.GetConsumingEnumerable())
+            foreach (string message in _messageQueue.GetConsumingEnumerable())
             {
                 _stream.WriteLine($"{TimeStamp} {message}");
                 writeCount = (writeCount + 1) % threshold;
@@ -183,23 +167,16 @@ namespace Microsoft.DotNet.Installer.Windows
                     _stream.Flush();
                 }
             }
-
-            _stream.Flush();
         }
 
+        /// <summary>
+        /// Writes the specified message to the log file. The message will first be added to an internal queue to be timestamped
+        /// before it's dequeued and written to the log.
+        /// </summary>
+        /// <param name="message">The message to log.</param>
         protected override void WriteMessage(string message)
         {
-            if (!_disposed)
-            {
-                try
-                {
-                    _messageQueue.Add(message);
-                }
-                catch (ObjectDisposedException)
-                {
-                    // There's a possible race condition where the queue has been disposed but the flag hasn't been set yet
-                }
-            }
+            _messageQueue.Add(message);
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             _workloadResolver = workloadResolver;
             _dependent = $"{DependentPrefix},{sdkFeatureBand},{HostArchitecture}";
 
-            AppDomain.CurrentDomain.ProcessExit += new EventHandler(OnProcessExit);
+            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
 
             Log?.LogMessage($"Executing: {Windows.GetProcessCommandLine()}, PID: {CurrentProcess.Id}, PPID: {ParentProcess.Id}");
             Log?.LogMessage($"{nameof(IsElevated)}: {IsElevated}");
@@ -453,6 +453,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             Log?.LogMessage("Shutdown completed.");
             Log?.LogMessage($"Restart required: {Restart}");
+            ((TimestampedFileLogger)Log).Dispose();
             _shutdown = true;
         }
 
@@ -879,6 +880,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     // Don't rethrow. We'll call ShutDown during abnormal termination when control is passing back to the host
                     // so there's nothing in the CLI that will catch the exception.
                     Log?.LogMessage($"OnProcessExit: Shutdown failed, {ex.Message}");
+                }
+                finally
+                {
+                    ((TimestampedFileLogger)Log).Dispose();
                 }
             }
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
     internal class NetSdkMsiInstallerServer : MsiInstallerBase
     {
         private bool _done;
+        private bool _shutdownRequested;
 
         public NetSdkMsiInstallerServer(InstallElevationContextBase elevationContext, PipeStreamSetupLogger logger)
             : base(elevationContext, logger)
@@ -58,7 +59,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     switch (request.RequestType)
                     {
                         case InstallRequestType.Shutdown:
-                            Dispatcher.Reply(new InstallResponseMessage());
+                            _shutdownRequested = true;
                             _done = true;
                             break;
 
@@ -109,10 +110,15 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         public void Shutdown()
         {
-            Log?.LogMessage("Shutting down server.");
-
             // Restart the update agent if we shut it down.
             UpdateAgent.Start();
+
+            Log?.LogMessage("Shutting down server.");
+
+            if (_shutdownRequested)
+            {
+                Dispatcher.Reply(new InstallResponseMessage());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The server previously responded immediately when it received a shutdown request, causing the client to terminate before the server can log all necessary shutdown steps, especially around WUA restarts.

The process exit event handler in the logger also caused issues because it would run the wrong order before the client's handler. Instead, the client will create the handler and call the logger's dispose to close out the log file and flush out pending requests from both the client/server./

This would also address the previous object disposed exception that could occur