### PR TITLE
reenable composite r2r singlefile test on OSX

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -299,48 +299,42 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData(false)]
         public void It_supports_composite_r2r(bool extractAll)
         {
-            // the test fails once in a while on OSX, but dumps are not very informative,
-            // so enabling this for non-OSX platforms, hoping to get a better crash dump
-            // if you see this failing on Linux, please preserve the dump.
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            var projName = "SingleFileTest";
+            if (extractAll)
             {
-                var projName = "SingleFileTest";
-                if (extractAll)
-                {
-                    projName += "Extracted";
-                }
-
-                var testProject = new TestProject()
-                {
-                    Name = projName,
-                    TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
-                    IsExe = true,
-                };
-
-                var testAsset = _testAssetsManager.CreateTestProject(testProject);
-                var publishCommand = new PublishCommand(testAsset);
-                var extraArgs = new List<string>() { PublishSingleFile, ReadyToRun, ReadyToRunComposite, RuntimeIdentifier };
-
-                if (extractAll)
-                {
-                    extraArgs.Add(IncludeAllContent);
-                }
-
-                publishCommand
-                    .Execute(extraArgs.ToArray())
-                    .Should()
-                    .Pass();
-
-                var publishDir = GetPublishDirectory(publishCommand, targetFramework: ToolsetInfo.CurrentTargetFramework).FullName;
-                var singleFilePath = Path.Combine(publishDir, $"{testProject.Name}{Constants.ExeSuffix}");
-
-                var command = new RunExeCommand(Log, singleFilePath);
-                command.Execute()
-                    .Should()
-                    .Pass()
-                    .And
-                    .HaveStdOutContaining("Hello World");
+                projName += "Extracted";
             }
+
+            var testProject = new TestProject()
+            {
+                Name = projName,
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var publishCommand = new PublishCommand(testAsset);
+            var extraArgs = new List<string>() { PublishSingleFile, ReadyToRun, ReadyToRunComposite, RuntimeIdentifier };
+
+            if (extractAll)
+            {
+                extraArgs.Add(IncludeAllContent);
+            }
+
+            publishCommand
+                .Execute(extraArgs.ToArray())
+                .Should()
+                .Pass();
+
+            var publishDir = GetPublishDirectory(publishCommand, targetFramework: ToolsetInfo.CurrentTargetFramework).FullName;
+            var singleFilePath = Path.Combine(publishDir, $"{testProject.Name}{Constants.ExeSuffix}");
+
+            var command = new RunExeCommand(Log, singleFilePath);
+            command.Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World");
         }
 
         [RequiresMSBuildVersionFact("16.8.0")]


### PR DESCRIPTION
The test was disabled on OSX since it caused random crashes with unactionable dumps. We kept the test enabled on Linux/Windows to see if we get dumps that are more debuggable. It looks like the test has been stable so the issues if they are still present are OSX-specific.  
It is also possible that the OSX instabilities were related to issues fixed as a part of cleanups in https://github.com/dotnet/runtime/pull/61938

Either way we should reenable the test.

Re: https://github.com/dotnet/runtime/issues/60308