### PR TITLE
Handle the case when procfs is inaccessible

### DIFF
--- a/src/Cli/dotnet/PerformanceLogEventSource.cs
+++ b/src/Cli/dotnet/PerformanceLogEventSource.cs
@@ -420,29 +420,38 @@ namespace Microsoft.DotNet.Cli
 
         private void Initialize()
         {
-            using (StreamReader reader = new StreamReader(File.OpenRead("/proc/meminfo")))
+            try
             {
-                string line;
-                while (!Valid && ((line = reader.ReadLine()) != null))
+                using (StreamReader reader = new StreamReader(File.OpenRead("/proc/meminfo")))
                 {
-                    if (line.StartsWith(MemTotal) || line.StartsWith(MemAvailable))
+                    string line;
+                    while (!Valid && ((line = reader.ReadLine()) != null))
                     {
-                        string[] tokens = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                        if (tokens.Length == 3)
+                        if (line.StartsWith(MemTotal) || line.StartsWith(MemAvailable))
                         {
-                            if (MemTotal.Equals(tokens[0]))
+                            string[] tokens = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                            if (tokens.Length == 3)
                             {
-                                TotalMemoryMB = (int)Convert.ToUInt64(tokens[1]) / 1024;
-                                _matchingLineCount++;
-                            }
-                            else if (MemAvailable.Equals(tokens[0]))
-                            {
-                                AvailableMemoryMB = (int)Convert.ToUInt64(tokens[1]) / 1024;
-                                _matchingLineCount++;
+                                if (MemTotal.Equals(tokens[0]))
+                                {
+                                    TotalMemoryMB = (int)Convert.ToUInt64(tokens[1]) / 1024;
+                                    _matchingLineCount++;
+                                }
+                                else if (MemAvailable.Equals(tokens[0]))
+                                {
+                                    AvailableMemoryMB = (int)Convert.ToUInt64(tokens[1]) / 1024;
+                                    _matchingLineCount++;
+                                }
                             }
                         }
                     }
                 }
+            }
+            catch (Exception ex) when (ex is IOException || ex.InnerException is IOException)
+            {
+                // in some environments (restricted docker container, shared hosting etc.),
+                // procfs is not accessible and we get UnauthorizedAccessException while the
+                // inner exception is set to IOException. Ignore and continue when that happens.
             }
         }
     }

--- a/src/Cli/dotnet/Telemetry/DockerContainerDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/DockerContainerDetectorForTelemetry.cs
@@ -46,18 +46,15 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 {
                     // in some environments (restricted docker container, shared hosting etc.),
                     // procfs is not accessible and we get UnauthorizedAccessException while the
-                    // inner exception is set to IOException. Return Unknown when that happens.
-                    return Cli.Telemetry.IsDockerContainer.Unknown;
+                    // inner exception is set to IOException. Ignore and continue when that happens.
                 }
             }
             else if (OperatingSystem.IsMacOS())
             {
                 return Cli.Telemetry.IsDockerContainer.False;
             }
-            else
-            {
-                return Cli.Telemetry.IsDockerContainer.Unknown;
-            }
+
+            return Cli.Telemetry.IsDockerContainer.Unknown;
         }
     }
 

--- a/src/Cli/dotnet/Telemetry/DockerContainerDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/DockerContainerDetectorForTelemetry.cs
@@ -48,9 +48,20 @@ namespace Microsoft.DotNet.Cli.Telemetry
 
         private static bool ReadProcToDetectDockerInLinux()
         {
-            return File
-                .ReadAllText("/proc/1/cgroup")
-                .Contains("/docker/");
+            try
+            {
+                return File
+                    .ReadAllText("/proc/1/cgroup")
+                    .Contains("/docker/");
+            }
+            catch (Exception ex) when (ex is IOException || ex.InnerException is IOException)
+            {
+                // in some environments (restricted docker container, shared hosting etc.),
+                // procfs is not accessible and we get UnauthorizedAccessException while the
+                // inner exception is set to IOException. Ignore and continue when that happens.
+            }
+
+            return false;
         }
     }
 


### PR DESCRIPTION
Access to proc filesystem is expected to be unavailable. In the runtime repo, we have most calls to files under `/proc` protected by unconditional `catch { }` and some with more specific handlers; either exception object or its inner exception object is `IOException`. This PR applies the latter pattern in two places where SDK reads files from under /proc.