### PR TITLE
Remove O# workaround from RazorSDK

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -61,16 +61,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RazorAdditionalFile Include="@(RazorComponentWithTargetPath)" />
       <!-- Ignore .cshtml files if RazorCompileOnBuild=false -->
       <_RazorAdditionalFile Include="@(RazorGenerateWithTargetPath)" Condition="'$(RazorCompileOnBuild)' != 'false'" />
-
-      <!-- Workaround for O# bug where it modifies the root path on Windows-->
-      <_RazorOmnisharpWorkAround Include="$([System.String]::Copy('%(_RazorAdditionalFile.RootDir)').ToLower())%(Directory)%(FileName)%(Extension)"
-        TargetPath="%(_RazorAdditionalFile.TargetPath)"
-        GeneratedOutputFullPath="%(_RazorAdditionalFile.GeneratedOutputFullPath)"
-        CssScope="%(_RazorAdditionalFile.CssScope)"
-        Condition="$([MSBuild]::IsOSPlatform(`Windows`))" />
-
-      <_RazorAdditionalFile Remove="@(_RazorAdditionalFile)" Condition="$([MSBuild]::IsOSPlatform(`Windows`))" />
-      <_RazorAdditionalFile Include="@(_RazorOmnisharpWorkAround)" Condition="$([MSBuild]::IsOSPlatform(`Windows`))" />
     </ItemGroup>
 
     <ItemGroup Condition="@(_RazorAdditionalFile->WithMetadataValue('Extension', '.cshtml')->Count()) > 0" >


### PR DESCRIPTION
### Description

As part of addressing https://github.com/dotnet/aspnetcore/issues/30750, we had added
a workaround to the RazorSDK to ensure building on Windows with the app open in VSCode worked. 
This issue is being resolved as part of the upcoming O# v1.37.16. In the meanwhile, the workaround affects
sourcelink for razor files.

Fixes https://github.com/dotnet/aspnetcore/issues/37182

----------------------------------------------------------

### Description

As part of addressing https://github.com/dotnet/aspnetcore/issues/30750, we had added
a workaround to the RazorSDK to ensure building on Windows with the app open in VSCode worked. 
This issue is being resolved as part of the upcoming O# v1.37.16. In the meanwhile, the workaround affects
sourcelink for razor files.

### Customer impact
Users are unable to have source link work correctly for .cshtml and .razor files packaged in Razor Class Libraries for 6.0 apps.

### Regression
This is a behavior regression compared to 5.0

### Testing
* Manual: 
    - Verified the user reported issue is resolved. 
    - Verified building with the updated O# works without issues
    - Building / running / hot reload in VS  works fine
- Automated: Verifies razor files continue to compile

### Risk
Low. The workaround was for a narrow scenario that was verified to be resolved. 
