### PR TITLE
Remove AoT Build Publish Args To Prevent Un-necessary Uploads

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -180,7 +180,8 @@ jobs:
       continueOnError: true	
       condition: always()
 
-- ${{ if in(parameters.agentOs, 'Windows_NT', 'Darwin') }}:
+# AoT Jobs
+- ${{ if and(in(parameters.agentOs, 'Windows_NT', 'Darwin'), or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'))) }}:
   - template: /eng/common/templates/job/job.yml
     parameters:
       name: ${{ parameters.agentOs }}_AoT_Tests

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -225,7 +225,6 @@ jobs:
       - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
         - script: eng\CIBuild.cmd
                     -configuration $(_BuildConfig)
-                    $(_PublishArgs)
                     $(_SignArgs)
                     $(_OfficialBuildIdArgs)
                     /p:Test=false


### PR DESCRIPTION
See discussion: https://github.com/dotnet/sdk/pull/22947#issuecomment-989145134

Doesn't appear to be an equivalent arg to remove on Darwin:

https://github.com/dotnet/sdk/blob/6cdac2c22a49d7d09909dece2f6b97b81a2f77aa/eng/build.yml#L258-L266