### PR TITLE
Use Environment.Process{Path,Id} & delete wrappers

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
@@ -11,7 +11,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     public class DotNetBuildFilter : IWatchFilter
     {
-        private readonly string _muxer = DotnetMuxer.MuxerPath;
         private readonly IFileSetFactory _fileSetFactory;
         private readonly ProcessRunner _processRunner;
         private readonly IReporter _reporter;
@@ -33,7 +32,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                 var processSpec = new ProcessSpec
                 {
-                    Executable = _muxer,
+                    Executable = DotnetMuxer.MuxerPath,
                     Arguments = arguments,
                     WorkingDirectory = context.ProcessSpec.WorkingDirectory,
                 };

--- a/src/BuiltInTools/dotnet-watch/Internal/DotnetMuxer.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/DotnetMuxer.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 
@@ -10,7 +11,7 @@ namespace Microsoft.DotNet.Watcher.Tools
     {
         static DotnetMuxer()
         {
-            MuxerPath = Process.GetCurrentProcess().MainModule.FileName;
+            MuxerPath = Environment.ProcessPath;
             Debug.Assert(Path.GetFileNameWithoutExtension(MuxerPath) == "dotnet", $"Invalid muxer path {MuxerPath}");
         }
 

--- a/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
@@ -20,7 +20,6 @@ namespace Microsoft.DotNet.Watcher.Internal
         private const string TargetName = "GenerateWatchList";
         private const string WatchTargetsFileName = "DotNetWatch.targets";
 
-        private readonly string _muxerPath;
         private readonly IReporter _reporter;
         private readonly DotNetWatchOptions _dotNetWatchOptions;
         private readonly string _projectFile;
@@ -35,14 +34,13 @@ namespace Microsoft.DotNet.Watcher.Internal
             string projectFile,
             bool waitOnError,
             bool trace)
-            : this(dotNetWatchOptions, DotnetMuxer.MuxerPath, reporter, projectFile, new OutputSink(), waitOnError, trace)
+            : this(dotNetWatchOptions, reporter, projectFile, new OutputSink(), waitOnError, trace)
         {
         }
 
         // output sink is for testing
         internal MsBuildFileSetFactory(
             DotNetWatchOptions dotNetWatchOptions,
-            string muxerPath,
             IReporter reporter,
             string projectFile,
             OutputSink outputSink,
@@ -53,7 +51,6 @@ namespace Microsoft.DotNet.Watcher.Internal
             Ensure.NotNullOrEmpty(projectFile, nameof(projectFile));
             Ensure.NotNull(outputSink, nameof(outputSink));
 
-            _muxerPath = muxerPath;
             _reporter = reporter;
             _dotNetWatchOptions = dotNetWatchOptions;
             _projectFile = projectFile;
@@ -93,7 +90,7 @@ namespace Microsoft.DotNet.Watcher.Internal
 
                     var processSpec = new ProcessSpec
                     {
-                        Executable = _muxerPath,
+                        Executable = DotnetMuxer.MuxerPath,
                         WorkingDirectory = projectDir,
                         Arguments = arguments,
                         OutputCapture = capture

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/DebugHelper.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/DebugHelper.cs
@@ -22,8 +22,14 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public static void WaitForDebugger()
         {
+#if NET5_0_OR_GREATER
+            int processId = Environment.ProcessId;
+#else
+            int processId = Process.GetCurrentProcess().Id;
+#endif
+
             Console.WriteLine(LocalizableStrings.WaitingForDebuggerToAttach);
-            Console.WriteLine(string.Format(LocalizableStrings.ProcessId, Process.GetCurrentProcess().Id));
+            Console.WriteLine(string.Format(LocalizableStrings.ProcessId, processId));
             Console.ReadLine();
         }
     }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -36,7 +36,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public Muxer()
         {
+#if NET6_0_OR_GREATER
+            _muxerPath = Environment.ProcessPath;
+#else
             _muxerPath = Process.GetCurrentProcess().MainModule.FileName;
+#endif
         }
 
         public static string GetDataFromAppDomain(string propertyName)

--- a/src/Cli/dotnet/PerformanceLogEventListener.cs
+++ b/src/Cli/dotnet/PerformanceLogEventListener.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.Text;
@@ -27,7 +26,6 @@ namespace Microsoft.DotNet.Cli.Utils
         };
 
         private const char EventDelimiter = '\n';
-        private string _processIDStr;
         private StreamWriter _writer;
 
         [ThreadStatic]
@@ -70,10 +68,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
         internal void Initialize(IFileSystem fileSystem, string logDirectory)
         {
-            _processIDStr = Process.GetCurrentProcess().Id.ToString();
-
             // Use a GUID disambiguator to make sure that we have a unique file name.
-            string logFilePath = Path.Combine(logDirectory, $"perf-{_processIDStr}-{Guid.NewGuid().ToString("N")}.log");
+            string logFilePath = Path.Combine(logDirectory, $"perf-{Environment.ProcessId}-{Guid.NewGuid().ToString("N")}.log");
 
             Stream outputStream = fileSystem.File.OpenFile(
                 logFilePath,
@@ -134,7 +130,7 @@ namespace Microsoft.DotNet.Cli.Utils
                     s_builder.Clear();
                 }
 
-                s_builder.Append($"[{DateTime.UtcNow.ToString("o")}] Event={eventData.EventSource.Name}/{eventData.EventName} ProcessID={_processIDStr} ThreadID={System.Threading.Thread.CurrentThread.ManagedThreadId}\t ");
+                s_builder.Append($"[{DateTime.UtcNow.ToString("o")}] Event={eventData.EventSource.Name}/{eventData.EventName} ProcessID={Environment.ProcessId} ThreadID={System.Threading.Thread.CurrentThread.ManagedThreadId}\t ");
                 for (int i = 0; i < eventData.PayloadNames.Count; i++)
                 {
                     s_builder.Append($"{eventData.PayloadNames[i]}=\"{eventData.Payload[i]}\" ");

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
@@ -134,8 +134,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             // Best effort to verify that the server was not started indirectly or being spoofed.
             if ((ParentProcess == null) || (ParentProcess.StartTime > CurrentProcess.StartTime) ||
-                string.IsNullOrWhiteSpace(CurrentProcess.MainModule.FileName) ||
-                !string.Equals(ParentProcess.MainModule.FileName, CurrentProcess.MainModule.FileName, StringComparison.OrdinalIgnoreCase))
+                !string.Equals(ParentProcess.MainModule.FileName, Environment.ProcessPath, StringComparison.OrdinalIgnoreCase))
             {
                 throw new SecurityException(String.Format(LocalizableStrings.NoTrustWithParentPID, ParentProcess?.Id));
             }
@@ -154,7 +153,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 PipeAccessRights.Read | PipeAccessRights.Write | PipeAccessRights.Synchronize, AccessControlType.Allow));
 
             // Initialize the named pipe for dispatching commands. The name of the pipe is based off the server PID since
