### PR TITLE
Exclude runtimeidentifiers for runtimepack

### DIFF
--- a/src/Tasks/Common/Logger.cs
+++ b/src/Tasks/Common/Logger.cs
@@ -127,11 +127,14 @@ namespace Microsoft.NET.Build.Tasks
                     break;
 
                 default:
+
                     if (code != null)
                     {
-                       throw new ArgumentException(
-                           "Message is prefixed with NETSDK error, but error codes should not be used for informational messages: "
-                           + $"{code}:{message}");
+                        //  Previously we would throw an error here, but that makes it hard to allow errors to be turned off but still displayed as messages
+                        //  (which ResolveApppHosts does).  So let's just let messages have NETSDK error codes if they want to also.
+                        //throw new ArgumentException(
+                        //    "Message is prefixed with NETSDK error, but error codes should not be used for informational messages: "
+                        //    + $"{code}:{message}");
                     }
                     break;
             }

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -27,7 +27,6 @@ namespace Microsoft.NET.Build.Tasks
         public const string FrameworkVersion = "FrameworkVersion";
         public const string IsTrimmable = "IsTrimmable";
         public const string RuntimeFrameworkName = "RuntimeFrameworkName";
-        public const string RuntimePackRuntimeIdentifiers = "RuntimePackRuntimeIdentifiers";
 
         // SDK Metadata
         public const string SDKPackageItemSpec = "SDKPackageItemSpec";
@@ -83,11 +82,16 @@ namespace Microsoft.NET.Build.Tasks
 
         // Targeting packs
         public const string PackageConflictPreferredPackages = "PackageConflictPreferredPackages";
+        public const string RuntimePackRuntimeIdentifiers = "RuntimePackRuntimeIdentifiers";
+        public const string RuntimePackExcludedRuntimeIdentifiers = "RuntimePackExcludedRuntimeIdentifiers";
 
         // Runtime packs
         public const string DropFromSingleFile = "DropFromSingleFile";
         public const string RuntimePackLabels = "RuntimePackLabels";
         public const string AdditionalFrameworkReferences = "AdditionalFrameworkReferences";
+
+        //  Apphost packs
+        public const string ExcludedRuntimeIdentifiers = "ExcludedRuntimeIdentifiers";
 
         // Content files
         public const string PPOutputPath = "PPOutputPath";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/NuGetUtils.NuGet.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/NuGetUtils.NuGet.cs
