### PR TITLE
Templating update 7.0.100 preview.2.22116.8

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.2.22111.3">
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.2.22116.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>f370f2bbbd98aba2686545410e08db62a7730b3d</Sha>
+      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.2.22111.3">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.2.22116.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>f370f2bbbd98aba2686545410e08db62a7730b3d</Sha>
+      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.2.22111.3">
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.2.22116.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>f370f2bbbd98aba2686545410e08db62a7730b3d</Sha>
+      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.2.22111.3">
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.2.22116.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>f370f2bbbd98aba2686545410e08db62a7730b3d</Sha>
+      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.2.22111.3">
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.2.22116.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>f370f2bbbd98aba2686545410e08db62a7730b3d</Sha>
+      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.2.22111.3">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.2.22116.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>f370f2bbbd98aba2686545410e08db62a7730b3d</Sha>
+      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.2.22114.13">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.2.22116.1">
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.2.22116.6">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
+      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.2.22116.1">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.2.22116.6">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
+      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.2.22116.1">
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.2.22116.6">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
+      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.2.22116.1">
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.2.22116.6">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
+      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.2.22116.1">
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.2.22116.6">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
+      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.2.22116.1">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.2.22116.6">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>14b37935f345d8c3df4645471a0403512c2f7c9a</Sha>
+      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.2.22114.13">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.2.22116.6">
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.2.22116.7">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
+      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.2.22116.6">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.2.22116.7">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
+      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.2.22116.6">
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.2.22116.7">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
+      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.2.22116.6">
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.2.22116.7">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
+      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.2.22116.6">
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.2.22116.7">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
+      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.2.22116.6">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.2.22116.7">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>02bc2d1a895dd19a63d2f2d246ce16073aef7997</Sha>
+      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.2.22114.13">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.2.22116.7">
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.2.22116.8">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
+      <Sha>8b6046550d69c4e021867a5d72da68f236b01ee8</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.2.22116.7">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.2.22116.8">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
+      <Sha>8b6046550d69c4e021867a5d72da68f236b01ee8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.2.22116.7">
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.2.22116.8">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
+      <Sha>8b6046550d69c4e021867a5d72da68f236b01ee8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.2.22116.7">
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.2.22116.8">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
+      <Sha>8b6046550d69c4e021867a5d72da68f236b01ee8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.2.22116.7">
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.2.22116.8">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
+      <Sha>8b6046550d69c4e021867a5d72da68f236b01ee8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.2.22116.7">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.2.22116.8">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>540575b280a8fb57edfbb3ffda95238506b458ab</Sha>
+      <Sha>8b6046550d69c4e021867a5d72da68f236b01ee8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.2.22114.13">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -112,11 +112,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.2.22111.3</MicrosoftTemplateEngineCliPackageVersion>
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.2.22111.3</MicrosoftTemplateEngineAbstractionsPackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.2.22111.3</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.2.22111.3</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.2.22111.3</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -112,11 +112,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateEngineCliPackageVersion>
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateEngineAbstractionsPackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -112,11 +112,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateEngineCliPackageVersion>
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateEngineAbstractionsPackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.2.22116.7</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.2.22116.8</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.2.22116.8</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.2.22116.8</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.2.22116.8</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.2.22116.8</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -112,11 +112,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateEngineCliPackageVersion>
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateEngineAbstractionsPackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.2.22116.1</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.2.22116.6</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/23962 is failing now due to `System.CommandLine` version mismatch.
Reverted last commits to be able to push fix for https://github.com/dotnet/installer/pull/13192#issuecomment-1035691082