### PR TITLE
Update developer-guide to instruct to source the dogfood bash script

### DIFF
--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -88,7 +88,7 @@ You can now run `dotnet` commands to test changes.
 Run the following commands from the root of the repository to setup the test environment:
 
 ```
-.\eng\dogfood.sh
+source ./eng/dogfood.sh
 ```
 
 Ensure the `dotnet` being used is from the artifacts directory:


### PR DESCRIPTION
Running the script does not work since it runs it in a sub-shell. You need to source the file so that it exports the env variables in the current shell.