### PR TITLE
Remove AoT `Publish Test Results` Step

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -284,16 +284,6 @@ jobs:
               RunAoTTests: 'true'
 
       - ${{ if in(parameters.agentOs, 'Windows_NT', 'Darwin') }}:
-        - task: PublishTestResults@2
-          displayName: Publish Test Results	
-          inputs:	
-            testResultsFormat: xUnit	
-            testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'	
-            testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'	
-            buildPlatform: '$(BuildPlatform)'	
-            buildConfiguration: '$(_BuildConfig)'	
-          condition: always()
-
         - task: CopyFiles@2	
           displayName: Gather Logs	
           inputs:	


### PR DESCRIPTION
Helix test results aren't output here, and since the AoT test suite is exclusively Helix tests, this step isn't needed.

Avoids `##[warning]No test result files matching artifacts/TestResults/Release/*.xml were found.`

Example: https://dev.azure.com/dnceng/public/_build/results?buildId=1501826&view=logs&j=c87185f3-6209-5c78-5ae3-375ac5d75c64&t=10041bc9-1a80-5757-2318-098cba9bf69b&l=11