### PR TITLE
Use NuGetPackageVersion in dotnet.*.js file name

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.5_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.5_0.targets
@@ -90,7 +90,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_DotNetJsVersion>%(_DotNetJsItem.NuGetPackageVersion)</_DotNetJsVersion>
-      <_DotNetJsVersion Condition="'$(_DotNetJsVersion)' == ''">$(TargetFramework)</_DotNetJsVersion>
       <_BlazorDotnetJsFileName>dotnet.$(_DotNetJsVersion).js</_BlazorDotnetJsFileName>
       <_BlazorDotNetJsFilePath>$(IntermediateOutputPath)$(_BlazorDotnetJsFileName)</_BlazorDotNetJsFilePath>
     </PropertyGroup>

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.5_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.5_0.targets
@@ -84,16 +84,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--
       We want the dotnet.js file output to have a version to better work with caching. We'll append the runtime version to the file name as soon as file has been discovered.
     -->
-    <PropertyGroup>
-      <_DotNetJsVersion>$(BundledNETCoreAppPackageVersion)</_DotNetJsVersion>
-      <_DotNetJsVersion Condition="'$(RuntimeFrameworkVersion)' != ''">$(RuntimeFrameworkVersion)</_DotNetJsVersion>
-      <_BlazorDotnetJsFileName>dotnet.$(_DotNetJsVersion).js</_BlazorDotnetJsFileName>
-      <_BlazorDotNetJsFilePath>$(IntermediateOutputPath)$(_BlazorDotnetJsFileName)</_BlazorDotNetJsFilePath>
-    </PropertyGroup>
-
     <ItemGroup>
       <_DotNetJsItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.DestinationSubPath)' == 'dotnet.js' AND '%(ReferenceCopyLocalPaths.AssetType)' == 'native'" />
     </ItemGroup>
+
+    <PropertyGroup>
+      <_DotNetJsVersion>%(_DotNetJsItem.NuGetPackageVersion)</_DotNetJsVersion>
+      <_DotNetJsVersion Condition="'$(_DotNetJsVersion)' == ''">$(TargetFramework)</_DotNetJsVersion>
+      <_BlazorDotnetJsFileName>dotnet.$(_DotNetJsVersion).js</_BlazorDotnetJsFileName>
+      <_BlazorDotNetJsFilePath>$(IntermediateOutputPath)$(_BlazorDotnetJsFileName)</_BlazorDotNetJsFilePath>
+    </PropertyGroup>
 
     <Copy
       SourceFiles="@(_DotNetJsItem)"
@@ -285,7 +285,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_CurrentWasmProjectStaticWebAssets Include="@(_ThisProjectStaticWebAssets)" Condition="'%(SourceId)' == '$(PackageId)'" />
       <_CurrentWasmProjectStaticWebAssets>
-        <!-- We set the asset kind explicitly to build becasue blazor before 6.0 did its own publishing and was
+        <!-- We set the asset kind explicitly to build because blazor before 6.0 did its own publishing and was
              not fully integrated with static web assets, so we let it be even when called from 6.0 targets
         -->
         <AssetKind>Build</AssetKind>

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -166,7 +166,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       TimeZoneSupport="$(_BlazorEnableTimeZoneSupport)"
       InvariantGlobalization="$(_BlazorInvariantGlobalization)"
       CopySymbols="$(_BlazorCopyOutputSymbolsToOutputDirectory)"
-      BlazorWebAssemblySdkTasksTFM="$(_BlazorWebAssemblySdkTasksTFM)"
       OutputPath="$(OutputPath)"
     >
       <Output TaskParameter="AssetCandidates" ItemName="_BuildAssetsCandidates" />
@@ -284,7 +283,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <StaticWebAsset Include="@(_BlazorGzipStaticWebAsset)" />
       <StaticWebAsset Include="@(_BuildBlazorBootJsonStaticWebAsset)" />
     </ItemGroup>
-
   </Target>
 
   <Target Name="_GenerateBuildBlazorBootJson" DependsOnTargets="ResolveStaticWebAssetsInputs">

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -407,7 +407,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       InvariantGlobalization="$(_BlazorInvariantGlobalization)"
       CopySymbols="$(CopyOutputSymbolsToPublishDirectory)"
       ExistingAssets="@(_BlazorPublishPrefilteredAssets)"
