### PR TITLE
Add a target and tests for re-generating scoped css files as part of hot reload

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -405,7 +405,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="StaticWebAssetsPrepareForRun" DependsOnTargets="$(StaticWebAssetsPrepareForRunDependsOn)" />
 
   <!-- Invoked by VS to re-generate scoped css bundle during hot reload -->
-  <Target Name="UpdateScopedCss" DependsOnTargets="ResolveReferencedProjectsStaticWebAssets;GenerateComputedBuildStaticWebAssets" />
+  <Target Name="UpdateStaticWebAssetsDesignTime" DependsOnTargets="ResolveReferencedProjectsStaticWebAssets;GenerateComputedBuildStaticWebAssets" />
 
   <Target Name="GenerateComputedBuildStaticWebAssets" DependsOnTargets="$(GenerateComputedBuildStaticWebAssetsDependsOn)" />
 

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -45,7 +45,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask
     TaskName="Microsoft.AspNetCore.Razor.Tasks.UpdatePackageStaticWebAssets"
     AssemblyFile="$(RazorSdkBuildTasksAssembly)"
-    Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />    
+    Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
   <UsingTask
     TaskName="Microsoft.AspNetCore.Razor.Tasks.DefineStaticWebAssets"
@@ -65,12 +65,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask
     TaskName="Microsoft.AspNetCore.Razor.Tasks.StaticWebAssetsGeneratePackagePropsFile"
     AssemblyFile="$(RazorSdkBuildTasksAssembly)"
-    Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />    
+    Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
   <UsingTask
     TaskName="Microsoft.AspNetCore.Razor.Tasks.CollectStaticWebAssetsToCopy"
     AssemblyFile="$(RazorSdkBuildTasksAssembly)"
-    Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />    
+    Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
   <UsingTask
     TaskName="Microsoft.AspNetCore.Razor.Tasks.MergeConfigurationProperties"
@@ -260,7 +260,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GetCopyToOutputDirectoryItemsDependsOn>$(GetCopyToOutputDirectoryItemsDependsOn);AddStaticWebAssetsManifest</GetCopyToOutputDirectoryItemsDependsOn>
 
     <CopyStaticWebAssetsToOutputDirectoryDependsOn>LoadStaticWebAssetsBuildManifest;$(CopyStaticWebAssetsToOutputDirectoryDependsOn)</CopyStaticWebAssetsToOutputDirectoryDependsOn>
-    
+
     <!-- StaticWebAssetsPrepareForPublish -> ComputeFilesToPublish -->
 
     <StaticWebAssetsPrepareForPublishDependsOn>$(StaticWebAssetsPrepareForPublishDependsOn);ResolveStaticWebAssetsConfiguration;GenerateStaticWebAssetsPublishManifest;GenerateComputedPublishStaticWebAssets</StaticWebAssetsPrepareForPublishDependsOn>
@@ -318,7 +318,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_StaticWebAssetsGeneratedBuildMultiTargetingPropsFileImportPath>..\buildMultiTargeting\$(PackageId).props</_StaticWebAssetsGeneratedBuildMultiTargetingPropsFileImportPath>
 
       <_CurrentProjectHasStaticWebAssets Condition="'@(_CurrentProjectStaticWebAsset->Count())' != '0'">true</_CurrentProjectHasStaticWebAssets>
-        
+
     </PropertyGroup>
 
     <MakeDir
@@ -340,7 +340,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="CopyStaticWebAssetsToOutputDirectory" DependsOnTargets="$(CopyStaticWebAssetsToOutputDirectoryDependsOn)" />
-  
+
   <Target Name="_SplitStaticWebAssetsByCopyOptions" AfterTargets="CopyStaticWebAssetsToOutputDirectory">
 
     <CollectStaticWebAssetsToCopy Assets="@(StaticWebAsset)" OutputPath="$(OutputPath)\wwwroot\">
@@ -354,7 +354,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target 
+  <Target
     Name="_BuildCopyStaticWebAssetsPreserveNewest"
     Inputs="@(_BuildStaticWebAssetsPreserveNewest)"
     Outputs="@(_BuildStaticWebAssetsPreserveNewest->'%(TargetPath)')"
@@ -374,7 +374,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target 
+  <Target
     Name="_BuildCopyStaticWebAssetsAlways"
     AfterTargets="_SplitStaticWebAssetsByCopyOptions">
 
