### PR TITLE
Files not ending in css are probably not css files

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -65,7 +65,7 @@ setTimeout(async function () {
     if (path && path.endsWith('.css')) {
       updateCssByPath(path);
     } else {
-      console.debug(`File change detected to css file ${path}. Reloading page...`);
+      console.debug(`File change detected to file ${path}. Reloading page...`);
       location.reload();
       return;
     }


### PR DESCRIPTION
The log message incorrectly labels these files "css" files, but actual "css" files are handled in the other branch.