### PR TITLE
Remove reference to PlatformAbstractions

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -50,7 +50,6 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <PackageReference Include="Microsoft.NET.HostModel" Version="$(MicrosoftNETHostModelVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />


### PR DESCRIPTION
This is causing an unnecessary file to be shipped in the Sdk.

## Customer impact

During source-build, we no longer build this PlatformAbstractions assembly. It is no longer apart of a repo that is built in our product. To make this reference work in source-build, we are shipping a "ref assembly" built from https://github.com/dotnet/source-build-reference-packages. Thus, in a source-built version of our product, this PlatformAbstractions assembly doesn't have any implementation in it - just `throw null` statements.

Removing the reference means it is no longer being shipped in the product (neither Microsoft-distributed or source-build).

## Regression

No.

## Risk

Low. No one is using this assembly, so not referencing it shouldn't cause problems.