### PR TITLE
Workloads: Enable support for SxS previews

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallerFactory.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallerFactory.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         public static InstallType GetWorkloadInstallType(SdkFeatureBand sdkFeatureBand, string dotnetDir)
         {
             string installerTypePath = Path.Combine(dotnetDir, "metadata",
-                "workloads", $"{sdkFeatureBand}", "installertype");
+                "workloads", $"{sdkFeatureBand.ToStringWithoutPrerelease()}", "installertype");
 
             if (File.Exists(Path.Combine(installerTypePath, "msi")))
             {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkFeatureBand.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkFeatureBand.cs
@@ -56,7 +56,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             return _featureBand.ToString();
         }
 
-        internal string ToStringWithoutPrerelease()
+        public string ToStringWithoutPrerelease()
         {
             return new ReleaseVersion(_featureBand.Major, _featureBand.Minor, _featureBand.SdkFeatureBand).ToString();
         }

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkFeatureBandTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkFeatureBandTests.cs
@@ -38,5 +38,19 @@ namespace ManifestReaderTests
             var parsedVersion = new SdkFeatureBand(version).ToString();
             parsedVersion.Should().Be(expectedParsedVersion);
         }
+
+        [Theory]
+        [InlineData("6.0.100", "6.0.100")]
+        [InlineData("10.0.512", "10.0.500")]
+        [InlineData("7.0.105-preview.1.12345", "7.0.100")]
+        [InlineData("7.0.100-dev", "7.0.100")]
+        [InlineData("7.0.100-ci", "7.0.100")]
+        [InlineData("6.0.100-rc.2.21505.57", "6.0.100")]
+        [InlineData("7.0.400-alpha.1.21558.2", "7.0.400")]
+        public void ItDiscardsPreleaseLabelsCorrectly(string version, string expectedParsedVersion)
+        {
+            var parsedVersion = new SdkFeatureBand(version).ToStringWithoutPrerelease();
+            parsedVersion.Should().Be(expectedParsedVersion);
+        }
     }
 }


### PR DESCRIPTION
Ensure that the sentinel file can be detected correctly. The sentinel file always resides in a folder that excludes any prerelease values, e.g. 7.0.104-preview.4 will still install the sentinel to 7.0.100. To support SxS installs of previews, the SdkFeatureBand version will include prerelease values, so we need to ensure that we use the short form that only includes the major.minor.featureband (without patch) to detect the sentinel file.