### PR TITLE
Skip Run_WithHotReloadEnabled_ReadsLaunchSettings_WhenUsingProjectOpt…

### DIFF
--- a/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             await app.Process.GetOutputLineAsync("Environment: Development", TimeSpan.FromSeconds(10));
         }
 
-        [CoreMSBuildOnlyFact]
+        [CoreMSBuildOnlyFact(Skip = "https://github.com/dotnet/aspnetcore/issues/39657")]
         public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings_WhenUsingProjectOption()
         {
             var testAsset = _testAssetsManager.CopyTestAsset("WatchAppWithLaunchSettings")


### PR DESCRIPTION
As discussed in https://github.com/dotnet/sdk/pull/23511. Fix tracked via https://github.com/dotnet/aspnetcore/issues/39657.