### PR TITLE
[WorkloadInstall] Simplify code workload install command line 

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             var configOption = parseResult.GetValueForOption(WorkloadInstallCommandParser.ConfigOption);
             var sourceOption = parseResult.GetValueForOption(WorkloadInstallCommandParser.SourceOption);
-            if (string.IsNullOrEmpty(configOption) && sourceOption != null && sourceOption.Any())
+            if (string.IsNullOrEmpty(configOption) && !(sourceOption != null && sourceOption.Any()))
             {
                 _packageSourceLocation = null;
             }
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        int PrintDownloadLink() { 
+        private int PrintDownloadLink() { 
             _reporter.WriteLine(string.Format(LocalizableStrings.ResolvingPackageUrls, string.Join(", ", _workloadIds)));
             var packageUrls = GetPackageDownloadUrlsAsync(_workloadIds.Select(id => new WorkloadId(id)), _skipManifestUpdate, _includePreviews).GetAwaiter().GetResult();
 
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             return _workloadInstaller.ExitCode;
         }
 
-        int DownloadToCache()
+        private int DownloadToCache()
         {
             try
             {
@@ -379,10 +379,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        async Task UseTempManifestsToResolvePacksAsync(DirectoryPath tempPath, bool includePreview)
+        private async Task UseTempManifestsToResolvePacksAsync(DirectoryPath tempPath, bool includePreview)
         {
             var manifestPackagePaths = await _workloadManifestUpdater.DownloadManifestPackagesAsync(includePreview, tempPath);
-            if (manifestPackagePaths != null && manifestPackagePaths.Any())
+            if (!(manifestPackagePaths != null && manifestPackagePaths.Any()))
             {
                 _reporter.WriteLine(LocalizableStrings.SkippingManifestUpdate);
                 return;
@@ -392,7 +392,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             _workloadResolver = _workloadResolver.CreateOverlayResolver(overlayProvider);
         }
 
-        async Task DownloadToOfflineCacheAsync(IEnumerable<WorkloadId> workloadIds, DirectoryPath offlineCache, bool skipManifestUpdate, bool includePreviews)
+        private async Task DownloadToOfflineCacheAsync(IEnumerable<WorkloadId> workloadIds, DirectoryPath offlineCache, bool skipManifestUpdate, bool includePreviews)
         {
             string? tempManifestDir = null;
             if (!skipManifestUpdate)
@@ -417,7 +417,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             switch (_workloadInstaller.GetInstallationUnit())
             {
                 case InstallationUnit.Packs:
-                    var packInstaller= _workloadInstaller.GetPackInstaller();
+                    var packInstaller = _workloadInstaller.GetPackInstaller();
                     var workloadPacks = GetPacksToInstall(workloadIds);
                     foreach (var pack in workloadPacks)
                     {
@@ -439,7 +439,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        IEnumerable<PackInfo?> GetPacksToInstall(IEnumerable<WorkloadId> workloadIds)
+        private IEnumerable<PackInfo?> GetPacksToInstall(IEnumerable<WorkloadId> workloadIds)
         {
             var installedPacks = _workloadInstaller.GetPackInstaller().GetInstalledPacks(_sdkFeatureBand);
             return workloadIds

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -12,8 +12,6 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Microsoft.DotNet.Configurer;
-using Microsoft.DotNet.ToolPackage;
-using NuGet.Versioning;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.Common;

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -358,10 +358,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        private async Task UseTempManifestsToResolvePacksAsync(DirectoryPath tempPath, bool includePreview)
+        async Task UseTempManifestsToResolvePacksAsync(DirectoryPath tempPath, bool includePreview)
         {
             var manifestPackagePaths = await _workloadManifestUpdater.DownloadManifestPackagesAsync(includePreview, tempPath);
-            if (manifestPackagePaths == null || !manifestPackagePaths.Any())
+            if (manifestPackagePaths != null && manifestPackagePaths.Any())
             {
                 _reporter.WriteLine(LocalizableStrings.SkippingManifestUpdate);
                 return;

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -208,18 +208,17 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         internal static void TryRunGarbageCollection(IInstaller workloadInstaller, IReporter reporter, VerbosityOptions verbosity, DirectoryPath? offlineCache = null)
         {
+            if (workloadInstaller.GetInstallationUnit() != InstallationUnit.Packs)
+                return;
             try
             {
-                if (workloadInstaller.GetInstallationUnit().Equals(InstallationUnit.Packs))
-                {
-                    workloadInstaller.GetPackInstaller().GarbageCollectInstalledWorkloadPacks(offlineCache);
-                }
+                workloadInstaller.GetPackInstaller().GarbageCollectInstalledWorkloadPacks(offlineCache);
             }
             catch (Exception e)
             {
                 // Garbage collection failed, warn user
                 reporter.WriteLine(string.Format(LocalizableStrings.GarbageCollectionFailed,
-                    verbosity.VerbosityIsDetailedOrDiagnostic() ? e.StackTrace.ToString() : e.Message).Yellow());
+                    verbosity.VerbosityIsDetailedOrDiagnostic() ? e.StackTrace : e.Message).Yellow());
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -330,7 +330,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        async Task<IEnumerable<string>> GetPackageDownloadUrlsAsync(IEnumerable<WorkloadId> workloadIds, bool skipManifestUpdate, bool includePreview)
+        private async Task<IEnumerable<string>> GetPackageDownloadUrlsAsync(IEnumerable<WorkloadId> workloadIds, bool skipManifestUpdate, bool includePreview)
         {
             var packageUrls = new List<string>();
             DirectoryPath? tempPath = null;

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -246,7 +246,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        void InstallPacksWithInstallRecord(
+        private void InstallPacksWithInstallRecord(
             IEnumerable<WorkloadId> workloadIds,
             SdkFeatureBand sdkFeatureBand,
             IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion)> manifestsToUpdate,

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -99,22 +99,19 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             ValidateWorkloadIdsInput();
         }
 
-        private void ValidateWorkloadIdsInput()
+        void ValidateWorkloadIdsInput()
         {
             var availableWorkloads = _workloadResolver.GetAvailableWorkloads();
             foreach (var workloadId in _workloadIds)
             {
-                if (!availableWorkloads.Select(workload => workload.Id.ToString()).Contains(workloadId))
-                {
-                    if (_workloadResolver.IsPlatformIncompatibleWorkload(new WorkloadId(workloadId)))
-                    {
-                        throw new GracefulException(string.Format(LocalizableStrings.WorkloadNotSupportedOnPlatform, workloadId), isUserError: false);
-                    }
-                    else
-                    {
-                        throw new GracefulException(string.Format(LocalizableStrings.WorkloadNotRecognized, workloadId), isUserError: false);
-                    }
-                }
+                if (availableWorkloads.Any(workload => workload.Id.ToString() == workloadId))
+                    continue;
+
+                var errorMsg = _workloadResolver.IsPlatformIncompatibleWorkload(new (workloadId)) ? 
+                    string.Format(LocalizableStrings.WorkloadNotSupportedOnPlatform, workloadId) :
+                    string.Format(LocalizableStrings.WorkloadNotRecognized, workloadId);
+                
+                throw new GracefulException(errorMsg, isUserError: false);
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -3,18 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.CommandLine.Parsing;
 using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
-using Product = Microsoft.DotNet.Cli.Utils.Product;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Microsoft.DotNet.Configurer;
-using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.DotNet.ToolPackage;
 using NuGet.Versioning;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;


### PR DESCRIPTION
I am trying to locate a bug that is hitting me in the xamarin-macios ci. I was finding it hard to follow the code and found some small bugs/issues while looking at it. I have tried to make it simpler for people like me :) 

1. I have removed all the not needed enum boxing that was done via Equals. I cannot think of a reason why that boxing was preferred.
2. Negated a number of || to use && which short-circuits making it a little better in performance but more important, easier to understand.
3. Reduced the number of nesting levels.
4. Removed a number of allocations that were not needed but got added to avoid a NRE in a captured variable, maybe Enumerable.Emty was not available when this was landed?
5. Removed the used or the TaskAwaiter which is meant to be used by the compiler but not by us humans.
6. Enabled nullability in the file, which pointed out a number of small errors.


I believe that the reviews will be easier done commit by commit, each commit makes changes to a single function when possible (nullability is an exception).