### PR TITLE
Embed FSharp.Core.nuget package in dotnet SDK

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
-@echo off
+@echo off 
 powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "& """%~dp0eng\common\build.ps1""" -build -restore %*"
 exit /b %ErrorLevel%

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
-@echo off 
+@echo off
 powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "& """%~dp0eng\common\build.ps1""" -build -restore %*"
 exit /b %ErrorLevel%

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <FSharpBuildVersion>16.6</FSharpBuildVersion>
     <MicrosoftBuildVersion>15.4.8</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>15.4.8</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.4.8</MicrosoftBuildUtilitiesCoreVersion>
@@ -117,7 +116,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->
-    <MicrosoftFSharpCompilerPackageVersion>12.0.1-beta.22057.4</MicrosoftFSharpCompilerPackageVersion>
+    <MicrosoftFSharpCompilerPackageVersion>12.0.2-beta.22105.6</MicrosoftFSharpCompilerPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
     <PackageReference Include="Microsoft.NET.ILLink.Analyzers" Version="$(MicrosoftNETILLinkAnalyzerPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" ExcludeAssets="contentFiles" GeneratePathProperty="true" />
 
     <!-- Lift up dependencies of dependencies to prevent build tasks from getting pinned to older versions -->
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
@@ -69,4 +70,17 @@
       <Analyzer Remove="@(Analyzer)"/>
     </ItemGroup>
   </Target>
+
+  <Target Name="_ResolvePublishFSharpNuGetPackages"
+       AfterTargets="CoreCompile">
+
+    <PropertyGroup>
+        <FSharpCorePath Condition="'$(DotNetFinalVersionKind)'!='release'">Shipping</FSharpCorePath>
+        <FSharpCorePath Condition="'$(DotNetFinalVersionKind)'=='release'">Release</FSharpCorePath>
+    </PropertyGroup>
+    <ItemGroup>
+        <ItemsToPushToBlobFeed Include="$(PkgMicrosoft_FSharp_Compiler)\contentFiles\$(FSharpCorePath)\FSharp.Core.*.nupkg"/>
+        <ItemsToPushToBlobFeed Include="$(PkgMicrosoft_FSharp_Compiler)\contentFiles\$(FSharpCorePath)\FSharp.Compiler.Service.*.nupkg" />
+    </ItemGroup>
+ </Target>
 </Project>

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
     <PackageReference Include="Microsoft.NET.ILLink.Analyzers" Version="$(MicrosoftNETILLinkAnalyzerPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" ExcludeAssets="contentFiles" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
 
     <!-- Lift up dependencies of dependencies to prevent build tasks from getting pinned to older versions -->
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />

--- a/src/Layout/tool_fsharp/tool_fsc.csproj
+++ b/src/Layout/tool_fsharp/tool_fsc.csproj
@@ -3,8 +3,9 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" ExcludeAssets="contentFiles" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(FSharpBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(FSharpBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(FSharpBuildVersion)" />
@@ -12,6 +13,10 @@
 
    <Target Name="_ResolvePublishNuGetPackagePdbsAndXml"
         AfterTargets="_ResolveCopyLocalAssetsForPublish">
+    <PropertyGroup>
+        <FSharpCorePath Condition="'$(DotNetFinalVersionKind)'!='release'">Shipping</FSharpCorePath>
+        <FSharpCorePath Condition="'$(DotNetFinalVersionKind)'=='release'">Release</FSharpCorePath>
+    </PropertyGroup>
     <ItemGroup>
         <ResolvedFileToPublish
           Include="$(PkgMicrosoft_FSharp_Compiler)/lib/net5.0/FSharp.Core.xml"
@@ -19,6 +24,17 @@
           DestinationSubPath="FSharp.Core.xml"
           RelativePath="FSharp.Core.xml"
           TargetPath="FSharpCore.xml" />
+        <FilesToCopyFromFSharpCompilerPackage Include="$(PkgMicrosoft_FSharp_Compiler)/contentFiles/$(FSharpCorePath)/FSharp.Core.*.nupkg" SubDir="library-packs\"/>
+        <FilesToCopyFromFSharpCompilerPackage Include="$(PkgMicrosoft_FSharp_Compiler)/contentFiles/$(FSharpCorePath)/Microsoft.FSharp.NetSdk.props" SubDir="" />
     </ItemGroup>
+    <ItemGroup>
+        <ResolvedFileToPublish
+          Include="@(FilesToCopyFromFSharpCompilerPackage)"
+          CopyToPublishDirectory="PreserveNewest"
+          DestinationSubPath="%(FilesToCopyFromFSharpCompilerPackage.SubDir)%(Filename)%(Extension)"
+          RelativePath="%(FilesToCopyFromFSharpCompilerPackage.SubDir)%(Filename)%(Extension)"
+          TargetPath="%(FilesToCopyFromFSharpCompilerPackage.SubDir)%(Filename%(Extension))" />
+    </ItemGroup>
+
   </Target>
 </Project>

--- a/src/Layout/tool_fsharp/tool_fsc.csproj
+++ b/src/Layout/tool_fsharp/tool_fsc.csproj
@@ -26,6 +26,7 @@
           TargetPath="FSharpCore.xml" />
         <FilesToCopyFromFSharpCompilerPackage Include="$(PkgMicrosoft_FSharp_Compiler)/contentFiles/$(FSharpCorePath)/FSharp.Core.*.nupkg" SubDir="library-packs\"/>
         <FilesToCopyFromFSharpCompilerPackage Include="$(PkgMicrosoft_FSharp_Compiler)/contentFiles/$(FSharpCorePath)/Microsoft.FSharp.NetSdk.props" SubDir="" />
+        <FilesToCopyFromFSharpCompilerPackage Include="$(PkgMicrosoft_FSharp_Compiler)/contentFiles/any/any/*" Exclude="$(PkgMicrosoft_FSharp_Compiler)/contentFiles/any/any/Microsoft.FSharp.NetSdk.props" SubDir="" />
     </ItemGroup>
     <ItemGroup>
         <ResolvedFileToPublish

--- a/src/Layout/tool_fsharp/tool_fsc.csproj
+++ b/src/Layout/tool_fsharp/tool_fsc.csproj
@@ -34,7 +34,7 @@
           CopyToPublishDirectory="PreserveNewest"
           DestinationSubPath="%(FilesToCopyFromFSharpCompilerPackage.SubDir)%(Filename)%(Extension)"
           RelativePath="%(FilesToCopyFromFSharpCompilerPackage.SubDir)%(Filename)%(Extension)"
-          TargetPath="%(FilesToCopyFromFSharpCompilerPackage.SubDir)%(Filename%(Extension))" />
+          TargetPath="%(FilesToCopyFromFSharpCompilerPackage.SubDir)%(Filename)%(Extension)" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
This PR adds the FSharp.Core nuget package to FSharp.Core.

To simplify the installers we embed the nuget package in the FSharp SDK directory, and have modifed the FSharp targets file to look there.

https://github.com/dotnet/fsharp/blob/main/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets#L57

Because we have simply added the file to the FSharp folder there is no need to update any of the installers, which is a good thing because there are windows/macos/linux of many flavours and zips.

The changes here add the necessary files to the FSharp subdirectory in dotnet-toolset-internal-$someVersion$.zip.

![image](https://user-images.githubusercontent.com/5175830/152670950-042d8f54-4d3f-49eb-9cd7-07b9294a25ec.png)


Also adds FSharp.Core.nuget and FSharp.Compiler.Service to the publish to nuget mechanism for packages

https://github.com/dotnet/sdk/compare/release/6.0.2xx...KevinRansom:includeFSharpCore?expand=1#diff-89302df072048fbd7dcd52b4119472becf4a97fe944edb1c29e8fec3ea8334a4R82

/CC @brettfo 