### PR TITLE
fixes dotnet/sdk#23162 dotnet new console --help doesn't work starting 6.0.2xx

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -217,7 +217,7 @@ namespace Microsoft.DotNet.Cli
                 }
                 else if (command.Name.Equals(NewCommandParser.GetCommand().Name))
                 {
-                    NewCommandShim.Run(helpArgs);
+                    NewCommandShim.Run(context.ParseResult.GetArguments());
                 }
                 else if (command.Name.Equals(VSTestCommandParser.GetCommand().Name))
                 {

--- a/src/Tests/dotnet-new.Tests/NewCommandTests.cs
+++ b/src/Tests/dotnet-new.Tests/NewCommandTests.cs
@@ -38,6 +38,26 @@ namespace Microsoft.DotNet.New.Tests
             cmd.Should().Pass();
         }
 
+        [Fact]
+        public void ItCanShowHelp()
+        {
+            var tempDir = _testAssetsManager.CreateTestDirectory();
+            var cmd = new DotnetCommand(Log).Execute("new", "--help");
+            cmd.Should().Pass()
+                .And.HaveStdOutContaining("Usage: new [options]");
+        }
+
+        [Fact]
+        public void ItCanShowHelpForTemplate()
+        {
+            var tempDir = _testAssetsManager.CreateTestDirectory();
+            var cmd = new DotnetCommand(Log).Execute("new", "classlib", "--help");
+            cmd.Should().Pass()
+                .And.NotHaveStdOutContaining("Usage: new [options]")
+                .And.HaveStdOutContaining("Class Library (C#)")
+                .And.HaveStdOutContaining("--framework");
+        }
+
         [Fact(Skip = "https://github.com/dotnet/templating/issues/1971")]
         public void WhenTemplateNameIsNotUniquelyMatchedThenItIndicatesProblemToUser()
         {


### PR DESCRIPTION
fixes dotnet/sdk#23162

Fix is only for dotnet new.