### PR TITLE
Eliminate pre-built assets during source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -92,6 +92,10 @@
       <Sha>df45061e218c9b5813c5531bc06fb238a23e30f6</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis" Version="4.0.0-6.21514.4">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>df45061e218c9b5813c5531bc06fb238a23e30f6</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-6.21514.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>df45061e218c9b5813c5531bc06fb238a23e30f6</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -121,7 +121,7 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
     <MicrosoftNetCompilersToolsetPackageVersion>4.0.0-6.21514.4</MicrosoftNetCompilersToolsetPackageVersion>
-    <MicrosoftCodeAnalysisPackageVersion>4.0.0-4.final</MicrosoftCodeAnalysisPackageVersion>
+    <MicrosoftCodeAnalysisPackageVersion>4.0.0-6.21514.4</MicrosoftCodeAnalysisPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>4.0.0-6.21514.4</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.0.0-6.21514.4</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.0.0-6.21514.4</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -43,6 +43,5 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />  
   </ItemGroup>
 </Project>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -8,9 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- We pin the versions of the assets that ship with the SDK in order to be able to run on older SDKs. 
-    Currently we support .NET 6 Preview5 or later. -->
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.0-1.21304.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
+++ b/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
@@ -12,9 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Instead of using the version of M.C.C defined in Version.props we pin to a minimum required
-    version to avoid issues with loading newer versions of the assembly in VS/VS Code. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Internal.SourceGenerator.Transport" Version="$(MicrosoftAspNetCoreRazorInternalSourceGeneratorTransportPackageVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 


### PR DESCRIPTION
This work eliminates using pre-built NuGet packages during source-build.

* Ensure Microsoft.CodeAnalysis participates in dependency flow
* Remove unnecessary reference to Microsoft.Win32.Registry, this library is referenced automatically in net6.0 and net472
* Remove hard-coded Roslyn versions in ApiCompatibility and use the Roslyn version used in the SDK
* Clean up the Razor source generator dependency and comment

Contributes to https://github.com/dotnet/source-build/issues/2422