### PR TITLE
Make aspnet-browser-refresh.js tolerate duplication insertions

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -76,7 +76,7 @@ setTimeout(async function () {
       document.querySelector(`link[href^="${document.baseURI}${path}"]`);
 
     // Receive a Clear-site-data header.
-    await fetch('_framework/clear-browser-cache');
+    await fetch('/_framework/clear-browser-cache');
 
     if (!styleElement || !styleElement.parentNode) {
       console.debug('Unable to find a stylesheet to update. Updating all local css files.');
@@ -140,7 +140,7 @@ setTimeout(async function () {
       }
     });
 
-    fetch('_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: JSON.stringify(deltas) })
+    fetch('/_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: JSON.stringify(deltas) })
       .then(response => {
         if (response.status == 200) {
           const etag = response.headers['etag'];

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -1,4 +1,11 @@
 setTimeout(async function () {
+  // Ensure we only try to connect once, even if the script is both injected and manually inserted
+  const scriptInjectedSentinel = '_dotnet_watch_ws_injected';
+  if (window.hasOwnProperty(scriptInjectedSentinel)) {
+    return;
+  }
+  window[scriptInjectedSentinel] = true;
+
   // dotnet-watch browser reload script
   const webSocketUrls = '{{hostString}}'.split(',');
   const sharedSecret = await getSecret('{{ServerKey}}');
@@ -69,7 +76,7 @@ setTimeout(async function () {
       document.querySelector(`link[href^="${document.baseURI}${path}"]`);
 
     // Receive a Clear-site-data header.
-    await fetch('/_framework/clear-browser-cache');
+    await fetch('_framework/clear-browser-cache');
 
     if (!styleElement || !styleElement.parentNode) {
       console.debug('Unable to find a stylesheet to update. Updating all local css files.');


### PR DESCRIPTION
## Description

Allows `aspnet-browser-refresh.js` to be inserted multiple times, so that it doesn't matter if it's both auto-injected and a developer adds it manually.

## Customer Impact

There are cases where we can't auto-inject `aspnet-browser-refresh.js` (the script that handles the JS side of hot reload), and in those cases we tell developers to add it to their page manually. But this is problematic if, in some cases, we *can* auto-inject it, because then it ends up being referenced twice and this leads to errors.

This PR is a very trivial tweak that makes duplicate insertions no-op to simplify things for developers in this case.

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Code change is super simple, and has been manually verified.

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

Addresses https://github.com/dotnet/aspnetcore/issues/35334