### PR TITLE
[Razor] Fix up-to-date check on static web assets

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -740,7 +740,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <ItemGroup>
         <FileWrites Include="$(StaticWebAssetsReferenceUpToDateMarkersListPath)" />
-        <FileWrites Include="$(StaticWebAssetsUpToDateMarker)" />
       </ItemGroup>
 
       <MergeConfigurationProperties
@@ -826,7 +825,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </PropertyGroup>
 
       <ReadStaticWebAssetsManifestFile ManifestPath="$(StaticWebAssetBuildManifestPath)"
-        Condition="'$(_ShouldReadBuildManifestAndUpdateItemGroup)' == 'true' and Exists($(StaticWebAssetBuildManifestPath))">
+        Condition="'$(_ShouldReadBuildManifestAndUpdateItemGroup)' == 'true'">
         <Output TaskParameter="Assets" ItemName="_CachedBuildStaticWebAssets" />
         <Output TaskParameter="DiscoveryPatterns" ItemName="_CachedBuildStaticWebAssetDiscoveryPatterns" />
       </ReadStaticWebAssetsManifestFile>

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -432,9 +432,23 @@ Copyright (c) .NET Foundation. All rights reserved.
       ManifestPath="$(StaticWebAssetDevelopmentManifestPath)">
     </GenerateStaticWebAssetsDevelopmentManifest>
 
-    <WriteLinesToFile File="$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel" Lines="2.0" WriteOnlyWhenDifferent="true" />
+    <ComputeReferenceStaticWebAssetItems
+      Assets="@(StaticWebAsset)"
+      Patterns="@(StaticWebAssetDiscoveryPattern)"
+      ProjectMode="$(StaticWebAssetProjectMode)"
+      AssetKind="Build"
+      Source="$(PackageId)"
+    >
+      <Output TaskParameter="StaticWebAssets" ItemName="_ReferencedStaticWebAssetsUpToDate" />
+      <Output TaskParameter="DiscoveryPatterns" ItemName="_ReferencedStaticWebAssetsUpToDate" />
+    </ComputeReferenceStaticWebAssetItems>
+    
+    <WriteLinesToFile File="$(StaticWebAssetsUpToDateMarker)" Lines="@(_ReferencedStaticWebAssetsUpToDate)" WriteOnlyWhenDifferent="true" Overwrite="true" />
 
+    <WriteLinesToFile File="$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel" Lines="2.0" WriteOnlyWhenDifferent="true" />
+    
     <ItemGroup>
+      <FileWrites Include="$(StaticWebAssetsUpToDateMarker)" />
       <FileWrites Include="$(StaticWebAssetBuildManifestPath)" />
       <FileWrites Include="$(StaticWebAssetDevelopmentManifestPath)" />
       <FileWrites Include="$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel" />
@@ -1031,19 +1045,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <UpToDateCheckInput SchemaName="Static Web Assets" Set="StaticWebAssets" Include="$(StaticWebAssetsReferenceUpToDateMarkersListPath)" />
       <UpToDateCheckInput SchemaName="Static Web Assets" Set="StaticWebAssets" Include="@(_ReferencedProjectsUpToDateMarkers)" />
     </ItemGroup>
-
-  </Target>
-
-  <Target
-    Name="EmitStaticWebAssetsUpToDateCheckMarker"
-    DependsOnTargets="ResolveStaticWebAssetsConfiguration"
-    AfterTargets="GenerateStaticWebAssetsManifest">
-
-    <CallTarget Targets="$(StaticWebAssetsGetBuildAssetsTargets)">
-      <Output TaskParameter="TargetOutputs" ItemName="_ReferencedStaticWebAssetsUpToDate" />
-    </CallTarget>
-
-    <WriteLinesToFile File="$(StaticWebAssetsUpToDateMarker)" Lines="@(_ReferencedStaticWebAssetsUpToDate)" WriteOnlyWhenDifferent="true" Overwrite="true" />
 
   </Target>
 

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -303,8 +303,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <StaticWebAssetBuildManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.build.json</StaticWebAssetBuildManifestPath>
       <StaticWebAssetDevelopmentManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.development.json</StaticWebAssetDevelopmentManifestPath>
       <StaticWebAssetPublishManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.publish.json</StaticWebAssetPublishManifestPath>
+      <StaticWebAssetsUpToDateMarker>$(_StaticWebAssetsManifestBase)staticwebassets.assetref.txt</StaticWebAssetsUpToDateMarker>
+      <StaticWebAssetsReferenceUpToDateMarkersListPath>$(_StaticWebAssetsManifestBase)staticwebassets.uptodate.txt</StaticWebAssetsReferenceUpToDateMarkersListPath>
 
       <_StaticWebAssetsIntermediateOutputPath>$(IntermediateOutputPath)staticwebassets\</_StaticWebAssetsIntermediateOutputPath>
