### PR TITLE
Enable launch profile arguments with dotnet run

### DIFF
--- a/src/Assets/TestProjects/TestAppWithLaunchSettings/Program.cs
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettings/Program.cs
@@ -11,6 +11,14 @@ namespace ConsoleApplication
         {
             Console.WriteLine("Hello world");
             Console.WriteLine($"MyCoolEnvironmentVariableKey={Environment.GetEnvironmentVariable("MyCoolEnvironmentVariableKey")}");
+            if (args.Length > 0)
+            {
+                Console.WriteLine(args[0]);
+            }
+            if (args.Length > 1)
+            {
+                Console.WriteLine(args[1]);
+            }
         }
     }
 }

--- a/src/Assets/TestProjects/TestAppWithLaunchSettings/Properties/launchSettings.json
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettings/Properties/launchSettings.json
@@ -3,6 +3,7 @@
     "TestAppWithLaunchSettings": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
+      "commandLineArgs": "TestAppCommandLineArguments SecondTestAppCommandLineArguments",
       "environmentVariables": {
         "MyCoolEnvironmentVariableKey": "MyCoolEnvironmentVariableValue"
       }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/BuiltInCommand.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/BuiltInCommand.cs
@@ -183,5 +183,9 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             throw new NotImplementedException();
         }
+        public ICommand SetCommandArgs(string commandArgs)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -188,6 +188,12 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public string CommandArgs => _process.StartInfo.Arguments;
 
+        public ICommand SetCommandArgs(string commandArgs)
+        {
+            _process.StartInfo.Arguments = commandArgs;
+            return this;
+        }
+
         private string FormatProcessInfo(ProcessStartInfo info)
         {
             if (string.IsNullOrWhiteSpace(info.Arguments))

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ICommand.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ICommand.cs
@@ -26,6 +26,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
         ICommand OnErrorLine(Action<string> handler);
 
+        ICommand SetCommandArgs(string commandArgs);
+
         string CommandName { get; }
 
         string CommandArgs { get; }

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -72,6 +72,10 @@ namespace Microsoft.DotNet.Tools.Run
                         //NOTE: MSBuild variables are not expanded like they are in VS
                         targetCommand.EnvironmentVariable(entry.Key, value);
                     }
+                    if (launchSettings.CommandLineArgs != null)
+                    {
+                        targetCommand.SetCommandArgs(launchSettings.CommandLineArgs);
+                    }
                 }
 
                 // Ignore Ctrl-C for the remainder of the command's execution

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Tools.Run
                         //NOTE: MSBuild variables are not expanded like they are in VS
                         targetCommand.EnvironmentVariable(entry.Key, value);
                     }
-                    if (launchSettings.CommandLineArgs != null)
+                    if (String.IsNullOrEmpty(targetCommand.CommandArgs) && launchSettings.CommandLineArgs != null)
                     {
                         targetCommand.SetCommandArgs(launchSettings.CommandLineArgs);
                     }

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -690,7 +690,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
-        public void ItIncludesCommandArgumentSpecifiedInLaunchSettings()
+        public void ItIncludesCommandArgumentsSpecifiedInLaunchSettings()
         {
             var expectedValue = "TestAppCommandLineArguments";
             var secondExpectedValue = "SecondTestAppCommandLineArguments";
@@ -707,6 +707,26 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                .HaveStdOutContaining(expectedValue)
                .And
                .HaveStdOutContaining(secondExpectedValue);
+        }
+
+        [Fact]
+        public void ItCLIArgsOverrideCommandArgumentsSpecifiedInLaunchSettings()
+        {
+            var expectedValue = "TestAppCommandLineArguments";
+            var secondExpectedValue = "SecondTestAppCommandLineArguments";
+            var testAppName = "TestAppWithLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            new DotnetCommand(Log, "run", "-- test")
+               .WithWorkingDirectory(testInstance.Path)
+               .Execute()
+               .Should()
+               .Pass()
+               .And
+               .NotHaveStdOutContaining(expectedValue)
+               .And
+               .NotHaveStdOutContaining(secondExpectedValue);
         }
     }
 }

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -688,5 +688,25 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                .And
                .HaveStdOutContaining(expectedValue);
         }
+
+        [Fact]
+        public void ItIncludesCommandArgumentSpecifiedInLaunchSettings()
+        {
+            var expectedValue = "TestAppCommandLineArguments";
+            var secondExpectedValue = "SecondTestAppCommandLineArguments";
+            var testAppName = "TestAppWithLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            new DotnetCommand(Log, "run")
+               .WithWorkingDirectory(testInstance.Path)
+               .Execute()
+               .Should()
+               .Pass()
+               .And
+               .HaveStdOutContaining(expectedValue)
+               .And
+               .HaveStdOutContaining(secondExpectedValue);
+        }
     }
 }


### PR DESCRIPTION
Fixes #23565
I specifically only set the arguments if there aren't arguments already so the user can override from the CLI 