### PR TITLE
Merge pull request #22284 from dotnet/marcpopMSFT-parallelnonwindows

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -131,6 +131,7 @@ stages:
               _BuildConfig: Release
               _PublishArgs: ''
               _SignType: test
+              _Test: -test
 
     - template: /eng/build.yml
       parameters:
@@ -147,6 +148,7 @@ stages:
               _BuildConfig: Release
               _PublishArgs: ''
               _SignType: test
+              _Test: -test
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates/job/publish-build-assets.yml

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -135,23 +135,13 @@ jobs:
         displayName: Build
         env:
           BuildConfig: $(_BuildConfig)
-      - script: eng/runTestsCannotRunOnHelix.sh
-                  --configuration $(_BuildConfig)
-                  --ci
-                  $(_OfficialBuildIdArgs)
-        displayName: Run Tests Cannot Run On Helix
-        env:
-          BuildConfig: $(_BuildConfig)
-      - script: eng/common/build.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              --ci
-              --restore
-              --test
-              --projects $(Build.SourcesDirectory)/src/Tests/UnitTests.proj
-              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/TestInHelix.binlog
-              /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
-        displayName: Run Tests in Helix
+      - powershell: eng/runHelixAndNonHelixInParallelNonWindows.ps1
+                -configuration $(_BuildConfig)
+                -buildSourcesDirectory $(Build.SourcesDirectory)
+                -customHelixTargetQueue ${{ parameters.helixTargetQueue }}
+                -officialBuildIdArgs "$(_OfficialBuildIdArgs)"
+                $(_Test)
+        displayName: Run Tests in Helix and non Helix in parallel
         condition: succeededOrFailed()
         env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/runHelixAndNonHelixInParallelNonWindows.ps1
+++ b/eng/runHelixAndNonHelixInParallelNonWindows.ps1
@@ -1,0 +1,35 @@
+  [CmdletBinding(PositionalBinding = $false)]
+  Param(
+      [string] $configuration,
+      [string] $buildSourcesDirectory,
+      [string] $customHelixTargetQueue,
+      [string] $officialBuildIdArgs,
+      [switch] $test
+  )
+
+  if (-not $test)
+  {
+      Write-Output "No '-test' switch. Skip both helix and non helix tests"
+      return
+  }
+
+  $runTestsCannotRunOnHelixArgs = ("-configuration", $configuration, "-ci", $officialBuildIdArgs)
+  $runTestsOnHelixArgs = ("-configuration", $configuration,
+    "-ci",
+  "-restore",
+  "-test",
+  "-projects", "$buildSourcesDirectory/src/Tests/UnitTests.proj",
+  "/bl:$buildSourcesDirectory/artifacts/log/$configuration/TestInHelix.binlog",
+  "/p:_CustomHelixTargetQueue=$customHelixTargetQueue")
+
+  $runTests = ("&'$PSScriptRoot/runTestsCannotRunOnHelix.sh' $runTestsCannotRunOnHelixArgs", "&'$PSScriptRoot/common/build.sh' $runTestsOnHelixArgs")
+
+  $runTests | ForEach-Object -Parallel { Invoke-Expression $_}
+
+  # An array of names of processes to stop on script exit
+  $processesToStopOnExit =  @('msbuild', 'dotnet', 'vbcscompiler')
+
+  Write-Host 'Stopping running build processes...'
+  foreach ($processName in $processesToStopOnExit) {
+    Get-Process -Name $processName -ErrorAction SilentlyContinue | Stop-Process
+  }


### PR DESCRIPTION
Switch the non-windows test builds to also run helix and non-helix in parallel.

Port of https://github.com/dotnet/sdk/pull/22284