### PR TITLE
Transformed --arch switch to --platform for dll tests container scenario

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
@@ -27,7 +27,8 @@ namespace Microsoft.DotNet.Cli
             ["--filter"] = "--testcasefilter",
             ["--list-tests"] = "--listtests",
             ["--test-adapter-path"] = "--testadapterpath",
-            ["--results-directory"] = "--resultsdirectory"
+            ["--results-directory"] = "--resultsdirectory",
+            ["--arch"] = "--platform"
         };
 
         private readonly Dictionary<string, string> VerbosityMapping = new Dictionary<string, string>

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -603,6 +603,31 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.StartInfo.EnvironmentVariables[dotnetRoot].Should().Be(Path.GetDirectoryName(dotnet));
         }
 
+        [Fact]
+        public void TestsFromCsprojAndArchSwitchShouldFlowToMsBuild()
+        {
+            string testAppName = "VSTestCore";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource()
+                .WithVersionVariables()
+                .WithProjectChanges(ProjectModification.AddDisplayMessageBeforeVsTestToProject);
+
+            var testProjectDirectory = testInstance.Path;
+
+            // Call test
+            CommandResult result = new DotnetTestCommand(Log)
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("--arch", "wrongArchitecture");
+
+            // Verify
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut.Should().Contain("error NETSDK1083: The specified RuntimeIdentifier");
+                result.StdOut.Should().Contain("wrongArchitecture");
+            }
+
+            result.ExitCode.Should().Be(1);
+        }
 
         private string CopyAndRestoreVSTestDotNetCoreTestApp([CallerMemberName] string callingMethod = "")
         {

--- a/src/Tests/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
@@ -70,6 +70,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
             public static IEnumerable<object[]> ArgTestCases { get; } = new List<object[]>
             {
                 new object[] { @"-h", "--help" },
+                new object[] { @"sometest.dll --arch x86" , @"sometest.dll --platform:x86"},
                 new object[] { @"sometest.dll -s test.settings", @"sometest.dll --settings:test.settings" },
                 new object[] { @"sometest.dll -t", @"sometest.dll --listtests" },
                 new object[] { @"sometest.dll --list-tests", @"sometest.dll --listtests" },
@@ -84,7 +85,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
                 new object[] { @"sometest.dll -s:testsettings -t -a:c:\path -f:net451 -d:log.txt --results-directory:c:\temp\", @"sometest.dll --settings:testsettings --listtests --testadapterpath:c:\path --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\" },
                 new object[] { @"sometest.dll --settings testsettings -t --test-adapter-path c:\path --framework net451 --diag log.txt --results-directory c:\temp\", @"sometest.dll --settings:testsettings --listtests --testadapterpath:c:\path --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\" },
                 new object[] { @"sometest.dll --blame", @"sometest.dll --blame" },
-                new object[] { @"sometest.dll --blame-crash", @"sometest.dll --blame:CollectDump" },                
+                new object[] { @"sometest.dll --blame-crash", @"sometest.dll --blame:CollectDump" },
                 new object[] { @"sometest.dll --blame-crash-dump-type full", @"sometest.dll --blame:CollectDump;DumpType=full" },
                 new object[] { @"sometest.dll --blame-crash-collect-always", @"sometest.dll --blame:CollectDump;CollectAlways=true" },
                 new object[] { @"sometest.dll --blame --blame-crash-dump-type full --blame-crash-collect-always", @"sometest.dll --blame:CollectDump;CollectAlways=true;DumpType=full" },


### PR DESCRIPTION
Transformed --arch switch to --platform for dll tests container scenario

This fix will add support to the `--arch` switch for the scenario where the test dll containers are provided by test file path:

`dotnet test c:\test\...\test.dll --arch x64`

At the moment we support only csproj invocation:

`dotnet test c:\test...\test.csproj --arch x64`