### PR TITLE
Add an option to run dotnet-watch in non-interactive mode

### DIFF
--- a/src/Assets/TestProjects/WatchAppWithLaunchSettings/Program.cs
+++ b/src/Assets/TestProjects/WatchAppWithLaunchSettings/Program.cs
@@ -4,5 +4,5 @@ Console.WriteLine($"Environment: {Environment.GetEnvironmentVariable("Environmen
 if (Environment.GetEnvironmentVariable("READ_INPUT") != null)
 {
     var read = Console.ReadLine();
-    Console.WriteLine("Echo:" + read);
+    Console.WriteLine("Echo: " + read);
 }

--- a/src/Assets/TestProjects/WatchAppWithLaunchSettings/Program.cs
+++ b/src/Assets/TestProjects/WatchAppWithLaunchSettings/Program.cs
@@ -1,2 +1,8 @@
 ﻿Console.WriteLine("Started");
 Console.WriteLine($"Environment: {Environment.GetEnvironmentVariable("EnvironmentFromProfile")}");
+
+if (Environment.GetEnvironmentVariable("READ_INPUT") != null)
+{
+    var read = Console.ReadLine();
+    Console.WriteLine("Echo:" + read);
+}

--- a/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Watcher
         public bool List { get; set; }
         public bool NoHotReload { get; set; }
 
+        public bool NonInteractive { get; set; }
         public IReadOnlyList<string> RemainingArguments { get; set; }
 
         public static bool IsPollingEnabled

--- a/src/BuiltInTools/dotnet-watch/DotNetWatchOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatchOptions.cs
@@ -21,6 +21,8 @@ namespace Microsoft.DotNet.Watcher
             RunningAsTest: IsEnvironmentSet("__DOTNET_WATCH_RUNNING_AS_TEST")
         );
 
+        public bool NonInteractive { get; set; }
+
         private static bool IsEnvironmentSet(string key)
         {
             var envValue = Environment.GetEnvironmentVariable(key);

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -23,7 +25,7 @@ namespace Microsoft.DotNet.Watcher
         private readonly ProcessRunner _processRunner;
         private readonly DotNetWatchOptions _dotNetWatchOptions;
         private readonly IWatchFilter[] _filters;
-        private readonly RudeEditDialog _rudeEditDialog;
+        private readonly RudeEditDialog? _rudeEditDialog;
 
         public HotReloadDotNetWatcher(IReporter reporter, IFileSetFactory fileSetFactory, DotNetWatchOptions dotNetWatchOptions, IConsole console)
         {
@@ -40,27 +42,34 @@ namespace Microsoft.DotNet.Watcher
                 new LaunchBrowserFilter(dotNetWatchOptions),
                 new BrowserRefreshFilter(dotNetWatchOptions, _reporter),
             };
-            _rudeEditDialog = new(reporter, _console);
+
+            if (!dotNetWatchOptions.NonInteractive)
+            {
+                _rudeEditDialog = new(reporter, _console);
+            }
         }
 
         public async Task WatchAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
             var processSpec = context.ProcessSpec;
 
-            _reporter.Output("Hot reload enabled. For a list of supported edits, see https://aka.ms/dotnet/hot-reload. " +
-                "Press \"Ctrl + R\" to restart.");
-
             var forceReload = new CancellationTokenSource();
 
-            _console.KeyPressed += (key) =>
+            _reporter.Output("Hot reload enabled. For a list of supported edits, see https://aka.ms/dotnet/hot-reload.");
+
+            if (!_dotNetWatchOptions.NonInteractive)
             {
-                var modifiers = ConsoleModifiers.Control;
-                if ((key.Modifiers & modifiers) == modifiers && key.Key == ConsoleKey.R)
+                _reporter.Output("Press \"Ctrl + R\" to restart.");
+                _console.KeyPressed += (key) =>
                 {
-                    var cancellationTokenSource = Interlocked.Exchange(ref forceReload, new CancellationTokenSource());
-                    cancellationTokenSource.Cancel();
-                }
-            };
+                    var modifiers = ConsoleModifiers.Control;
+                    if ((key.Modifiers & modifiers) == modifiers && key.Key == ConsoleKey.R)
+                    {
+                        var cancellationTokenSource = Interlocked.Exchange(ref forceReload, new CancellationTokenSource());
+                        cancellationTokenSource.Cancel();
+                    }
+                };
+            }
 
             while (true)
             {
@@ -114,7 +123,7 @@ namespace Microsoft.DotNet.Watcher
 
                     _reporter.Output("Started");
 
-                    Task<FileItem[]> fileSetTask;
+                    Task<FileItem[]?> fileSetTask;
                     Task finishedTask;
 
                     while (true)
@@ -163,8 +172,14 @@ namespace Microsoft.DotNet.Watcher
                             }
                             else
                             {
-                                await _rudeEditDialog.EvaluateAsync(combinedCancellationSource.Token);
-
+                                if (_rudeEditDialog is not null)
+                                {
+                                    await _rudeEditDialog.EvaluateAsync(combinedCancellationSource.Token);
+                                }
+                                else
+                                {
+                                    _reporter.Verbose("Restarting without prompt since dotnet-watch is running in non-interactive mode.");
+                                }
                                 break;
                             }
                         }