@@ -390,7 +390,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </Copy>
 
-  </Target>  
+  </Target>
 
   <Target Name="AddStaticWebAssetsManifest" DependsOnTargets="ResolveStaticWebAssetsConfiguration">
     <ItemGroup>
@@ -403,6 +403,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="StaticWebAssetsPrepareForRun" DependsOnTargets="$(StaticWebAssetsPrepareForRunDependsOn)" />
+
+  <!-- Invoked by VS to re-generate scoped css bundle during hot reload -->
+  <Target Name="UpdateScopedCss" DependsOnTargets="ResolveReferencedProjectsStaticWebAssets;GenerateComputedBuildStaticWebAssets" />
 
   <Target Name="GenerateComputedBuildStaticWebAssets" DependsOnTargets="$(GenerateComputedBuildStaticWebAssetsDependsOn)" />
 
@@ -433,7 +436,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <FileWrites Include="$(StaticWebAssetDevelopmentManifestPath)" />
       <FileWrites Include="$(BaseIntermediateOutputPath)staticwebassets.pack.sentinel" />
     </ItemGroup>
-    
+
   </Target>
 
   <Target Name="ResolveStaticWebAssetsInputs" DependsOnTargets="$(ResolveStaticWebAssetsInputsDependsOn)" />
@@ -477,7 +480,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Publish -->
 
-  <Target Name="StaticWebAssetsPrepareForPublish" 
+  <Target Name="StaticWebAssetsPrepareForPublish"
     BeforeTargets="ComputeFilesToPublish"
     DependsOnTargets="$(StaticWebAssetsPrepareForPublishDependsOn)" />
 
@@ -493,7 +496,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       Mode="$(StaticWebAssetProjectMode)"
       ManifestType="Publish"
       ReferencedProjectsConfigurations="@(StaticWebAssetProjectConfiguration)"
-      DiscoveryPatterns="@(StaticWebAssetDiscoveryPattern)"  
+      DiscoveryPatterns="@(StaticWebAssetDiscoveryPattern)"
       Assets="@(_FinalPublishStaticWebAsset)"
       ManifestPath="$(StaticWebAssetPublishManifestPath)">
     </GenerateStaticWebAssetsManifest>
@@ -503,7 +506,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="ResolvePublishStaticWebAssets" DependsOnTargets="$(ResolvePublishStaticWebAssetsDependsOn)" />
-  
+
   <Target Name="LoadStaticWebAssetsBuildManifest" BeforeTargets="ComputeResolvedFilesToPublishList">
     <!-- Before we load assets from the manifest we cleanup any potential existing asset that might be present by default
          for example, assets from packages as a result of a publish (no-build) invocation. Those assets were already taken
@@ -681,7 +684,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ReadStaticWebAssetsManifestFile ManifestPath="$(StaticWebAssetBuildManifestPath)">
         <Output TaskParameter="Assets" ItemName="_CleanupStaticWebAsset" />
       </ReadStaticWebAssetsManifestFile>
-        
+
       <ItemGroup>
         <Content Remove="@(_CleanupStaticWebAsset->'%(OriginalItemSpec)')" />
         <ContentWithTargetPath Remove="@(_CleanupStaticWebAsset->'%(OriginalItemSpec)')" />
@@ -690,7 +693,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ResolvedFileToPublish Remove="@(_CleanupStaticWebAsset->'%(OriginalItemSpec)')" />
       </ItemGroup>
     </Target>
-  
+
     <Target Name="ResolveReferencedProjectsStaticWebAssetsConfiguration" DependsOnTargets="ResolveStaticWebAssetsConfiguration;PrepareProjectReferences">
       <ItemGroup>
         <!-- It is explicitly ok to take a dependency on _MSBuildProjectReferenceExistent as it is
@@ -951,7 +954,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!-- We need to use a separate target because MSBuild doesn't capture the output item groups from tasks
-       and as a result, the output of ComputeStaticWebAssetsTargetPaths is not defined on incremental builds 
+       and as a result, the output of ComputeStaticWebAssetsTargetPaths is not defined on incremental builds
   -->
   <Target Name="IncludeStaticWebAssetsPackItems">
     <!-- We need to adjust the path for files without extension (LICENSE) for example. Otherwise, when they get packed, nuget creates an

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
@@ -547,7 +547,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             File.WriteAllLines(scopedCssFile, File.ReadAllLines(scopedCssFile).Concat(new[] { "body { background-color: orangered; }" }));
 
             build = new BuildCommand(ProjectDirectory);