+
+      <!-- Targets invoked for retrieving referenced assets from referencing projects -->
+      <StaticWebAssetsGetPublishAssetsTargets Condition="'$(StaticWebAssetsGetPublishAssetsTargets)' == ''">ComputeReferencedStaticWebAssetsPublishManifest;GetCurrentProjectPublishStaticWebAssetItems</StaticWebAssetsGetPublishAssetsTargets>
+      <StaticWebAssetsGetBuildAssetsTargets Condition="'$(StaticWebAssetsGetBuildAssetsTargets)' == ''">GetCurrentProjectBuildStaticWebAssetItems</StaticWebAssetsGetBuildAssetsTargets>
 
       <!-- Temporary files -->
       <_GeneratedStaticWebAssetsPropsFile>$(_StaticWebAssetsIntermediateOutputPath)msbuild.$(PackageId).Microsoft.AspNetCore.StaticWebAssets.props</_GeneratedStaticWebAssetsPropsFile>
@@ -711,20 +717,28 @@ Copyright (c) .NET Foundation. All rights reserved.
         <Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectsConfiguration" />
       </MSBuild>
 
-    <MergeConfigurationProperties
-      CandidateConfigurations="@(_ReferencedProjectsConfiguration)"
-      ProjectReferences="@(_StaticWebAssetProjectReference)">
+      <ItemGroup>
+        <_StaticWebAssetsUpToDateMarkers Include="%(_ReferencedProjectsConfiguration.DesignTimeUpToDateMarker)"
+          Condition="'%(_ReferencedProjectsConfiguration.DesignTimeUpToDateMarker)' != ''" />
+      </ItemGroup>
 
-      <Output TaskParameter="ProjectConfigurations" ItemName="StaticWebAssetProjectConfiguration" />
-    </MergeConfigurationProperties>
+      <WriteLinesToFile Lines="@(_StaticWebAssetsUpToDateMarkers)" File="$(StaticWebAssetsReferenceUpToDateMarkersListPath)" WriteOnlyWhenDifferent="true" Overwrite="true" />
+
+      <ItemGroup>
+        <FileWrites Include="$(StaticWebAssetsReferenceUpToDateMarkersListPath)" />
+        <FileWrites Include="$(StaticWebAssetsUpToDateMarker)" />
+      </ItemGroup>
+
+      <MergeConfigurationProperties
+        CandidateConfigurations="@(_ReferencedProjectsConfiguration)"
+        ProjectReferences="@(_StaticWebAssetProjectReference)">
+
+        <Output TaskParameter="ProjectConfigurations" ItemName="StaticWebAssetProjectConfiguration" />
+      </MergeConfigurationProperties>
 
     </Target>
 
     <Target Name="GetStaticWebAssetsProjectConfiguration" Returns="@(_StaticWebAssetThisProjectConfiguration)" DependsOnTargets="ResolveStaticWebAssetsConfiguration">
-      <PropertyGroup>
-        <StaticWebAssetsGetPublishAssetsTargets Condition="'$(StaticWebAssetsGetPublishAssetsTargets)' == ''">ComputeReferencedStaticWebAssetsPublishManifest;GetCurrentProjectPublishStaticWebAssetItems</StaticWebAssetsGetPublishAssetsTargets>
-        <StaticWebAssetsGetBuildAssetsTargets Condition="'$(StaticWebAssetsGetBuildAssetsTargets)' == ''">GetCurrentProjectBuildStaticWebAssetItems</StaticWebAssetsGetBuildAssetsTargets>
-      </PropertyGroup>
       <ItemGroup>
         <_StaticWebAssetThisProjectConfiguration Include="$(MSBuildProjectFullPath)">
           <Version>2</Version>
@@ -735,6 +749,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           <GetPublishAssetsTargets>$(StaticWebAssetsGetPublishAssetsTargets)</GetPublishAssetsTargets>
           <AdditionalPublishProperties>$(StaticWebAssetsAdditionalPublishProperties)</AdditionalPublishProperties>
           <AdditionalPublishPropertiesToRemove>$(StaticWebAssetsAdditionalPublishPropertiesToRemove)</AdditionalPublishPropertiesToRemove>
+          <DesignTimeUpToDateMarker>$(StaticWebAssetsUpToDateMarker)</DesignTimeUpToDateMarker>
         </_StaticWebAssetThisProjectConfiguration>
       </ItemGroup>
     </Target>
@@ -797,7 +812,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </PropertyGroup>
 
       <ReadStaticWebAssetsManifestFile ManifestPath="$(StaticWebAssetBuildManifestPath)"
