### PR TITLE
[release/6.0.2xx] Backport Catch dotnet watch task cancellation (#23316)

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationWorkspaceProvider.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationWorkspaceProvider.cs
@@ -24,15 +24,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             CancellationToken cancellationToken)
         {
             var taskCompletionSource = new TaskCompletionSource<(Solution, WatchHotReloadService)>(TaskCreationOptions.RunContinuationsAsynchronously);
-            try
-            {
-                CreateProject(taskCompletionSource, hotReloadCapabilitiesTask, projectPath, reporter, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                taskCompletionSource.TrySetException(ex);
-            }
-
+            CreateProject(taskCompletionSource, hotReloadCapabilitiesTask, projectPath, reporter, cancellationToken);
             return taskCompletionSource.Task;
         }
 
@@ -43,39 +35,46 @@ namespace Microsoft.DotNet.Watcher.Tools
             IReporter reporter,
             CancellationToken cancellationToken)
         {
-            var workspace = MSBuildWorkspace.Create();
-
-            workspace.WorkspaceFailed += (_sender, diag) =>
+            try
             {
-                if (diag.Diagnostic.Kind == WorkspaceDiagnosticKind.Warning)
+                var workspace = MSBuildWorkspace.Create();
+
+                workspace.WorkspaceFailed += (_sender, diag) =>
                 {
-                    reporter.Verbose($"MSBuildWorkspace warning: {diag.Diagnostic}");
-                }
-                else
+                    if (diag.Diagnostic.Kind == WorkspaceDiagnosticKind.Warning)
+                    {
+                        reporter.Verbose($"MSBuildWorkspace warning: {diag.Diagnostic}");
+                    }
+                    else
+                    {
+                        taskCompletionSource.TrySetException(new InvalidOperationException($"Failed to create MSBuildWorkspace: {diag.Diagnostic}"));
+                    }
+                };
+
+                await workspace.OpenProjectAsync(projectPath, cancellationToken: cancellationToken);
+                var currentSolution = workspace.CurrentSolution;
+
+                var hotReloadCapabilities = await GetHotReloadCapabilitiesAsync(hotReloadCapabilitiesTask, reporter);
+                var hotReloadService = new WatchHotReloadService(workspace.Services, await hotReloadCapabilitiesTask);
+
+                await hotReloadService.StartSessionAsync(currentSolution, cancellationToken);
+
+                // Read the documents to memory
+                await Task.WhenAll(
+                    currentSolution.Projects.SelectMany(p => p.Documents.Concat(p.AdditionalDocuments)).Select(d => d.GetTextAsync(cancellationToken)));
+
+                // Warm up the compilation. This would help make the deltas for first edit appear much more quickly
+                foreach (var project in currentSolution.Projects)
                 {
-                    taskCompletionSource.TrySetException(new InvalidOperationException($"Failed to create MSBuildWorkspace: {diag.Diagnostic}"));
+                    await project.GetCompilationAsync(cancellationToken);
                 }
-            };
 
-            await workspace.OpenProjectAsync(projectPath, cancellationToken: cancellationToken);
-            var currentSolution = workspace.CurrentSolution;
-
-            var hotReloadCapabilities = await GetHotReloadCapabilitiesAsync(hotReloadCapabilitiesTask, reporter);
-            var hotReloadService = new WatchHotReloadService(workspace.Services, await hotReloadCapabilitiesTask);
-
-            await hotReloadService.StartSessionAsync(currentSolution, cancellationToken);
-
-            // Read the documents to memory
-            await Task.WhenAll(
-                currentSolution.Projects.SelectMany(p => p.Documents.Concat(p.AdditionalDocuments)).Select(d => d.GetTextAsync(cancellationToken)));
-
-            // Warm up the compilation. This would help make the deltas for first edit appear much more quickly
-            foreach (var project in currentSolution.Projects)
-            {
-                await project.GetCompilationAsync(cancellationToken);
+                taskCompletionSource.TrySetResult((currentSolution, hotReloadService));
             }
-
-            taskCompletionSource.TrySetResult((currentSolution, hotReloadService));
+            catch (Exception ex)
+            {
+                taskCompletionSource.TrySetException(ex);
+            }
         }
 
         private static async Task<ImmutableArray<string>> GetHotReloadCapabilitiesAsync(Task<ImmutableArray<string>> hotReloadCapabilitiesTask, IReporter reporter)


### PR DESCRIPTION
(cherry picked from commit abaa78399fa0ce8389346ad4b17bc1772f009241)

Backports https://github.com/dotnet/sdk/pull/23316

View with https://github.com/dotnet/sdk/pull/23386/files?diff=unified&w=1