### PR TITLE
Improve loading of Roslyn assemblies on validate package task

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
@@ -15,8 +15,9 @@
     <PropertyGroup Condition="'$(RoslynAssembliesPath)' == ''">
       <RoslynAssembliesPath>$(RoslynTargetsPath)</RoslynAssembliesPath>
       <_packageReferenceList>@(PackageReference)</_packageReferenceList>
-      <RoslynAssembliesPath Condition="'$(MSBuildProjectExtension)' == '.csproj' and $(_packageReferenceList.Contains('Microsoft.Net.Compilers.Toolset'))">$([System.IO.Path]::GetDirectoryName($(CSharpCoreTargetsPath)))</RoslynAssembliesPath>
-      <RoslynAssembliesPath Condition="'$(MSBuildProjectExtension)' == '.vbproj' and $(_packageReferenceList.Contains('Microsoft.Net.Compilers.Toolset'))">$([System.IO.Path]::GetDirectoryName($(VisualBasicCoreTargetsPath)))</RoslynAssembliesPath>
+      <!-- CSharpCoreTargetsPath and VisualBasicCoreTargetsPath point to the same location, Microsoft.CodeAnalysis.CSharp and Microsoft.CodeAnalysis.VisualBasic
+      are on the same directory as Microsoft.CodeAnalysis. So there is no need to distinguish between csproj or vbproj. -->
+      <RoslynAssembliesPath Condition="$(_packageReferenceList.Contains('Microsoft.Net.Compilers.Toolset'))">$([System.IO.Path]::GetDirectoryName($(CSharpCoreTargetsPath)))</RoslynAssembliesPath>
       <RoslynAssembliesPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$([System.IO.Path]::Combine('$(RoslynAssembliesPath)', bincore))</RoslynAssembliesPath>
     </PropertyGroup>
 


### PR DESCRIPTION
With: https://github.com/dotnet/runtime/issues/59908 we realized various things:

1) We were loading the roslyn assemblies into the default Assembly Load Context because we were using `Assembly.LoadFrom` on .NET Core and that is a legacy API on Core which just loads the assembly to the default load context. That could lead to different problems one of them for example: if there is an MSBuild Task that runs before package validation and that task depends on Microsoft.CodeAnalysis and carries it's own copy of it with the package and it is the same assembly version, since it could be loaded into the same default Assembly Load Context, we could endup in a state where we load `Microsoft.CodeAnalysis.CSharp` from a different path and have miss match problems.

2) If the toolset package is referenced, we were only setting the RoslynAssembliesPath for projects with the `.csproj` or `vbproj` extensions, so for example in `dotnet/runtime` we have an `.ilproj` and another project with `.pkgproj` extension which because of this reason, ended using the roslyn from the SDK and causing this possible miss match described on point 1.

3) If package validation runs on a package that has no `lib` or `ref` assets, say a tools or a native package, `API Compat` would never be invoked so only `Microsoft.CodeAnalysis` would be loaded, leading to potential miss matches of `Microsoft.CodeAnalysis.dll` vs `Microsoft.CodeAnalysis.CSharp.dll` whenever we run package validation on a package on the same build where we do need to run `API Compat` (which is actually what was causing the issue in dotnet/runtime) even if loading the assemblies into the Task ALC rather than the default ALC. So to fix this we will defensively load both assemblies when either one of them is requested to make sure on the first instance of the task on the current MSBuild node, we load both assemblies from the same location regardless of if we need them or not into the task ALC.

What we encountered in dotnet/runtime was a combination of 2 and 3.