### PR TITLE
Enable signing of tools host on mac (#21894)

### DIFF
--- a/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
+++ b/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
@@ -61,7 +61,8 @@ namespace Microsoft.DotNet.ShellShim
                                          appHostDestinationFilePath: appHostDestinationFilePath,
                                          appBinaryFilePath: appBinaryFilePath,
                                          windowsGraphicalUserInterface: false,
-                                         assemblyToCopyResorcesFrom: null);
+                                         assemblyToCopyResorcesFrom: null,
+                                         enableMacOSCodeSign: OperatingSystem.IsMacOS());
             }
 
             _filePermissionSetter.SetUserExecutionPermission(appHostDestinationFilePath);


### PR DESCRIPTION
## Description
Mac currently enforces signing requirements on new hardware so when creating the apphost during dotnet tool installation, we need to sign that apphost.  The runtime added that functionality but the sdk was never opted into that behavior.

## Regression?
No

## Risk
Low

## Verification
[X] Manual (required)
[] Automated