### PR TITLE
Fix ConcatenateCssFiles when used with Razor class libraries

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.ScopedCss.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.ScopedCss.targets
@@ -334,7 +334,6 @@ Integration with static web assets:
   <!-- Incrementalism is built into the task itself. -->
   <ItemGroup>
     <_CurrentProjectDiscoveredScopedCssFiles Include="@(_DiscoveredScopedCssFiles)" />
-    <_EmptyProjectBundlesList />
   </ItemGroup>
 
   <!-- This is the bundle for the app, we will always generate it when there are scoped css files for the current project or
@@ -354,7 +353,7 @@ Integration with static web assets:
   <ConcatenateCssFiles
     Condition="'@(_ScopedCss)' != ''"
     ScopedCssFiles="@(_CurrentProjectDiscoveredScopedCssFiles)"
-    ProjectBundles="@(_EmptyProjectBundlesList)"
+    ProjectBundles=""
     ScopedCssBundleBasePath="$(_ScopedCssBundleBasePath)"
     OutputFile="$(_ScopedCssProjectOutputPath)" />
 

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.ScopedCss.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.ScopedCss.targets
@@ -334,6 +334,7 @@ Integration with static web assets:
   <!-- Incrementalism is built into the task itself. -->
   <ItemGroup>
     <_CurrentProjectDiscoveredScopedCssFiles Include="@(_DiscoveredScopedCssFiles)" />
+    <_EmptyProjectBundlesList />
   </ItemGroup>
 
   <!-- This is the bundle for the app, we will always generate it when there are scoped css files for the current project or
@@ -353,7 +354,7 @@ Integration with static web assets:
   <ConcatenateCssFiles
     Condition="'@(_ScopedCss)' != ''"
     ScopedCssFiles="@(_CurrentProjectDiscoveredScopedCssFiles)"
-    ProjectBundles="@()"
+    ProjectBundles="@(_EmptyProjectBundlesList)"
     ScopedCssBundleBasePath="$(_ScopedCssBundleBasePath)"
     OutputFile="$(_ScopedCssProjectOutputPath)" />
 


### PR DESCRIPTION
Previously we were passing the hardcoded value `@()` which does *not* supply an empty array. It supplies what seems to be an array with one entry, whose values are all defaults:

![image](https://user-images.githubusercontent.com/1101362/137005149-51419078-3bd9-4eb6-9b1d-83916eb684de.png)

This was leading to a bug in the `ConcatenateCssFiles.cs` task, making it think it needed to emit an `@import` even though there was no data to go into it. The result was the following CSS file:

```css
@import '';

/* real content here */
```

Then, this strange import directive caused the browser's CSS object model to contain an invalid entry, which in turn caused browserlink to throw a nullref-type error:

![image](https://user-images.githubusercontent.com/1101362/137005270-9286baf7-7d17-4121-af5e-5fe51b30bebf.png)

### The fix

I don't know if there's meant to be some real syntax for an empty array literal in MSBuild, but defining an empty itemgroup does the right thing.

cc @javiercn 


----

# Shiproom template

Fixes SDK bug that ultimately led to errors in the browser console when browserlink is enabled (which it now is by default because of hot reload).

Addresses https://github.com/dotnet/aspnetcore/issues/37492

## Description

Because of a typo-level bug in our targets, we were generating some invalid CSS import declarations like `@import '';`. These were ignored by the browser, so we didn't notice this in 5.0. However in 6.0 we have browserlink on by default in VS because of sourcelink, and browserlink doesn't tolerate the malformed imports and throws.

## Customer Impact

Without this, every Razor Class Library will cause JS console errors by default when the project is launched from VS.

## Regression?

- [x] Yes
- [ ] No

Regression since 5.0, because in 5.0 we didn't have browserlink on by default.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Spectacularly low-risk, since this is just changing a typo for not-a-typo. It was *always* wrong before, and now it's not wrong.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A