-      BlazorWebAssemblySdkTasksTFM="$(_BlazorWebAssemblySdkTasksTFM)"
     >
       <Output TaskParameter="NewCandidates" ItemName="_NewBlazorPublishStaticWebAssets" />
       <Output TaskParameter="FilesToRemove" ItemName="_PublishResolvedFilesToRemove" />

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -399,6 +399,14 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'%(StaticWebAsset.AssetTraitName)' == 'BlazorWebAssemblyResource' or '%(StaticWebAsset.AssetTraitName)' == 'Culture' or '%(AssetRole)' == 'Alternative'" />
     </ItemGroup>
 
+    <ItemGroup>
+      <_DotNetJsItem Include="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.DestinationSubPath)' == 'dotnet.js' AND '%(ResolvedFileToPublish.AssetType)' == 'native'" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_DotNetJsVersion>%(_DotNetJsItem.NuGetPackageVersion)</_DotNetJsVersion>
+    </PropertyGroup>
+
     <ComputeBlazorPublishAssets
       ResolvedFilesToPublish="@(ResolvedFileToPublish)"
       TimeZoneSupport="$(_BlazorEnableTimeZoneSupport)"
@@ -407,6 +415,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       InvariantGlobalization="$(_BlazorInvariantGlobalization)"
       CopySymbols="$(CopyOutputSymbolsToPublishDirectory)"
       ExistingAssets="@(_BlazorPublishPrefilteredAssets)"
+      DotNetJsVersion="$(_DotNetJsVersion)"
     >
       <Output TaskParameter="NewCandidates" ItemName="_NewBlazorPublishStaticWebAssets" />
       <Output TaskParameter="FilesToRemove" ItemName="_PublishResolvedFilesToRemove" />

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -166,7 +166,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       TimeZoneSupport="$(_BlazorEnableTimeZoneSupport)"
       InvariantGlobalization="$(_BlazorInvariantGlobalization)"
       CopySymbols="$(_BlazorCopyOutputSymbolsToOutputDirectory)"
-      BundledNETCoreAppPackageVersion="$(BundledNETCoreAppPackageVersion)"
+      BlazorWebAssemblySdkTasksTFM="$(_BlazorWebAssemblySdkTasksTFM)"
       OutputPath="$(OutputPath)"
     >
       <Output TaskParameter="AssetCandidates" ItemName="_BuildAssetsCandidates" />
@@ -409,7 +409,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       InvariantGlobalization="$(_BlazorInvariantGlobalization)"
       CopySymbols="$(CopyOutputSymbolsToPublishDirectory)"
       ExistingAssets="@(_BlazorPublishPrefilteredAssets)"
-      BundledNETCoreAppPackageVersion="$(BundledNETCoreAppPackageVersion)"
+      BlazorWebAssemblySdkTasksTFM="$(_BlazorWebAssemblySdkTasksTFM)"
     >
       <Output TaskParameter="NewCandidates" ItemName="_NewBlazorPublishStaticWebAssets" />
       <Output TaskParameter="FilesToRemove" ItemName="_PublishResolvedFilesToRemove" />

--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
@@ -43,9 +43,6 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
         [Required]
         public bool CopySymbols { get; set; }
 
-        [Required]
-        public string BlazorWebAssemblySdkTasksTFM { get; set; }
-
         [Output]
         public ITaskItem[] AssetCandidates { get; set; }
 
