### PR TITLE
Reverse versions in error message

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -142,9 +142,9 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     {
                         if (_manifests.TryGetValue(dependency.Key, out var resolvedDependency))
                         {
-                            if (FXVersion.Compare(dependency.Value, resolvedDependency.ParsedVersion) < 0)
+                            if (FXVersion.Compare(dependency.Value, resolvedDependency.ParsedVersion) > 0)
                             {
-                                throw new WorkloadManifestCompositionException(Strings.ManifestDependencyVersionTooLow, dependency.Key, dependency.Value, resolvedDependency.Version, manifest.Id, manifest.InformationalPath);
+                                throw new WorkloadManifestCompositionException(Strings.ManifestDependencyVersionTooLow, dependency.Key, resolveDependency.Version, dependency.Value, manifest.Id, manifest.InformationalPath);
                             }
                         }
                         else

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -142,7 +142,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     {
                         if (_manifests.TryGetValue(dependency.Key, out var resolvedDependency))
                         {
-                            if (FXVersion.Compare(dependency.Value, resolvedDependency.ParsedVersion) > 0)
+                            if (FXVersion.Compare(dependency.Value, resolvedDependency.ParsedVersion) < 0)
                             {
                                 throw new WorkloadManifestCompositionException(Strings.ManifestDependencyVersionTooLow, dependency.Key, dependency.Value, resolvedDependency.Version, manifest.Id, manifest.InformationalPath);
                             }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -144,7 +144,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                         {
                             if (FXVersion.Compare(dependency.Value, resolvedDependency.ParsedVersion) > 0)
                             {
-                                throw new WorkloadManifestCompositionException(Strings.ManifestDependencyVersionTooLow, dependency.Key, resolveDependency.Version, dependency.Value, manifest.Id, manifest.InformationalPath);
+                                throw new WorkloadManifestCompositionException(Strings.ManifestDependencyVersionTooLow, dependency.Key, resolvedDependency.Version, dependency.Value, manifest.Id, manifest.InformationalPath);
                             }
                         }
                         else

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
@@ -203,7 +203,7 @@ namespace ManifestReaderTests
             };
 
             var inconsistentManifestEx = Assert.Throws<WorkloadManifestCompositionException>(() => WorkloadResolver.CreateForTests(inconsistentManifestProvider, fakeRootPath));
-            Assert.StartsWith("Workload manifest dependency 'DDD' version '39.0.0' is lower than version '30.0.0' required by manifest 'BBB'", inconsistentManifestEx.Message);
+            Assert.StartsWith("Workload manifest dependency 'DDD' version '30.0.0' is lower than version '39.0.0' required by manifest 'BBB'", inconsistentManifestEx.Message);
         }
 
         [Fact]


### PR DESCRIPTION
based on https://github.com/dotnet/sdk/blob/4122a50afa09e012a6a4eb094c410afbf84dd909/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/FXVersion.cs#L37-L43 it looks like this condition is reversed but I could be reading it wrong.  This check is failing however in a case I would expect it to work