### PR TITLE
Hide RazorGeneral rule file properties

### DIFF
--- a/src/RazorSdk/Targets/Rules/RazorGeneral.xaml
+++ b/src/RazorSdk/Targets/Rules/RazorGeneral.xaml
@@ -23,7 +23,7 @@
     DisplayName="Razor Language Version"
     Name="RazorLangVersion"
     ReadOnly="True"
-    Visible="True" />
+    Visible="False" />
 
   <StringProperty
     Category="General"
@@ -31,6 +31,6 @@
     DisplayName="Razor Configuration Name"
     Name="RazorDefaultConfiguration"
     ReadOnly="True"
-    Visible="True" />
+    Visible="False" />
 
 </Rule>


### PR DESCRIPTION
Fixes dotnet/aspnetcore#31150

Follows on from #16623

These properties are only intended for programmatic access, and not for display to the user.

The current configuration of these rules means they appear in the updated Project Properties UI for ASP.NET projects.

Making these properties non-visible fixes the issue.