@@ -240,7 +255,7 @@ namespace Microsoft.DotNet.Watcher
                 }
 
                 if (filePath.EndsWith(".cshtml", StringComparison.Ordinal) &&
-                    context.ProjectGraph.GraphRoots.FirstOrDefault() is { } project &&
+                    context.ProjectGraph!.GraphRoots.FirstOrDefault() is { } project &&
                     project.ProjectInstance.GetPropertyValue("AddCshtmlFilesToDotNetWatchList") is not "false")
                 {
                     // For cshtml files, runtime compilation can opt out of watching cshtml files.

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -139,18 +139,23 @@ Examples:
             var noHotReloadOption = new Option<bool>(
                 new[] { "--no-hot-reload" },
                 "Suppress hot reload for supported apps.");
+			var nonInteractive = new Option<bool>(
+                    new[] { "--non-interactive" },
+                    "Runs dotnet-watch in non-interative mode. This option is only supported when running with Hot Reload enabled. " +
+                    "Use this option to prevent console input from being captured."),
             var root = new RootCommand(Description)
             {
                  quiet,
                  verbose,
                  noHotReloadOption,
+                 nonInteractiveOption,
                  longProjectOption,
                  shortProjectOption,
                  listOption
             };
 
             root.TreatUnmatchedTokensAsErrors = false;
-            var binder = new CommandLineOptionsBinder(longProjectOption, shortProjectOption, quiet, listOption, noHotReloadOption, verbose, reporter);
+            var binder = new CommandLineOptionsBinder(longProjectOption, shortProjectOption, quiet, listOption, noHotReloadOption, nonInteractiveOption, verbose, reporter);
             root.SetHandler((CommandLineOptions options) => handler(options), binder);
             return root;
         }
@@ -233,6 +238,7 @@ Examples:
             }
 
             var watchOptions = DotNetWatchOptions.Default;
+            watchOptions.NonInteractive = options.NonInteractive;
 
             var fileSetFactory = new MsBuildFileSetFactory(reporter,
                 watchOptions,

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -139,10 +139,10 @@ Examples:
             var noHotReloadOption = new Option<bool>(
                 new[] { "--no-hot-reload" },
                 "Suppress hot reload for supported apps.");
-			var nonInteractive = new Option<bool>(
-                    new[] { "--non-interactive" },
-                    "Runs dotnet-watch in non-interative mode. This option is only supported when running with Hot Reload enabled. " +
-                    "Use this option to prevent console input from being captured."),
+            var nonInteractiveOption = new Option<bool>(
+                new[] { "--non-interactive" },
+                "Runs dotnet-watch in non-interative mode. This option is only supported when running with Hot Reload enabled. " +
+                "Use this option to prevent console input from being captured.");
             var root = new RootCommand(Description)
             {
                  quiet,
@@ -151,7 +151,7 @@ Examples:
                  nonInteractiveOption,
                  longProjectOption,
                  shortProjectOption,
-                 listOption
+                 listOption,
             };
 
             root.TreatUnmatchedTokensAsErrors = false;
@@ -410,16 +410,26 @@ Examples:
             private readonly Option<bool> _quietOption;
             private readonly Option<bool> _listOption;
             private readonly Option<bool> _noHotReloadOption;
+            private readonly Option<bool> _nonInteractiveOption;
             private readonly Option<bool> _verboseOption;
             private readonly IReporter _reporter;
 
-            internal CommandLineOptionsBinder(Option<string> longProjectOption, Option<string> shortProjectOption, Option<bool> quietOption, Option<bool> listOption, Option<bool> noHotReloadOption, Option<bool> verboseOption, IReporter reporter)
+            internal CommandLineOptionsBinder(
+                Option<string> longProjectOption,
+                Option<string> shortProjectOption,
+                Option<bool> quietOption,
+                Option<bool> listOption,
+                Option<bool> noHotReloadOption,
+                Option<bool> nonInteractiveOption,
+                Option<bool> verboseOption,
+                IReporter reporter)
             {
                 _longProjectOption = longProjectOption;
                 _shortProjectOption = shortProjectOption;
                 _quietOption = quietOption;
                 _listOption = listOption;
                 _noHotReloadOption = noHotReloadOption;
+                _nonInteractiveOption = nonInteractiveOption;
                 _verboseOption = verboseOption;
                 _reporter = reporter;
             }
@@ -457,6 +467,7 @@ Examples:
                     Quiet = parseResults.GetValueForOption(_quietOption),
                     List = parseResults.GetValueForOption(_listOption),
                     NoHotReload = parseResults.GetValueForOption(_noHotReloadOption),
+                    NonInteractive = parseResults.GetValueForOption(_nonInteractiveOption),
                     Verbose = parseResults.GetValueForOption(_verboseOption),
                     Project = projectValue,
                     RemainingArguments = remainingArguments.AsReadOnly(),

--- a/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
@@ -185,7 +185,6 @@ namespace Microsoft.DotNet.Watcher.Tools
             };
 
             app.DotnetWatchArgs.Add("--verbose");
