### PR TITLE
Use project path instead of working directory to resolve launchSettings.json

### DIFF
--- a/src/Assets/TestProjects/WatchAppWithLaunchSettings/Program.cs
+++ b/src/Assets/TestProjects/WatchAppWithLaunchSettings/Program.cs
@@ -1,0 +1,2 @@
+﻿Console.WriteLine("Started");
+Console.WriteLine($"Environment: {Environment.GetEnvironmentVariable("EnvironmentFromProfile")}");

--- a/src/Assets/TestProjects/WatchAppWithLaunchSettings/Properties/launchSettings.json
+++ b/src/Assets/TestProjects/WatchAppWithLaunchSettings/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+    "profiles": {
+      "app": {
+        "commandName": "Project",
+        "environmentVariables": {
+          "EnvironmentFromProfile": "Development"
+        }
+      }
+    }
+  }

--- a/src/Assets/TestProjects/WatchAppWithLaunchSettings/WatchAppWithLaunchSettings.csproj
+++ b/src/Assets/TestProjects/WatchAppWithLaunchSettings/WatchAppWithLaunchSettings.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -278,7 +278,7 @@ Examples:
                 _reporter.Output("Polling file watcher is enabled");
             }
 
-            var defaultProfile = LaunchSettingsProfile.ReadDefaultProfile(_workingDirectory, reporter) ?? new();
+            var defaultProfile = LaunchSettingsProfile.ReadDefaultProfile(processInfo.WorkingDirectory, reporter) ?? new();
 
             var context = new DotNetWatchContext
             {

--- a/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             Assert.Equal(messagePrefix + " --no-restore -- wait", message.Trim());
         }
 
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings()
         {
             var testAsset = _testAssetsManager.CopyTestAsset("WatchAppWithLaunchSettings")
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             await app.Process.GetOutputLineAsync("Environment: Development", TimeSpan.FromSeconds(10));
         }
 
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings_WhenUsingProjectOption()
         {
             var testAsset = _testAssetsManager.CopyTestAsset("WatchAppWithLaunchSettings")

--- a/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
@@ -129,5 +129,44 @@ namespace Microsoft.DotNet.Watcher.Tools
             message = await app.Process.GetOutputLineStartsWithAsync(messagePrefix, TimeSpan.FromMinutes(2));
             Assert.Equal(messagePrefix + " --no-restore -- wait", message.Trim());
         }
+
+        [Fact]
+        public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings()
+        {
+            var testAsset = _testAssetsManager.CopyTestAsset("WatchAppWithLaunchSettings")
+                .WithSource()
+                .Path;
+
+            using var app = new WatchableApp(testAsset, _logger);
+
+            app.DotnetWatchArgs.Add("--verbose");
+
+            await app.StartWatcherAsync();
+
+            await app.Process.GetOutputLineAsync("Environment: Development", TimeSpan.FromSeconds(10));
+        }
+
+        [Fact]
+        public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings_WhenUsingProjectOption()
+        {
+            var testAsset = _testAssetsManager.CopyTestAsset("WatchAppWithLaunchSettings")
+                .WithSource()
+                .Path;
+
+            var directoryInfo = new DirectoryInfo(testAsset);
+            using var app = new WatchableApp(testAsset, _logger)
+            {
+                // Configure the working directory to be one level above the test app directory.
+                WorkingDirectory = Path.GetFullPath(directoryInfo.Parent.FullName),
+            };
+
+            app.DotnetWatchArgs.Add("--verbose");
+            app.DotnetWatchArgs.Add("--project");
+            app.DotnetWatchArgs.Add(Path.Combine(directoryInfo.Name, "WatchAppWithLaunchSettings.csproj"));
+
+            await app.StartWatcherAsync();
+
+            await app.Process.GetOutputLineAsync("Environment: Development", TimeSpan.FromSeconds(10));
+        }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/Utilities/WatchableApp.cs
+++ b/src/Tests/dotnet-watch.Tests/Utilities/WatchableApp.cs
@@ -38,6 +38,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public string SourceDirectory { get; }
 
+        public string WorkingDirectory { get; set; }
+
         public Task HasRestarted()
             => HasRestarted(DefaultMessageTimeOut);
 
@@ -76,7 +78,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             var commandSpec = new DotnetCommand(_logger, args.ToArray())
             {
-                WorkingDirectory = SourceDirectory,
+                WorkingDirectory = WorkingDirectory ?? SourceDirectory,
             };
             commandSpec.WithEnvironmentVariable("DOTNET_USE_POLLING_FILE_WATCHER", "true");
             commandSpec.WithEnvironmentVariable("__DOTNET_WATCH_RUNNING_AS_TEST", "true");


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35393

dotnet-watch attempts to read the app's launchSettings.json to read things like the launch URL. Currently the URL is read relative to the working directory (it looks for `$WorkDir/Properties/launchSettings.json`). However, this is incorrect if the `--project` option is used to specify a project path / directory. This change updates the code to use the project directory and adds a couple of tests.