### PR TITLE
Update to RTM SDK release

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-rc.1.21430.12",
+    "dotnet": "6.0.100",
     "runtimes": {
       "dotnet": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)"


### PR DESCRIPTION
It's a convenient to have the dogfood environment to have the RTM runtime / templates.