### PR TITLE
set encoding to UTF8 in case output is redirected (sdk-wide)

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -26,6 +26,11 @@ namespace Microsoft.DotNet.Cli
 
         public static int Main(string[] args)
         {
+            if (Console.IsOutputRedirected)
+            {
+                Console.OutputEncoding = Encoding.UTF8;
+            }
+
             DebugHelper.HandleDebugSwitch(ref args);
 
             // Capture the current timestamp to calculate the host overhead.

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -26,9 +26,15 @@ namespace Microsoft.DotNet.Cli
 
         public static int Main(string[] args)
         {
-            if (Console.IsOutputRedirected)
+            //setting output encoding is not available on those platforms
+            if (!OperatingSystem.IsIOS() && !OperatingSystem.IsAndroid() && !OperatingSystem.IsTvOS())
             {
-                Console.OutputEncoding = Encoding.UTF8;
+                //if output is redirected, force encoding to utf-8;
+                //otherwise the caller may not decode it correctly
+                if (Console.IsOutputRedirected)
+                {
+                    Console.OutputEncoding = Encoding.UTF8;
+                }
             }
 
             DebugHelper.HandleDebugSwitch(ref args);


### PR DESCRIPTION
follow up for https://github.com/dotnet/sdk/pull/19847

couple of reasons for this change:
- https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/4236/Character-Encoding-Issues?anchor=stdout recommends to set output to UTF 8 in case it is redirected. We would like to adhere to this guideline for dotnet new, however it also makes sense to do it sdk-wide
- we forced it previously in dotnet new CLI code (https://github.com/dotnet/templating/commit/48f5e8392ebbdd3d2f3c239854055277e68e0c57), however since we are moving to System.CommandLine it should be moved to sdk repo prior to new command will be parsed, as parsing may do error reporting to console.
- we have issues recently (https://github.com/dotnet/templating/issues/2789) where sdk command was run as process with output being redirected and was not properly encoded (but we never could repro it) and I believe that this can fix it. Since I cannot repro it, I cannot 100% guarantee it will fix it.

if there are any objections to it, please let me know - I think of making it applicable only to dotnet new when integrating new way of parsing for dotnet new, however this might not help for reason 3.
