### PR TITLE
Remove sql-cache from dotnet help

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -59,7 +59,6 @@ sdk-options:
 {LocalizableStrings.AdditionalTools}
   dev-certs         {LocalizableStrings.DevCertsDefinition}
   fsi               {LocalizableStrings.FsiDefinition}
-  sql-cache         {LocalizableStrings.SqlCacheDefinition}
   user-secrets      {LocalizableStrings.UserSecretsDefinition}
   watch             {LocalizableStrings.WatchDefinition}
 

--- a/src/Cli/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -282,9 +282,6 @@
   <data name="DevCertsDefinition" xml:space="preserve">
     <value>Create and manage development certificates.</value>
   </data>
-  <data name="SqlCacheDefinition" xml:space="preserve">
-    <value>SQL Server cache command-line tools.</value>
-  </data>
   <data name="UserSecretsDefinition" xml:space="preserve">
     <value>Manage development user secrets.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -267,11 +267,6 @@
         <target state="translated">Vytvoří a spravuje certifikáty pro vývoj.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">Nástroje příkazového řádku mezipaměti SQL Serveru</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">Spravuje tajné kódy uživatelů pro vývoj.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -267,11 +267,6 @@
         <target state="translated">Hiermit erstellen und verwalten Sie Entwicklungszertifikate.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">SQL Server-Cache-Befehlszeilentools.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">Hiermit verwalten Sie Benutzergeheimnisse zur Entwicklung.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -267,11 +267,6 @@
         <target state="translated">Crea y administra certificados de desarrollo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">Herramientas de la línea de comandos de la caché de SQL Server.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">Administra secretos de usuario de desarrollo.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -267,11 +267,6 @@
         <target state="translated">Créez et gérez des certificats de développement.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">Outils en ligne de commande du cache SQL Server.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">Gérez les secrets d'utilisateur de développement.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -267,11 +267,6 @@
         <target state="translated">Consente di creare e gestire i certificati di sviluppo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">Strumenti da riga di comando della cache di SQL Server.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">Consente di gestire i segreti degli utenti di sviluppo.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -267,11 +267,6 @@
         <target state="translated">開発証明書を作成し、管理します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">SQL Server キャッシュ コマンドライン ツール。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">開発ユーザーのシークレットを管理します。</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -267,11 +267,6 @@
         <target state="translated">개발 인증서를 만들고 관리합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">SQL Server 캐시 명령줄 도구입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">개발 사용자 비밀을 관리합니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -267,11 +267,6 @@
         <target state="translated">Utwórz certyfikaty deweloperskie i zarządzaj nimi.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">Narzędzia wiersza polecenia pamięci podręcznej programu SQL Server.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">Zarządzaj wpisami tajnymi użytkowników dotyczącymi czynności deweloperskich.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -267,11 +267,6 @@
         <target state="translated">Crie e gerencie certificados de desenvolvimento.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">Ferramentas de linha de comando do cache do SQL Server.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">Gerencie segredos do usuário de desenvolvimento.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -267,11 +267,6 @@
         <target state="translated">Создание сертификатов разработки и управление ими.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">Инструменты командной строки кэша SQL Server.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">Управление развертыванием секретов пользователей.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -267,11 +267,6 @@
         <target state="translated">Geliştirme sertifikaları oluşturun ve yönetin.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">SQL Server önbellek komut satırı araçları.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">Kullanıcı gizli dizilerini yönetin.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -267,11 +267,6 @@
         <target state="translated">创建和管理开发证书。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">SQL Server 缓存命令行工具。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">管理开发用户密码。</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -267,11 +267,6 @@
         <target state="translated">建立及管理開發憑證。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SqlCacheDefinition">
-        <source>SQL Server cache command-line tools.</source>
-        <target state="translated">SQL Server 快取命令列工具。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UserSecretsDefinition">
         <source>Manage development user secrets.</source>
         <target state="translated">管理開發使用者祕密。</target>

--- a/src/Tests/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/src/Tests/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -67,7 +67,6 @@ SDK commands:
 Additional commands from bundled tools:
   dev-certs         Create and manage development certificates.
   fsi               Start F# Interactive / execute F# scripts.
-  sql-cache         SQL Server cache command-line tools.
   user-secrets      Manage development user secrets.
   watch             Start a file watcher that runs a command when files change.
 


### PR DESCRIPTION
The sql-cache subcommand has been removed, but it's still documented as being available. Trying to run it produces an error.

Fixes: #13016