### PR TITLE
Add OS and Process Architecture

### DIFF
--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -35,7 +35,6 @@ namespace Microsoft.DotNet.Cli.Telemetry
         private const string OSVersion = "OS Version";
         private const string OSPlatform = "OS Platform";
         private const string OSArchitecture = "OS Architecture";
-        private const string ProcessArchitecture = "Process Architecture";
         private const string OutputRedirected = "Output Redirected";
         private const string RuntimeId = "Runtime Id";
         private const string ProductVersion = "Product Version";
@@ -63,7 +62,6 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 {OSVersion, RuntimeEnvironment.OperatingSystemVersion},
                 {OSPlatform, RuntimeEnvironment.OperatingSystemPlatform.ToString()},
                 {OSArchitecture, RuntimeInformation.OSArchitecture.ToString()},
-                {ProcessArchitecture, RuntimeInformation.ProcessArchitecture.ToString()},
                 {OutputRedirected, Console.IsOutputRedirected.ToString()},
                 {RuntimeId, RuntimeInformation.RuntimeIdentifier},
                 {ProductVersion, Product.Version},

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -34,6 +34,8 @@ namespace Microsoft.DotNet.Cli.Telemetry
         private IUserLevelCacheWriter _userLevelCacheWriter;
         private const string OSVersion = "OS Version";
         private const string OSPlatform = "OS Platform";
+        private const string OSArchitecture = "OS Architecture";
+        private const string ProcessArchitecture = "Process Architecture";
         private const string OutputRedirected = "Output Redirected";
         private const string RuntimeId = "Runtime Id";
         private const string ProductVersion = "Product Version";
@@ -60,6 +62,8 @@ namespace Microsoft.DotNet.Cli.Telemetry
             {
                 {OSVersion, RuntimeEnvironment.OperatingSystemVersion},
                 {OSPlatform, RuntimeEnvironment.OperatingSystemPlatform.ToString()},
+                {OSArchitecture, RuntimeInformation.OSArchitecture.ToString()},
+                {ProcessArchitecture, RuntimeInformation.ProcessArchitecture.ToString()},
                 {OutputRedirected, Console.IsOutputRedirected.ToString()},
                 {RuntimeId, RuntimeInformation.RuntimeIdentifier},
                 {ProductVersion, Product.Version},

--- a/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -78,6 +78,14 @@ namespace Microsoft.DotNet.Tests
             unitUnderTest.GetTelemetryCommonProperties()["Kernel Version"].Should().Be(RuntimeInformation.OSDescription);
         }
 
+        [Fact]
+        public void TelemetryCommonPropertiesShouldContainArchitectureInformation()
+        {
+            var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
+            unitUnderTest.GetTelemetryCommonProperties()["OS Architecture"].Should().Be(RuntimeInformation.OSArchitecture.ToString());
+            unitUnderTest.GetTelemetryCommonProperties()["Process Architecture"].Should().Be(RuntimeInformation.ProcessArchitecture.ToString());
+        }
+
         [WindowsOnlyFact]
         public void TelemetryCommonPropertiesShouldContainWindowsInstallType()
         {

--- a/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -83,7 +83,6 @@ namespace Microsoft.DotNet.Tests
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
             unitUnderTest.GetTelemetryCommonProperties()["OS Architecture"].Should().Be(RuntimeInformation.OSArchitecture.ToString());
-            unitUnderTest.GetTelemetryCommonProperties()["Process Architecture"].Should().Be(RuntimeInformation.ProcessArchitecture.ToString());
         }
 
         [WindowsOnlyFact]


### PR DESCRIPTION
## Description
During our discussions around [arm64]( https://github.com/dotnet/designs/pull/217) it became clear that we weren't sure how often customers use an SDK that doesn't match their current OS.  Adding this will help us answer that question so we know whether to prioritize this or not.

## Regression?
No

## Risk
Low, no functional change. 

For performance measurements, I ran `dotnet build --help` 100 times in a row with and without the change which triggers on telemetry call.  I found it 109 seconds with the change and 108 seconds without for a slowdown of ~10ms potentially.

## Verification
[X] Manual (required)
[x] Automated