### PR TITLE
Skip adding build configurations for shared projects

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -278,11 +278,6 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             }
         }
 
-        public bool AreBuildConfigurationsApplicable()
-        {
-            return Path.GetExtension(_filePath) == ".shproj";
-        }
-
         public int Line { get; private set; }
         internal bool Processed { get; set; }
 

--- a/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -278,6 +278,11 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             }
         }
 
+        public bool AreBuildConfigurationsApplicable()
+        {
+            return Path.GetExtension(_filePath) == ".shproj";
+        }
+
         public int Line { get; private set; }
         internal bool Processed { get; set; }
 

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -75,11 +75,13 @@ namespace Microsoft.DotNet.Tools.Common
                 // section comes first we need to add it first. This doesn't affect correctness but does
                 // stop VS from re-ordering things later on. Since we are keeping the SlnFile class low-level
                 // it shouldn't care about the VS implementation details. That's why we handle this here.
-                slnFile.AddDefaultBuildConfigurations();
+                if (slnProject.AreBuildConfigurationsApplicable()) {
+                    slnFile.AddDefaultBuildConfigurations();
 
-                slnFile.MapSolutionConfigurationsToProject(
-                    projectInstance,
-                    slnFile.ProjectConfigurationsSection.GetOrCreatePropertySet(slnProject.Id));
+                    slnFile.MapSolutionConfigurationsToProject(
+                        projectInstance,
+                        slnFile.ProjectConfigurationsSection.GetOrCreatePropertySet(slnProject.Id));
+                }
 
                 if (solutionFolders != null)
                 {

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -95,9 +95,9 @@ namespace Microsoft.DotNet.Tools.Common
             }
         }
 
-        private static bool AreBuildConfigurationsApplicable(string path)
+        private static bool AreBuildConfigurationsApplicable(string projectFilePath)
         {
-            return !Path.GetExtension(path).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
+            return !Path.GetExtension(projectFilePath).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void AddDefaultBuildConfigurations(this SlnFile slnFile)

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Tools.Common
 
         private static bool AreBuildConfigurationsApplicable(this SlnFile slnFile, string path)
         {
-            return !Path.GetExtension(path).Equals(".shproj", StringComparison.CurrentCultureIgnoreCase);
+            return !Path.GetExtension(path).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void AddDefaultBuildConfigurations(this SlnFile slnFile)

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Tools.Common
                 // section comes first we need to add it first. This doesn't affect correctness but does
                 // stop VS from re-ordering things later on. Since we are keeping the SlnFile class low-level
                 // it shouldn't care about the VS implementation details. That's why we handle this here.
-                if (slnFile.AreBuildConfigurationsApplicable(relativeProjectPath)) {
+                if (AreBuildConfigurationsApplicable(relativeProjectPath)) {
                     slnFile.AddDefaultBuildConfigurations();
 
                     slnFile.MapSolutionConfigurationsToProject(
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.Tools.Common
             }
         }
 
-        private static bool AreBuildConfigurationsApplicable(this SlnFile slnFile, string path)
+        private static bool AreBuildConfigurationsApplicable(string path)
         {
             return !Path.GetExtension(path).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
         }

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Tools.Common
                 // section comes first we need to add it first. This doesn't affect correctness but does
                 // stop VS from re-ordering things later on. Since we are keeping the SlnFile class low-level
                 // it shouldn't care about the VS implementation details. That's why we handle this here.
-                if (slnProject.AreBuildConfigurationsApplicable()) {
+                if (slnFile.AreBuildConfigurationsApplicable(relativeProjectPath)) {
                     slnFile.AddDefaultBuildConfigurations();
 
                     slnFile.MapSolutionConfigurationsToProject(
@@ -93,6 +93,11 @@ namespace Microsoft.DotNet.Tools.Common
                 Reporter.Output.WriteLine(
                     string.Format(CommonLocalizableStrings.ProjectAddedToTheSolution, relativeProjectPath));
             }
+        }
+
+        private static bool AreBuildConfigurationsApplicable(this SlnFile slnFile, string path)
+        {
+            return !Path.GetExtension(path).Equals(".shproj", StringComparison.CurrentCultureIgnoreCase);
         }
 
         private static void AddDefaultBuildConfigurations(this SlnFile slnFile)


### PR DESCRIPTION
Fixes #22921

When adding shared projects using the `dotnet sln add` command-line the cli adds a build configuration in the solution file. Build configurations aren't necessary for shared projects.