@@ -83,19 +83,37 @@ namespace Microsoft.NET.Build.Tasks
         public static string GetBestMatchingRid(RuntimeGraph runtimeGraph, string runtimeIdentifier,
             IEnumerable<string> availableRuntimeIdentifiers, out bool wasInGraph)
         {
+            return GetBestMatchingRidWithExclusion(runtimeGraph, runtimeIdentifier,
+                runtimeIdentifiersToExclude: null,
+                availableRuntimeIdentifiers, out wasInGraph);
+        }
+
+        public static string GetBestMatchingRidWithExclusion(RuntimeGraph runtimeGraph, string runtimeIdentifier,
+            IEnumerable<string> runtimeIdentifiersToExclude,
+            IEnumerable<string> availableRuntimeIdentifiers, out bool wasInGraph)
+        {
             wasInGraph = runtimeGraph.Runtimes.ContainsKey(runtimeIdentifier);
 
+            string bestMatch = null;
+
             HashSet<string> availableRids = new HashSet<string>(availableRuntimeIdentifiers);
+            HashSet<string> excludedRids = runtimeIdentifiersToExclude switch { null => null, _ => new HashSet<string>(runtimeIdentifiersToExclude) };
             foreach (var candidateRuntimeIdentifier in runtimeGraph.ExpandRuntime(runtimeIdentifier))
             {
-                if (availableRids.Contains(candidateRuntimeIdentifier))
+                if (bestMatch == null && availableRids.Contains(candidateRuntimeIdentifier))
                 {
-                    return candidateRuntimeIdentifier;
+                    bestMatch = candidateRuntimeIdentifier;
+                }
+
+                if (excludedRids != null && excludedRids.Contains(candidateRuntimeIdentifier))
+                {
+                    //  Don't treat this as a match
+                    return null;
                 }
             }
 
             //  No compatible RID found in availableRuntimeIdentifiers
-            return null;
+            return bestMatch;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/NuGetUtils.NuGet.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/NuGetUtils.NuGet.cs
@@ -96,8 +96,8 @@ namespace Microsoft.NET.Build.Tasks
 
             string bestMatch = null;
 
-            HashSet<string> availableRids = new HashSet<string>(availableRuntimeIdentifiers);
-            HashSet<string> excludedRids = runtimeIdentifiersToExclude switch { null => null, _ => new HashSet<string>(runtimeIdentifiersToExclude) };
+            HashSet<string> availableRids = new HashSet<string>(availableRuntimeIdentifiers, StringComparer.Ordinal);
+            HashSet<string> excludedRids = runtimeIdentifiersToExclude switch { null => null, _ => new HashSet<string>(runtimeIdentifiersToExclude, StringComparer.Ordinal) };
             foreach (var candidateRuntimeIdentifier in runtimeGraph.ExpandRuntime(runtimeIdentifier))
             {
                 if (bestMatch == null && availableRids.Contains(candidateRuntimeIdentifier))
@@ -112,7 +112,6 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            //  No compatible RID found in availableRuntimeIdentifiers
             return bestMatch;
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -456,10 +456,12 @@ namespace Microsoft.NET.Build.Tasks
         {
             var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
             var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = selectedRuntimePack.RuntimePackRuntimeIdentifiers.Split(';');
+            var knownFrameworkReferenceRuntimePackExcludedRuntimeIdentifiers = selectedRuntimePack.RuntimePackExcludedRuntimeIdentifiers.Split(';');
 
-            string runtimePackRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(
+            string runtimePackRuntimeIdentifier = NuGetUtils.GetBestMatchingRidWithExclusion(
                     runtimeGraph,
                     runtimeIdentifier,
+                    knownFrameworkReferenceRuntimePackExcludedRuntimeIdentifiers,
                     knownFrameworkReferenceRuntimePackRuntimeIdentifiers,
                     out bool wasInGraph);
 
@@ -848,6 +850,8 @@ namespace Microsoft.NET.Build.Tasks
             public string RuntimePackNamePatterns => _item.GetMetadata("RuntimePackNamePatterns");
 
             public string RuntimePackRuntimeIdentifiers => _item.GetMetadata(MetadataKeys.RuntimePackRuntimeIdentifiers);
+
+            public string RuntimePackExcludedRuntimeIdentifiers => _item.GetMetadata(MetadataKeys.RuntimePackExcludedRuntimeIdentifiers);
 
             public string IsTrimmable => _item.GetMetadata(MetadataKeys.IsTrimmable);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -221,15 +221,17 @@ namespace Microsoft.NET.Build.Tasks
             string appHostRuntimeIdentifiers = selectedAppHostPack.GetMetadata("AppHostRuntimeIdentifiers");
             string appHostPackPattern = selectedAppHostPack.GetMetadata("AppHostPackNamePattern");
             string appHostPackVersion = selectedAppHostPack.GetMetadata("AppHostPackVersion");
+            string runtimeIdentifiersToExclude = selectedAppHostPack.GetMetadata(MetadataKeys.ExcludedRuntimeIdentifiers);
 
             if (!string.IsNullOrEmpty(RuntimeFrameworkVersion))
             {
                 appHostPackVersion = RuntimeFrameworkVersion;
             }
 
-            string bestAppHostRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(
+            string bestAppHostRuntimeIdentifier = NuGetUtils.GetBestMatchingRidWithExclusion(
                 new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
                 runtimeIdentifier,
+                runtimeIdentifiersToExclude.Split(';'),
                 appHostRuntimeIdentifiers.Split(';'),
                 out bool wasInGraph);
 

--- a/src/Tests/Microsoft.NET.Build.Tests/KnownRuntimePackTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/KnownRuntimePackTests.cs
@@ -106,6 +106,40 @@ namespace Microsoft.NET.Build.Tests
 
         }
 
+        [Fact]
+        public void AspNetRuntimePackIsNotRestoredForAndroid()
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = "net6.0",
+                IsExe = true
+            };
+            testProject.AdditionalProperties["RuntimeIdentifiers"] = "android-arm;android-arm64;android-x86;android-x64";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var knownFrameworkReferenceUpdate = new XElement("KnownFrameworkReference",
+                new XAttribute("Update", "Microsoft.AspNetCore.App"),
+                new XAttribute("RuntimePackExcludedRuntimeIdentifiers", "android"));
+
+            AddItem(testAsset, knownFrameworkReferenceUpdate);
+
+            var getValuesCommand = new GetValuesCommand(testAsset, "PackageDownload", GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "ProcessFrameworkReferences",
+                ShouldRestore = false
+            };
+
+            getValuesCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var packageDownloads = getValuesCommand.GetValues();
+
+            packageDownloads.Should().NotContain(packageDownload => packageDownload.StartsWith("Microsoft.AspNetCore.App.Runtime."));
+        }
+
         private XElement CreateTestKnownRuntimePack()
         {
             var knownRuntimePack = new XElement("KnownRuntimePack",

--- a/src/Tests/Microsoft.NET.Build.Tests/KnownRuntimePackTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/KnownRuntimePackTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.NET.Build.Tests
         {
             var testProject = new TestProject()
             {
-                TargetFrameworks = "net6.0",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true
             };
             testProject.AdditionalProperties["RuntimeIdentifiers"] = "android-arm;android-arm64;android-x86;android-x64";


### PR DESCRIPTION
Allow RuntimeIdentifiers to be excluded from runtime packs.

Will fix #19891, once we add `RuntimePackExcludedRuntimeIdentifiers="android"` to the ASP.NET KnownFrameworkReference items.

Also fixes an unrelated issue where ResolveAppHosts would generate errors in debug mode because it was generating messages prefixed with NETSDK error codes.