### PR TITLE
Fix over-warning bug when specifying runtime CLI option on dotnet run

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -33,6 +33,10 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option<bool> InteractiveOption = CommonOptions.InteractiveMsBuildForwardOption();
 
+        public static readonly Option SelfContainedOption = CommonOptions.SelfContainedOption();
+
+        public static readonly Option NoSelfContainedOption = CommonOptions.NoSelfContainedOption();
+
         public static Command GetCommand()
         {
             var command = new Command("run", LocalizableStrings.AppFullName);
@@ -47,6 +51,8 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(NoBuildOption);
             command.AddOption(InteractiveOption);
             command.AddOption(NoRestoreOption);
+            command.AddOption(SelfContainedOption);
+            command.AddOption(NoSelfContainedOption);
             command.AddOption(CommonOptions.VerbosityOption());
             command.AddOption(CommonOptions.ArchitectureOption());
             command.AddOption(CommonOptions.OperatingSystemOption());

--- a/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -192,12 +192,12 @@ namespace Microsoft.DotNet.Cli.Build.Tests
                .HaveStdOutContaining("NETSDK1179");
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("build")]
         [InlineData("run")]
         public void It_does_not_warn_on_rid_with_self_contained_options(string commandName)
         {
-            var testInstance = _testAssetsManager.CopyTestAsset("HelloWorld")
+            var testInstance = _testAssetsManager.CopyTestAsset("HelloWorld", identifier: commandName)
                 .WithSource()
                 .WithTargetFrameworkOrFrameworks("net6.0", false)
                 .Restore(Log);

--- a/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -192,17 +192,19 @@ namespace Microsoft.DotNet.Cli.Build.Tests
                .HaveStdOutContaining("NETSDK1179");
         }
 
-        [Fact]
-        public void It_does_not_warn_on_rid_with_self_contained_options()
+        [Theory]
+        [InlineData("build")]
+        [InlineData("run")]
+        public void It_does_not_warn_on_rid_with_self_contained_options(string commandName)
         {
             var testInstance = _testAssetsManager.CopyTestAsset("HelloWorld")
                 .WithSource()
                 .WithTargetFrameworkOrFrameworks("net6.0", false)
                 .Restore(Log);
 
-            new DotnetBuildCommand(Log)
+            new DotnetCommand(Log)
                .WithWorkingDirectory(testInstance.Path)
-               .Execute("-r", "win-x64", "--self-contained")
+               .Execute(commandName, "-r", "win-x64", "--self-contained")
                .Should()
                .Pass()
                .And


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/21560