### PR TITLE
Fix run warning output formatting issue

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-run/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/Program.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Tools.Run
             var project = parseResult.ValueForOption(RunCommandParser.ProjectOption);
             if (parseResult.UsingRunCommandShorthandProjectOption())
             {
-                Console.WriteLine(LocalizableStrings.RunCommandProjectAbbreviationDeprecated.Yellow());
+                Reporter.Output.WriteLine(LocalizableStrings.RunCommandProjectAbbreviationDeprecated.Yellow());
                 project = parseResult.GetRunCommandShorthandProjectValues().FirstOrDefault();
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/22000