-            // the client knows this value and ensures both processes can generate the same name. 
+            // the client knows this value and ensures both processes can generate the same name.
             string pipeName = WindowsUtils.CreatePipeName(CurrentProcess.Id);
             NamedPipeServerStream serverPipe = NamedPipeServerStreamAcl.Create(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message,
                 PipeOptions.None, 65535, 65535, pipeSecurity);

--- a/src/RazorSdk/Tasks/DotnetToolTask.cs
+++ b/src/RazorSdk/Tasks/DotnetToolTask.cs
@@ -83,7 +83,13 @@ namespace Microsoft.AspNetCore.Razor.Tasks
         {
             if (Debug)
             {
-                Log.LogMessage(MessageImportance.High, "Waiting for debugger in pid: {0}", Process.GetCurrentProcess().Id);
+#if NET5_0_OR_GREATER
+                var processId = Environment.ProcessId;
+#else
+                var processId = Process.GetCurrentProcess().Id;
+#endif
+
+                Log.LogMessage(MessageImportance.High, "Waiting for debugger in pid: {0}", processId);
                 while (!Debugger.IsAttached)
                 {
                     Thread.Sleep(TimeSpan.FromSeconds(3));

--- a/src/RazorSdk/Tool/DebugMode.cs
+++ b/src/RazorSdk/Tool/DebugMode.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             {
                 args = args.Skip(1).ToArray();
 
-                Console.WriteLine("Waiting for debugger in pid: {0}", Process.GetCurrentProcess().Id);
+                Console.WriteLine("Waiting for debugger in pid: {0}", Environment.ProcessId);
                 while (!Debugger.IsAttached)
                 {
                     Thread.Sleep(TimeSpan.FromSeconds(3));

--- a/src/RazorSdk/Tool/DefaultRequestDispatcher.cs
+++ b/src/RazorSdk/Tool/DefaultRequestDispatcher.cs
@@ -341,7 +341,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
                     if (request.IsShutdownRequest())
                     {
                         // Reply with the PID of this process so that the client can wait for it to exit.
-                        var response = new ShutdownServerResponse(Process.GetCurrentProcess().Id);
+                        var response = new ShutdownServerResponse(Environment.ProcessId);
                         await response.WriteAsync(connection.Stream, cancellationToken);
 
                         // We can safely disconnect the client, then when this connection gets cleaned up by the event loop

--- a/src/RazorSdk/Tool/ServerCommand.cs
+++ b/src/RazorSdk/Tool/ServerCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -148,7 +147,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             // <pipename>
 
             const int DefaultBufferSize = 4096;
-            var processId = Process.GetCurrentProcess().Id;
+            var processId = Environment.ProcessId;
             var fileName = $"rzc-{processId}";
 
             // Make sure the directory exists.

--- a/src/RazorSdk/Tool/ServerProtocol/ServerLogger.cs
+++ b/src/RazorSdk/Tool/ServerProtocol/ServerLogger.cs
@@ -111,7 +111,8 @@ namespace Microsoft.NET.Sdk.Razor.Tool
         {
             if (IsLoggingEnabled)
             {
-                var prefix = GetLoggingPrefix();
+                var prefix = string.Format(CultureInfo.InvariantCulture, "{0} PID={1} TID={2} Ticks={3}: ", s_prefix,
+                    GetCurrentProcessId(), Environment.CurrentManagedThreadId, Environment.TickCount);
 
                 var output = prefix + message + "\r\n";
                 var bytes = Encoding.UTF8.GetBytes(output);
@@ -124,23 +125,11 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             }
         }
 
-        private static int GetCurrentProcessId()
-        {
-            var process = Process.GetCurrentProcess();
-            return process.Id;
-        }
-
-        private static int GetCurrentThreadId()
-        {
-            return Environment.CurrentManagedThreadId;
-        }
-
-        /// <summary>
-        /// Get the string that prefixes all log entries. Shows the process, thread, and time.
-        /// </summary>
-        private static string GetLoggingPrefix()
-        {
-            return string.Format(CultureInfo.InvariantCulture, "{0} PID={1} TID={2} Ticks={3}: ", s_prefix, GetCurrentProcessId(), GetCurrentThreadId(), Environment.TickCount);
-        }
+        private static int GetCurrentProcessId() =>
+#if NET5_0_OR_GREATER
+            Environment.ProcessId;
+#else
+            Process.GetCurrentProcess().Id;
+#endif
     }
 }

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -72,7 +72,11 @@ namespace Microsoft.DotNet.NativeWrapper
 
             if (string.IsNullOrWhiteSpace(dotnetExe))
             {
+#if NET6_0_OR_GREATER
+                dotnetExe = Environment.ProcessPath;
+#else
                 dotnetExe = Process.GetCurrentProcess().MainModule.FileName;
+#endif
             }
 
             return Path.GetDirectoryName(dotnetExe);

--- a/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
+++ b/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
@@ -22,8 +22,6 @@ namespace Microsoft.DotNet.Watcher.Tools
         private readonly IReporter _reporter;
         private readonly TestAssetsManager _testAssets;
 
-        private static string DotNetHostPath => TestContext.Current.ToolsetUnderTest.DotNetHostPath;
-
         public MsBuildFileSetFactoryTest(ITestOutputHelper output)
         {
             _reporter = new TestReporter(output);
@@ -328,7 +326,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             var output = new OutputSink();
             var options = GetWatchOptions();
-            var filesetFactory = new MsBuildFileSetFactory(options, DotNetHostPath, _reporter, projectA, output, waitOnError: false, trace: true);
+            var filesetFactory = new MsBuildFileSetFactory(options, _reporter, projectA, output, waitOnError: false, trace: true);
 
             var fileset = await GetFileSet(filesetFactory);
 
@@ -363,10 +361,10 @@ namespace Microsoft.DotNet.Watcher.Tools
         private Task<FileSet> GetFileSet(string projectPath)
         {
             DotNetWatchOptions options = GetWatchOptions();
-            return GetFileSet(new MsBuildFileSetFactory(options, DotNetHostPath, _reporter, projectPath, new OutputSink(), waitOnError: false, trace: false));
+            return GetFileSet(new MsBuildFileSetFactory(options, _reporter, projectPath, new OutputSink(), waitOnError: false, trace: false));
         }
 
-        private static DotNetWatchOptions GetWatchOptions() => 
+        private static DotNetWatchOptions GetWatchOptions() =>
             new DotNetWatchOptions(false, false, false, false, false);
 
         private static string GetTestProjectPath(TestAsset target) => Path.Combine(GetTestProjectDirectory(target), target.TestProject.Name + ".csproj");


### PR DESCRIPTION
Replaces:

* `Process.GetCurrentProcess().MainModule.FileName` in a few places with [`Environment.ProcessPath`](https://docs.microsoft.com/en-us/dotnet/api/system.environment.processpath#System_Environment_ProcessPath) property, which was introduced in .NET 6.
* `Process.GetCurrentProcess().Id` in a few places with [`Environment.ProcessId`](https://docs.microsoft.com/en-us/dotnet/api/system.environment.processid#System_Environment_ProcessPath) property, which was introduced in .NET 5.