### PR TITLE
Catch dotnet watch task cancellation after `CTRL+C`

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationWorkspaceProvider.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationWorkspaceProvider.cs
@@ -24,15 +24,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             CancellationToken cancellationToken)
         {
             var taskCompletionSource = new TaskCompletionSource<(Solution, WatchHotReloadService)>(TaskCreationOptions.RunContinuationsAsynchronously);
-            try
-            {
-                CreateProject(taskCompletionSource, hotReloadCapabilitiesTask, projectPath, reporter, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                taskCompletionSource.TrySetException(ex);
-            }
-
+            CreateProject(taskCompletionSource, hotReloadCapabilitiesTask, projectPath, reporter, cancellationToken);
             return taskCompletionSource.Task;
         }
 
@@ -43,39 +35,46 @@ namespace Microsoft.DotNet.Watcher.Tools
             IReporter reporter,
             CancellationToken cancellationToken)
         {
-            var workspace = MSBuildWorkspace.Create();
-
-            workspace.WorkspaceFailed += (_sender, diag) =>
+            try
             {
-                if (diag.Diagnostic.Kind == WorkspaceDiagnosticKind.Warning)
+                var workspace = MSBuildWorkspace.Create();
+
+                workspace.WorkspaceFailed += (_sender, diag) =>
                 {
-                    reporter.Verbose($"MSBuildWorkspace warning: {diag.Diagnostic}");
-                }
-                else
+                    if (diag.Diagnostic.Kind == WorkspaceDiagnosticKind.Warning)
+                    {
+                        reporter.Verbose($"MSBuildWorkspace warning: {diag.Diagnostic}");
+                    }
+                    else
+                    {
+                        taskCompletionSource.TrySetException(new InvalidOperationException($"Failed to create MSBuildWorkspace: {diag.Diagnostic}"));
+                    }
+                };
+
+                await workspace.OpenProjectAsync(projectPath, cancellationToken: cancellationToken);
+                var currentSolution = workspace.CurrentSolution;
+
+                var hotReloadCapabilities = await GetHotReloadCapabilitiesAsync(hotReloadCapabilitiesTask, reporter);
+                var hotReloadService = new WatchHotReloadService(workspace.Services, await hotReloadCapabilitiesTask);
+
+                await hotReloadService.StartSessionAsync(currentSolution, cancellationToken);
+
+                // Read the documents to memory
+                await Task.WhenAll(
+                    currentSolution.Projects.SelectMany(p => p.Documents.Concat(p.AdditionalDocuments)).Select(d => d.GetTextAsync(cancellationToken)));
+
+                // Warm up the compilation. This would help make the deltas for first edit appear much more quickly
+                foreach (var project in currentSolution.Projects)
                 {
-                    taskCompletionSource.TrySetException(new InvalidOperationException($"Failed to create MSBuildWorkspace: {diag.Diagnostic}"));
+                    await project.GetCompilationAsync(cancellationToken);
                 }
-            };
 
-            await workspace.OpenProjectAsync(projectPath, cancellationToken: cancellationToken);
-            var currentSolution = workspace.CurrentSolution;
-
-            var hotReloadCapabilities = await GetHotReloadCapabilitiesAsync(hotReloadCapabilitiesTask, reporter);
-            var hotReloadService = new WatchHotReloadService(workspace.Services, await hotReloadCapabilitiesTask);
-
-            await hotReloadService.StartSessionAsync(currentSolution, cancellationToken);
-
-            // Read the documents to memory
-            await Task.WhenAll(
-                currentSolution.Projects.SelectMany(p => p.Documents.Concat(p.AdditionalDocuments)).Select(d => d.GetTextAsync(cancellationToken)));
-
-            // Warm up the compilation. This would help make the deltas for first edit appear much more quickly
-            foreach (var project in currentSolution.Projects)
-            {
-                await project.GetCompilationAsync(cancellationToken);
+                taskCompletionSource.TrySetResult((currentSolution, hotReloadService));
             }
-
-            taskCompletionSource.TrySetResult((currentSolution, hotReloadService));
+            catch (Exception ex)
+            {
+                taskCompletionSource.TrySetException(ex);
+            }
         }
 
         private static async Task<ImmutableArray<string>> GetHotReloadCapabilitiesAsync(Task<ImmutableArray<string>> hotReloadCapabilitiesTask, IReporter reporter)


### PR DESCRIPTION
This is a pretty flaky issue, but after this change I've been unable to repro the task cancellation. 

View with [`w=1` (no whitespace changes)](https://github.com/dotnet/sdk/pull/23316/files?w=1) to simplify review. I just moved the try/catch block to the method, rather than have it at the call location, as we do not await the `async` function at the call location.

Fixes: https://github.com/dotnet/aspnetcore/issues/37113
Fixes: https://github.com/dotnet/aspnetcore/issues/37047