### PR TITLE
Better caching for RazorSourceGenerator when SuppressRazorSourceGener…

### DIFF
--- a/src/RazorSdk/SourceGenerators/IncrementalValueProviderExtensions.cs
+++ b/src/RazorSdk/SourceGenerators/IncrementalValueProviderExtensions.cs
@@ -1,4 +1,3 @@
-
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
@@ -10,6 +9,30 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
     internal static class IncrementalValuesProviderExtensions
     {
+        /// <summary>
+        /// Adds a comparer used to determine if an incremental steps needs to be re-run accounting for <see cref="RazorSourceGenerationOptions.SuppressRazorSourceGenerator"/>.
+        /// <para>
+        /// In VS, design time builds are executed with <see cref="RazorSourceGenerationOptions.SuppressRazorSourceGenerator"/> set to <c>true</c>. In this case, RSG can safely
+        /// allow previously cached results to be used, while no-oping in the step that adds sources to the context. This allows source generator caches from being evicted
+        /// when the value of this property flip-flips during a hot-reload / EnC session.
+        /// </para>
+        /// </summary>
+        internal static IncrementalValueProvider<(T Left, RazorSourceGenerationOptions Right)> WithRazorSourceGeneratorComparer<T>(
+            this IncrementalValueProvider<(T Left, RazorSourceGenerationOptions Right)> source,
+            Func<T, T, bool>? equals = null)
+            where T : notnull
+        {
+            return source.WithComparer(new RazorSourceGeneratorComparer<T>(equals));
+        }
+
+        internal static IncrementalValuesProvider<(T Left, RazorSourceGenerationOptions Right)> WithRazorSourceGeneratorComparer<T>(
+            this IncrementalValuesProvider<(T Left, RazorSourceGenerationOptions Right)> source,
+            Func<T, T, bool>? equals = null)
+            where T : notnull
+        {
+            return source.WithComparer(new RazorSourceGeneratorComparer<T>(equals));
+        }
+
         internal static IncrementalValueProvider<T> WithLambdaComparer<T>(this IncrementalValueProvider<T> source, Func<T, T, bool> equal, Func<T, int> getHashCode)
         {
             var comparer = new LambdaComparer<T>(equal, getHashCode);

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerationOptions.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerationOptions.cs
@@ -15,18 +15,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         public RazorConfiguration Configuration { get; set; } = RazorConfiguration.Default;
 
         /// <summary>
-        /// Gets a flag that determines if the source generator waits for the debugger to attach.
-        /// <para>
-        /// To configure this using MSBuild, use the <c>_RazorSourceGeneratorDebug</c> property.
-        /// For instance <c>dotnet msbuild /p:_RazorSourceGeneratorDebug=true</c>
-        /// </para>
-        /// </summary>
-        public bool WaitForDebugger { get; set; } = false;
-
-        /// <summary>
         /// Gets a flag that determines if generated Razor views and Pages includes the <c>RazorSourceChecksumAttribute</c>.
         /// </summary>
-        public bool GenerateMetadataSourceChecksumAttributes { get; set; } = false;
+        public bool GenerateMetadataSourceChecksumAttributes { get; set; }
 
         /// <summary>
         /// Gets a flag that determines if the source generator should no-op.
@@ -36,7 +27,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         /// The property is set by the SDK via an editor config.
         /// </para>
         /// </summary>
-        public bool SuppressRazorSourceGenerator { get; set; } = false;
+        public bool SuppressRazorSourceGenerator { get; set; }
 
         /// <summary>
         /// Gets the CSharp language version currently used by the compilation.
@@ -46,14 +37,17 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         /// <summary>
         /// Gets a flag that determines if localized component names should be supported.</c>.
         /// </summary>
-        public bool SupportLocalizedComponentNames { get; set; } = false;
+        public bool SupportLocalizedComponentNames { get; set; }
 
         public bool Equals(RazorSourceGenerationOptions other)
+            => SuppressRazorSourceGenerator == other.SuppressRazorSourceGenerator && EqualsIgnoringSupression(other);
+
+        public bool EqualsIgnoringSupression(RazorSourceGenerationOptions other)
         {
-            return RootNamespace == other.RootNamespace &&
-                Configuration == other.Configuration &&
+            return
+                RootNamespace == other.RootNamespace &&
+                Configuration.Equals(other.Configuration) &&
                 GenerateMetadataSourceChecksumAttributes == other.GenerateMetadataSourceChecksumAttributes &&
-                SuppressRazorSourceGenerator == other.SuppressRazorSourceGenerator &&
                 CSharpLanguageVersion == other.CSharpLanguageVersion &&
                 SupportLocalizedComponentNames == other.SupportLocalizedComponentNames;
         }

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
@@ -24,7 +24,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             globalOptions.TryGetValue("build_property.RazorConfiguration", out var configurationName);
             globalOptions.TryGetValue("build_property.RootNamespace", out var rootNamespace);
             globalOptions.TryGetValue("build_property.SupportLocalizedComponentNames", out var supportLocalizedComponentNames);
-            globalOptions.TryGetValue("build_property._RazorSourceGeneratorDebug", out var waitForDebugger);
             globalOptions.TryGetValue("build_property.SuppressRazorSourceGenerator", out var suppressRazorSourceGenerator);
             globalOptions.TryGetValue("build_property.GenerateRazorMetadataSourceChecksumAttributes", out var generateMetadataSourceChecksumAttributes);
 
@@ -41,10 +40,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
             var razorConfiguration = RazorConfiguration.Create(razorLanguageVersion, configurationName ?? "default", System.Linq.Enumerable.Empty<RazorExtension>(), true);
             
-            var razorSourceGenerationOptions = new RazorSourceGenerationOptions()
+            var razorSourceGenerationOptions = new RazorSourceGenerationOptions
             {
                 Configuration = razorConfiguration,
-                WaitForDebugger = waitForDebugger == "true",
                 SuppressRazorSourceGenerator = suppressRazorSourceGenerator == "true",
                 GenerateMetadataSourceChecksumAttributes = generateMetadataSourceChecksumAttributes == "true",
                 RootNamespace = rootNamespace ?? "ASP",

--- a/src/RazorSdk/SourceGenerators/RazorSourceGeneratorComparer.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGeneratorComparer.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    /// <summary>
+    /// A comparer used to determine if an incremental steps needs to be re-run accounting for <see cref="RazorSourceGenerationOptions.SuppressRazorSourceGenerator"/>.
+    /// <para>
+    /// In VS, design time builds are executed with <see cref="RazorSourceGenerationOptions.SuppressRazorSourceGenerator"/> set to <c>true</c>. In this case, RSG can safely
+    /// allow previously cached results to be used, while no-oping in the step that adds sources to the context. This allows source generator caches from being evicted
+    /// when the value of this property flip-flips during a hot-reload / EnC session.
+    /// </para>
+    /// </summary>
+    internal sealed class RazorSourceGeneratorComparer<T> : IEqualityComparer<(T Left, RazorSourceGenerationOptions Right)> where T : notnull
+    {
+        private readonly Func<T, T, bool> _equals;
+        public RazorSourceGeneratorComparer(Func<T, T, bool>? equals = null)
+        {
+            _equals = equals ?? EqualityComparer<T>.Default.Equals;
+        }
+
+        public bool Equals((T Left, RazorSourceGenerationOptions Right) x, (T Left, RazorSourceGenerationOptions Right) y)
+        {
+            if (y.Right.SuppressRazorSourceGenerator)
+            {
+                // If source generation is suppressed, we can always use previously cached results.
+                return true;
+            }
+
+            return _equals(x.Left, y.Left) && x.Right.EqualsIgnoringSupression(y.Right);
+        }
+
+        public int GetHashCode((T Left, RazorSourceGenerationOptions Right) obj) => obj.Left.GetHashCode();
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGenerationOptionsTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGenerationOptionsTest.cs
@@ -1,0 +1,231 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    public class RazorSourceGenerationOptionsTest
+    {
+        [Fact]
+        public void Equals_ReturnsFalse_IfConfigurationChanged()
+        {
+            // Arrange
+            var options1 = new RazorSourceGenerationOptions
+            {
+                Configuration = RazorConfiguration.Default,
+            };
+
+            var options2 = new RazorSourceGenerationOptions
+            {
+                Configuration = RazorConfiguration.Create(RazorLanguageVersion.Latest, "3.1", Enumerable.Empty<RazorExtension>()),
+            };
+
+            // Act
+            var equals = options1.Equals(options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalse_IfLanguageChanged()
+        {
+            // Arrange
+            var options1 = new RazorSourceGenerationOptions
+            {
+                CSharpLanguageVersion = LanguageVersion.CSharp10,
+                Configuration = RazorConfiguration.Default,
+            };
+
+            var options2 = new RazorSourceGenerationOptions
+            {
+                Configuration = RazorConfiguration.Default,
+                CSharpLanguageVersion = LanguageVersion.CSharp9,
+            };
+
+            // Act
+            var equals = options1.Equals(options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalse_IfGenerateMetadataSourceChecksumAttributesChanged()
+        {
+            // Arrange
+            var options1 = new RazorSourceGenerationOptions
+            {
+                CSharpLanguageVersion = LanguageVersion.CSharp10,
+                Configuration = RazorConfiguration.Default, 
+                GenerateMetadataSourceChecksumAttributes = false,
+            };
+
+            var options2 = new RazorSourceGenerationOptions
+            {
+                Configuration = RazorConfiguration.Default,
+                CSharpLanguageVersion = LanguageVersion.CSharp9,
+                GenerateMetadataSourceChecksumAttributes = true,
+            };
+
+            // Act
+            var equals = options1.Equals(options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalse_IfRootNamespaceChanged()
+        {
+            // Arrange
+            var options1 = new RazorSourceGenerationOptions
+            {
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                Configuration = RazorConfiguration.Default,
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Initial",
+            };
+
+            var options2 = new RazorSourceGenerationOptions
+            {
+                Configuration = RazorConfiguration.Default,
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Different",
+            };
+
+            // Act
+            var equals = options1.Equals(options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalse_IfSupportLocalizedComponentNameChanged()
+        {
+            // Arrange
+            var options1 = new RazorSourceGenerationOptions
+            {
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                Configuration = RazorConfiguration.Default,
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Asp",
+                SupportLocalizedComponentNames = false,
+            };
+
+            var options2 = new RazorSourceGenerationOptions
+            {
+                Configuration = RazorConfiguration.Default,
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Asp",
+                SupportLocalizedComponentNames = true,
+            };
+
+            // Act
+            var equals = options1.Equals(options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalse_IfSuppressRazorSourceGeneratorChanged()
+        {
+            // Arrange
+            var options1 = new RazorSourceGenerationOptions
+            {
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                Configuration = RazorConfiguration.Default,
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Asp",
+                SupportLocalizedComponentNames = true,
+                SuppressRazorSourceGenerator = true,
+            };
+
+            var options2 = new RazorSourceGenerationOptions
+            {
+                Configuration = RazorConfiguration.Default,
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Asp",
+                SupportLocalizedComponentNames = true,
+                SuppressRazorSourceGenerator = false,
+            };
+
+            // Act
+            var equals = options1.Equals(options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_ReturnsTrue_IfValuesAreUnchanged()
+        {
+            // Arrange
+            var options1 = new RazorSourceGenerationOptions
+            {
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                Configuration = RazorConfiguration.Default,
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Asp",
+                SupportLocalizedComponentNames = true,
+                SuppressRazorSourceGenerator = true,
+            };
+
+            var options2 = new RazorSourceGenerationOptions
+            {
+                Configuration = RazorConfiguration.Default,
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Asp",
+                SupportLocalizedComponentNames = true,
+                SuppressRazorSourceGenerator = true,
+            };
+
+            // Act
+            var equals = options1.Equals(options2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_ReturnsTrue_IfRazorConfigurationAreDifferentInstancesButEqualValues()
+        {
+            // Arrange
+            var options1 = new RazorSourceGenerationOptions
+            {
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                Configuration = RazorConfiguration.Create(RazorLanguageVersion.Parse("6.0"), "Default", Enumerable.Empty<RazorExtension>(), useConsolidatedMvcViews: true),
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Asp",
+                SupportLocalizedComponentNames = true,
+                SuppressRazorSourceGenerator = true,
+            };
+
+            var options2 = new RazorSourceGenerationOptions
+            {
+                Configuration = RazorConfiguration.Create(RazorLanguageVersion.Parse("6.0"), "Default", Enumerable.Empty<RazorExtension>(), useConsolidatedMvcViews: true),
+                CSharpLanguageVersion = LanguageVersion.Latest,
+                GenerateMetadataSourceChecksumAttributes = true,
+                RootNamespace = "Asp",
+                SupportLocalizedComponentNames = true,
+                SuppressRazorSourceGenerator = true,
+            };
+
+            // Act
+            var equals = options1.Equals(options2);
+
+            // Assert
+            Assert.True(equals);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorComparerTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorComparerTest.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators.Tests
+{
+    public class RazorSourceGeneratorComparerTest
+    {
+        [Fact]
+        public void Equals_ReturnsTrue_IfSuppressRazorSourceGeneratorOnRightIsTrue()
+        {
+            // Arrange
+            var left = (new ComparableType(), new RazorSourceGenerationOptions());
+            var right = (new ComparableType(), new RazorSourceGenerationOptions { SuppressRazorSourceGenerator = true });
+
+            var razorComparer = new RazorSourceGeneratorComparer<ComparableType>();
+
+            // Act
+            var result = razorComparer.Equals(left, right);
+
+            // Assert
+            Assert.True(result);
+            Assert.False(right.Item1.EqualsCalled);
+        }
+
+        [Fact]
+        public void Equals_ComparesWithoutSuppressRazorSourceGenerator()
+        {
+            // Arrange
+            var left = (new ComparableType(), new RazorSourceGenerationOptions { SuppressRazorSourceGenerator = true /* This is ignored */});
+            var right = (new ComparableType(), new RazorSourceGenerationOptions());
+
+            var razorComparer = new RazorSourceGeneratorComparer<ComparableType>();
+
+            // Act
+            var result = razorComparer.Equals(left, right);
+
+            // Assert
+            Assert.True(result);
+            Assert.True(left.Item1.EqualsCalled);
+        }
+
+        [Fact]
+        public void Equals_UsesProvidedComparer()
+        {
+            // Arrange
+            var left = (new ComparableType(), new RazorSourceGenerationOptions { SuppressRazorSourceGenerator = true /* This is ignored */});
+            var right = (new ComparableType(), new RazorSourceGenerationOptions());
+            var invoked = false;
+
+            var razorComparer = new RazorSourceGeneratorComparer<ComparableType>((a, b) =>
+            {
+                invoked = true;
+                return true;
+            });
+
+            // Act
+            var result = razorComparer.Equals(left, right);
+
+            // Assert
+            Assert.True(result);
+            Assert.False(left.Item1.EqualsCalled);
+            Assert.True(invoked);
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalse_IfItemComparersReturnFalse()
+        {
+            // Arrange
+            var left = (new ComparableType(), new RazorSourceGenerationOptions());
+            var right = (new ComparableType { Value = "Different" }, new RazorSourceGenerationOptions());
+
+            var razorComparer = new RazorSourceGeneratorComparer<ComparableType>();
+
+            // Act
+            var result = razorComparer.Equals(left, right);
+
+            // Assert
+            Assert.False(result);
+            Assert.True(left.Item1.EqualsCalled);
+        }
+
+        [Fact]
+        public void GetHashCode_ReturnsValueFromItem()
+        {
+            // Arrange
+            var item = (new ComparableType(), new RazorSourceGenerationOptions());
+
+            var razorComparer = new RazorSourceGeneratorComparer<ComparableType>();
+
+            // Act
+            var result = razorComparer.GetHashCode(item);
+
+            // Assert
+            Assert.Equal(42, result);
+        }
+
+        private class ComparableType : IEquatable<ComparableType>
+        {
+            public string Value { get; set; } = "Some value";
+
+            public bool EqualsCalled = false;
+
+            public bool Equals(ComparableType other)
+            {
+                EqualsCalled = true;
+                return Value.Equals(other.Value);
+            }
+
+            public override int GetHashCode() => 42;
+
+            public override bool Equals(object obj) => obj is ComparableType other && Equals(other);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
@@ -1002,6 +1002,257 @@ public class HeaderTagHelper : TagHelper
                 });
         }
 
+        [Fact]
+        public async Task SourceGenerator_UsesPreviouslyCachedResults_IfSuppressRazorSourceGeneratorIsTrue_AndWasPreviouslyFalse()
+        {
+            // When SuppressRazorSourceGenerator=true, we can safely re-use previously cached results instead of 
+            // re-running steps and producing no-op results.
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] =
+@"
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+<h1>Counter</h1>
+<button @onclick=""@(() => {})"">Click me</button>",
+            });
+
+            var compilation = await project.GetCompilationAsync();
+            TestAnalyzerConfigOptionsProvider? testOptionsProvider = null;
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project, optionsProvider =>
+            {
+                testOptionsProvider = optionsProvider;
+                optionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "false";
+            });
+
+            var result = RunGenerator(compilation!, ref driver);
+            Assert.Empty(result.Diagnostics);
+            Assert.Collection(
+                result.GeneratedSources,
+                sourceResult =>
+                {
+                    Assert.Contains("public partial class Index", sourceResult.SourceText.ToString());
+                },
+                sourceResult =>
+                {
+                    var sourceText = sourceResult.SourceText.ToString();
+                    Assert.Contains("public partial class Counter", sourceText);
+                    Assert.Contains("__builder.AddAttribute(2, \"onclick\", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this,", sourceText);
+                });
+
+            var updatedOptionsProvider = new TestAnalyzerConfigOptionsProvider();
+            foreach (var option in testOptionsProvider!.AdditionalTextOptions)
+            {
+                updatedOptionsProvider.AdditionalTextOptions[option.Key] = option.Value;
+            }
+
+            foreach (var option in testOptionsProvider!.TestGlobalOptions.Options)
+            {
+                updatedOptionsProvider.TestGlobalOptions[option.Key] = option.Value;
+            }
+
+            updatedOptionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "true";
+
+            driver = driver.WithUpdatedAnalyzerConfigOptions(updatedOptionsProvider);
+            eventListener.Events.Clear();
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.GeneratedSources);
+            Assert.Collection(eventListener.Events,
+                e => Assert.Equal("ComputeRazorSourceGeneratorOptions", e.EventName));
+        }
+
+        [Fact]
+        public async Task SourceGenerator_UsesPreviouslyCachedResults_IfSuppressRazorSourceGeneratorIsTrue_AndWasPreviouslyTrue()
+        {
+            // When SuppressRazorSourceGenerator=true, we can safely re-use previously cached results instead of
+            // re-running steps and producing no-op results.
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] =
+@"
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+<h1>Counter</h1>
+<button @onclick=""@(() => {})"">Click me</button>",
+            });
+
+            var compilation = await project.GetCompilationAsync();
+            TestAnalyzerConfigOptionsProvider? testOptionsProvider = null;
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project, optionsProvider =>
+            {
+                testOptionsProvider = optionsProvider;
+                optionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "true";
+            });
+
+            var result = RunGenerator(compilation!, ref driver);
+            Assert.Empty(result.Diagnostics);
+            Assert.Empty(result.GeneratedSources);
+
+            var updatedOptionsProvider = new TestAnalyzerConfigOptionsProvider();
+            foreach (var option in testOptionsProvider!.AdditionalTextOptions)
+            {
+                updatedOptionsProvider.AdditionalTextOptions[option.Key] = option.Value;
+            }
+
+            foreach (var option in testOptionsProvider!.TestGlobalOptions.Options)
+            {
+                updatedOptionsProvider.TestGlobalOptions[option.Key] = option.Value;
+            }
+
+            updatedOptionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "true";
+
+            driver = driver.WithUpdatedAnalyzerConfigOptions(updatedOptionsProvider);
+
+            eventListener.Events.Clear();
+            result = RunGenerator(compilation!, ref driver);
+
+            Assert.Empty(result.GeneratedSources);
+            Assert.Collection(eventListener.Events,
+                e => Assert.Equal("ComputeRazorSourceGeneratorOptions", e.EventName));
+        }
+
+        [Fact]
+        public async Task SourceGenerator_UsesPreviouslyCachedResults_BetweenSuppressRazorSourceGeneratorsChanges()
+        {
+            // When SuppressRazorSourceGenerator=true, we can safely re-use previously cached results instead of
+            // re-running steps and producing no-op results.
+            // This test verifies if the suppression changes from false -> true -> false, we can continue using
+            // results from previously cached results.
+            // Arrange
+            using var eventListener = new RazorEventListener();
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+                ["Pages/Counter.razor"] =
+@"
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+<h1>Counter</h1>
+<button @onclick=""@(() => {})"">Click me</button>",
+            });
+
+            var compilation = await project.GetCompilationAsync();
+            TestAnalyzerConfigOptionsProvider? testOptionsProvider = null;
+            var (driver, additionalTexts) = await GetDriverWithAdditionalTextAsync(project, optionsProvider =>
+            {
+                testOptionsProvider = optionsProvider;
+                optionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "false";
+            });
+
+            var result = RunGenerator(compilation!, ref driver);
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.GeneratedSources.Length);
+
+            var indexText = additionalTexts.First(f => f.Path == "Pages/Index.razor");
+
+            for (var i = 0; i < 10; i++)
+            {
+                // Step 2
+                var updatedOptionsProvider = new TestAnalyzerConfigOptionsProvider();
+                foreach (var option in testOptionsProvider!.AdditionalTextOptions)
+                {
+                    updatedOptionsProvider.AdditionalTextOptions[option.Key] = option.Value;
+                }
+
+                foreach (var option in testOptionsProvider!.TestGlobalOptions.Options)
+                {
+                    updatedOptionsProvider.TestGlobalOptions[option.Key] = option.Value;
+                }
+
+                updatedOptionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "true";
+
+                driver = driver.WithUpdatedAnalyzerConfigOptions(updatedOptionsProvider);
+                eventListener.Events.Clear();
+                result = RunGenerator(compilation!, ref driver);
+
+                Assert.Empty(result.GeneratedSources);
+
+                // Step 3
+                updatedOptionsProvider = new TestAnalyzerConfigOptionsProvider();
+                foreach (var option in testOptionsProvider!.AdditionalTextOptions)
+                {
+                    updatedOptionsProvider.AdditionalTextOptions[option.Key] = option.Value;
+                }
+
+                foreach (var option in testOptionsProvider!.TestGlobalOptions.Options)
+                {
+                    updatedOptionsProvider.TestGlobalOptions[option.Key] = option.Value;
+                }
+
+                updatedOptionsProvider.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "false";
+                driver = driver.WithUpdatedAnalyzerConfigOptions(updatedOptionsProvider);
+
+                // Simulate text change
+                var updatedText = new TestAdditionalText("Pages/Index.razor", SourceText.From($"<h1>Hello world {(i + 1)}</h1>", Encoding.UTF8));
+                driver = driver.ReplaceAdditionalText(indexText, updatedText);
+                indexText = updatedText;
+
+                eventListener.Events.Clear();
+                result = RunGenerator(compilation!, ref driver);
+
+                Assert.Collection(
+                    result.GeneratedSources,
+                    sourceResult =>
+                    {
+                        Assert.Contains($"Hello world {(i + 1)}", sourceResult.SourceText.ToString());
+                    },
+                    sourceResult =>
+                    {
+                        var sourceText = sourceResult.SourceText.ToString();
+                        Assert.Contains("public partial class Counter", sourceText);
+                        // Regression test for https://github.com/dotnet/aspnetcore/issues/36116. Verify that @onclick is resolved as a component, and not as a regular attribute
+                        Assert.Contains("__builder.AddAttribute(2, \"onclick\", Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this,", sourceText);
+                    });
+
+                Assert.Collection(
+                    eventListener.Events,
+                    e => Assert.Equal("ComputeRazorSourceGeneratorOptions", e.EventName),
+                    e =>
+                    {
+                        Assert.Equal("GenerateDeclarationCodeStart", e.EventName);
+                        var file = Assert.Single(e.Payload);
+                        Assert.Equal("/Pages/Index.razor", file);
+                    },
+                    e =>
+                    {
+                        Assert.Equal("GenerateDeclarationCodeStop", e.EventName);
+                        var file = Assert.Single(e.Payload);
+                        Assert.Equal("/Pages/Index.razor", file);
+                    },
+                    e =>
+                    {
+                        Assert.Equal("RazorCodeGenerateStart", e.EventName);
+                        var file = Assert.Single(e.Payload);
+                        Assert.Equal("/Pages/Index.razor", file);
+                    },
+                    e =>
+                    {
+                        Assert.Equal("RazorCodeGenerateStop", e.EventName);
+                        var file = Assert.Single(e.Payload);
+                        Assert.Equal("/Pages/Index.razor", file);
+                    },
+                    e =>
+                    {
+                        Assert.Equal("AddSyntaxTrees", e.EventName);
+                        var file = Assert.Single(e.Payload);
+                        Assert.Equal("Pages_Index_razor.g.cs", file);
+                    },
+                    e =>
+                    {
+                        Assert.Equal("AddSyntaxTrees", e.EventName);
+                        var file = Assert.Single(e.Payload);
+                        Assert.Equal("Pages_Counter_razor.g.cs", file);
+                    });
+            }
+        }
+
         private static async ValueTask<GeneratorDriver> GetDriverAsync(Project project)
         {
             var (driver, _) = await GetDriverWithAdditionalTextAsync(project);


### PR DESCRIPTION
…ator changes

In VisualStudio SuppressRazorSourceGenerator changes when it's being invoked by the EnC and tooling.
In our current implementation, while we no-op the operation, when SuppressRazorSourceGenerator=true,
the code also evicts the valid previously cached results when SuppressRazorSourceGenerator=false by returning null values,
causing us do work the next time its false.

Fixes https://github.com/dotnet/aspnetcore/issues/32867