### PR TITLE
Opt into IEventSource4

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -61,6 +61,13 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         public void Initialize(IEventSource eventSource)
         {
+            // Declare lack of dependency on having properties/items in ProjectStarted events
+            // (since this logger doesn't ever care about those events it's irrelevant)
+            if (eventSource is IEventSource4 eventSource4)
+            {
+                eventSource4.IncludeEvaluationPropertiesAndItems();
+            }
+
             try
             {
                 if (_telemetry != null && _telemetry.Enabled)


### PR DESCRIPTION
This enables MSBuild to use more-efficient and higher-fidelity logging approaches that ensure capturing the post-evaluation state of items and properties, which is extremely helpful for debugging.

Fixes #23248.