### PR TITLE
Ensure references added using "Reference" are correctly copied in BlazorWASM projects

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -125,6 +125,10 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>078701b97eeef2283c1f4605032b5bcf55a80653</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Build.NuGetSdkResolver" Version="6.0.0-rc.278">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>078701b97eeef2283c1f4605032b5bcf55a80653</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.0.0">
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>68bd10d3aee862a9fbb0bac8b3d474bc323024f3</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,7 +58,7 @@
     <NuGetBuildTasksPackPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksPackPackageVersion>
     <NuGetCommandLineXPlatPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetCommandLineXPlatPackageVersion>
     <NuGetProjectModelPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetProjectModelPackageVersion>
-    <MicrosoftBuildNuGetSdkResolverPackageVersion>$(NuGetBuildTasksPackageVersion)</MicrosoftBuildNuGetSdkResolverPackageVersion>
+    <MicrosoftBuildNuGetSdkResolverPackageVersion>6.0.0-rc.278</MicrosoftBuildNuGetSdkResolverPackageVersion>
     <NuGetCommonPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetCommonPackageVersion>
     <NuGetConfigurationPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetConfigurationPackageVersion>
     <NuGetFrameworksPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetFrameworksPackageVersion>

--- a/src/BlazorWasmSdk/BlazorWasmSdk.slnf
+++ b/src/BlazorWasmSdk/BlazorWasmSdk.slnf
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "path": "..\\..\\sdk.sln",
+    "projects": [
+      "src\\BlazorWasmSdk\\Tasks\\Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.csproj",
+      "src\\BlazorWasmSdk\\Tool\\Microsoft.NET.Sdk.BlazorWebAssembly.Tool.csproj",
+      "src\\Tests\\Microsoft.NET.Sdk.BlazorWebAssembly.Tests\\Microsoft.NET.Sdk.BlazorWebAssembly.Tests.csproj"
+    ]
+  }
+}

--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -129,6 +128,14 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                         candidate.SetMetadata("RelativePath", $"_framework/{destinationSubPath}");
                     }
 
+                    // Workaround for https://github.com/dotnet/aspnetcore/issues/37574.
+                    // For items added as "Reference" in project references, the OriginalItemSpec is incorrect.
+                    // Ignore it, and use the FullPath instead.
+                    if (candidate.GetMetadata("ReferenceSourceTarget") == "ProjectReference")
+                    {
+                        candidate.SetMetadata("OriginalItemSpec", candidate.ItemSpec);
+                    }
+
                     var culture = candidate.GetMetadata("Culture");
                     if (!string.IsNullOrEmpty(culture))
                     {
@@ -180,7 +187,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                         "_framework",
                         ProjectAssembly[0].GetMetadata("FileName") + ProjectAssembly[0].GetMetadata("Extension")));
 
-                    var normalizedPath = assetCandidate.GetMetadata("TargetPath").Replace('\\',  '/');
+                    var normalizedPath = assetCandidate.GetMetadata("TargetPath").Replace('\\', '/');
 
                     assetCandidate.SetMetadata("AssetKind", "Build");
                     assetCandidate.SetMetadata("AssetRole", "Related");

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/ComputeBlazorBuildAssetsTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/ComputeBlazorBuildAssetsTest.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests;
+
+public class ComputeBlazorBuildAssetsTest
+{
+    [Fact]
+    public void Execute_FixesReferencesTo()
+    {
+        // Arrange
+        var taskInstance = new ComputeBlazorBuildAssets
+        {
+            Candidates = new[]
+            {
+                new TaskItem(Path.Combine("x:", "refassembly", "file.dll"), new Dictionary<string, string>()
+                {
+                    ["OriginalItemSpec"] = Path.Combine("x:", "MyRefProject", "bin", "Debug", "net6.0", "MyRefProject.dll"),
+                    ["ReferenceSourceTarget"] = "ProjectReference",
+                }),
+                new TaskItem(Path.Combine("x:", "MyRefProject", "bin", "Debug", "net6.0", "MyRefProject.dll"), new Dictionary<string, string>()
+                {
+                    ["OriginalItemSpec"] = Path.Combine("x:", "MyRefProject", "bin", "Debug", "net6.0", "MyRefProject.dll"),
+                    ["ReferenceSourceTarget"] = "ProjectReference",
+                }),
+            },
+            ProjectAssembly = new[]
+            {
+                new TaskItem(Path.Combine("x:", "MyProject", "bin", "Debug", "MyProject.dll"), new Dictionary<string, object>
+                {
+                    ["OriginalItemSpec"] = Path.Combine("x:", "MyProject", "bin", "Debug", "MyProject.dll"),
+                })
+            },
+            ProjectDebugSymbols = new[]
+            {
+                new TaskItem(Path.Combine("x:", "MyProject", "bin", "Debug", "MyProject.pdb"), new Dictionary<string, object>
+                {
+                    ["OriginalItemSpec"] = Path.Combine("x:", "MyProject", "bin", "Debug", "MyProject.pdb"),
+                })
+            },
+            SatelliteAssemblies = Array.Empty<ITaskItem>(),
+            ProjectSatelliteAssemblies = Array.Empty<ITaskItem>(),
+            BuildEngine = Mock.Of<IBuildEngine>(),
+        };
+
+        // Act
+        taskInstance.Execute();
+
+        // Assert
+        Assert.Collection(
+            taskInstance.AssetCandidates,
+            item =>
+            {
+                Assert.Equal(Path.Combine("x:", "refassembly", "file.dll"), item.ItemSpec);
+                Assert.Equal(Path.Combine("x:", "refassembly", "file.dll"), item.GetMetadata("OriginalItemSpec"));
+            },
+            item =>
+            {
+                Assert.Equal(Path.Combine("x:", "MyRefProject", "bin", "Debug", "net6.0", "MyRefProject.dll"), item.ItemSpec);
+                Assert.Equal(Path.Combine("x:", "MyRefProject", "bin", "Debug", "net6.0", "MyRefProject.dll"), item.GetMetadata("OriginalItemSpec"));
+            },
+            item =>
+            {
+                Assert.Equal(Path.Combine("x:", "MyProject", "bin", "Debug", "MyProject.dll"), item.ItemSpec);
+                Assert.Equal(Path.Combine("x:", "MyProject", "bin", "Debug", "MyProject.dll"), item.GetMetadata("OriginalItemSpec"));
+            },
+            item =>
+            {
+                Assert.Equal(Path.Combine("x:", "MyProject", "bin", "Debug", "MyProject.pdb"), item.ItemSpec);
+                Assert.Empty(item.GetMetadata("OriginalItemSpec"));
+            });
+    }
+}
+

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
@@ -1280,6 +1280,59 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(secondAppPublishDirectory, "_framework", "Newtonsoft.Json.dll.br")).Should().NotExist();
         }
 