@@ -103,7 +100,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                     if (candidate.GetMetadata("FileName") == "dotnet" && candidate.GetMetadata("Extension") == ".js")
                     {
                         var itemHash = FileHasher.GetFileHash(candidate.ItemSpec);
-                        var cacheBustedDotNetJSFileName = $"dotnet.{BlazorWebAssemblySdkTasksTFM}.{itemHash}.js";
+                        var cacheBustedDotNetJSFileName = $"dotnet.{candidate.GetMetadata("NuGetPackageVersion")}.{itemHash}.js";
 
                         var originalFileFullPath = Path.GetFullPath(candidate.ItemSpec);
                         var originalFileDirectory = Path.GetDirectoryName(originalFileFullPath);

--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
         public bool CopySymbols { get; set; }
 
         [Required]
-        public string BundledNETCoreAppPackageVersion { get; set; }
+        public string BlazorWebAssemblySdkTasksTFM { get; set; }
 
         [Output]
         public ITaskItem[] AssetCandidates { get; set; }
@@ -103,7 +103,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                     if (candidate.GetMetadata("FileName") == "dotnet" && candidate.GetMetadata("Extension") == ".js")
                     {
                         var itemHash = FileHasher.GetFileHash(candidate.ItemSpec);
-                        var cacheBustedDotNetJSFileName = $"dotnet.{BundledNETCoreAppPackageVersion}.{itemHash}.js";
+                        var cacheBustedDotNetJSFileName = $"dotnet.{BlazorWebAssemblySdkTasksTFM}.{itemHash}.js";
 
                         var originalFileFullPath = Path.GetFullPath(candidate.ItemSpec);
                         var originalFileDirectory = Path.GetDirectoryName(originalFileFullPath);

--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
@@ -48,9 +48,6 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
         [Required]
         public string PublishPath { get; set; }
 
-        [Required]
-        public string BlazorWebAssemblySdkTasksTFM { get; set; }
-
         [Output]
         public ITaskItem[] NewCandidates { get; set; }
 

--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
@@ -194,7 +194,10 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                     {
                         newDotNetJs = new TaskItem(Path.GetFullPath(aotDotNetJs.ItemSpec), asset.CloneCustomMetadata());
                         newDotNetJs.SetMetadata("OriginalItemSpec", aotDotNetJs.ItemSpec);
-                        newDotNetJs.SetMetadata("RelativePath", $"_framework/{$"dotnet.{BlazorWebAssemblySdkTasksTFM}.{FileHasher.GetFileHash(aotDotNetJs.ItemSpec)}.js"}");
+
+                        var version = asset.GetMetadata("NuGetPackageVersion");
+                        var hash = FileHasher.GetFileHash(aotDotNetJs.ItemSpec);
+                        newDotNetJs.SetMetadata("RelativePath", $"_framework/{$"dotnet.{version}.{hash}.js"}");
 
                         updateMap.Add(asset.ItemSpec, newDotNetJs);
                         Log.LogMessage("Replacing asset '{0}' with AoT version '{1}'", asset.ItemSpec, newDotNetJs.ItemSpec);
@@ -525,7 +528,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
             {
                 if (ComputeBlazorBuildAssets.ShouldFilterCandidate(candidate, TimeZoneSupport, InvariantGlobalization, CopySymbols, out var reason))
                 {
-                    Log.LogMessage("Skipping asset '{0}' becasue '{1}'", candidate.ItemSpec, reason);
+                    Log.LogMessage("Skipping asset '{0}' because '{1}'", candidate.ItemSpec, reason);
                     if (!resolvedFilesToPublishToRemove.ContainsKey(candidate.ItemSpec))
                     {
                         resolvedFilesToPublishToRemove.Add(candidate.ItemSpec, candidate);

--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
@@ -191,10 +191,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                     {
                         newDotNetJs = new TaskItem(Path.GetFullPath(aotDotNetJs.ItemSpec), asset.CloneCustomMetadata());
                         newDotNetJs.SetMetadata("OriginalItemSpec", aotDotNetJs.ItemSpec);
-
-                        var version = asset.GetMetadata("NuGetPackageVersion");
-                        var hash = FileHasher.GetFileHash(aotDotNetJs.ItemSpec);
-                        newDotNetJs.SetMetadata("RelativePath", $"_framework/{$"dotnet.{version}.{hash}.js"}");
+                        newDotNetJs.SetMetadata("RelativePath", $"_framework/{$"dotnet.{BlazorWebAssemblySdkTasksTFM}.{FileHasher.GetFileHash(aotDotNetJs.ItemSpec)}.js"}");
 
                         updateMap.Add(asset.ItemSpec, newDotNetJs);
                         Log.LogMessage("Replacing asset '{0}' with AoT version '{1}'", asset.ItemSpec, newDotNetJs.ItemSpec);
@@ -525,7 +522,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
             {
                 if (ComputeBlazorBuildAssets.ShouldFilterCandidate(candidate, TimeZoneSupport, InvariantGlobalization, CopySymbols, out var reason))
                 {
-                    Log.LogMessage("Skipping asset '{0}' because '{1}'", candidate.ItemSpec, reason);
+                    Log.LogMessage("Skipping asset '{0}' becasue '{1}'", candidate.ItemSpec, reason);
                     if (!resolvedFilesToPublishToRemove.ContainsKey(candidate.ItemSpec))
                     {
                         resolvedFilesToPublishToRemove.Add(candidate.ItemSpec, candidate);

--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
@@ -48,6 +48,9 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
         [Required]
         public string PublishPath { get; set; }
 
+        [Required]
+        public string DotNetJsVersion { get; set; }
+
         [Output]
         public ITaskItem[] NewCandidates { get; set; }
 
@@ -191,7 +194,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                     {
                         newDotNetJs = new TaskItem(Path.GetFullPath(aotDotNetJs.ItemSpec), asset.CloneCustomMetadata());
                         newDotNetJs.SetMetadata("OriginalItemSpec", aotDotNetJs.ItemSpec);
-                        newDotNetJs.SetMetadata("RelativePath", $"_framework/{$"dotnet.{BlazorWebAssemblySdkTasksTFM}.{FileHasher.GetFileHash(aotDotNetJs.ItemSpec)}.js"}");
+                        newDotNetJs.SetMetadata("RelativePath", $"_framework/{$"dotnet.{DotNetJsVersion}.{FileHasher.GetFileHash(aotDotNetJs.ItemSpec)}.js"}");
 
                         updateMap.Add(asset.ItemSpec, newDotNetJs);
                         Log.LogMessage("Replacing asset '{0}' with AoT version '{1}'", asset.ItemSpec, newDotNetJs.ItemSpec);
@@ -522,7 +525,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
             {
                 if (ComputeBlazorBuildAssets.ShouldFilterCandidate(candidate, TimeZoneSupport, InvariantGlobalization, CopySymbols, out var reason))
                 {
-                    Log.LogMessage("Skipping asset '{0}' becasue '{1}'", candidate.ItemSpec, reason);
+                    Log.LogMessage("Skipping asset '{0}' because '{1}'", candidate.ItemSpec, reason);
                     if (!resolvedFilesToPublishToRemove.ContainsKey(candidate.ItemSpec))
                     {
                         resolvedFilesToPublishToRemove.Add(candidate.ItemSpec, candidate);

--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorPublishAssets.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
         public string PublishPath { get; set; }
 
         [Required]
-        public string BundledNETCoreAppPackageVersion { get; set; }
+        public string BlazorWebAssemblySdkTasksTFM { get; set; }
 
         [Output]
         public ITaskItem[] NewCandidates { get; set; }
@@ -194,7 +194,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                     {
                         newDotNetJs = new TaskItem(Path.GetFullPath(aotDotNetJs.ItemSpec), asset.CloneCustomMetadata());
                         newDotNetJs.SetMetadata("OriginalItemSpec", aotDotNetJs.ItemSpec);
-                        newDotNetJs.SetMetadata("RelativePath", $"_framework/{$"dotnet.{BundledNETCoreAppPackageVersion}.{FileHasher.GetFileHash(aotDotNetJs.ItemSpec)}.js"}");
+                        newDotNetJs.SetMetadata("RelativePath", $"_framework/{$"dotnet.{BlazorWebAssemblySdkTasksTFM}.{FileHasher.GetFileHash(aotDotNetJs.ItemSpec)}.js"}");
 
                         updateMap.Add(asset.ItemSpec, newDotNetJs);
                         Log.LogMessage("Replacing asset '{0}' with AoT version '{1}'", asset.ItemSpec, newDotNetJs.ItemSpec);

--- a/src/RazorSdk/Tasks/StaticWebAssets/DefineStaticWebAssets.cs
+++ b/src/RazorSdk/Tasks/StaticWebAssets/DefineStaticWebAssets.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     if (filter != null && !filter.Match(relativePathCandidate).HasMatches)
                     {
                         Log.LogMessage(
-                            "Skipping '{0}' becasue the relative path '{1}' did not match the filter '{2}'.",
+                            "Skipping '{0}' because the relative path '{1}' did not match the filter '{2}'.",
                             candidate.ItemSpec,
                             relativePathCandidate,
                             RelativePathFilter);

--- a/src/RazorSdk/Tasks/StaticWebAssets/DefineStaticWebAssets.cs
+++ b/src/RazorSdk/Tasks/StaticWebAssets/DefineStaticWebAssets.cs
@@ -59,6 +59,8 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         public string CopyToPublishDirectory { get; set; } = StaticWebAsset.AssetCopyOptions.PreserveNewest;
 
+        public string NuGetPackageVersion { get; set; }
+
         [Output]
         public ITaskItem[] Assets { get; set; }
 
@@ -117,6 +119,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     var assetTraitValue = ComputePropertyValue(candidate, nameof(StaticWebAsset.AssetTraitValue), AssetTraitValue, !StaticWebAsset.AssetRoles.IsPrimary(assetRole));
                     var copyToOutputDirectory = ComputePropertyValue(candidate, nameof(StaticWebAsset.CopyToOutputDirectory), CopyToOutputDirectory);
                     var copyToPublishDirectory = ComputePropertyValue(candidate, nameof(StaticWebAsset.CopyToPublishDirectory), CopyToPublishDirectory);
+                    var nuGetPackageVersion = ComputePropertyValue(candidate, nameof(StaticWebAsset.NuGetPackageVersion), NuGetPackageVersion, isRequired: false);
                     var originalItemSpec = ComputePropertyValue(
                         candidate, 
                         nameof(StaticWebAsset.OriginalItemSpec),
@@ -155,7 +158,8 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                         assetTraitValue,
                         copyToOutputDirectory,
                         copyToPublishDirectory,
-                        originalItemSpec);
+                        originalItemSpec,
+                        nuGetPackageVersion);
 
                     var item = asset.ToTaskItem();
 

--- a/src/RazorSdk/Tasks/StaticWebAssets/DefineStaticWebAssets.cs
+++ b/src/RazorSdk/Tasks/StaticWebAssets/DefineStaticWebAssets.cs
@@ -59,8 +59,6 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         public string CopyToPublishDirectory { get; set; } = StaticWebAsset.AssetCopyOptions.PreserveNewest;
 
-        public string NuGetPackageVersion { get; set; }
-
         [Output]
         public ITaskItem[] Assets { get; set; }
 
@@ -119,7 +117,6 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     var assetTraitValue = ComputePropertyValue(candidate, nameof(StaticWebAsset.AssetTraitValue), AssetTraitValue, !StaticWebAsset.AssetRoles.IsPrimary(assetRole));
                     var copyToOutputDirectory = ComputePropertyValue(candidate, nameof(StaticWebAsset.CopyToOutputDirectory), CopyToOutputDirectory);
                     var copyToPublishDirectory = ComputePropertyValue(candidate, nameof(StaticWebAsset.CopyToPublishDirectory), CopyToPublishDirectory);
-                    var nuGetPackageVersion = ComputePropertyValue(candidate, nameof(StaticWebAsset.NuGetPackageVersion), NuGetPackageVersion, isRequired: false);
                     var originalItemSpec = ComputePropertyValue(
                         candidate, 
                         nameof(StaticWebAsset.OriginalItemSpec),
@@ -158,8 +155,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                         assetTraitValue,
                         copyToOutputDirectory,
                         copyToPublishDirectory,
-                        originalItemSpec,
-                        nuGetPackageVersion);
+                        originalItemSpec);
 
                     var item = asset.ToTaskItem();
 

--- a/src/RazorSdk/Tasks/StaticWebAssets/MergeConfigurationProperties.cs
+++ b/src/RazorSdk/Tasks/StaticWebAssets/MergeConfigurationProperties.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 }
                 else
                 {
-                    Log.LogMessage("Rejected project reference '{0}' for configuration item '{1}' becasue paths don't match.", configurationFullPath, projectReferenceFullPath);
+                    Log.LogMessage("Rejected project reference '{0}' for configuration item '{1}' because paths don't match.", configurationFullPath, projectReferenceFullPath);
                 }
             }
 

--- a/src/RazorSdk/Tasks/StaticWebAssets/StaticWebAsset.cs
+++ b/src/RazorSdk/Tasks/StaticWebAssets/StaticWebAsset.cs
@@ -43,6 +43,8 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         public string OriginalItemSpec { get; set; }
 
+        public string NuGetPackageVersion { get; set; }
+
         public static StaticWebAsset FromTaskItem(ITaskItem item)
         {
             var result = FromTaskItemCore(item);
@@ -170,6 +172,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 CopyToOutputDirectory = item.GetMetadata(nameof(CopyToOutputDirectory)),
                 CopyToPublishDirectory = item.GetMetadata(nameof(CopyToPublishDirectory)),
                 OriginalItemSpec = item.GetMetadata(nameof(OriginalItemSpec)),
+                NuGetPackageVersion = item.GetMetadata(nameof(NuGetPackageVersion)),
             };
 
         public void ApplyDefaults()
@@ -214,6 +217,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             result.SetMetadata(nameof(CopyToOutputDirectory), CopyToOutputDirectory);
             result.SetMetadata(nameof(CopyToPublishDirectory), CopyToPublishDirectory);
             result.SetMetadata(nameof(OriginalItemSpec), OriginalItemSpec);
+            result.SetMetadata(nameof(NuGetPackageVersion), NuGetPackageVersion);
             return result;
         }
 
@@ -253,7 +257,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             if (string.IsNullOrEmpty(OriginalItemSpec))
             {
                 throw new InvalidOperationException($"The '{nameof(OriginalItemSpec)}' for the asset must be defined for '{Identity}'.");
-            }            
+            }
 
             switch (AssetKind)
             {
@@ -311,7 +315,8 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             string assetTraitValue,
             string copyToOutputDirectory,
             string copyToPublishDirectory,
-            string originalItemSpec)
+            string originalItemSpec,
+            string nuGetPackageVersion)
         {
             var result = new StaticWebAsset
             {
@@ -329,7 +334,8 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 AssetTraitValue = assetTraitValue,
                 CopyToOutputDirectory = copyToOutputDirectory,
                 CopyToPublishDirectory = copyToPublishDirectory,
-                OriginalItemSpec = originalItemSpec
+                OriginalItemSpec = originalItemSpec,
+                NuGetPackageVersion = nuGetPackageVersion,
             };
 
             result.ApplyDefaults();
@@ -463,7 +469,8 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                    AssetTraitValue == asset.AssetTraitValue &&
                    CopyToOutputDirectory == asset.CopyToOutputDirectory &&
                    CopyToPublishDirectory == asset.CopyToPublishDirectory &&
-                   OriginalItemSpec == asset.OriginalItemSpec;
+                   OriginalItemSpec == asset.OriginalItemSpec &&
+                   NuGetPackageVersion == asset.NuGetPackageVersion;
         }
 
         public static class AssetModes
@@ -538,7 +545,8 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             $"AssetTraitValue: {AssetTraitValue}, " +
             $"CopyToOutputDirectory: {CopyToOutputDirectory}, " +
             $"CopyToPublishDirectory: {CopyToPublishDirectory}, " +
-            $"OriginalItemSpec: {OriginalItemSpec}";
+            $"OriginalItemSpec: {OriginalItemSpec}, " +
+            $"NuGetPackageVersion: {NuGetPackageVersion}";
 
         public override int GetHashCode()
         {
@@ -559,6 +567,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             hash.Add(CopyToOutputDirectory);
             hash.Add(CopyToPublishDirectory);
             hash.Add(OriginalItemSpec);
+            hash.Add(NuGetPackageVersion);
             return hash.ToHashCode();
 #else
             int hashCode = 1447485498;
@@ -577,6 +586,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CopyToOutputDirectory);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CopyToPublishDirectory);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(OriginalItemSpec);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(NuGetPackageVersion);
             return hashCode;
 #endif
         }

--- a/src/RazorSdk/Tasks/StaticWebAssets/StaticWebAsset.cs
+++ b/src/RazorSdk/Tasks/StaticWebAssets/StaticWebAsset.cs
@@ -43,8 +43,6 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         public string OriginalItemSpec { get; set; }
 
-        public string NuGetPackageVersion { get; set; }
-
         public static StaticWebAsset FromTaskItem(ITaskItem item)
         {
             var result = FromTaskItemCore(item);
@@ -172,7 +170,6 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 CopyToOutputDirectory = item.GetMetadata(nameof(CopyToOutputDirectory)),
                 CopyToPublishDirectory = item.GetMetadata(nameof(CopyToPublishDirectory)),
                 OriginalItemSpec = item.GetMetadata(nameof(OriginalItemSpec)),
-                NuGetPackageVersion = item.GetMetadata(nameof(NuGetPackageVersion)),
             };
 
         public void ApplyDefaults()
@@ -217,7 +214,6 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             result.SetMetadata(nameof(CopyToOutputDirectory), CopyToOutputDirectory);
             result.SetMetadata(nameof(CopyToPublishDirectory), CopyToPublishDirectory);
             result.SetMetadata(nameof(OriginalItemSpec), OriginalItemSpec);
-            result.SetMetadata(nameof(NuGetPackageVersion), NuGetPackageVersion);
             return result;
         }
 
@@ -257,7 +253,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             if (string.IsNullOrEmpty(OriginalItemSpec))
             {
                 throw new InvalidOperationException($"The '{nameof(OriginalItemSpec)}' for the asset must be defined for '{Identity}'.");
-            }
+            }            
 
             switch (AssetKind)
             {
@@ -315,8 +311,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             string assetTraitValue,
             string copyToOutputDirectory,
             string copyToPublishDirectory,
-            string originalItemSpec,
-            string nuGetPackageVersion)
+            string originalItemSpec)
         {
             var result = new StaticWebAsset
             {
@@ -334,8 +329,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 AssetTraitValue = assetTraitValue,
                 CopyToOutputDirectory = copyToOutputDirectory,
                 CopyToPublishDirectory = copyToPublishDirectory,
-                OriginalItemSpec = originalItemSpec,
-                NuGetPackageVersion = nuGetPackageVersion,
+                OriginalItemSpec = originalItemSpec
             };
 
             result.ApplyDefaults();
@@ -469,8 +463,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                    AssetTraitValue == asset.AssetTraitValue &&
                    CopyToOutputDirectory == asset.CopyToOutputDirectory &&
                    CopyToPublishDirectory == asset.CopyToPublishDirectory &&
-                   OriginalItemSpec == asset.OriginalItemSpec &&
-                   NuGetPackageVersion == asset.NuGetPackageVersion;
+                   OriginalItemSpec == asset.OriginalItemSpec;
         }
 
         public static class AssetModes
@@ -545,8 +538,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             $"AssetTraitValue: {AssetTraitValue}, " +
             $"CopyToOutputDirectory: {CopyToOutputDirectory}, " +
             $"CopyToPublishDirectory: {CopyToPublishDirectory}, " +
-            $"OriginalItemSpec: {OriginalItemSpec}, " +
-            $"NuGetPackageVersion: {NuGetPackageVersion}";
+            $"OriginalItemSpec: {OriginalItemSpec}";
 
         public override int GetHashCode()
         {
@@ -567,7 +559,6 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             hash.Add(CopyToOutputDirectory);
             hash.Add(CopyToPublishDirectory);
             hash.Add(OriginalItemSpec);
-            hash.Add(NuGetPackageVersion);
             return hash.ToHashCode();
 #else
             int hashCode = 1447485498;
@@ -586,7 +577,6 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CopyToOutputDirectory);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CopyToPublishDirectory);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(OriginalItemSpec);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(NuGetPackageVersion);
             return hashCode;
 #endif
         }

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
@@ -228,7 +228,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var numFilesUpdated = 0;
             foreach (var f in manifest.Assets)
             {
-                if (Regex.Match(f.Identity, DotNet5JSRegexPattern).Success)
+                if (Regex.Match(f.RelativePath, DotNet5JSRegexPattern).Success)
                 {
                     f.Identity = Regex.Replace(f.Identity, DotNet5JSRegexPattern, DotNet5JSTemplate);
                     f.RelativePath = Regex.Replace(f.RelativePath, DotNet5JSRegexPattern, DotNet5JSTemplate);

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Razor.Tasks;
 using Microsoft.NET.TestFramework.Assertions;
@@ -17,8 +18,12 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
     public class BlazorWasmStaticWebAssetsIntegrationTest : BlazorWasmBaselineTests
     {
+        private static readonly string DotNet5JSRegexPattern = "dotnet\\.5\\.[0-9]+\\.[0-9]+\\.js";
+        private readonly string DotNet5JSTemplate;
+
         public BlazorWasmStaticWebAssetsIntegrationTest(ITestOutputHelper log) : base(log, GenerateBaselines)
         {
+            DotNet5JSTemplate = $"dotnet.{RuntimeVersion}.js";
         }
 
         [Fact]
@@ -215,6 +220,25 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var path = Path.Combine(intermediateOutputPath, "staticwebassets.build.json");
             new FileInfo(path).Should().Exist();
             var manifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(path));
+
+            // We have to special case this test given we are forcing `blazorwasm` to be a `net5` project above.
+            // Given this, the `dotnet.*.js` file produced will be a dotnet.5.*.*.js file in line with the TFM and not the SDK (which is .NET 6 or beyond).
+            // This conflicts with our assumptions throughout the rest of the test suite that the SDK version matches the TFM.
+            // To minimize special casing throughout the entire test suite, we just update this particular test's assets to reflect the SDK version.
+            var numFilesUpdated = 0;
+            foreach (var f in manifest.Assets)
+            {
+                if (Regex.Match(f.Identity, DotNet5JSRegexPattern).Success)
+                {
+                    f.Identity = Regex.Replace(f.Identity, DotNet5JSRegexPattern, DotNet5JSTemplate);
+                    f.RelativePath = Regex.Replace(f.RelativePath, DotNet5JSRegexPattern, DotNet5JSTemplate);
+                    f.OriginalItemSpec = Regex.Replace(f.OriginalItemSpec, DotNet5JSRegexPattern, DotNet5JSTemplate);
+
+                    numFilesUpdated++;
+                }
+            }
+            Assert.Equal(2, numFilesUpdated);
+
             AssertManifest(manifest, LoadBuildManifest());
 
             // GenerateStaticWebAssetsManifest should copy the file to the output folder.
@@ -268,6 +292,24 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var path = Path.Combine(intermediateOutputPath, "staticwebassets.publish.json");
             new FileInfo(path).Should().Exist();
             var manifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(path));
+
+            // We have to special case this test given we are forcing `blazorwasm` to be a `net5` project above.
+            // Given this, the `dotnet.*.js` file produced will be a dotnet.5.*.*.js file in line with the TFM and not the SDK (which is .NET 6 or beyond).
+            // This conflicts with our assumptions throughout the rest of the test suite that the SDK version matches the TFM.
+            // To minimize special casing throughout the entire test suite, we just update this particular test's assets to reflect the SDK version.
+            var numFilesUpdated = 0;
+            var frameworkFolder = Path.Combine(publishPath, "wwwroot", "_framework");
+            var frameworkFolderFiles = Directory.GetFiles(frameworkFolder, "*", new EnumerationOptions { RecurseSubdirectories = false });
+            foreach (var f in frameworkFolderFiles)
+            {
+                if (Regex.Match(f, DotNet5JSRegexPattern).Success)
+                {
+                    File.Move(f, Regex.Replace(f, DotNet5JSRegexPattern, DotNet5JSTemplate));
+                    numFilesUpdated++;
+                }
+            }
+            Assert.Equal(3, numFilesUpdated);
+
             AssertManifest(manifest, LoadPublishManifest());
 
             AssertPublishAssets(


### PR DESCRIPTION
## Description / Customer Impact

Users running a .NET 6.0 SDK with a .NET 5.0 TFM would get a `dotnet.{VERSION}.js` file annotated with the SDK version rather than the TFM/package versions. However the contents of the file would reflect the TFM/package versions and _NOT_ the SDK. To prevent confusion this'll cause, this PR ensures the VERSION used for the `dotnet.js` file matches the `NuGetPackageVersion` rather than the SDK. 

Ex. Say you run a 6.0 SDK against a 5.0 TFM, you'll see `dotnet.6.0.0-preview-xyz.js` file in the build/publish outputs, which may lead you to believe you're running a 6.0 app. However, it is still a 5.0 app with 5.0 content/packages.

<details>
<summary>Another example</summary>

> If you use the .NET 5 SDK to create a Blazor WebAssembly application, at runtime it will load a JS file called `dotnet.5.0.10.js`.
>
> If you then install the .NET 6 SDK (and assuming there's no `global.json` pinning you to the older SDK), then when you next build and run the application, the same JS file will now be called `dotnet.6.0.0-rtm.21478.11.js` or similar. That is,
>
> * The *name* of the file reflects the SDK you built your app with, regardless of the TFM or package versions you're referencing. So in this case it looks like it's a 6.0.x file.
> * The *contents* of the file match up with the TFM/package versions you're using, i.e., it's actually a 5.0.x file.

</details>

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

When `MonoPlatform` actually finds & utilizes this file, it [globs based on the prefix `dotnet.` and suffix `.js`](https://github.com/dotnet/aspnetcore/blob/d02192f634038ff944d461dbddff28db80683ad4/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts#L176-L182), hence the version / hash do not impact functionality.

## Verification
- [x] Manual (required)
- [ ] Automated

<details>
<summary>Manual Validation Details</summary>

### net5.0 TFM with 6.0 SDK

Build:
![image](https://user-images.githubusercontent.com/14852843/136624795-14e26895-9c4d-4968-a0b7-e1355e1fb63f.png)

Publish:
![image](https://user-images.githubusercontent.com/14852843/136624721-fcd83d7c-0795-4271-a055-61918d261571.png)

---

### net6.0 TFM with 6.0 SDK

Build:
![image](https://user-images.githubusercontent.com/14852843/136636827-a608274e-33ad-411b-b872-2314b88f1e60.png)

Publish:
![image](https://user-images.githubusercontent.com/14852843/136636846-ffae088d-dd49-4701-9d57-8cb26ce31b4a.png)

</details>

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Fixes: https://github.com/dotnet/aspnetcore/issues/37256

