### PR TITLE
Add missing space to dotnet-watch restart always rude edit message

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/RudeEditPreference.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/RudeEditPreference.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             if (alwaysRestart == "1" || string.Equals(alwaysRestart, "true", StringComparison.OrdinalIgnoreCase))
             {
-                _reporter.Verbose($"DOTNET_WATCH_RESTART_ON_RUDE_EDIT= '{alwaysRestart}'. Restarting without prompt.");
+                _reporter.Verbose($"DOTNET_WATCH_RESTART_ON_RUDE_EDIT = '{alwaysRestart}'. Restarting without prompt.");
                 _restartImmediatelySessionPreference = true;
             }
         }


### PR DESCRIPTION
Makes a very minor change to add a space between the environment variable name and the equals sign.