### PR TITLE
Switch the non-windows test builds to also run helix and non-helix in parallel.

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -131,6 +131,7 @@ stages:
               _BuildConfig: Release
               _PublishArgs: ''
               _SignType: test
+              _Test: -test
 
     - template: /eng/build.yml
       parameters:
@@ -147,6 +148,7 @@ stages:
               _BuildConfig: Release
               _PublishArgs: ''
               _SignType: test
+              _Test: -test
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates/job/publish-build-assets.yml

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -139,7 +139,7 @@ jobs:
                 -configuration $(_BuildConfig)
                 -buildSourcesDirectory $(Build.SourcesDirectory)
                 -customHelixTargetQueue ${{ parameters.helixTargetQueue }}
-                -officialBuildIdArgs BuildIdArgs:$(_OfficialBuildIdArgs)
+                -officialBuildIdArgs "$(_OfficialBuildIdArgs)"
                 $(_Test)
         displayName: Run Tests in Helix and non Helix in parallel
         condition: succeededOrFailed()

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -82,6 +82,7 @@ jobs:
               -buildSourcesDirectory $(Build.SourcesDirectory)
               -customHelixTargetQueue ${{ parameters.helixTargetQueue }}
               $(_Test)
+              -windows
         displayName: Run Tests in Helix and non Helix in parallel
         condition: succeededOrFailed()
         env:
@@ -106,6 +107,7 @@ jobs:
               -buildSourcesDirectory $(Build.SourcesDirectory)
               -customHelixTargetQueue ${{ parameters.helixTargetQueue }}
               $(_Test)
+              -windows
         displayName: Run Tests in Helix and non Helix in parallel
         condition: succeededOrFailed()
         env:
@@ -135,23 +137,13 @@ jobs:
         displayName: Build
         env:
           BuildConfig: $(_BuildConfig)
-      - script: eng/runTestsCannotRunOnHelix.sh
-                  --configuration $(_BuildConfig)
-                  --ci
-                  $(_OfficialBuildIdArgs)
-        displayName: Run Tests Cannot Run On Helix
-        env:
-          BuildConfig: $(_BuildConfig)
-      - script: eng/common/build.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              --ci
-              --restore
-              --test
-              --projects $(Build.SourcesDirectory)/src/Tests/UnitTests.proj
-              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/TestInHelix.binlog
-              /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
-        displayName: Run Tests in Helix
+      - powershell: eng/runHelixAndNonHelixInParallel.ps1
+                -configuration $(_BuildConfig)
+                -buildSourcesDirectory $(Build.SourcesDirectory)
+                -customHelixTargetQueue ${{ parameters.helixTargetQueue }}
+                $(_Test)
+                -officialBuildIdArgs $(_OfficialBuildIdArgs)
+        displayName: Run Tests in Helix and non Helix in parallel
         condition: succeededOrFailed()
         env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -82,7 +82,6 @@ jobs:
               -buildSourcesDirectory $(Build.SourcesDirectory)
               -customHelixTargetQueue ${{ parameters.helixTargetQueue }}
               $(_Test)
-              -windows
         displayName: Run Tests in Helix and non Helix in parallel
         condition: succeededOrFailed()
         env:
@@ -107,7 +106,6 @@ jobs:
               -buildSourcesDirectory $(Build.SourcesDirectory)
               -customHelixTargetQueue ${{ parameters.helixTargetQueue }}
               $(_Test)
-              -windows
         displayName: Run Tests in Helix and non Helix in parallel
         condition: succeededOrFailed()
         env:
@@ -137,12 +135,12 @@ jobs:
         displayName: Build
         env:
           BuildConfig: $(_BuildConfig)
-      - powershell: eng/runHelixAndNonHelixInParallel.ps1
+      - powershell: eng/runHelixAndNonHelixInParallelNonWindows.ps1
                 -configuration $(_BuildConfig)
                 -buildSourcesDirectory $(Build.SourcesDirectory)
                 -customHelixTargetQueue ${{ parameters.helixTargetQueue }}
