### PR TITLE
Fix 1ES image name

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -48,7 +48,7 @@ stages:
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Internal
-          queue:  BuildPool.Windows.10.Amd64.VS2019.Pre
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre
       helixTargetQueue: Windows.Server.Amd64.VS2019.Pre.Open
       strategy:
         matrix:


### PR DESCRIPTION
We've missed one image name when upgrading main to 1ES hosted pools.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276