### PR TITLE
Update dead link in runtime-configuration-file.md

### DIFF
--- a/documentation/specs/runtime-configuration-file.md
+++ b/documentation/specs/runtime-configuration-file.md
@@ -128,6 +128,7 @@ The files are both JSON files stored in UTF-8 encoding. Below are sample files. 
 This section is created when building a project. Settings include:
 * `configProperties` - Indicates configuration properties to configure the runtime and the framework
   * Examples:    
+    * Full list of [configuration properties](https://github.com/dotnet/docs/blob/main/docs/core/run-time-config/index.md) for CoreCLR. 
     * `System.GC.Server` (old: `gcServer`) - Boolean indicating if the server GC should be used (Default: `true`).
     * `System.GC.Concurrent` (old: `gcConcurrent`) - Boolean indicating if background garbage collection should be used.
 * `framework` - Indicates the `name`, `version`, and other properties of the shared framework to use when activating the application including `applyPathes` and `rollForwardOnNoCandidateFx`. The presence of this section (or another framework in the new `frameworks` section) indicates that the application is a framework-dependent app.

--- a/documentation/specs/runtime-configuration-file.md
+++ b/documentation/specs/runtime-configuration-file.md
@@ -127,8 +127,7 @@ The files are both JSON files stored in UTF-8 encoding. Below are sample files. 
 
 This section is created when building a project. Settings include:
 * `configProperties` - Indicates configuration properties to configure the runtime and the framework
-  * Examples:
-    * Full list of [configuration properties](https://github.com/dotnet/coreclr/blob/main/Documentation/project-docs/clr-configuration-knobs.md) for CoreCLR.
+  * Examples:    
     * `System.GC.Server` (old: `gcServer`) - Boolean indicating if the server GC should be used (Default: `true`).
     * `System.GC.Concurrent` (old: `gcConcurrent`) - Boolean indicating if background garbage collection should be used.
 * `framework` - Indicates the `name`, `version`, and other properties of the shared framework to use when activating the application including `applyPathes` and `rollForwardOnNoCandidateFx`. The presence of this section (or another framework in the new `frameworks` section) indicates that the application is a framework-dependent app.


### PR DESCRIPTION
The following line:

> Full list of [configuration properties](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/clr-configuration-knobs.md) for CoreCLR.

...links to the `clr-configuration-knobs.md` file which was deleted by @jkotas on Nov/2019 via this [commit](https://github.com/dotnet/runtime/commit/fa25aeaca87d9d37324cd27d7341b6c201179f06). The commit message says `The officially supported settings are documented in https://github.com/dotnet/docs` but I couldn't find a specific file under `dotnet/docs` to link to, so I have tentatively deleted the link altogether but it would be nice to find an alternative link and use that :+1:

**EDIT:** I restored the deleted line and used an alternative link suggested by @jkotas [here](https://github.com/dotnet/cli/pull/13797#issuecomment-932773587)