### PR TITLE
Update handling of SelfContained and RuntimeIdentifier properties when specified on the command line

### DIFF
--- a/documentation/general/SelfContainedBreakingChangeNotification.md
+++ b/documentation/general/SelfContainedBreakingChangeNotification.md
@@ -1,0 +1,53 @@
+# [Breaking change]: Handling of command-line RuntimeIdentifier and SelfContained properties across project references
+
+## Description
+
+The `RuntimeIdentifier` and `SelfContained` properties can be specified on the command line to commands such as `dotnet build` and `dotnet publish`.
+They can be specified either via parameters such as `-r` or `--self-contained`, or via the generic `-p:Key=Value` parameter, such as `-p:SelfContained=true`.
+
+If these properties are specified on the command line, we've updated how they are applied (or not applied) to projects referenced by the initial project that is being built.
+
+## Version
+
+???
+
+## Previous behavior
+
+If `SelfContained` was specified on the command line, it would always flow to referenced projects.
+
+`RuntimeIdentifier` would flow to referenced projects where either the `RuntimeIdentifier` or `RuntimeIdentifiers` properties were non-empty.
+
+## New Behavior
+
+Both `SelfContained` and `RuntimeIdentifier` will flow a referenced project if any of the following are true for the referenced project:
+
+- The `AcceptsRuntimeIdentifier` property is set to `true`
+- The `OutputType` is `Exe` or `WinExe`
+- Either the `RuntimeIdentifer` or `RuntimeIdentifiers` property is non-empty
+
+## Type of breaking change
+
+Source incompatible
+
+## Reason for change
+
+As of .NET SDK 6.0.100, we recommend specifying the value for self-contained on the command line if you specify the RuntimeIdentifier.
+(This is because in the future we are considering [changing the logic](https://github.com/dotnet/designs/blob/main/accepted/2021/architecture-targeting.md)
+so that specifying the RuntimeIdentifier on the command line doesn't automatically set the app to self-contained.)  We also added a warning message
+to guide you to do so.
+
+However, if you followed the warning and switched to a command specifying both the RuntimeIdentifier and the value for self-contained (for example
+`dotnet build -r win-x64 --self-contained`), the command could fail if you referenced an Exe project, because the `RuntimeIdentifier` you specified
+would not apply to the referenced project, but the `SelfContained` value would, and it's an error for an Exe project to have `SelfContained` set to
+true without having a `RuntimeIdentifier` set.
+
+## Recommended action
+
+If you were relying on the `SelfContained` property to apply to all projects when it was specified on the command line, then you can get similar behavior
+by setting `AcceptsRuntimeIdentifier` to true (either in a file [such as Directory.Build.props](https://docs.microsoft.com/visualstudio/msbuild/customize-your-build#directorybuildprops-and-directorybuildtargets)),
+or as a command-line parameter such as `-p:AcceptsRuntimeIdentifier=true`.
+
+## Open Questions
+
+TODO: How does this apply to solutions?  Could a solution build set AcceptsRuntimeIdentifier for all projects, and would that fix other issues we have when specifying the RuntimeIdentifier for a solution build?
+TODO: What happens if there's an Exe1 -> Library -> Exe2 reference, especially if there's also a direct reference from Exe1 -> Exe2

--- a/documentation/general/SelfContainedBreakingChangeNotification.md
+++ b/documentation/general/SelfContainedBreakingChangeNotification.md
@@ -19,7 +19,7 @@ If `SelfContained` was specified on the command line, it would always flow to re
 
 ## New Behavior
 
-Both `SelfContained` and `RuntimeIdentifier` will flow a referenced project if any of the following are true for the referenced project:
+Both `SelfContained` and `RuntimeIdentifier` will flow to a referenced project if any of the following are true for the referenced project:
 
 - The `IsRidAgnostic` property is set to `false`
 - The `OutputType` is `Exe` or `WinExe`

--- a/documentation/general/SelfContainedBreakingChangeNotification.md
+++ b/documentation/general/SelfContainedBreakingChangeNotification.md
@@ -21,7 +21,7 @@ If `SelfContained` was specified on the command line, it would always flow to re
 
 Both `SelfContained` and `RuntimeIdentifier` will flow a referenced project if any of the following are true for the referenced project:
 
-- The `AcceptsRuntimeIdentifier` property is set to `true`
+- The `IsRidAgnostic` property is set to `false`
 - The `OutputType` is `Exe` or `WinExe`
 - Either the `RuntimeIdentifer` or `RuntimeIdentifiers` property is non-empty
 
@@ -44,10 +44,10 @@ true without having a `RuntimeIdentifier` set.
 ## Recommended action
 
 If you were relying on the `SelfContained` property to apply to all projects when it was specified on the command line, then you can get similar behavior
-by setting `AcceptsRuntimeIdentifier` to true (either in a file [such as Directory.Build.props](https://docs.microsoft.com/visualstudio/msbuild/customize-your-build#directorybuildprops-and-directorybuildtargets)),
-or as a command-line parameter such as `-p:AcceptsRuntimeIdentifier=true`.
+by setting `IsRidAgnostic` to false either in a file ([such as Directory.Build.props](https://docs.microsoft.com/visualstudio/msbuild/customize-your-build#directorybuildprops-and-directorybuildtargets)),
+or as a command-line parameter such as `-p:IsRidAgnostic=false`.
 
 ## Open Questions
 
-TODO: How does this apply to solutions?  Could a solution build set AcceptsRuntimeIdentifier for all projects, and would that fix other issues we have when specifying the RuntimeIdentifier for a solution build?
+TODO: How does this apply to solutions?  Could a solution build set IsRidAgnostic to false for all projects, and would that fix other issues we have when specifying the RuntimeIdentifier for a solution build?
 TODO: What happens if there's an Exe1 -> Library -> Exe2 reference, especially if there's also a direct reference from Exe1 -> Exe2

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -14,6 +14,8 @@ namespace Microsoft.NET.Build.Tasks
     {
         public bool SelfContained { get; set; }
 
+        public bool SelfContainedIsGlobalProperty { get; set; }
+
         public bool IsExecutable { get; set; }
 
         public ITaskItem[] ReferencedProjects { get; set; } = Array.Empty<ITaskItem>();
@@ -52,6 +54,14 @@ namespace Microsoft.NET.Build.Tasks
                 bool shouldBeValidatedAsExecutableReference = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["ShouldBeValidatedAsExecutableReference"], true);
                 bool referencedProjectIsExecutable = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["_IsExecutable"]);
                 bool referencedProjectIsSelfContained = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["SelfContained"]);
+
+                if (SelfContainedIsGlobalProperty && project.GetBooleanMetadata("AcceptsRuntimeIdentifier") == true)
+                {
+                    //  If AcceptsRuntimeIdentifier is true for the project, and SelfContained was set as a global property,
+                    //  then the SelfContained value will flow across the project reference when we go to build it, despite the
+                    //  fact that we ignored it when doing the GetTargetFrameworks negotiation.
+                    referencedProjectIsSelfContained = SelfContained;
+                }
 
                 if (referencedProjectIsExecutable && shouldBeValidatedAsExecutableReference)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -55,16 +55,16 @@ namespace Microsoft.NET.Build.Tasks
 
                 bool selfContainedIsGlobalProperty = BuildEngine6.GetGlobalProperties().ContainsKey("SelfContained");
 
-                bool projectAcceptsRuntimeIdentifier = false;
-                if (projectAdditionalProperties.TryGetValue("AcceptsRuntimeIdentifier", out string acceptsRID) &&
-                    bool.TryParse(acceptsRID, out bool acceptsRIDParseResult))
+                bool projectIsRidAgnostic = true;
+                if (projectAdditionalProperties.TryGetValue("IsRidAgnostic", out string isRidAgnostic) &&
+                    bool.TryParse(isRidAgnostic, out bool isRidAgnosticParseResult))
                 {
-                    projectAcceptsRuntimeIdentifier = acceptsRIDParseResult;
+                    projectIsRidAgnostic = isRidAgnosticParseResult;
                 }
 
-                if (selfContainedIsGlobalProperty && projectAcceptsRuntimeIdentifier)
+                if (selfContainedIsGlobalProperty && !projectIsRidAgnostic)
                 {
-                    //  If AcceptsRuntimeIdentifier is true for the project, and SelfContained was set as a global property,
+                    //  If a project is NOT RID agnostic, and SelfContained was set as a global property,
                     //  then the SelfContained value will flow across the project reference when we go to build it, despite the
                     //  fact that we ignored it when doing the GetTargetFrameworks negotiation.
                     referencedProjectIsSelfContained = SelfContained;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -55,7 +55,14 @@ namespace Microsoft.NET.Build.Tasks
 
                 bool selfContainedIsGlobalProperty = BuildEngine6.GetGlobalProperties().ContainsKey("SelfContained");
 
-                if (selfContainedIsGlobalProperty && project.GetBooleanMetadata("AcceptsRuntimeIdentifier") == true)
+                bool projectAcceptsRuntimeIdentifier = false;
+                if (projectAdditionalProperties.TryGetValue("AcceptsRuntimeIdentifier", out string acceptsRID) &&
+                    bool.TryParse(acceptsRID, out bool acceptsRIDParseResult))
+                {
+                    projectAcceptsRuntimeIdentifier = acceptsRIDParseResult;
+                }
+
+                if (selfContainedIsGlobalProperty && projectAcceptsRuntimeIdentifier)
                 {
                     //  If AcceptsRuntimeIdentifier is true for the project, and SelfContained was set as a global property,
                     //  then the SelfContained value will flow across the project reference when we go to build it, despite the

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -14,8 +14,6 @@ namespace Microsoft.NET.Build.Tasks
     {
         public bool SelfContained { get; set; }
 
-        public bool SelfContainedIsGlobalProperty { get; set; }
-
         public bool IsExecutable { get; set; }
 
         public ITaskItem[] ReferencedProjects { get; set; } = Array.Empty<ITaskItem>();
@@ -55,7 +53,9 @@ namespace Microsoft.NET.Build.Tasks
                 bool referencedProjectIsExecutable = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["_IsExecutable"]);
                 bool referencedProjectIsSelfContained = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["SelfContained"]);
 
-                if (SelfContainedIsGlobalProperty && project.GetBooleanMetadata("AcceptsRuntimeIdentifier") == true)
+                bool selfContainedIsGlobalProperty = BuildEngine6.GetGlobalProperties().ContainsKey("SelfContained");
+
+                if (selfContainedIsGlobalProperty && project.GetBooleanMetadata("AcceptsRuntimeIdentifier") == true)
                 {
                     //  If AcceptsRuntimeIdentifier is true for the project, and SelfContained was set as a global property,
                     //  then the SelfContained value will flow across the project reference when we go to build it, despite the

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -22,6 +22,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
+
+  </PropertyGroup>
+  
+  <!-- Set the AcceptsRuntimeIdentifier property if this project should accept global RuntimeIdentifier and SelfContained
+       property values from referencing projects. -->
+  <PropertyGroup Condition="'$(AcceptsRuntimeIdentifier)' == ''">
+    <AcceptsRuntimeIdentifier Condition="'$(_IsExecutable)' == 'true' Or
+                                         '$(RuntimeIdentifier)' != '' Or
+                                         '$(RuntimeIdentifiers)' != ''">true</AcceptsRuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(HasRuntimeOutput)' == ''">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -25,14 +25,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </PropertyGroup>
   
-  <!-- Set the AcceptsRuntimeIdentifier property if this project should accept global RuntimeIdentifier and SelfContained
-       property values from referencing projects. -->
-  <PropertyGroup Condition="'$(AcceptsRuntimeIdentifier)' == ''">
-    <AcceptsRuntimeIdentifier Condition="'$(_IsExecutable)' == 'true' Or
-                                         '$(RuntimeIdentifier)' != '' Or
-                                         '$(RuntimeIdentifiers)' != ''">true</AcceptsRuntimeIdentifier>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(HasRuntimeOutput)' == ''">
     <HasRuntimeOutput>$(_IsExecutable)</HasRuntimeOutput>
     <_UsingDefaultForHasRuntimeOutput>true</_UsingDefaultForHasRuntimeOutput>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1096,12 +1096,25 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_UseAttributeForTargetFrameworkInfoPropertyNames Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), '17.0'))">true</_UseAttributeForTargetFrameworkInfoPropertyNames>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Check if SelfContained is specified as a global property, by trying to change its value and seeing if that's successful.
+         We need to know if it's a global property because if it is, then it will flow to referenced projects that had
+         AcceptsRuntimeIdentifier set to true, possibly overriding the value for SelfContained that we got back from
+         the GetTargetFrameworks negotiation. -->
+    <_SelfContainedBackupValue>$(SelfContained)</_SelfContainedBackupValue>
+    <SelfContained>NotAValue</SelfContained>
+    <_SelfContainedIsGlobalProperty Condition="'$(SelfContained)' == '$(_SelfContainedBackupValue)'">true</_SelfContainedIsGlobalProperty>
+    <SelfContained>$(_SelfContainedBackupValue)</SelfContained>
+    <_SelfContainedBackupValue></_SelfContainedBackupValue>
+  </PropertyGroup>
+  
   <Target Name="ValidateExecutableReferences"
           AfterTargets="_GetProjectReferenceTargetFrameworkProperties"
           Condition="'$(ValidateExecutableReferencesMatchSelfContained)' != 'false'">
 
     <ValidateExecutableReferences
       SelfContained="$(SelfContained)"
+      SelfContainedIsGlobalProperty="$(_SelfContainedIsGlobalProperty)"
       IsExecutable="$(_IsExecutable)"
       ReferencedProjects="@(_MSBuildProjectReferenceExistent)"
       UseAttributeForTargetFrameworkInfoPropertyNames="$(_UseAttributeForTargetFrameworkInfoPropertyNames)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -79,12 +79,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PredefinedCulturesOnly Condition="'$(PredefinedCulturesOnly)' == '' and '$(InvariantGlobalization)' == 'true'">true</PredefinedCulturesOnly>
   </PropertyGroup>
 
-  <!-- Set the AcceptsRuntimeIdentifier property if this project should accept global RuntimeIdentifier and SelfContained
+  <!-- Set the IsRidAgnostic property if this project should NOT accept global RuntimeIdentifier and SelfContained
        property values from referencing projects. -->
-  <PropertyGroup Condition="'$(AcceptsRuntimeIdentifier)' == '' And '$(IsTestProject)' != 'true'">
-    <AcceptsRuntimeIdentifier Condition="'$(_IsExecutable)' == 'true' Or
-                                         '$(RuntimeIdentifier)' != '' Or
-                                         '$(RuntimeIdentifiers)' != ''">true</AcceptsRuntimeIdentifier>
+  <PropertyGroup Condition="'$(IsRidAgnostic)' == ''">
+    <IsRidAgnostic Condition="('$(_IsExecutable)' == 'true' And '$(IsTestProject)' != 'true') Or
+                              '$(RuntimeIdentifier)' != '' Or
+                              '$(RuntimeIdentifiers)' != ''">false</IsRidAgnostic>
+    <IsRidAgnostic Condition="'$(IsRidAgnostic)' == ''">true</IsRidAgnostic>
   </PropertyGroup>
 
   <!-- Opt into .NET Core resource-serialization strategy by default when targeting frameworks
@@ -1077,6 +1078,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup>
     <AdditionalTargetFrameworkInfoProperty Include="SelfContained"/>
     <AdditionalTargetFrameworkInfoProperty Include="_IsExecutable"/>
+    <AdditionalTargetFrameworkInfoProperty Include="IsRidAgnostic"/>
     <AdditionalTargetFrameworkInfoProperty Include="ShouldBeValidatedAsExecutableReference"/>
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1104,25 +1104,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_UseAttributeForTargetFrameworkInfoPropertyNames Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), '17.0'))">true</_UseAttributeForTargetFrameworkInfoPropertyNames>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Check if SelfContained is specified as a global property, by trying to change its value and seeing if that's successful.
-         We need to know if it's a global property because if it is, then it will flow to referenced projects that had
-         AcceptsRuntimeIdentifier set to true, possibly overriding the value for SelfContained that we got back from
-         the GetTargetFrameworks negotiation. -->
-    <_SelfContainedBackupValue>$(SelfContained)</_SelfContainedBackupValue>
-    <SelfContained>NotAValue</SelfContained>
-    <_SelfContainedIsGlobalProperty Condition="'$(SelfContained)' == '$(_SelfContainedBackupValue)'">true</_SelfContainedIsGlobalProperty>
-    <SelfContained>$(_SelfContainedBackupValue)</SelfContained>
-    <_SelfContainedBackupValue></_SelfContainedBackupValue>
-  </PropertyGroup>
-  
   <Target Name="ValidateExecutableReferences"
           AfterTargets="_GetProjectReferenceTargetFrameworkProperties"
           Condition="'$(ValidateExecutableReferencesMatchSelfContained)' != 'false'">
 
     <ValidateExecutableReferences
       SelfContained="$(SelfContained)"
-      SelfContainedIsGlobalProperty="$(_SelfContainedIsGlobalProperty)"
       IsExecutable="$(_IsExecutable)"
       ReferencedProjects="@(_MSBuildProjectReferenceExistent)"
       UseAttributeForTargetFrameworkInfoPropertyNames="$(_UseAttributeForTargetFrameworkInfoPropertyNames)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -79,6 +79,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PredefinedCulturesOnly Condition="'$(PredefinedCulturesOnly)' == '' and '$(InvariantGlobalization)' == 'true'">true</PredefinedCulturesOnly>
   </PropertyGroup>
 
+  <!-- Set the AcceptsRuntimeIdentifier property if this project should accept global RuntimeIdentifier and SelfContained
+       property values from referencing projects. -->
+  <PropertyGroup Condition="'$(AcceptsRuntimeIdentifier)' == '' And '$(IsTestProject)' != 'true'">
+    <AcceptsRuntimeIdentifier Condition="'$(_IsExecutable)' == 'true' Or
+                                         '$(RuntimeIdentifier)' != '' Or
+                                         '$(RuntimeIdentifiers)' != ''">true</AcceptsRuntimeIdentifier>
+  </PropertyGroup>
+
   <!-- Opt into .NET Core resource-serialization strategy by default when targeting frameworks
        that support it by default.
        -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1080,8 +1080,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <AdditionalTargetFrameworkInfoProperty Include="_IsExecutable"/>
     <AdditionalTargetFrameworkInfoProperty Include="IsRidAgnostic"/>
     <AdditionalTargetFrameworkInfoProperty Include="ShouldBeValidatedAsExecutableReference"/>
+    <AdditionalTargetFrameworkInfoProperty Include="_SelfContainedWasSpecified"/>
   </ItemGroup>
-
+  
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
     <!-- Don't generate a NETSDK1151 error if a non self-contained Exe references a Blazor wasm Exe -->
     <ShouldBeValidatedAsExecutableReference>false</ShouldBeValidatedAsExecutableReference>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -488,8 +488,8 @@ namespace Microsoft.NET.Build.Tests
                 testProj.AdditionalProperties["TargetPlatformIdentifier"] = targetPlatformIdentifier;
                 testProj.AdditionalProperties["TargetPlatformVersion"] = targetPlatformVersion;
             }
-            var testAsset = _testAssetsManager.CreateTestProject(testProj, targetFramework);
-            File.WriteAllText(Path.Combine(testAsset.Path, testProj.Name, $"{testProj.Name}.cs"), @"
+
+            testProj.SourceFiles[$"{testProj.Name}.cs"] = @"
 using System;
 class Program
 {
@@ -529,7 +529,8 @@ class Program
             Console.WriteLine(""IOS"");
         #endif
     }
-}");
+}";
+            var testAsset = _testAssetsManager.CreateTestProject(testProj, targetFramework);
 
             var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.Path, testProj.Name));
             buildCommand

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -392,6 +392,7 @@ namespace Microsoft.NET.Build.Tests
                     XElement itemGroup = new XElement(ns + "ItemGroup");
                     project.Root.Add(itemGroup);
                     itemGroup.Add(new XElement(ns + "Compile", new XAttribute("Include", testProject.Name + ".cs")));