+        [Fact]
+        public void Publish_WithTransitiveReference_Works()
+        {
+            // Regression test for https://github.com/dotnet/aspnetcore/issues/37574.
+            var testInstance = CreateAspNetSdkTestAsset("BlazorWasmWithLibrary");
+
+            var buildCommand = new BuildCommand(testInstance, "classlibrarywithsatelliteassemblies");
+            buildCommand.Execute().Should().Pass();
+            var referenceAssemblyPath = new FileInfo(Path.Combine(
+                buildCommand.GetOutputDirectory(DefaultTfm).ToString(),
+                "classlibrarywithsatelliteassemblies.dll"));
+
+            referenceAssemblyPath.Should().Exist();
+
+            testInstance.WithProjectChanges((path, project) =>
+            {
+                if (path.Contains("razorclasslibrary"))
+                {
+                    var ns = project.Root.Name.Namespace;
+                    // <ItemGroup>
+                    //  <Reference Include="classlibrarywithsatelliteassemblies" HintPath="$Path\classlibrarywithsatelliteassemblies.dll" />
+                    // </ItemGroup>
+                    var itemGroup = new XElement(ns + "ItemGroup",
+                        new XElement(ns + "Reference",
+                            new XAttribute("Include", "classlibrarywithsatelliteassemblies"),
+                            new XAttribute("HintPath", referenceAssemblyPath)));
+
+                    project.Root.Add(itemGroup);
+                }
+            });
+
+            // Ensure a compile time reference exists between the project and the assembly added as a reference. This is required for 
+            // the assembly to be resolved by the "app" as part of RAR
+            File.WriteAllText(Path.Combine(testInstance.Path, "razorclasslibrary", "TestReference.cs"),
+@"
+public class TestReference
+{
+    public void Method() => System.GC.KeepAlive(typeof(classlibrarywithsatelliteassemblies.Class1));
+}");
+
+            var publishCommand = new PublishCommand(testInstance, "blazorwasm");
+            publishCommand.Execute().Should().Pass();
+
+            // Assert
+            var outputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
+            var fileInWwwroot = new FileInfo(Path.Combine(outputDirectory, "wwwroot", "_framework", "classlibrarywithsatelliteassemblies.dll"));
+            fileInWwwroot.Should().Exist();
+
+            // Make sure it's a the correct copy.
+            fileInWwwroot.Length.Should().Be(referenceAssemblyPath.Length);
+            Assert.Equal(File.ReadAllBytes(referenceAssemblyPath.FullName), File.ReadAllBytes(fileInWwwroot.FullName));
+        }
+
         private static void VerifyBootManifestHashes(TestAsset testAsset, string blazorPublishDirectory)
         {
             var bootManifestResolvedPath = Path.Combine(blazorPublishDirectory, "_framework", "blazor.boot.json");


### PR DESCRIPTION
As part of .NET6, we rely on OriginalItemSpec to copy items around. Unfortunately there is an issue with RAR where references
added using `Reference` have an incorrect ItemSpec (intentionally so). This change works around this case by special casing references from projects where the OriginalItemSpec differs from it's full path.

Fixes https://github.com/dotnet/aspnetcore/issues/37574

--- ---


### Description / Customer impact

Consider a 6.0 Blazor WebAssembly project that references a class library (ClassLibrary1) with a binary added via `Reference` / `HintPath` (MyReferencedBinary.dll). In 6.0, running this project results in a runtime failure. Turns out the SDK does something to effect of:

```
cp ClassLibrary.dll $BlazorWebAppPath/bin/Debug/MyReferencedBinary.dll
```

The root cause is a odd behavior with `ResolveAssemblyReference` that records the `OriginalItemSpec` for `MyReferencedBinary.dll` as `ClassLibrary.dll` which is what Blazor's SDK uses to copy files around. The workaround is to ignore the `OriginalItemSpec` for assemblies resolved as project references and use their actual `ItemSpec` instead.

We had a customer reach out to us since it blocks them from upgrading to 6.0.

### Regression
[x] Yes - .NET 6 RC1
[ ] No

### Testing
* [x] Manual (Verified the user submitted repro is fixed) 
* [x] Automated (added SDK tests to verify this is fixed)

### Risk
* [ ] High
* [ ] Medium
* [x] Low

The workaround is fairly narrow and reasonable, and we have reasonable e2e test coverage, but there's a small risk it regresses another esoteric project configuration we haven't thought about / have tests for. 