### PR TITLE
Allow skipping ILLink target

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -101,6 +101,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="ILLink"
           Condition=" '$(PublishTrimmed)' == 'true' And
+                      '$(RunILLink)' != 'false' And
                       '$(_TargetFrameworkVersionWithoutV)' >= '3.0' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' "
           DependsOnTargets="_RunILLink">
 
@@ -211,8 +212,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- The defaults currently root non-framework assemblies, which
          is a no-op for portable apps. If we later support more ways
          to customize the behavior we can allow linking portable apps
-         in some cases. -->
-    <NETSdkError Condition="'$(SelfContained)' != 'true'" ResourceName="ILLinkNotSupportedError" />
+         in some cases. If we're not running ILLink because e.g. this
+         is a NativeAOT app, value of SelfContained doesn't matter. -->
+    <NETSdkError Condition="'$(RunILLink)' != 'false' And '$(SelfContained)' != 'true'" ResourceName="ILLinkNotSupportedError" />
 
     <PropertyGroup Condition=" '$(ILLinkWarningLevel)' == '' ">
       <ILLinkWarningLevel Condition=" '$(EffectiveAnalysisLevel)' != '' And


### PR DESCRIPTION
For NativeAOT we need to be able to opt in to all `PublishTrimmed` behaviors except the part that runs ILLink. We currently do that in a hacky way (set `PublishTrimmed` to true and create ILLink semaphore file to trick ILLink into not running); it's not great.

I tried introducing a `EnableTrimmingBehaviors` property that becomes true when `PublishTrimmed` is true, but in the end, we would like to be able to support NativeAOT for projects that have `PublishTrimmed` in the project file without NativeAOT failing, so what we really need is a way to disable running ILLink even though `PublishTrimmed` is true.