### PR TITLE
Allow overriding ServerGarbageCollection in WebSdk

### DIFF
--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -17,7 +17,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
     <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
     <GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">true</GenerateDependencyFile>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ServerGarbageCollection Condition="'$(ServerGarbageCollection)' == ''">true</ServerGarbageCollection>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == '' and '$(IsPackable)' == 'false'">true</WarnOnPackingNonPackableProject>
   </PropertyGroup>


### PR DESCRIPTION
fixes https://github.com/dotnet/sdk/issues/22372

------

### Motivation:

we are running .net webservices in Kubernetes and have noticed that with server gc they consume massive amounts of memory.

For our workloads, client gc seems better suited.

Therefore we would like to default all our projects to client gc using ``Directory.build.props``.

Most of the other properties already follow this pattern, just ``ServerGarbageCollection`` stands out by not checking whether it's already defined beforehand.