### PR TITLE
Adding `DotNetWatchBuild` variable to the msbuild initiated by dotnet-watch

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
@@ -28,8 +28,8 @@ namespace Microsoft.DotNet.Watcher.Tools
             while (!cancellationToken.IsCancellationRequested)
             {
                 var arguments = context.Iteration == 0 || (context.ChangedFile?.FilePath is string changedFile && changedFile.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)) ?
-                   new[] { "msbuild", "/t:Build", "/restore", "/nologo" } :
-                   new[] { "msbuild", "/t:Build", "/nologo" };
+                   new[] { "msbuild", "/t:Build", "/restore", "/nologo", "/p:DotNetWatchBuild=true" } :
+                   new[] { "msbuild", "/t:Build", "/nologo", "/p:DotNetWatchBuild=true" };
 
                 var processSpec = new ProcessSpec
                 {


### PR DESCRIPTION
# Summary 
This code change makes sure the `DotNetWatchBuild` variable is passed to the `DotNetBuildFilter` so when the first build or a full build is forced we know that that build was initiated via `dotnet-watch`

# Details
This is an important extensibility point so the community can build some integrations with other technologies like "blazor+tailwindcss",  which can use the `DotNetBuildFilter` to decide whether to trigger hot-reload for css or not.

😸😸 Thanks for your time team, awesome feature!

Addresses https://github.com/dotnet/aspnetcore/issues/35838