### PR TITLE
Update SDK to attempt to resolve tool install issues in tests

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.100-alpha.1.21478.48",
+    "dotnet": "7.0.100-alpha.1.21518.14",
     "runtimes": {
       "dotnet": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion)"


### PR DESCRIPTION
It looks like dotnet tool install is taking the bundled target framework from the TFM of the binary itself. Attempt a stage0 update.