### PR TITLE
Fix demand for internal build on Windows

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -48,7 +48,7 @@ stages:
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Internal
-          queue:  BuildPool.Windows.10.Amd64.VS2019.Pre
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre
       helixTargetQueue: Windows.Server.Amd64.VS2019.Pre.Open
       strategy:
         matrix:


### PR DESCRIPTION
Add demand for internal build to match what is being used on 6.0.1xx-rc2, because otherwise Ubuntu machine is selected to do the build. 