+                -officialBuildIdArgs BuildIdArgs:$(_OfficialBuildIdArgs)
                 $(_Test)
-                -officialBuildIdArgs $(_OfficialBuildIdArgs)
         displayName: Run Tests in Helix and non Helix in parallel
         condition: succeededOrFailed()
         env:

--- a/eng/runHelixAndNonHelixInParallel.ps1
+++ b/eng/runHelixAndNonHelixInParallel.ps1
@@ -3,9 +3,7 @@
         [string] $configuration,
         [string] $buildSourcesDirectory,
         [string] $customHelixTargetQueue,
-        [string] $officialBuildIdArgs,
-        [switch] $test,
-        [switch] $windows
+        [switch] $test
     )
 
     if (-not $test)
@@ -20,37 +18,23 @@
             [string] $configuration,
             [string] $buildSourcesDirectory,
             [string] $customHelixTargetQueue,
-            [string] $engfolderPath,
-            [string] $officialBuildIdArgs,
-            [boolean] $windows
+            [string] $engfolderPath
         )
 
         $runTestsCannotRunOnHelixArgs = ("-configuration", $configuration, "-ci")
-        if (-Not $windows)
-        {
-            InlineScript{$runTestsCannotRunOnHelixArgs.Add($officialBuildIdArgs)}
-        }
         $runTestsOnHelixArgs = ("-configuration", $configuration,
         "-prepareMachine",
         "-ci",
         "-restore",
         "-test",
         "-projects", "$buildSourcesDirectory/src/Tests/UnitTests.proj",
-        "/bl:$buildSourcesDirectory/artifacts/log/$configuration/TestInHelix.binlog",
+        "/bl:$buildSourcesDirectory\artifacts\log\$configuration\TestInHelix.binlog",
         "/p:_CustomHelixTargetQueue=$customHelixTargetQueue")
 
-        if (-Not $windows)
-        {
-            Invoke-Expression "&'$engfolderPath/runTestsCannotRunOnHelix.sh' $runTestsCannotRunOnHelixArgs"
-            Invoke-Expression "&'$engfolderPath/common/build.sh' $runTestsOnHelixArgs"
-        }
-        else
-        {
-            parallel {
-                Invoke-Expression "&'$engfolderPath\runTestsCannotRunOnHelix.ps1' $runTestsCannotRunOnHelixArgs"
-                Invoke-Expression "&'$engfolderPath\common\build.ps1' $runTestsOnHelixArgs"
-            }
+        parallel {
+            Invoke-Expression "&'$engfolderPath\runTestsCannotRunOnHelix.ps1' $runTestsCannotRunOnHelixArgs"
+            Invoke-Expression "&'$engfolderPath\common\build.ps1' $runTestsOnHelixArgs"
         }
     }
 
-    runHelixAndNonHelixInParallel -configuration $configuration -buildSourcesDirectory $buildSourcesDirectory -customHelixTargetQueue $customHelixTargetQueue -engfolderPath $PSScriptRoot -windows:$windows -officialBuildIdArgs $officialBuildIdArgs
+    runHelixAndNonHelixInParallel -configuration $configuration -buildSourcesDirectory $buildSourcesDirectory -customHelixTargetQueue $customHelixTargetQueue -engfolderPath $PSScriptRoot

--- a/eng/runHelixAndNonHelixInParallelNonWindows.ps1
+++ b/eng/runHelixAndNonHelixInParallelNonWindows.ps1
@@ -1,0 +1,28 @@
+    [CmdletBinding(PositionalBinding = $false)]
+    Param(
+        [string] $configuration,
+        [string] $buildSourcesDirectory,
+        [string] $customHelixTargetQueue,
+        [string] $officialBuildIdArgs,
+        [switch] $test
+    )
+
+    if (-not $test)
+    {
+        Write-Output "No '-test' switch. Skip both helix and non helix tests"
+        return
+    }
+
+    $runTestsCannotRunOnHelixArgs = ("-configuration", $configuration, "-ci", $officialBuildIdArgs.Substring(12))
+    $runTestsOnHelixArgs = ("-configuration", $configuration,
+    "-prepareMachine",
+    "-ci",
+    "-restore",
+    "-test",
+    "-projects", "$buildSourcesDirectory/src/Tests/UnitTests.proj",
+    "/bl:$buildSourcesDirectory/artifacts/log/$configuration/TestInHelix.binlog",
+    "/p:_CustomHelixTargetQueue=$customHelixTargetQueue")
+
+   $runTests = ("&'$PSScriptRoot/runTestsCannotRunOnHelix.sh' $runTestsCannotRunOnHelixArgs", "&'$PSScriptRoot/common/build.sh' $runTestsOnHelixArgs")
+
+   $runTests | ForEach-Object -Parallel { Invoke-Expression $_}