+                    itemGroup.Add(new XElement(ns + "Compile", new XAttribute("Include", testProject.Name + "Program.cs")));
                 });
 
             var projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);
@@ -409,7 +410,7 @@ namespace Microsoft.NET.Build.Tests
 
             var compileItems = getCompileItemsCommand.GetValues();
             RemoveGeneratedCompileItems(compileItems);
-            compileItems.ShouldBeEquivalentTo(new[] { testProject.Name + ".cs" });
+            compileItems.ShouldBeEquivalentTo(new[] { testProject.Name + ".cs", testProject.Name + "Program.cs" });
 
             // Validate None items.
             var getNoneItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "None", GetValuesCommand.ValueType.Item);

--- a/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Build.Tests
             return arguments;
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("17.4.0.41702")]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
@@ -90,7 +90,7 @@ namespace Microsoft.NET.Build.Tests
             ValidateProperties(testAsset, _referencedProject, expectSelfContained: false, expectRuntimeIdentifier: false);
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("17.4.0.41702")]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
@@ -108,7 +108,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("17.4.0.41702")]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
@@ -145,7 +145,7 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("17.4.0.41702")]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
@@ -166,7 +166,7 @@ namespace Microsoft.NET.Build.Tests
                 expectedRuntimeIdentifier: buildingSelfContained ? "" : _referencedProject.RuntimeIdentifier);
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("17.4.0.41702")]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
@@ -196,7 +196,7 @@ namespace Microsoft.NET.Build.Tests
                 targetFramework: "net7.0");
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("17.4.0.41702")]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]