-            app.DotnetWatchArgs.Add("--project");
             app.DotnetWatchArgs.Add("--non-interactive");
 
             await app.StartWatcherAsync();
@@ -194,7 +193,6 @@ namespace Microsoft.DotNet.Watcher.Tools
             var inputString = "This is a test input";
 
             await standardInput.WriteLineAsync(inputString).WaitAsync(TimeSpan.FromSeconds(10));
-            await standardInput.FlushAsync().WaitAsync(TimeSpan.FromSeconds(10));
             await app.Process.GetOutputLineAsync($"Echo: {inputString}", TimeSpan.FromSeconds(10));
         }
     }

--- a/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
@@ -168,5 +168,34 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             await app.Process.GetOutputLineAsync("Environment: Development", TimeSpan.FromSeconds(10));
         }
+
+        [CoreMSBuildOnlyFact]
+        public async Task Run_WithHotReloadEnabled_DoesNotReadConsoleIn_InNonInteractiveMode()
+        {
+            var testAsset = _testAssetsManager.CopyTestAsset("WatchAppWithLaunchSettings")
+                .WithSource()
+                .Path;
+
+            using var app = new WatchableApp(testAsset, _logger)
+            {
+                EnvironmentVariables =
+                {
+                    ["READ_INPUT"] = "true",
+                },
+            };
+
+            app.DotnetWatchArgs.Add("--verbose");
+            app.DotnetWatchArgs.Add("--project");
+            app.DotnetWatchArgs.Add("--non-interactive");
+
+            await app.StartWatcherAsync();
+
+            var standardInput = app.Process.Process.StandardInput;
+            var inputString = "This is a test input";
+
+            await standardInput.WriteLineAsync(inputString).WaitAsync(TimeSpan.FromSeconds(10));
+            await standardInput.FlushAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            await app.Process.GetOutputLineAsync($"Echo: {inputString}", TimeSpan.FromSeconds(10));
+        }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
+++ b/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
-using Microsoft.Extensions.Internal;
 using Microsoft.NET.TestFramework.Commands;
 using Xunit.Abstractions;
 
@@ -41,6 +40,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public int Id => _process.Id;
 
+        public Process Process => _process;
+
         public void Start()
         {
             if (_process != null)
@@ -51,6 +52,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             var processStartInfo = _spec.GetProcessStartInfo();
             processStartInfo.RedirectStandardOutput = true;
             processStartInfo.RedirectStandardError = true;
+            processStartInfo.RedirectStandardInput = true;
 
             _process = new Process
             {


### PR DESCRIPTION
In hot-reload, dotnet-watch always captures Console.Input (this is so that we capture when a user does Control+R). Unfortunately this means the app cannot read the Console.Input reliably any more. This PR adds an option to prevent hijacking Console.Input by adding a non-interactive mode.

Fixes https://github.com/dotnet/sdk/issues/23238