### PR TITLE
Blame switch args should not swallow following arg

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
@@ -130,7 +130,6 @@ namespace Microsoft.DotNet.Cli
                         if (blame.IsBlameSwitch(arg))
                         {
                             blame.UpdateBlame(arg, null);
-                            activeArgument = arg;
                         }
                         else
                         {

--- a/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
@@ -177,7 +177,10 @@ namespace Microsoft.DotNet.Cli
                     {
                         UpdateVerbosity(arg, newArgList);
                     }
-                    // This case should be processed before 's_ignoredArguments.Contains'.
+                    // It's possible to have activeArgument that is both ignored and considered as a switch.
+                    // Order of the two contains clauses is important because the current implementation wants
+                    // to check first if activeArgument is a switch first so that we don't consume the arg, and the
+                    // inner if will take care of deciding if active argument should be ignored or handled.
                     else if (s_switchArguments.Contains(activeArgument))
                     {
                         if (s_ignoredArguments.Contains(activeArgument))
@@ -194,14 +197,26 @@ namespace Microsoft.DotNet.Cli
                         // either add it to the ignored args or have a specific failure.
                         newArgList.Add(arg);
                     }
+                    // When reaching this point, we are sure that activeArgument is not a switch so we
+                    // can add it and the arg to the list of ignored arguments.
                     else if (s_ignoredArguments.Contains(activeArgument))
                     {
                         ignoredArgs.Add(activeArgument);
                         ignoredArgs.Add(arg);
                     }
+                    // When entering this condition, we know that the activeArgument is either a blame
+                    // switch or a blame argument. Blame args have to be handled differently because
+                    // they are cumulative and so need to be combined. The inner logic will decide how 
+                    // to handle it.
                     else if (BlameArgs.IsBlameArg(activeArgument))
                     {
-                        if (!BlameArgs.IsBlameSwitch(activeArgument)
+                        // We know that activeArgument is a blame kind, we now want to see if arg is linked to the
+                        // blame or not. 
+                        // If activeArgument is a not blame switch (e.g., --blame-crash-dump-type full) or if it is the
+                        // legacy blame syntax (e.g., --blame CollectDump;DumpType=full) then we do want to 
+                        // update the blame combination based both on activeArgument and arg.
+                        // Otherwise, we have a simple blame switch (e.g., --blame some.dll) so we can add it to the
+                        // args list.
                             || BlameArgs.IsLegacyBlame(activeArgument, arg))
                         {
                             blame.UpdateBlame(activeArgument, arg);

--- a/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
@@ -1,58 +1,87 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
 namespace Microsoft.DotNet.Cli
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using static BlameArgs;
-
     /// <summary>
-    /// Converts the given arguments to vstest parsable arguments
+    /// Converts the given arguments to vstest parsable arguments.
     /// </summary>
+    /// <remarks>
+    /// This converter is only used when running <c>dotnet test</c> with a dll/exe,
+    /// not when called for project, solution, directory, or with no path.
+    /// </remarks>
     public class VSTestArgumentConverter
     {
-        private const string verbosityString = "--logger:console;verbosity=";
+        private const string VerbosityString = "--logger:console;verbosity=";
 
-        private readonly Dictionary<string, string> ArgumentMapping = new Dictionary<string, string>
-        {
-            ["-h"] = "--help",
-            ["-s"] = "--settings",
-            ["-t"] = "--listtests",
-            ["-a"] = "--platform",
-            ["-l"] = "--logger",
-            ["-f"] = "--framework",
-            ["-d"] = "--diag",
-            ["--filter"] = "--testcasefilter",
-            ["--list-tests"] = "--listtests",
-            ["--test-adapter-path"] = "--testadapterpath",
-            ["--results-directory"] = "--resultsdirectory",
-            ["--arch"] = "--platform"
-        };
+        private static readonly ImmutableDictionary<string, string> s_argumentMapping
+            = new Dictionary<string, string>()
+            {
+                ["-h"] = "--help",
+                ["-s"] = "--settings",
+                ["-t"] = "--listtests",
+                // .NET 7 breaking change, before we had ["-a"] = "--testadapterpath",
+                ["-a"] = "--platform",
+                ["-l"] = "--logger",
+                ["-f"] = "--framework",
+                ["-d"] = "--diag",
+                ["--filter"] = "--testcasefilter",
+                ["--list-tests"] = "--listtests",
+                ["--test-adapter-path"] = "--testadapterpath",
+                // .NET 7 breaking change, before we had ["-r"] = "--resultsdirectory",
+                ["--results-directory"] = "--resultsdirectory",
+                ["--arch"] = "--platform"
+            }.ToImmutableDictionary();
 
-        private readonly Dictionary<string, string> VerbosityMapping = new Dictionary<string, string>
-        {
-            ["q"] = "quiet",
-            ["m"] = "minimal",
-            ["n"] = "normal",
-            ["d"] = "detailed",
-            ["diag"] = "diagnostic"
-        };
+        private static readonly ImmutableDictionary<string, string> s_verbosityMapping
+            = new Dictionary<string, string>()
+            {
+                ["q"] = "quiet",
+                ["m"] = "minimal",
+                ["n"] = "normal",
+                ["d"] = "detailed",
+                ["diag"] = "diagnostic"
+            }.ToImmutableDictionary();
 
-        private readonly string[] IgnoredArguments = new string[]
-        {
-            "-c",
-            "--configuration",
-            "--runtime",
-            "-o",
-            "--output",
-            "--no-build",
-            "--no-restore",
-            "--interactive",
-            "--testSessionId",
-            "--artifacts-processing-mode"
-        };
+        private static readonly ImmutableHashSet<string> s_ignoredArguments
+            = ImmutableHashSet.Create(
+                StringComparer.OrdinalIgnoreCase,
+                "-c",
+                "--configuration",
+                "-r",
+                "--runtime",
+                "-o",
+                "--output",
+                "--no-build",
+                "--no-restore",
+                "--interactive",
+                "--testSessionCorrelationId",
+                "--artifactsProcessingMode-collect"
+            );
+
+        /// <summary>
+        /// The expanded (after applying argument mapping) list of arguments to consider
+        /// as switches (i.e., for which we don't expect a non dashed arg). This also
+        /// includes ignored arguments.
+        /// </summary>
+        private static readonly ImmutableHashSet<string> s_switchArguments
+            = ImmutableHashSet.Create(
+                StringComparer.OrdinalIgnoreCase,
+                // Arguments
+                "--listtests",
+                "--nologo",
+
+                // Ignored arguments
+                "--no-build",
+                "--no-restore",
+                "--interactive",
+                "--artifactsProcessingMode-collect"
+            );
 
         /// <summary>
         /// Converts the given arguments to vstest parsable arguments
@@ -66,24 +95,24 @@ namespace Microsoft.DotNet.Cli
             ignoredArgs = new List<string>();
 
             string activeArgument = null;
-            BlameArgs blame = new BlameArgs();
+            BlameArgs blame = new();
 
-            foreach (var arg in args)
+            foreach (string arg in args)
             {
                 if (arg == "--")
                 {
                     throw new ArgumentException("Inline settings should not be passed to Convert.");
                 }
 
-                if (arg.StartsWith("-"))
+                if (arg.StartsWith('-'))
                 {
                     if (!string.IsNullOrEmpty(activeArgument))
                     {
-                        if (IgnoredArguments.Contains(activeArgument))
+                        if (s_ignoredArguments.Contains(activeArgument))
                         {
                             ignoredArgs.Add(activeArgument);
                         }
-                        else if (blame.IsBlameArg(activeArgument, null))
+                        else if (BlameArgs.IsBlameArg(activeArgument))
                         {
                             // do nothing, we process remaining arguments ourselves
                         }
@@ -95,46 +124,47 @@ namespace Microsoft.DotNet.Cli
                     }
 
                     // Check if the arg contains the value separated by colon
-                    if (arg.Contains(":"))
+                    if (arg.Contains(':'))
                     {
-                        var argValues = arg.Split(':');
+                        string[] argValues = arg.Split(':');
 
-                        if (IgnoredArguments.Contains(argValues[0]))
+                        if (s_ignoredArguments.Contains(argValues[0]))
                         {
                             ignoredArgs.Add(arg);
                             continue;
                         }
 
-                        if (this.IsVerbosityArg(argValues[0]))
+                        if (IsVerbosityArg(argValues[0]))
                         {
                             UpdateVerbosity(argValues[1], newArgList);
                             continue;
                         }
 
-                        if (blame.IsBlameArg(argValues[0], argValues[1]))
+                        if (BlameArgs.IsBlameArg(argValues[0]))
                         {
                             blame.UpdateBlame(argValues[0], argValues[1]);
                             continue;
                         }
 
                         // Check if the argument is shortname
-                        if (ArgumentMapping.TryGetValue(argValues[0].ToLower(), out var longName))
+                        if (s_argumentMapping.TryGetValue(argValues[0].ToLower(), out string longName))
                         {
                             argValues[0] = longName;
                         }
 
-                        newArgList.Add(string.Join(":", argValues));
+                        newArgList.Add(string.Join(':', argValues));
                     }
                     else
                     {
-                        if (blame.IsBlameSwitch(arg))
+                        if (BlameArgs.IsBlameSwitch(arg))
                         {
                             blame.UpdateBlame(arg, null);
+                            activeArgument = arg;
                         }
                         else
                         {
                             activeArgument = arg.ToLower();
-                            if (ArgumentMapping.TryGetValue(activeArgument, out var value))
+                            if (s_argumentMapping.TryGetValue(activeArgument, out string value))
                             {
                                 activeArgument = value;
                             }
@@ -147,14 +177,39 @@ namespace Microsoft.DotNet.Cli
                     {
                         UpdateVerbosity(arg, newArgList);
                     }
-                    else if (IgnoredArguments.Contains(activeArgument))
+                    // This case should be processed before 's_ignoredArguments.Contains'.
+                    else if (s_switchArguments.Contains(activeArgument))
+                    {
+                        if (s_ignoredArguments.Contains(activeArgument))
+                        {
+                            ignoredArgs.Add(activeArgument);
+                        }
+                        else
+                        {
+                            newArgList.Add(activeArgument);
+                        }
+
+                        // The only real case where we would end-up here is when the item under test (.dll or .exe)
+                        // is passed as last argument so we could potentially check the extension and for invalid ones,
+                        // either add it to the ignored args or have a specific failure.
+                        newArgList.Add(arg);
+                    }
+                    else if (s_ignoredArguments.Contains(activeArgument))
                     {
                         ignoredArgs.Add(activeArgument);
                         ignoredArgs.Add(arg);
                     }
-                    else if (blame.IsBlameArg(activeArgument, arg))
+                    else if (BlameArgs.IsBlameArg(activeArgument))
                     {
-                        blame.UpdateBlame(activeArgument, arg);
+                        if (!BlameArgs.IsBlameSwitch(activeArgument)
+                            || BlameArgs.IsLegacyBlame(activeArgument, arg))
+                        {
+                            blame.UpdateBlame(activeArgument, arg);
+                        }
+                        else
+                        {
+                            newArgList.Add(arg);
+                        }
                     }
                     else
                     {
@@ -165,7 +220,7 @@ namespace Microsoft.DotNet.Cli
                 }
                 else
                 {
-                    if (blame.IsBlameArg(arg, null))
+                    if (BlameArgs.IsBlameArg(arg))
                     {
                         blame.UpdateBlame(arg, null);
                     }
@@ -178,11 +233,12 @@ namespace Microsoft.DotNet.Cli
 
             if (!string.IsNullOrEmpty(activeArgument))
             {
-                if (IgnoredArguments.Contains(activeArgument))
+                if (s_ignoredArguments.Contains(activeArgument))
                 {
                     ignoredArgs.Add(activeArgument);
                 }
-                else if( blame.IsBlameArg(activeArgument, null)) {
+                else if (BlameArgs.IsBlameArg(activeArgument))
+                {
                     // do nothing, we process remaining arguments ourselves
                 }
                 else
@@ -199,84 +255,89 @@ namespace Microsoft.DotNet.Cli
             return newArgList;
         }
 
-        private bool IsVerbosityArg(string arg)
-        {
-            return string.Equals(arg, "-v", System.StringComparison.OrdinalIgnoreCase) || string.Equals(arg, "--verbosity", System.StringComparison.OrdinalIgnoreCase);
-        }
+        private static bool IsVerbosityArg(string arg)
+            => string.Equals(arg, "-v", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(arg, "--verbosity", StringComparison.OrdinalIgnoreCase);
 
-        private void UpdateVerbosity(string verbosity, List<string> newArgList)
+        private static void UpdateVerbosity(string verbosity, List<string> newArgList)
         {
-            if (VerbosityMapping.TryGetValue(verbosity.ToLower(), out string longValue))
+            if (s_verbosityMapping.TryGetValue(verbosity.ToLower(), out string longValue))
             {
-                newArgList.Add(verbosityString + longValue);
+                newArgList.Add(VerbosityString + longValue);
                 return;
             }
-            newArgList.Add(verbosityString + verbosity);
+            newArgList.Add(VerbosityString + verbosity);
         }
     }
 
     class BlameArgs
     {
-        public bool Blame = false;
-        public string LegacyBlame = null;
+        public bool Blame;
+        private string _legacyBlame;
 
-        public bool CollectCrashDump = false;
-        public string CollectCrashDumpType = null;
-        public bool CollectCrashDumpAlways = false;
+        private bool _collectCrashDump;
+        private string _collectCrashDumpType;
+        private bool _collectCrashDumpAlways;
 
-        public bool CollectHangDump = false;
-        public string CollectHangDumpType = null;
-        public string CollectHangDumpTimeout = null;
+        private bool _collectHangDump;
+        private string _collectHangDumpType;
+        private string _collectHangDumpTimeout;
 
-        public static string BlameParam = "--blame";
-        public static string BlameCrashParam = "--blame-crash";
-        public static string BlameCrashDumpTypeParam = "--blame-crash-dump-type";
-        public static string BlameCrashCollectAlwaysParam = "--blame-crash-collect-always";
-        public static string BlameHangParam = "--blame-hang";
-        public static string BlameHangDumpTypeParam = "--blame-hang-dump-type";
-        public static string BlameHangTimeoutParam = "--blame-hang-timeout";
+        private const string BlameParam = "--blame";
+        private const string BlameCrashParam = "--blame-crash";
+        private const string BlameCrashDumpTypeParam = "--blame-crash-dump-type";
+        private const string BlameCrashCollectAlwaysParam = "--blame-crash-collect-always";
+        private const string BlameHangParam = "--blame-hang";
+        private const string BlameHangDumpTypeParam = "--blame-hang-dump-type";
+        private const string BlameHangTimeoutParam = "--blame-hang-timeout";
+
+        private const string LegacyBlameCollectDump = "CollectDump";
+        private const string LegacyBlameCollectHangDump = "CollectHangDump";
 
         // parameters that expect arguments
-        private readonly string[] _blameArgList = new string[]{
-            BlameCrashDumpTypeParam,
+        private static readonly ImmutableArray<string> s_blameArgList
+            = ImmutableArray.Create(
+                BlameCrashDumpTypeParam,
 
-            BlameHangDumpTypeParam,
-            BlameHangTimeoutParam
-        };
+                BlameHangDumpTypeParam,
+                BlameHangTimeoutParam
+            );
 
         // parameters that don't expect any arguments
-        private readonly string[] _blameSwitchList = new string[]{
-            BlameParam,
+        private static readonly ImmutableArray<string> s_blameSwitchList
+            = ImmutableArray.Create(
+                BlameParam,
 
-            BlameCrashParam,
-            BlameCrashCollectAlwaysParam,
+                BlameCrashParam,
+                BlameCrashCollectAlwaysParam,
 
-            BlameHangParam,
-        };
+                BlameHangParam
+            );
 
 
-        internal bool IsBlameArg(string parameter, string value)
+        internal static bool IsBlameArg(string parameter)
         {
-            return _blameArgList.Any(p => Eq(p, parameter)) || _blameSwitchList.Any(p => Eq(p, parameter));
+            return s_blameArgList.Any(p => Eq(p, parameter)) || s_blameSwitchList.Any(p => Eq(p, parameter));
         }
 
-        private bool IsLegacyBlame(string parameter, string value)
+        internal static bool IsLegacyBlame(string parameter, string value)
         {
             // when provided --blame <value>, we do not want to process it any further
             // most likely a legacy call, and the param is already in the format that vstest.console expects
-            return Eq(BlameParam, parameter) && !string.IsNullOrWhiteSpace(value);
+            return Eq(BlameParam, parameter)
+                && value != null
+                && (value.StartsWith(LegacyBlameCollectDump, StringComparison.OrdinalIgnoreCase)
+                    || value.StartsWith(LegacyBlameCollectHangDump, StringComparison.OrdinalIgnoreCase));
         }
 
-        internal bool IsBlame(string parameter)
+        internal static bool IsBlame(string parameter)
         {
             return Eq(BlameParam, parameter);
-
         }
 
-        internal bool IsBlameSwitch(string parameter)
+        internal static bool IsBlameSwitch(string parameter)
         {
-            return _blameSwitchList.Any(p => Eq(p, parameter));
-
+            return s_blameSwitchList.Any(p => Eq(p, parameter));
         }
 
         internal void UpdateBlame(string parameter, string argument)
@@ -284,7 +345,7 @@ namespace Microsoft.DotNet.Cli
             if (IsLegacyBlame(parameter, argument))
             {
                 Blame = true;
-                LegacyBlame = argument;
+                _legacyBlame = argument;
             }
 
             if (Eq(parameter, BlameParam))
@@ -296,46 +357,46 @@ namespace Microsoft.DotNet.Cli
             if (Eq(parameter, BlameCrashParam))
             {
                 Blame = true;
-                CollectCrashDump = true;
+                _collectCrashDump = true;
             }
 
             if (Eq(parameter, BlameCrashCollectAlwaysParam))
             {
                 Blame = true;
-                CollectCrashDump = true;
-                CollectCrashDumpAlways = true;
+                _collectCrashDump = true;
+                _collectCrashDumpAlways = true;
             }
 
             if (Eq(parameter, BlameCrashDumpTypeParam))
             {
                 Blame = true;
-                CollectCrashDump = true;
-                CollectCrashDumpType = argument;
+                _collectCrashDump = true;
+                _collectCrashDumpType = argument;
             }
 
             // Any Blame-hang param implies that we collect hang dump
             if (Eq(parameter, BlameHangParam))
             {
                 Blame = true;
-                CollectHangDump = true;
+                _collectHangDump = true;
             }
 
             if (Eq(parameter, BlameHangDumpTypeParam))
             {
                 Blame = true;
-                CollectHangDump = true;
-                CollectHangDumpType = argument;
+                _collectHangDump = true;
+                _collectHangDumpType = argument;
             }
 
             if (Eq(parameter, BlameHangTimeoutParam))
             {
                 Blame = true;
-                CollectHangDump = true;
-                CollectHangDumpTimeout = argument;
+                _collectHangDump = true;
+                _collectHangDumpTimeout = argument;
             }
         }
 
-        private bool Eq(string left, string right)
+        private static bool Eq(string left, string right)
         {
             return string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
         }
@@ -345,46 +406,46 @@ namespace Microsoft.DotNet.Cli
             if (!Blame)
                 return;
 
-            if (!string.IsNullOrWhiteSpace(LegacyBlame))
+            if (!string.IsNullOrWhiteSpace(_legacyBlame))
             {
                 // when legacy call is detected don't process
                 // any more parameters
-                newArgList.Add($"--blame:{LegacyBlame}");
+                newArgList.Add($"--blame:{_legacyBlame}");
                 return;
             }
 
             string crashDumpArgs = null;
             string hangDumpArgs = null;
 
-            if (CollectCrashDump)
+            if (_collectCrashDump)
             {
                 crashDumpArgs = "CollectDump";
-                if (CollectCrashDumpAlways)
+                if (_collectCrashDumpAlways)
                 {
                     crashDumpArgs += ";CollectAlways=true";
                 }
 
-                if (!string.IsNullOrWhiteSpace(CollectCrashDumpType))
+                if (!string.IsNullOrWhiteSpace(_collectCrashDumpType))
                 {
-                    crashDumpArgs += $";DumpType={CollectCrashDumpType}";
+                    crashDumpArgs += $";DumpType={_collectCrashDumpType}";
                 }
             }
 
-            if (CollectHangDump)
+            if (_collectHangDump)
             {
                 hangDumpArgs = "CollectHangDump";
-                if (!string.IsNullOrWhiteSpace(CollectHangDumpType))
+                if (!string.IsNullOrWhiteSpace(_collectHangDumpType))
                 {
-                    hangDumpArgs += $";DumpType={CollectHangDumpType}";
+                    hangDumpArgs += $";DumpType={_collectHangDumpType}";
                 }
 
-                if (!string.IsNullOrWhiteSpace(CollectHangDumpTimeout))
+                if (!string.IsNullOrWhiteSpace(_collectHangDumpTimeout))
                 {
-                    hangDumpArgs += $";TestTimeout={CollectHangDumpTimeout}";
+                    hangDumpArgs += $";TestTimeout={_collectHangDumpTimeout}";
                 }
             }
 
-            if (CollectCrashDump || CollectHangDump)
+            if (_collectCrashDump || _collectHangDump)
             {
                 newArgList.Add($@"--blame:{string.Join(";", crashDumpArgs, hangDumpArgs).Trim(';')}");
             }

--- a/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
@@ -177,10 +177,11 @@ namespace Microsoft.DotNet.Cli
                     {
                         UpdateVerbosity(arg, newArgList);
                     }
-                    // It's possible to have activeArgument that is both ignored and considered as a switch.
-                    // Order of the two contains clauses is important because the current implementation wants
-                    // to check first if activeArgument is a switch first so that we don't consume the arg, and the
-                    // inner if will take care of deciding if active argument should be ignored or handled.
+                    // It's possible to have activeArgument that is both ignored and considered as
+                    // a switch. Order of the two contains clauses is important because the current
+                    // implementation wants to check first if activeArgument is a switch first so
+                    // that we don't consume the arg, and the inner if will take care of deciding
+                    // if active argument should be ignored or handled.
                     else if (s_switchArguments.Contains(activeArgument))
                     {
                         if (s_ignoredArguments.Contains(activeArgument))
@@ -192,31 +193,33 @@ namespace Microsoft.DotNet.Cli
                             newArgList.Add(activeArgument);
                         }
 
-                        // The only real case where we would end-up here is when the item under test (.dll or .exe)
-                        // is passed as last argument so we could potentially check the extension and for invalid ones,
-                        // either add it to the ignored args or have a specific failure.
+                        // The only real case where we would end-up here is when the item under
+                        // test (.dll or .exe) is passed as last argument so we could potentially
+                        // check the extension and for invalid ones, either add it to the ignored
+                        // args or have a specific failure.
                         newArgList.Add(arg);
                     }
-                    // When reaching this point, we are sure that activeArgument is not a switch so we
-                    // can add it and the arg to the list of ignored arguments.
+                    // When reaching this point, we are sure that activeArgument is not a switch
+                    // so we can add it and the arg to the list of ignored arguments.
                     else if (s_ignoredArguments.Contains(activeArgument))
                     {
                         ignoredArgs.Add(activeArgument);
                         ignoredArgs.Add(arg);
                     }
-                    // When entering this condition, we know that the activeArgument is either a blame
-                    // switch or a blame argument. Blame args have to be handled differently because
-                    // they are cumulative and so need to be combined. The inner logic will decide how 
-                    // to handle it.
+                    // When entering this condition, we know that the activeArgument is either a
+                    // blame switch or a blame argument. Blame args have to be handled differently
+                    // because they are cumulative and so need to be combined. The inner logic will
+                    // decide how to handle it.
                     else if (BlameArgs.IsBlameArg(activeArgument))
                     {
-                        // We know that activeArgument is a blame kind, we now want to see if arg is linked to the
-                        // blame or not. 
-                        // If activeArgument is a not blame switch (e.g., --blame-crash-dump-type full) or if it is the
-                        // legacy blame syntax (e.g., --blame CollectDump;DumpType=full) then we do want to 
-                        // update the blame combination based both on activeArgument and arg.
-                        // Otherwise, we have a simple blame switch (e.g., --blame some.dll) so we can add it to the
-                        // args list.
+                        // We know that activeArgument is a blame kind, we now want to see if arg
+                        // is linked to the blame or not. If activeArgument is a not blame switch
+                        // (e.g., --blame-crash-dump-type full) or if it is the legacy blame syntax
+                        // (e.g., --blame CollectDump;DumpType=full) then we do want to update the
+                        // blame combination based both on activeArgument and arg. Otherwise, we
+                        // have a simple blame switch (e.g., --blame some.dll) so we can add it to
+                        // the args list.
+                        if (!BlameArgs.IsBlameSwitch(activeArgument)
                             || BlameArgs.IsLegacyBlame(activeArgument, arg))
                         {
                             blame.UpdateBlame(activeArgument, arg);

--- a/src/Tests/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
@@ -5,6 +5,8 @@ using FluentAssertions;
 using Microsoft.DotNet.Cli;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.DotNet.Tests.ParserTests
@@ -12,35 +14,35 @@ namespace Microsoft.DotNet.Tests.ParserTests
     public class VSTestArgumentConverterTests
     {
         [Theory]
-        [MemberData(nameof(DataSource.ArgTestCases), MemberType = typeof(DataSource))]
+        [MemberData(nameof(DataSource.GetArguments), MemberType = typeof(DataSource))]
         public void ConvertArgsShouldConvertValidArgsIntoVSTestParsableArgs(string input, string expectedString)
         {
             string[] args = input.Split(' ');
             string[] expectedArgs = expectedString.Split(' ');
 
             // Act
-            var convertedArgs = new VSTestArgumentConverter().Convert(args, out var ignoredArgs);
+            List<string> convertedArgs = new VSTestArgumentConverter().Convert(args, out List<string> ignoredArgs);
 
             convertedArgs.Should().BeEquivalentTo(expectedArgs);
             ignoredArgs.Should().BeEmpty();
         }
 
         [Theory]
-        [MemberData(nameof(DataSource.VerbosityTestCases), MemberType = typeof(DataSource))]
+        [MemberData(nameof(DataSource.GetVerbosityArguments), MemberType = typeof(DataSource))]
         public void ConvertArgshouldConvertsVerbosityArgsIntoVSTestParsableArgs(string input, string expectedString)
         {
             string[] args = input.Split(' ');
             string[] expectedArgs = expectedString.Split(' ');
 
             // Act
-            var convertedArgs = new VSTestArgumentConverter().Convert(args, out var ignoredArgs);
+            List<string> convertedArgs = new VSTestArgumentConverter().Convert(args, out List<string> ignoredArgs);
 
             convertedArgs.Should().BeEquivalentTo(expectedArgs);
             ignoredArgs.Should().BeEmpty();
         }
 
         [Theory]
-        [MemberData(nameof(DataSource.IgnoredArgTestCases), MemberType = typeof(DataSource))]
+        [MemberData(nameof(DataSource.GetIgnoredArguments), MemberType = typeof(DataSource))]
         public void ConvertArgsShouldIgnoreKnownArgsWhileConvertingArgsIntoVSTestParsableArgs(string input, string expectedArgString, string expIgnoredArgString)
         {
             string[] args = input.Split(' ');
@@ -48,10 +50,10 @@ namespace Microsoft.DotNet.Tests.ParserTests
             string[] expIgnoredArgs = expIgnoredArgString.Split(' ');
 
             // Act
-            var convertedArgs = new VSTestArgumentConverter().Convert(args, out var ignoredArgs);
+            List<string> convertedArgs = new VSTestArgumentConverter().Convert(args, out List<string> ignoredArgs);
 
             convertedArgs.Should().BeEquivalentTo(expectedArgs);
-            Assert.Equal(expIgnoredArgs, ignoredArgs);
+            ignoredArgs.Select(x => x.ToUpperInvariant()).Should().BeEquivalentTo(expIgnoredArgs.Select(x => x.ToUpperInvariant()));
         }
 
         [Fact]
@@ -65,96 +67,196 @@ namespace Microsoft.DotNet.Tests.ParserTests
                 .WithMessage("Inline settings should not be passed to Convert.");
         }
 
-        [Theory]
-        [InlineData("--blame", "--blame")]
-        [InlineData("--blame-crash", "--blame:CollectDump")]
-        [InlineData("--blame-crash-collect-always", "--blame:CollectDump;CollectAlways=true")]
-        [InlineData("--blame-hang", "--blame:CollectHangDump")]
-        public void ConvertArgsBlameSwitchDoNotIgnoreNextArg(string blameSwitch, string expectedArg)
-        {
-            var args = $"{blameSwitch} sometest.dll".Split(" ");
-            var expected = $"{expectedArg} sometest.dll".Split(" ");
-
-            // Act
-            var convertedArgs = new VSTestArgumentConverter().Convert(args, out var ignoredArgs);
-
-            ignoredArgs.Should().BeEmpty();
-            convertedArgs.Should().BeEquivalentTo(expected);
-        }
-
         public static class DataSource
         {
-            public static IEnumerable<object[]> ArgTestCases { get; } = new List<object[]>
+            private static readonly ImmutableArray<string> s_supportedPathKind
+                = ImmutableArray.Create(
+                    // Dll
+                    "SomeProject.dll",
+                    // Exe
+                    "SomeProject.exe"
+                // Do not return <PROJECT> | <SOLUTION> | <DIRECTORY> | <EMPTY> cases because they
+                // won't be handled by the VSTestArgumentConverter.
+                );
+
+            private static readonly ImmutableArray<(string option, string vstestEquivalent)> s_supportedOptions
+                = ImmutableArray.Create(
+                    (@"--test-adapter-path c:\adapterpath\temp", @"--testadapterpath:c:\adapterpath\temp"),
+                    (@"-a x86", "--platform:x86"),
+                    ("--arch x86", "--platform:x86"),
+                    ("--blame", "--blame"),
+                    ("--blame-crash", "--blame:CollectDump"),
+                    ("--blame-crash-dump-type full", "--blame:CollectDump;DumpType=full"),
+                    ("--blame-crash-collect-always", "--blame:CollectDump;CollectAlways=true"),
+                    ("--blame-hang", "--blame:CollectHangDump"),
+                    ("--blame-hang-dump-type full", "--blame:CollectHangDump;DumpType=full"),
+                    ("--blame-hang-timeout 10min", "--blame:CollectHangDump;TestTimeout=10min"),
+                    ("--collect coverage", "--collect:coverage"),
+                    (@"-d c:\temp\log.txt", @"--diag:c:\temp\log.txt"),
+                    (@"--diag c:\temp\log.txt", @"--diag:c:\temp\log.txt"),
+                    ("-f net451", "--framework:net451"),
+                    ("--framework net451", "--framework:net451"),
+                    ("--filter accceptance", "--testcasefilter:accceptance"),
+                    ("-l trx", "--logger:trx"),
+                    ("--logger trx", "--logger:trx"),
+                    ("--nologo", "--nologo"),
+                    ("--os linux", "--os:linux"),
+                    (@"--results-directory c:\temp\", @"--resultsdirectory:c:\temp\"),
+                    ("-s test.settings", "--settings:test.settings"),
+                    ("--settings test.settings", "--settings:test.settings"),
+                    ("-t", "--listtests"),
+                    ("--list-tests", "--listtests")
+                );
+
+            private static readonly ImmutableDictionary<string, string> s_verbosityLevelMapping
+                = new Dictionary<string, string>()
+                {
+                    ["q"] = "quiet",
+                    ["m"] = "minimal",
+                    ["n"] = "normal",
+                    ["d"] = "detailed",
+                    ["diag"] = "diagnostic"
+                }.ToImmutableDictionary();
+
+            private static readonly ImmutableArray<string> s_ignoredOptions
+                = ImmutableArray.Create(
+                    "-c Debug",
+                    "--configuration Debug",
+                    "-r win10-x64",
+                    "--runtime win10-x64",
+                    @"-o c:\temp2",
+                    @"--output c:\temp2",
+                    "--no-build",
+                    "--no-restore",
+                    "--interactive",
+                    "--testSessionCorrelationId SomeId",
+                    "--artifactsProcessingMode-collect"
+                );
+
+            private static readonly ImmutableArray<(string option, string vstestEquivalent)> s_specificOptionCombinations
+                = ImmutableArray.Create(
+                    // Blame combinations
+                    (@"--blame --blame-crash-dump-type full --blame-crash-collect-always", @"--blame:CollectDump;CollectAlways=true;DumpType=full"),
+                    (@"--blame-hang-dump-type full", @"--blame:CollectHangDump;DumpType=full"),
+                    (@"--blame-hang-timeout 10min", @"--blame:CollectHangDump;TestTimeout=10min"),
+                    (@"--blame --blame-hang-dump-type full --blame-hang-timeout 10min", @"--blame:CollectHangDump;DumpType=full;TestTimeout=10min"),
+                    (@"--blame --blame-hang-dump-type full --blame-hang-timeout 10min --blame-crash-dump-type mini --blame-crash-collect-always", @"--blame:CollectDump;CollectAlways=true;DumpType=mini;CollectHangDump;DumpType=full;TestTimeout=10min"),
+                    // using the legacy --blame syntax when we provide the parameter that are already in vstest.console format still work
+                    (@"--blame CollectDump;DumpType=full", @"--blame:CollectDump;DumpType=full"),
+                    (@"--blame:CollectDump;DumpType=full", @"--blame:CollectDump;DumpType=full"),
+                    // Non-blame combinations
+                    (@"-s testsettings -t -f net451 -d log.txt --results-directory c:\temp\", @"--settings:testsettings --listtests --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\"),
+                    (@"-s:testsettings -t -f:net451 -d:log.txt --results-directory:c:\temp\", @"--settings:testsettings --listtests --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\"),
+                    (@"--settings testsettings -t --test-adapter-path c:\path --framework net451 --diag log.txt --results-directory c:\temp\", @"--settings:testsettings --listtests --testadapterpath:c:\path --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\")
+                );
+
+            public static IEnumerable<object[] /* input, expectedString */> GetArguments()
             {
-                new object[] { @"-h", "--help" },
-                new object[] { @"sometest.dll --arch x86" , @"sometest.dll --platform:x86"},
-                new object[] { @"sometest.dll -s test.settings", @"sometest.dll --settings:test.settings" },
-                new object[] { @"sometest.dll -a x86", @"sometest.dll --platform:x86" },
-                new object[] { @"sometest.dll -t", @"sometest.dll --listtests" },
-                new object[] { @"sometest.dll --list-tests", @"sometest.dll --listtests" },
-                new object[] { @"sometest.dll --filter", @"sometest.dll --testcasefilter" },
-                new object[] { @"sometest.dll -l trx", @"sometest.dll --logger:trx" },
-                new object[] { @"sometest.dll --test-adapter-path c:\adapterpath\temp", @"sometest.dll --testadapterpath:c:\adapterpath\temp" },
-                new object[] { @"sometest.dll -f net451", @"sometest.dll --framework:net451" },
-                new object[] { @"sometest.dll -d c:\temp\log.txt", @"sometest.dll --diag:c:\temp\log.txt" },
-                new object[] { @"sometest.dll --results-directory c:\temp\", @"sometest.dll --resultsdirectory:c:\temp\" },
-                new object[] { @"sometest.dll -s testsettings -t -f net451 -d log.txt --results-directory c:\temp\", @"sometest.dll --settings:testsettings --listtests --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\" },
-                new object[] { @"sometest.dll -s:testsettings -t -f:net451 -d:log.txt --results-directory:c:\temp\", @"sometest.dll --settings:testsettings --listtests --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\" },
-                new object[] { @"sometest.dll --settings testsettings -t --test-adapter-path c:\path --framework net451 --diag log.txt --results-directory c:\temp\", @"sometest.dll --settings:testsettings --listtests --testadapterpath:c:\path --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\" },
-                new object[] { @"sometest.dll --blame", @"sometest.dll --blame" },
-                new object[] { @"sometest.dll --blame-crash", @"sometest.dll --blame:CollectDump" },
-                new object[] { @"sometest.dll --blame-crash-dump-type full", @"sometest.dll --blame:CollectDump;DumpType=full" },
-                new object[] { @"sometest.dll --blame-crash-collect-always", @"sometest.dll --blame:CollectDump;CollectAlways=true" },
-                new object[] { @"sometest.dll --blame --blame-crash-dump-type full --blame-crash-collect-always", @"sometest.dll --blame:CollectDump;CollectAlways=true;DumpType=full" },
-                new object[] { @"sometest.dll --blame-hang", @"sometest.dll --blame:CollectHangDump" },
-                new object[] { @"sometest.dll --blame-hang-dump-type full", @"sometest.dll --blame:CollectHangDump;DumpType=full" },
-                new object[] { @"sometest.dll --blame-hang-timeout 10min", @"sometest.dll --blame:CollectHangDump;TestTimeout=10min" },
-                new object[] { @"sometest.dll --blame --blame-hang-dump-type full --blame-hang-timeout 10min", @"sometest.dll --blame:CollectHangDump;DumpType=full;TestTimeout=10min" },
-                new object[] { @"sometest.dll --blame --blame-hang-dump-type full --blame-hang-timeout 10min --blame-crash-dump-type mini --blame-crash-collect-always", @"sometest.dll --blame:CollectDump;CollectAlways=true;DumpType=mini;CollectHangDump;DumpType=full;TestTimeout=10min" },
-                // using the legacy --blame syntax when we provide the parameter that are already in vstest.console format still works
-                new object[] { @"sometest.dll --blame CollectDump;DumpType=full", @"sometest.dll --blame:CollectDump;DumpType=full" },
-                new object[] { @"sometest.dll --blame:CollectDump;DumpType=full", @"sometest.dll --blame:CollectDump;DumpType=full" },
+                yield return new[] { @"-h", "--help" };
 
+                // Returns the various combination of path and options
+                foreach ((string option, string vstestEquivalent) in s_supportedOptions)
+                {
+                    foreach (string pathKind in s_supportedPathKind)
+                    {
+                        string pathKindPrefix = pathKind + " ";
+                        string pathKindSuffix = " " + pathKind;
+                        yield return new[] { pathKindPrefix + option, pathKindPrefix + vstestEquivalent };
+                        yield return new[] { option + pathKindSuffix, vstestEquivalent + pathKindSuffix };
 
-
-            };
-
-            public static IEnumerable<object[]> VerbosityTestCases { get; } = new List<object[]>
-            {
-                new object[] { "sometest.dll -v q", "sometest.dll --logger:console;verbosity=quiet" },
-                new object[] { "sometest.dll -v m", "sometest.dll --logger:console;verbosity=minimal" },
-                new object[] { "sometest.dll -v n", "sometest.dll --logger:console;verbosity=normal" },
-                new object[] { "sometest.dll -v d", "sometest.dll --logger:console;verbosity=detailed" },
-                new object[] { "sometest.dll -v diag", "sometest.dll --logger:console;verbosity=diagnostic" },
-
-                new object[] { "sometest.dll --verbosity q", "sometest.dll --logger:console;verbosity=quiet" },
-                new object[] { "sometest.dll -v:q", "sometest.dll --logger:console;verbosity=quiet" },
-                new object[] { "sometest.dll --verbosity:q", "sometest.dll --logger:console;verbosity=quiet" },
-            };
-
-            public static IEnumerable<object[]> IgnoredArgTestCases { get; } = new List<object[]>
-            {
-                new object[] { "sometest.dll -c Debug", "sometest.dll", "-c Debug" },
-                new object[] { "sometest.dll --configuration Debug", "sometest.dll", "--configuration Debug" },
-                new object[] { "sometest.dll --runtime win10-x64", "sometest.dll", "--runtime win10-x64" },
-                new object[] { "sometest.dll -o c:\temp2", "sometest.dll", "-o c:\temp2" },
-                new object[] { "sometest.dll --output c:\temp2", "sometest.dll", "--output c:\temp2" },
-                new object[] { "sometest.dll --interactive", "sometest.dll", "--interactive" },
-                new object[] { "sometest.dll --no-build", "sometest.dll", "--no-build" },
-                new object[] { "sometest.dll --no-restore", "sometest.dll", "--no-restore" },
-
-                new object[] {
-                    @"sometest.dll -s testsettings -t -f net451 -d log.txt --configuration Debug --output C:\foo --runtime win10-x64 --results-directory c:\temp\ --no-build --no-restore --interactive",
-                    @"sometest.dll --settings:testsettings --listtests --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\",
-                    @"--configuration Debug --output C:\foo --runtime win10-x64 --no-build --no-restore --interactive"
-                },
-                new object[] {
-                    @"sometest.dll --settings testsettings --list-tests -f net451 --diag log.txt --collect coverage --blame --configuration Debug --output C:\foo --runtime win10-x64 --results-directory c:\temp\ --no-build --no-restore --interactive",
-                    @"sometest.dll --settings:testsettings --listtests --framework:net451 --diag:log.txt --collect:coverage --blame --resultsdirectory:c:\temp\",
-                    @"--configuration Debug --output C:\foo --runtime win10-x64 --no-build --no-restore --interactive"
+                        // It's also possible to call the option with a colon as separator rather than with space
+                        // e.g., "--diag:log.txt" instead of "--diag log.txt"
+                        string[] optionAndArg = option.Split(' ');
+                        if (optionAndArg.Length == 2)
+                        {
+                            var optionWithColon = optionAndArg[0] + ":" + optionAndArg[1];
+                            yield return new[] { pathKindPrefix + optionWithColon, pathKindPrefix + vstestEquivalent };
+                            yield return new[] { optionWithColon + pathKindSuffix, vstestEquivalent + pathKindSuffix };
+                        }
+                    }
                 }
-            };
-        }
 
+                // Returns specific combinations to test
+                foreach ((string option, string vstestEquivalent) in s_specificOptionCombinations)
+                {
+                    foreach (string pathKind in s_supportedPathKind)
+                    {
+                        string pathKindPrefix = pathKind + " ";
+                        string pathKindSuffix = " " + pathKind;
+                        yield return new[] { pathKindPrefix + option, pathKindPrefix + vstestEquivalent };
+                        yield return new[] { option + pathKindSuffix, vstestEquivalent + pathKindSuffix };
+                    }
+                }
+            }
+
+            public static IEnumerable<object[] /* input, expectedString */> GetVerbosityArguments()
+            {
+                foreach ((string levelShort, string levelLong) in s_verbosityLevelMapping)
+                {
+                    foreach (string pathKind in s_supportedPathKind)
+                    {
+                        string pathKindPrefix = pathKind + " ";
+                        string pathKindSuffix = " " + pathKind;
+                        string vstestEquivalent = $"--logger:console;verbosity={levelLong}";
+
+                        foreach (string argument in new[] { "-v", "--verbosity" })
+                        {
+                            foreach (string separator in new[] { " ", ":" })
+                            {
+                                yield return new[] { pathKindPrefix + argument + separator + levelShort, pathKindPrefix + vstestEquivalent };
+                                yield return new[] { pathKindPrefix + argument + separator + levelLong, pathKindPrefix + vstestEquivalent };
+                                yield return new[] { argument + separator + levelShort + pathKindSuffix, vstestEquivalent + pathKindSuffix };
+                                yield return new[] { argument + separator + levelLong + pathKindSuffix, vstestEquivalent + pathKindSuffix };
+                            }
+                        }
+                    }
+                }
+            }
+
+            public static IEnumerable<object[] /* input, expectedString, expectedIgnoredString */> GetIgnoredArguments()
+            {
+                // Returns the various combination of path and options
+                foreach (string ignoredOption in s_ignoredOptions)
+                {
+                    foreach (string pathKind in s_supportedPathKind)
+                    {
+                        string pathKindPrefix = pathKind + " ";
+                        string pathKindSuffix = " " + pathKind;
+                        yield return new[] { pathKindPrefix + ignoredOption, pathKind, ignoredOption };
+                        yield return new[] { ignoredOption + pathKindSuffix, pathKind, ignoredOption };
+
+                        // It's also possible to call the option with a colon as separator rather than with space
+                        // e.g., "--diag:log.txt" instead of "--diag log.txt"
+                        string[] optionAndArg = ignoredOption.Split(' ');
+                        if (optionAndArg.Length == 2)
+                        {
+                            var optionWithColon = optionAndArg[0] + ":" + optionAndArg[1];
+                            yield return new[] { pathKindPrefix + optionWithColon, pathKind, optionWithColon };
+                            yield return new[] { optionWithColon + pathKindSuffix, pathKind, optionWithColon };
+                        }
+                    }
+                }
+
+                // Returns a combination of args and ignored args
+                foreach ((string combinationOption, string vstestEquivalent) in s_specificOptionCombinations)
+                {
+                    foreach (string pathKind in s_supportedPathKind)
+                    {
+                        string pathKindPrefix = pathKind + " ";
+                        string pathKindSuffix = " " + pathKind;
+                        string ignoredOptions = string.Join(" ", s_ignoredOptions);
+
+                        yield return new[] { pathKindPrefix + ignoredOptions + " " + combinationOption, pathKindPrefix + vstestEquivalent, ignoredOptions };
+                        yield return new[] { pathKindPrefix + combinationOption + " " + ignoredOptions, pathKindPrefix + vstestEquivalent, ignoredOptions };
+
+                        yield return new[] { ignoredOptions + " " + combinationOption + pathKindSuffix, vstestEquivalent + pathKindSuffix, ignoredOptions };
+                        yield return new[] { combinationOption + " " + ignoredOptions + pathKindSuffix, vstestEquivalent + pathKindSuffix, ignoredOptions };
+
+                        yield return new[] { ignoredOptions + " " + pathKindPrefix + combinationOption, pathKindPrefix + vstestEquivalent, ignoredOptions };
+                        yield return new[] { combinationOption + " " + pathKindPrefix + ignoredOptions, pathKindPrefix + vstestEquivalent, ignoredOptions };
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Tests/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
@@ -65,6 +65,23 @@ namespace Microsoft.DotNet.Tests.ParserTests
                 .WithMessage("Inline settings should not be passed to Convert.");
         }
 
+        [Theory]
+        [InlineData("--blame", "--blame")]
+        [InlineData("--blame-crash", "--blame:CollectDump")]
+        [InlineData("--blame-crash-collect-always", "--blame:CollectDump;CollectAlways=true")]
+        [InlineData("--blame-hang", "--blame:CollectHangDump")]
+        public void ConvertArgsBlameSwitchDoNotIgnoreNextArg(string blameSwitch, string expectedArg)
+        {
+            var args = $"{blameSwitch} sometest.dll".Split(" ");
+            var expected = $"{expectedArg} sometest.dll".Split(" ");
+
+            // Act
+            var convertedArgs = new VSTestArgumentConverter().Convert(args, out var ignoredArgs);
+
+            ignoredArgs.Should().BeEmpty();
+            convertedArgs.Should().BeEquivalentTo(expected);
+        }
+
         public static class DataSource
         {
             public static IEnumerable<object[]> ArgTestCases { get; } = new List<object[]>


### PR DESCRIPTION
Fixes #20241 and [AB#1489335](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1489335)

Given the many changes I did, I went ahead to fix all styling following the in-place `.editorconfig`. Let me know if you prefer to postpone the styling changes to a follow-up PR.