### PR TITLE
Skip restoring 1.x in Source Build

### DIFF
--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -7,7 +7,7 @@ function InitializeCustomSDKToolset {
 
   # The following frameworks and tools are used only for testing.
   # Do not attempt to install them in source build.
-  if [[ $properties == *"ArcadeBuildFromSource\=true"* ]]; then
+  if [[ $properties == *"ArcadeBuildFromSource=true"* ]]; then
     return
   fi
 

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -7,7 +7,7 @@ function InitializeCustomSDKToolset {
 
   # The following frameworks and tools are used only for testing.
   # Do not attempt to install them in source build.
-  if [[ "${DotNetBuildFromSource:-}" == "true" ]]; then
+  if [[ $properties == *"ArcadeBuildFromSource\=true"* ]]; then
     return
   fi
 


### PR DESCRIPTION
Hack to skip installing 1.x when `build.sh` was called from https://github.com/dotnet/sdk/blob/d0d56c4e723b5b35c180641b9913c2f8cfb6bc49/eng/common/templates/steps/source-build.yml#L71-L79