### PR TITLE
Fixed vstest version in release/6.0.2xx

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -129,9 +129,9 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>0a2795fb4ae20042ff55a1da21f71ae1d7f116ba</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220113-04">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.1.0-release-20220113-05">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>d39826aa6461b639f8a1121c4d95c9f48ea68e11</Sha>
+      <Sha>d3c6439b04452047cb62fc645ce341a034bdb5be</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.200-1.22057.6">
       <Uri>https://github.com/dotnet/linker</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/vstest -->
-    <MicrosoftNETTestSdkPackageVersion>17.2.0-preview-20220113-04</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>17.1.0-release-20220113-05</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
[Test Platform 17.2](https://github.com/microsoft/vstest) versions leaked into this branch because of an incorrect config,
this commit inserts the correct version instead.