### PR TITLE
Fix ordering of gathering files from Sdks

### DIFF
--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -48,12 +48,12 @@
     <ProjectReference Include="..\tool_nuget\tool_nuget.csproj" />
     <ProjectReference Include="..\..\Cli\dotnet\dotnet.csproj" />
     <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj"
-                      ReferenceOutputAssembly="false" />
+                      ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
     <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Extensions.Tasks\Microsoft.NET.Build.Extensions.Tasks.csproj"
-                      ReferenceOutputAssembly="false" />
+                      ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
     <ProjectReference Include="..\..\Resolvers\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj" />
     <ProjectReference Include="$(RepoRoot)src\BuiltInTools\dotnet-watch\dotnet-watch.csproj"
-                      ReferenceOutputAssembly="false" />
+                      ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix issue that happened with build [20211210.4](https://dev.azure.com/dnceng/internal/_build/results?buildId=1506603&view=results), where files under `Microsoft.NET.Sdk\Sdk` and `Microsoft.NET.Sdk\targets` weren't included in the layout.

The problem is that these files are copied to `PackageLayoutOutputPath` (for example `artifacts\bin\Release\Sdks\Microsoft.NET.Sdk`) in the outer build of Microsoft.NET.Build.Tasks.csproj.  However, in the build with this issue, that `PackageLayoutOutputPath` target ran after the `PublishNetSdks` target in redist.csproj, which is supposed to consume them.

The solution is to add `SkipGetTargetFrameworkProperties="true"` to the appropriate `ProjectReference` items.  This ensures that the outer build of the referenced project happens before `redist.csproj` builds.