-        Condition="'$(_ShouldReadBuildManifestAndUpdateItemGroup)' == 'true'">
+        Condition="'$(_ShouldReadBuildManifestAndUpdateItemGroup)' == 'true' and Exists($(StaticWebAssetBuildManifestPath))">
         <Output TaskParameter="Assets" ItemName="_CachedBuildStaticWebAssets" />
         <Output TaskParameter="DiscoveryPatterns" ItemName="_CachedBuildStaticWebAssetDiscoveryPatterns" />
       </ReadStaticWebAssetsManifestFile>
@@ -994,6 +1009,51 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TfmSpecificPackageFile Include="%(_PackStaticWebAssetWithTargetPath.Identity)">
         <PackagePath>%(_PackStaticWebAssetWithTargetPath.TargetPath)</PackagePath>
       </TfmSpecificPackageFile>
+    </ItemGroup>
+
+  </Target>
+
+  <Target
+    Name="EnsureStaticWebAssetsUpToDateMarkersList"
+    Condition="!Exists($(StaticWebAssetsReferenceUpToDateMarkersListPath))"
+    DependsOnTargets="ResolveReferencedProjectsStaticWebAssetsConfiguration" />
+
+  <Target
+    Name="StaticWebAssetsUpToDateCheckInputsDesignTime"
+    DependsOnTargets="ResolveStaticWebAssetsConfiguration"
+    BeforeTargets="CollectUpToDateCheckInputDesignTime">
+
+    <ReadLinesFromFile File="$(StaticWebAssetsReferenceUpToDateMarkersListPath)">
+      <Output TaskParameter="Lines" ItemName="_ReferencedProjectsUpToDateMarkers" />
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <UpToDateCheckInput SchemaName="Static Web Assets" Set="StaticWebAssets" Include="$(StaticWebAssetsReferenceUpToDateMarkersListPath)" />
+      <UpToDateCheckInput SchemaName="Static Web Assets" Set="StaticWebAssets" Include="@(_ReferencedProjectsUpToDateMarkers)" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target
+    Name="EmitStaticWebAssetsUpToDateCheckMarker"
+    DependsOnTargets="ResolveStaticWebAssetsConfiguration"
+    AfterTargets="GenerateStaticWebAssetsManifest">
+
+    <CallTarget Targets="$(StaticWebAssetsGetBuildAssetsTargets)">
+      <Output TaskParameter="TargetOutputs" ItemName="_ReferencedStaticWebAssetsUpToDate" />
+    </CallTarget>
+
+    <WriteLinesToFile File="$(StaticWebAssetsUpToDateMarker)" Lines="@(_ReferencedStaticWebAssetsUpToDate)" WriteOnlyWhenDifferent="true" Overwrite="true" />
+
+  </Target>
+
+  <Target
+    Name="StaticWebAssetsUpToDateCheckBuiltDesignTime"
+    DependsOnTargets="ResolveStaticWebAssetsConfiguration"
+    BeforeTargets="CollectUpToDateCheckBuiltDesignTime">
+
+    <ItemGroup>
+      <UpToDateCheckOutput SchemaName="Static Web Assets" Set="StaticWebAssets" Include="$(StaticWebAssetBuildManifestPath)" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
When the up to date check is triggered for a project, we emit a file to disk with the list of assets from that project that other projects would reference.

On a referencing project we collect the list of files from referenced projects as up to date check inputs and use our static web assets build manifest as the up to date check built.

When the user makes an edit in a given project (like adding, renaming, or removing a file) the up to date check in that project is triggered. As a result, the marker file would change at that point.

When a build is triggered for the server project, one of the marker files will have changed, and that will cause the server project to also rebuild.

Here is the example of it working:
![image](https://user-images.githubusercontent.com/6995051/137322487-86ad1af7-dcaa-45fb-94f0-77aff4875933.png)

* We rebuild
* We build again (For some reason it thinks an assembly has changed and rebuilds two projects)
* After that second build, the up to date check returns everything is up to date
* We then make a change on a file in the Client project, which updates the marker
* After that, we trigger a build on the server project. It builds both the client and the server projects.
* We do another build and at this time it only builds the client project (the server is now up to date)
* We change a c# file on the client project and build the server project (only the client builds
* We trigger another build on the server project (now everything is up to date)

Fixes https://github.com/dotnet/aspnetcore/issues/37508

## Customer Impact

When a customer adds a static file to a referenced project, visual studio still believes the referencing project is up to date and won't update the static web assets manifest.

## Regression?

- [X] Yes
- [ ] No

This change would be detected in previous versions.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The introduced changes only affect the computation of the up-to-date check by visual studio. This change does not impact any of the core functionality of the application.

## Verification

- [X] Manual (required)
- [ ] Automated

The testing is completely manual because it can't be automated due to this being a service invoked by the Visual Studio project system.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A