--- a/eng/runHelixAndNonHelixInParallelNonWindows.ps1
+++ b/eng/runHelixAndNonHelixInParallelNonWindows.ps1
@@ -1,28 +1,35 @@
-    [CmdletBinding(PositionalBinding = $false)]
-    Param(
-        [string] $configuration,
-        [string] $buildSourcesDirectory,
-        [string] $customHelixTargetQueue,
-        [string] $officialBuildIdArgs,
-        [switch] $test
-    )
+  [CmdletBinding(PositionalBinding = $false)]
+  Param(
+      [string] $configuration,
+      [string] $buildSourcesDirectory,
+      [string] $customHelixTargetQueue,
+      [string] $officialBuildIdArgs,
+      [switch] $test
+  )
 
-    if (-not $test)
-    {
-        Write-Output "No '-test' switch. Skip both helix and non helix tests"
-        return
-    }
+  if (-not $test)
+  {
+      Write-Output "No '-test' switch. Skip both helix and non helix tests"
+      return
+  }
 
-    $runTestsCannotRunOnHelixArgs = ("-configuration", $configuration, "-ci", $officialBuildIdArgs.Substring(12))
-    $runTestsOnHelixArgs = ("-configuration", $configuration,
-    "-prepareMachine",
+  $runTestsCannotRunOnHelixArgs = ("-configuration", $configuration, "-ci", $officialBuildIdArgs)
+  $runTestsOnHelixArgs = ("-configuration", $configuration,
     "-ci",
-    "-restore",
-    "-test",
-    "-projects", "$buildSourcesDirectory/src/Tests/UnitTests.proj",
-    "/bl:$buildSourcesDirectory/artifacts/log/$configuration/TestInHelix.binlog",
-    "/p:_CustomHelixTargetQueue=$customHelixTargetQueue")
+  "-restore",
+  "-test",
+  "-projects", "$buildSourcesDirectory/src/Tests/UnitTests.proj",
+  "/bl:$buildSourcesDirectory/artifacts/log/$configuration/TestInHelix.binlog",
+  "/p:_CustomHelixTargetQueue=$customHelixTargetQueue")
 
-   $runTests = ("&'$PSScriptRoot/runTestsCannotRunOnHelix.sh' $runTestsCannotRunOnHelixArgs", "&'$PSScriptRoot/common/build.sh' $runTestsOnHelixArgs")
+  $runTests = ("&'$PSScriptRoot/runTestsCannotRunOnHelix.sh' $runTestsCannotRunOnHelixArgs", "&'$PSScriptRoot/common/build.sh' $runTestsOnHelixArgs")
 
-   $runTests | ForEach-Object -Parallel { Invoke-Expression $_}
+  $runTests | ForEach-Object -Parallel { Invoke-Expression $_}
+
+  # An array of names of processes to stop on script exit
+  $processesToStopOnExit =  @('msbuild', 'dotnet', 'vbcscompiler')
+
+  Write-Host 'Stopping running build processes...'
+  foreach ($processName in $processesToStopOnExit) {
+    Get-Process -Name $processName -ErrorAction SilentlyContinue | Stop-Process
+  }


### PR DESCRIPTION
Added a -windows flag to the run test script
Pass in additional arguments for the non-windows path
Change to / path separators
Tested the script locally but not much more than that