-            build.Execute("/t:UpdateScopedCss").Should().Pass();
+            build.Execute("/t:UpdateStaticWebAssetsDesignTime").Should().Pass();
 
             var fileInfo = new FileInfo(bundlePath);
             fileInfo.Should().Exist();
@@ -578,7 +578,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             File.WriteAllLines(scopedCssFile, File.ReadAllLines(scopedCssFile).Concat(new[] { "body { background-color: orangered; }" }));
 
             build = new BuildCommand(ProjectDirectory, "AppWithPackageAndP2PReference");
-            build.Execute("/t:UpdateScopedCss").Should().Pass();
+            build.Execute("/t:UpdateStaticWebAssetsDesignTime").Should().Pass();
 
             var fileInfo = new FileInfo(bundlePath);
             fileInfo.Should().Exist();

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
@@ -525,5 +525,67 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             appBundle.Should().Contain("_content/ClassLibrary/ClassLibrary.bundle.scp.css");
             appBundle.Should().Contain("_content/PackageLibraryDirectDependency/PackageLibraryDirectDependency.bundle.scp.css");
         }
+
+        // This test verifies if the targets that VS calls to update scoped css works to update these files
+        [Fact]
+        public void RegeneratingScopedCss_ForProject()
+        {
+            // Arrange
+            var testAsset = "RazorComponentApp";
+            ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+            var build = new BuildCommand(ProjectDirectory);
+            build.Execute().Should().Pass();
+
+            var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+            var bundlePath = Path.Combine(intermediateOutputPath, "scopedcss", "bundle", "ComponentApp.styles.css");
+
+            new FileInfo(bundlePath).Should().Exist();
+
+            // Make an edit
+            var scopedCssFile = Path.Combine(ProjectDirectory.TestRoot, "Components", "Pages", "Index.razor.css");
+            File.WriteAllLines(scopedCssFile, File.ReadAllLines(scopedCssFile).Concat(new[] { "body { background-color: orangered; }" }));
+
+            build = new BuildCommand(ProjectDirectory);
+            build.Execute("/t:UpdateScopedCss").Should().Pass();
+
+            var fileInfo = new FileInfo(bundlePath);
+            fileInfo.Should().Exist();
+            // Verify the generated file contains newly added css
+            fileInfo.ReadAllText().Should().Contain("background-color: orangered");
+        }
+
+        // Regression test for https://github.com/dotnet/aspnetcore/issues/37592
+        [Fact]
+        public void RegeneratingScopedCss_ForProjectWithReferences()
+        {
+            var testAsset = "RazorAppWithPackageAndP2PReference";
+            ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+            var scopedCssFile = Path.Combine(ProjectDirectory.Path, "AppWithPackageAndP2PReference", "Index.razor.css");
+            File.WriteAllText(scopedCssFile, "/* Empty css */");
+            File.WriteAllText(Path.Combine(ProjectDirectory.Path, "AppWithPackageAndP2PReference", "Index.razor"), "This is a test razor component.");
+
+            var build = new BuildCommand(ProjectDirectory, "AppWithPackageAndP2PReference");
+            build.Execute().Should().Pass();
+
+            var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+            var bundlePath = Path.Combine(intermediateOutputPath, "scopedcss", "bundle", "AppWithPackageAndP2PReference.styles.css");
+
+            new FileInfo(bundlePath).Should().Exist();
+
+            // Make an edit to a scoped css file
+            File.WriteAllLines(scopedCssFile, File.ReadAllLines(scopedCssFile).Concat(new[] { "body { background-color: orangered; }" }));
+
+            build = new BuildCommand(ProjectDirectory, "AppWithPackageAndP2PReference");
+            build.Execute("/t:UpdateScopedCss").Should().Pass();
+
+            var fileInfo = new FileInfo(bundlePath);
+            fileInfo.Should().Exist();
+            // Verify the generated file contains newly added css
+            var text = fileInfo.ReadAllText();
+            text.Should().Contain("background-color: orangered");
+            text.Should().Contain("@import '_content/ClassLibrary/ClassLibrary.bundle.scp.css");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/37592

VS will fix this issue for 17.0 GA by calling the two targets separately. For the longer term (we'll port this fix to 17.1), we'll have VS switch to calling the new target that is being added here and we can own ensuring that it does all the right things.