### PR TITLE
Unskip Blazor Integration Tests

### DIFF
--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
@@ -278,7 +278,8 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                 ".props" when fromMonoPackage => "extension is .props is not supported.",
                 ".blat" when !timezoneSupport => "timezone support is not enabled.",
                 ".dat" when invariantGlobalization && fileName.StartsWith("icudt") => "invariant globalization is enabled",
-                ".json" when fromMonoPackage && fileName == "emcc-props" => $"{fileName}{extension} is not used by Blazor",
+                ".json" when fromMonoPackage && (fileName == "emcc-props" || fileName == "package") => $"{fileName}{extension} is not used by Blazor",
+                ".ts" when fromMonoPackage && fileName == "dotnet.d" => "dotnet type definition is not used by Blazor",
                 ".js" when assetType == "native" && fileName != "dotnet" => $"{fileName}{extension} is not used by Blazor",
                 ".pdb" when !copySymbols => "copying symbols is disabled",
                 _ => null

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             DotNet5JSTemplate = $"dotnet.{RuntimeVersion}.js";
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/38844")]
+        [Fact]
         public void StaticWebAssets_BuildMinimal_Works()
         {
             // Arrange
@@ -90,7 +90,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 intermediateOutputPath);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/38844")]
+        [Fact]
         public void StaticWebAssets_Build_Hosted_Works()
         {
             // Arrange

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
@@ -432,7 +432,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "_bin", "blazorwasm.dll")).Should().NotExist();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/38844")]
+        [Fact]
         public void Build_SatelliteAssembliesAreCopiedToBuildOutput()
         {
             // Arrange

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmJsModulesIntegrationTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmJsModulesIntegrationTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/38844")]
+        [Fact]
         public void Build_DoesNotGenerateManifestJson_IncludesJSModulesOnBlazorBootJsonManifest()
         {
             // Arrange
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(outputPath, "wwwroot", "blazorwasm-minimal.modules.json")).Should().NotExist();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/38844")]
+        [Fact]
         public void JSModules_ManifestIncludesModuleTargetPaths()
         {
             // Arrange


### PR DESCRIPTION
Tests were skipped to unblock https://github.com/dotnet/sdk/pull/22892. The `package.json` and `dotnet.d.ts` files were [recently added](https://github.com/dotnet/sdk/pull/22892#issuecomment-985925815) which was causing issues with out baselines. I've filtered those files out as @pavelsavara mentioned they aren't needed.

Fixes: https://github.com/dotnet/aspnetcore/issues/38844