### PR TITLE
Fix cli translation issue in Strings.zh-Hans.xlf

### DIFF
--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -752,7 +752,7 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="SelfContainedOptionShouldBeUsedWithRuntime">
         <source>NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</source>
-        <target state="translated">NETSDK1179: 使用“--runtime”时，必需选择“--自包含”或“--非自包含”选项。</target>
+        <target state="translated">NETSDK1179: 使用“--runtime”时，必需选择“--self-contained”或“--no-self-contained”选项。</target>
         <note>{StrBegin="NETSDK1179: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">


### PR DESCRIPTION
The Chinese translation of NETSDK1179:  `warning NETSDK1179: 使用“--runtime”时，必需选择“--自包含”或“--非自包含”选项。(NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.)`. It seems that the parameters `--self-contained` and `--no-self-contained` were translated into `--自包含` and `--非自包含` by mistake. This PR fixes the issue.