### PR TITLE
Fix compatibility task paths in props and targets

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.Compatibility/build/Microsoft.DotNet.Compatibility.targets
+++ b/src/Compatibility/Microsoft.DotNet.Compatibility/build/Microsoft.DotNet.Compatibility.targets
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <DotNetCompatibilityAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.Compatibility.dll</DotNetCompatibilityAssembly>
-    <DotNetCompatibilityAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.Compatibility.dll</DotNetCompatibilityAssembly>
+    <DotNetCompatibilityAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.Compatibility.dll</DotNetCompatibilityAssembly>
     <UseCompatibilityPackage>true</UseCompatibilityPackage>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.props
@@ -2,6 +2,6 @@
 <Project>
   <PropertyGroup>
     <DotNetCompatibilityAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.Compatibility.dll</DotNetCompatibilityAssembly>
-    <DotNetCompatibilityAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.Compatibility.dll</DotNetCompatibilityAssembly>
+    <DotNetCompatibilityAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.Compatibility.dll</DotNetCompatibilityAssembly>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
When the repository tfm was updated to net7.0 on: https://github.com/dotnet/sdk/pull/20973/commits/45710fbe0430ea2feefbfee49fbdb53cd678c279, the wrong compatibility task path was updated to use net7.0 as the directory containing the task. The one that was updated is the one that ships as part of the OOB package and the package intentionally targets net6.0 so that we can run this task on a 6.0 SDK even if a newer package is used. 

The one that needed to move to net7.0 is the one declared when using the SDK built-in tooling as the SDK now generates a layout for net7.0.

Discovered on: https://github.com/dotnet/runtime/pull/60847