--- a/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
@@ -1,0 +1,276 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GlobalPropertyFlowTests : SdkTest
+    {
+        TestProject _testProject;
+        TestProject _referencedProject;
+
+        public GlobalPropertyFlowTests(ITestOutputHelper log) : base(log)
+        {
+            _referencedProject = new TestProject("ReferencedProject")
+            {
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = false
+            };
+
+            _testProject = new TestProject("TestProject")
+            {
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+            _testProject.ReferencedProjects.Add(_referencedProject);
+
+            _testProject.RecordProperties("RuntimeIdentifier", "SelfContained");
+            _referencedProject.RecordProperties("RuntimeIdentifier", "SelfContained");
+        }
+
+        TestAsset Build(bool passSelfContained, bool passRuntimeIdentifier, [CallerMemberName] string callingMethod = "", string identifier = "")
+        {
+            var testAsset = _testAssetsManager.CreateTestProject(_testProject, identifier:identifier);
+
+            var arguments = GetDotnetArguments(passSelfContained, passRuntimeIdentifier);
+
+            new DotnetBuildCommand(testAsset, arguments.ToArray())
+                .Execute()
+                .Should()
+                .Pass();
+
+            return testAsset;
+        }
+
+        List<string> GetDotnetArguments(bool passSelfContained, bool passRuntimeIdentifier)
+        {
+            var runtimeIdentifier = EnvironmentInfo.GetCompatibleRid();
+
+            List<string> arguments = new List<string>();
+            if (passSelfContained)
+            {
+                arguments.Add("--self-contained");
+            }
+            if (passRuntimeIdentifier)
+            {
+                arguments.Add("-r");
+                arguments.Add(runtimeIdentifier);
+            }
+
+            return arguments;
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TestGlobalPropertyFlowToLibrary(bool passSelfContained, bool passRuntimeIdentifier)
+        {
+            var testAsset = Build(passSelfContained, passRuntimeIdentifier, identifier: passSelfContained.ToString() + "_" + passRuntimeIdentifier);
+
+            bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
+
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: false, expectRuntimeIdentifier: false);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TestGlobalPropertyFlowToExe(bool passSelfContained, bool passRuntimeIdentifier)
+        {
+            _referencedProject.IsExe = true;
+
+            var testAsset = Build(passSelfContained, passRuntimeIdentifier, identifier: passSelfContained.ToString() + "_" + passRuntimeIdentifier);
+
+            bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
+
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+        }
+
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TestGlobalPropertyFlowToExeWithSelfContainedFalse(bool passSelfContained, bool passRuntimeIdentifier)
+        {
+            _referencedProject.IsExe = true;
+            _referencedProject.AdditionalProperties["SelfContained"] = "false";
+
+            string identifier = passSelfContained.ToString() + "_" + passRuntimeIdentifier;
+
+            if (!passSelfContained && passRuntimeIdentifier)
+            {
+                //  This combination results in a build error because it ends up being a self-contained Exe referencing a framework dependent one
+                var testAsset = _testAssetsManager.CreateTestProject(_testProject, identifier: identifier);
+
+                new DotnetBuildCommand(testAsset, "-r", EnvironmentInfo.GetCompatibleRid())
+                    .Execute()
+                    .Should()
+                    .Fail()
+                    .And
+                    .HaveStdOutContaining("NETSDK1150");
+            }
+            else
+            {
+
+                var testAsset = Build(passSelfContained, passRuntimeIdentifier, identifier: identifier);
+
+                bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
+
+                ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+                //  SelfContained will only flow to referenced project if it's explicitly passed in this case
+                ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TestGlobalPropertyFlowToLibraryWithRuntimeIdentifier(bool passSelfContained, bool passRuntimeIdentifier)
+        {
+            //  Set a RuntimeIdentifier in the referenced project that is different from what is passed in on the command line
+            _referencedProject.RuntimeIdentifier = "win7-x64";
+
+            var testAsset = Build(passSelfContained, passRuntimeIdentifier, identifier: passSelfContained.ToString() + "_" + passRuntimeIdentifier);
+
+            bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
+
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: buildingSelfContained,
+                //  Right now passing "--self-contained" also causes the RuntimeIdentifier to be passed as a global property.
+                //  That should change with https://github.com/dotnet/sdk/pull/26143, which will likely require updating this and other tests in this class
+                expectedRuntimeIdentifier: buildingSelfContained ? "" : _referencedProject.RuntimeIdentifier);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TestGlobalPropertyFlowToMultitargetedProject(bool passSelfContained, bool passRuntimeIdentifier)
+        {
+            _testProject.TargetFrameworks = "net6.0;net7.0";
+
+            _referencedProject.TargetFrameworks = "net6.0;net7.0";
+            _referencedProject.IsExe = true;
+            _referencedProject.ProjectChanges.Add(project =>
+            {
+                project.Root.Element("PropertyGroup").Add(XElement.Parse(@"<OutputType Condition=""'$(TargetFramework)' == 'net6.0'"">Library</OutputType>"));
+            });
+
+            var testAsset = Build(passSelfContained, passRuntimeIdentifier, identifier: passSelfContained.ToString() + "_" + passRuntimeIdentifier);
+
+            bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
+
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained,
+                targetFramework: "net6.0");
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained,
+                targetFramework: "net7.0");
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: false, expectRuntimeIdentifier: false,
+                targetFramework: "net6.0");
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained,
+                targetFramework: "net7.0");
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TestGlobalPropertyFlowInSolution(bool passSelfContained, bool passRuntimeIdentifier)
+        {
+            var identifier = passSelfContained.ToString() + "_" + passRuntimeIdentifier;
+
+            var testAsset = _testAssetsManager.CreateTestProject(_testProject, identifier: identifier);
+
+            new DotnetCommand(Log, "new", "sln")
+                .WithWorkingDirectory(testAsset.TestRoot)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetCommand(Log, "sln", "add", _testProject.Name)
+                .WithWorkingDirectory(testAsset.TestRoot)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetCommand(Log, "sln", "add", _referencedProject.Name)
+                .WithWorkingDirectory(testAsset.TestRoot)
+                .Execute()
+                .Should()
+                .Pass();
+
+            var arguments = GetDotnetArguments(passSelfContained, passRuntimeIdentifier);
+
+            if (passSelfContained || passRuntimeIdentifier)
+            {
+                new DotnetBuildCommand(Log, arguments.ToArray())
+                    .WithWorkingDirectory(testAsset.TestRoot)
+                    .Execute()
+                    .Should()
+                    .Fail()
+                    .And
+                    .HaveStdOutContaining("NETSDK1134");
+            }
+            else
+            {
+                new DotnetBuildCommand(Log, arguments.ToArray())
+                    .WithWorkingDirectory(testAsset.TestRoot)
+                    .Execute()
+                    .Should()
+                    .Pass();
+            }
+        }
+
+        private static void ValidateProperties(TestAsset testAsset, TestProject testProject, bool expectSelfContained, bool expectRuntimeIdentifier, string targetFramework = null, string expectedRuntimeIdentifier = "")
+        {
+            targetFramework = targetFramework ?? testProject.TargetFrameworks;
+
+            
+            if (string.IsNullOrEmpty(expectedRuntimeIdentifier) && (expectSelfContained || expectRuntimeIdentifier))
+            {
+                //  RuntimeIdentifier might be inferred, so look at the output path to figure out what the actual value used was
+                string dir = (Path.Combine(testAsset.TestRoot, testProject.Name, "bin", "Debug", targetFramework));
+                expectedRuntimeIdentifier = Path.GetFileName(Directory.GetDirectories(dir).Single());
+            }
+
+            var properties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework: targetFramework, runtimeIdentifier: expectedRuntimeIdentifier);
+            if (expectSelfContained)
+            {
+                properties["SelfContained"].ToLowerInvariant().Should().Be("true");
+            }
+            else
+            {
+                properties["SelfContained"].ToLowerInvariant().Should().BeOneOf("false", "");
+            }
+            
+            properties["RuntimeIdentifier"].Should().Be(expectedRuntimeIdentifier);
+        }
+
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/DotnetBuildCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/DotnetBuildCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Xunit.Abstractions;
 
@@ -11,6 +12,11 @@ namespace Microsoft.NET.TestFramework.Commands
         {
             Arguments.Add("build");
             Arguments.AddRange(args);
+        }
+
+        public DotnetBuildCommand(TestAsset testAsset, params string[] args) : this(testAsset.Log, args)
+        {
+            WorkingDirectory = Path.Combine(testAsset.TestRoot, testAsset.TestProject.Name);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -327,11 +327,9 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
             if (SourceFiles.Count == 0)
             {
-                string source;
-
                 if (this.IsExe || this.IsWinExe)
                 {
-                    source =
+                    string source =
     @"using System;
 
 class Program
@@ -343,40 +341,49 @@ class Program
 
                     foreach (var dependency in this.ReferencedProjects)
                     {
-                        source += $"        Console.WriteLine({dependency.Name}.{dependency.Name}Class.Name);" + Environment.NewLine;
-                        source += $"        Console.WriteLine({dependency.Name}.{dependency.Name}Class.List);" + Environment.NewLine;
+                        string safeDependencyName = dependency.Name.Replace('.', '_');
+
+                        source += $"        Console.WriteLine({safeDependencyName}.{safeDependencyName}Class.Name);" + Environment.NewLine;
+                        source += $"        Console.WriteLine({safeDependencyName}.{safeDependencyName}Class.List);" + Environment.NewLine;
                     }
 
                     source +=
     @"    }
 }";
+                    string sourcePath = Path.Combine(targetFolder, this.Name + "Program.cs");
+
+                    File.WriteAllText(sourcePath, source);
                 }
-                else
+
                 {
-                    source =
+                    string safeThisName = this.Name.Replace('.', '_');
+                    string source =
     $@"using System;
 using System.Collections.Generic;
 
-namespace {this.Name}
+namespace {safeThisName}
 {{
-    public class {this.Name}Class
+    public class {safeThisName}Class
     {{
         public static string Name {{ get {{ return ""{this.Name}""; }} }}
         public static List<string> List {{ get {{ return null; }} }}
 ";
                     foreach (var dependency in this.ReferencedProjects)
                     {
-                        source += $"        public string {dependency.Name}Name {{ get {{ return {dependency.Name}.{dependency.Name}Class.Name; }} }}" + Environment.NewLine;
-                        source += $"        public List<string> {dependency.Name}List {{ get {{ return {dependency.Name}.{dependency.Name}Class.List; }} }}" + Environment.NewLine;
+                        string safeDependencyName = dependency.Name.Replace('.', '_');
+
+                        source += $"        public string {safeDependencyName}Name {{ get {{ return {safeDependencyName}.{safeDependencyName}Class.Name; }} }}" + Environment.NewLine;
+                        source += $"        public List<string> {safeDependencyName}List {{ get {{ return {safeDependencyName}.{safeDependencyName}Class.List; }} }}" + Environment.NewLine;
                     }
 
                     source +=
     @"    }
 }";
-                }
-                string sourcePath = Path.Combine(targetFolder, this.Name + ".cs");
+                    string sourcePath = Path.Combine(targetFolder, this.Name + ".cs");
 
-                File.WriteAllText(sourcePath, source);
+                    File.WriteAllText(sourcePath, source);
+                }
+
             }
             else
             {

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Xml.Linq;
 using Microsoft.Build.Utilities;
 using NuGet.Frameworks;
+using Xunit.Sdk;
 
 namespace Microsoft.NET.TestFramework.ProjectConstruction
 {
@@ -62,6 +63,12 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
         public List<KeyValuePair<string, Dictionary<string, string>>> AdditionalItems { get; } = new ();
 
         public List<Action<XDocument>> ProjectChanges { get; } = new List<Action<XDocument>>();
+
+        /// <summary>
+        /// A list of properties to record the values for when the project is built.
+        /// Values can be retrieved with <see cref="GetPropertyValues"/>
+        /// </summary>
+        public List<string> PropertiesToRecord { get; } = new List<string>();
 
         public IEnumerable<string> TargetFrameworkIdentifiers
         {
@@ -397,6 +404,41 @@ namespace {safeThisName}
             {
                 File.WriteAllText(Path.Combine(targetFolder, kvp.Key), kvp.Value);
             }
+
+            if (PropertiesToRecord.Any())
+            {
+                string propertiesElements = "";
+                foreach (var propertyName in PropertiesToRecord)
+                {
+                    propertiesElements += $"      <LinesToWrite Include=`{propertyName}: $({propertyName})`/>" + Environment.NewLine;
+                }
+
+                string injectTargetContents =
+    $@"<Project>
+  <Target Name=`WritePropertyValues` BeforeTargets=`AfterBuild`>
+    <ItemGroup>
+{propertiesElements}
+    </ItemGroup>
+    <WriteLinesToFile
+      File=`$(IntermediateOutputPath)\PropertyValues.txt`
+      Lines=`@(LinesToWrite)`
+      Overwrite=`true`
+      Encoding=`Unicode`
+      />
+  </Target>
+</Project>";
+
+                injectTargetContents = injectTargetContents.Replace('`', '"');
+
+                string targetPath = Path.Combine(targetFolder, "obj", Name + ".csproj.WriteValuesToFile.g.targets");
+
+                if (!Directory.Exists(Path.GetDirectoryName(targetPath)))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
+                }
+
+                File.WriteAllText(targetPath, injectTargetContents);
+            }
         }
 
         public void AddItem(string itemName, string attributeName, string attributeValue)
@@ -407,6 +449,35 @@ namespace {safeThisName}
         public void AddItem(string itemName, Dictionary<string, string> attributes)
         {
             AdditionalItems.Add(new(itemName, attributes));
+        }
+
+        public void RecordProperties(params string[] propertyNames)
+        {
+            PropertiesToRecord.AddRange(propertyNames);
+        }
+
+        public Dictionary<string, string> GetPropertyValues(string testRoot, string configuration = "Debug", string targetFramework = null, string runtimeIdentifier = null)
+        {
+            var propertyValues = new Dictionary<string, string>();
+
+            string intermediateOutputPath = Path.Combine(testRoot, Name, "obj", configuration, targetFramework ?? TargetFrameworks);
+            if (!string.IsNullOrEmpty(runtimeIdentifier))
+            {
+                intermediateOutputPath = Path.Combine(intermediateOutputPath, runtimeIdentifier);
+            }
+
+            foreach (var line in File.ReadAllLines(Path.Combine(intermediateOutputPath, "PropertyValues.txt")))
+            {
+                int colonIndex = line.IndexOf(':');
+                if (colonIndex > 0)
+                {
+                    string propertyName = line.Substring(0, colonIndex);
+                    string propertyValue = line.Length == colonIndex + 1 ? String.Empty : line.Substring(colonIndex + 2);
+                    propertyValues[propertyName] = propertyValue;
+                }
+            }
+
+            return propertyValues;
         }
 
         public static bool ReferenceAssembliesAreInstalled(TargetDotNetFrameworkVersion targetFrameworkVersion)

--- a/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -269,6 +269,33 @@ namespace Microsoft.DotNet.Cli.Build.Tests
                .NotHaveStdOutContaining("NETSDK1031");
         }
 
+        [Fact]
+        public void It_builds_referenced_exe_with_self_contained_specified_via_command_line_argument()
+        {
+            var referencedProject = new TestProject("ReferencedProject")
+            {
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+
+            var testProject = new TestProject("TestProject")
+            {
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+            testProject.ReferencedProjects.Add(referencedProject);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            new DotnetCommand(Log)
+               .WithWorkingDirectory(Path.Combine(testAsset.Path, testProject.Name))
+               .Execute("build", "-r", EnvironmentInfo.GetCompatibleRid(), "--self-contained")
+               .Should()
+               .Pass()
+               .And
+               .NotHaveStdOutContaining("NETSDK1179");
+        }
+
         [Theory]
         [InlineData("roslyn3.9")]
         [InlineData("roslyn4.0")]

--- a/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -269,7 +269,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
                .NotHaveStdOutContaining("NETSDK1031");
         }
 
-        [Fact]
+        [RequiresMSBuildVersionFact("17.4.0.41702")]
         public void It_builds_referenced_exe_with_self_contained_specified_via_command_line_argument()
         {
             var referencedProject = new TestProject("ReferencedProject")


### PR DESCRIPTION
Fixes #21677

Also changes how the SelfContained and RuntimeIdentifier properties flow between projects when they are specified on the command line.  More details are in the comments and the breaking change documentation included in this PR.

This also requires the changes in dotnet/msbuild#6924