### PR TITLE
Fix version comparison for dotnet tool install

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
@@ -7,7 +7,6 @@ using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
@@ -24,8 +23,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 {
     internal delegate IShellShimRepository CreateShellShimRepository(string appHostSourceDirectory, DirectoryPath? nonGlobalLocation = null);
     internal delegate (IToolPackageStore, IToolPackageStoreQuery, IToolPackageInstaller) CreateToolPackageStoresAndInstaller(
-		DirectoryPath? nonGlobalLocation = null,
-		IEnumerable<string> forwardRestoreArguments = null);
+        DirectoryPath? nonGlobalLocation = null,
+        IEnumerable<string> forwardRestoreArguments = null);
 
     internal class ToolInstallGlobalOrToolPathCommand : CommandBase
     {
@@ -67,7 +66,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             _architectureOption = parseResult.GetValueForOption(ToolInstallCommandParser.ArchitectureOption);
 
             _createToolPackageStoresAndInstaller = createToolPackageStoreAndInstaller ?? ToolPackageFactory.CreateToolPackageStoresAndInstaller;
-			_forwardRestoreArguments = parseResult.OptionValuesToBeForwarded(ToolInstallCommandParser.GetCommand());
+            _forwardRestoreArguments = parseResult.OptionValuesToBeForwarded(ToolInstallCommandParser.GetCommand());
 
             _environmentPathInstruction = environmentPathInstruction
                 ?? EnvironmentPathFactory.CreateEnvironmentPathInstruction();
@@ -134,9 +133,12 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                         versionRange: versionRange,
                         targetFramework: _framework, verbosity: _verbosity);
 
-                    var framework = string.IsNullOrEmpty(_framework) && package.Frameworks.Count() > 0  ?
-                        package.Frameworks.Where(f => f.Version < new Version(Product.Version)).MaxBy(f => f.Version) :
+                    NuGetVersion productVersion = new NuGetVersion(Product.Version);
+
+                    var framework = string.IsNullOrEmpty(_framework) && package.Frameworks.Count() > 0 ?
+                        package.Frameworks.Where(f => f.Version < productVersion.Version).MaxBy(f => f.Version) :
                         NuGetFramework.Parse(_framework);
+
                     string appHostSourceDirectory = _shellShimTemplateFinder.ResolveAppHostSourceDirectoryAsync(_architectureOption, framework, RuntimeInformation.ProcessArchitecture).Result;
                     IShellShimRepository shellShimRepository = _createShellShimRepository(appHostSourceDirectory, toolPath);
 
@@ -170,7 +172,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             {
                 throw new GracefulException(
                     messages: InstallToolCommandLowLevelErrorConverter.GetUserFacingMessages(ex, _packageId),
-                    verboseMessages: new[] {ex.ToString()},
+                    verboseMessages: new[] { ex.ToString() },
                     isUserError: false);
             }
         }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
@@ -133,10 +133,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                         versionRange: versionRange,
                         targetFramework: _framework, verbosity: _verbosity);
 
-                    NuGetVersion productVersion = new NuGetVersion(Product.Version);
-
                     var framework = string.IsNullOrEmpty(_framework) && package.Frameworks.Count() > 0 ?
-                        package.Frameworks.Where(f => f.Version < productVersion.Version).MaxBy(f => f.Version) :
+                        package.Frameworks.Where(f => f.Version < (new NuGetVersion(Product.Version)).Version).MaxBy(f => f.Version) :
                         NuGetFramework.Parse(_framework);
 
                     string appHostSourceDirectory = _shellShimTemplateFinder.ResolveAppHostSourceDirectoryAsync(_architectureOption, framework, RuntimeInformation.ProcessArchitecture).Result;


### PR DESCRIPTION
.version file can contain semantic versions causing Version.Parse to throw an exception. Since we're only comparing against the package framework versions, we'll parse and then discard the semantic elements.