### PR TITLE
`dotnet watch` test fix search console history

### DIFF
--- a/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             await app.StartWatcherAsync();
 
-            await app.Process.GetOutputLineAsync("Environment: Development", TimeSpan.FromSeconds(10));
+            await app.Process.GetOutputLineAsyncWithConsoleHistoryAsync("Environment: Development", TimeSpan.FromSeconds(10));
         }
 
         [CoreMSBuildOnlyFact]
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             await app.StartWatcherAsync();
 
-            await app.Process.GetOutputLineAsync("Environment: Development", TimeSpan.FromSeconds(10));
+            await app.Process.GetOutputLineAsyncWithConsoleHistoryAsync("Environment: Development", TimeSpan.FromSeconds(10));
         }
 
         [CoreMSBuildOnlyFact]

--- a/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
+++ b/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
@@ -75,6 +75,18 @@ namespace Microsoft.DotNet.Watcher.Tools
             WriteTestOutput($"{DateTime.Now}: process started: '{_process.StartInfo.FileName} {_process.StartInfo.Arguments}'");
         }
 
+        public Task<string> GetOutputLineAsyncWithConsoleHistoryAsync(string message, TimeSpan timeout)
+        {
+            if (_lines.Contains(message))
+            {
+                WriteTestOutput($"Found [msg == '{message}'] in console history.");
+                return Task.FromResult(message);
+            }
+            
+            WriteTestOutput($"Did not find [msg == '{message}'] in console history.");
+            return GetOutputLineAsync(message, timeout);
+        }
+
         public async Task<string> GetOutputLineAsync(string message, TimeSpan timeout)
         {
             WriteTestOutput($"Waiting for output line [msg == '{message}']. Will wait for {timeout.TotalSeconds} sec.");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/39657

This is written in order (Started, Env var):

https://github.com/dotnet/sdk/blob/6b5a47ae285945d8bc1ac59d3bb6ab7b4740298c/src/Assets/TestProjects/WatchAppWithLaunchSettings/Program.cs#L1-L2

However the [process output](https://github.com/dotnet/sdk/blob/6b5a47ae285945d8bc1ac59d3bb6ab7b4740298c/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs#L66-L67) is publishing the lines out of order.

https://github.com/dotnet/sdk/blob/6b5a47ae285945d8bc1ac59d3bb6ab7b4740298c/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs#L133

```
        1/20/2022 12:29:35 PM: post: 'Environment: Development'
        1/20/2022 12:29:35 PM: recv: 'watch : Started'. Does not match condition '[msg == 'Started']'.
        1/20/2022 12:29:35 PM: recv: 'Environment: Development'. Does not match condition '[msg == 'Started']'.
        1/20/2022 12:29:35 PM: post: 'Started'
        1/20/2022 12:29:35 PM: recv: 'Started'. Matches condition '[msg == 'Started']'.
        Waiting for output line [msg == 'Environment: Development']. Will wait for 10 sec.
```


I applied the fix for the problematic tests that @marcpopMSFT called out, we can expand to all tests if necessary.