### PR TITLE
[Release/6.0.1xx] Build Microsoft.DotNet.Compatilibity in source-build

### DIFF
--- a/source-build.slnf
+++ b/source-build.slnf
@@ -4,8 +4,8 @@
     "projects": [
       "src\\BlazorWasmSdk\\Tasks\\Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.csproj",
       "src\\BlazorWasmSdk\\Tool\\Microsoft.NET.Sdk.BlazorWebAssembly.Tool.csproj",
-      "src\\BuiltInTools\\DotNetDeltaApplier\\Microsoft.Extensions.DotNetDeltaApplier.csproj",
       "src\\BuiltInTools\\BrowserRefresh\\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj",
+      "src\\BuiltInTools\\DotNetDeltaApplier\\Microsoft.Extensions.DotNetDeltaApplier.csproj",
       "src\\BuiltInTools\\DotNetWatchTasks\\DotNetWatchTasks.csproj",
       "src\\BuiltInTools\\dotnet-watch\\dotnet-watch.csproj",
       "src\\Cli\\Microsoft.DotNet.Cli.Sln.Internal\\Microsoft.DotNet.Cli.Sln.Internal.csproj",
@@ -14,6 +14,8 @@
       "src\\Cli\\Microsoft.DotNet.InternalAbstractions\\Microsoft.DotNet.InternalAbstractions.csproj",
       "src\\Cli\\dotnet\\dotnet.csproj",
       "src\\Compatibility\\Microsoft.DotNet.ApiCompatibility\\Microsoft.DotNet.ApiCompatibility.csproj",
+      "src\\Compatibility\\Microsoft.DotNet.Compatibility\\Microsoft.DotNet.Compatibility.csproj",
+      "src\\Compatibility\\Microsoft.DotNet.PackageValidation\\Microsoft.DotNet.PackageValidation.csproj",
       "src\\Layout\\redist\\redist.csproj",
       "src\\Layout\\tool_fsharp\\tool_fsc.csproj",
       "src\\Layout\\tool_msbuild\\tool_msbuild.csproj",


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2498.

This is needed in order to eliminate prebuilts - the runtime repo is consuming this package.