### PR TITLE
Fix version.details entry for System.Commandline

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -268,9 +268,9 @@
       <Sha>c750b5a665adb75b528a93d844f238bd1360a91a</Sha>
       <SourceBuild RepoName="roslyn-analyzers" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21601.2">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21473.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>8f280ecd202ab3ce64af177a6e2aa18644a26f6f</Sha>
+      <Sha>82273cb56c83b589e8e5b63da0ac9745ffc6e105</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.257901">
       <Uri>https://github.com/dotnet/command-line-api</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -272,9 +272,9 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>82273cb56c83b589e8e5b63da0ac9745ffc6e105</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.257901">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.247301">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>de978c68b470123a2df3891f98ee9974c323c41f</Sha>
+      <Sha>82273cb56c83b589e8e5b63da0ac9745ffc6e105</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21519.2">

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -7,7 +7,7 @@ function InitializeCustomSDKToolset {
 
   # The following frameworks and tools are used only for testing.
   # Do not attempt to install them in source build.
-  if [[ "${ArcadeBuildFromSource:-}" == "true" ]]; then
+  if [[ "${DotNetBuildFromSource:-}" == "true" ]]; then
     return
   fi
 

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -7,7 +7,7 @@ function InitializeCustomSDKToolset {
 
   # The following frameworks and tools are used only for testing.
   # Do not attempt to install them in source build.
-  if [[ "${DotNetBuildFromSource:-}" == "true" ]]; then
+  if [[ "${ArcadeBuildFromSource:-}" == "true" ]]; then
     return
   fi
 


### PR DESCRIPTION
Matches what we have in 6.0.1xx, and should unblock https://github.com/dotnet/installer/pull/12981