### PR TITLE
Remove override into preview version of System.Security.Cryptography.ProtectedData

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -85,7 +85,6 @@
     <!-- Dependencies from https://github.com/dotnet/runtime -->
     <SystemCodeDomPackageVersion>7.0.0-preview.2.22116.9</SystemCodeDomPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>7.0.0-preview.2.22116.9</SystemTextEncodingCodePagesPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20364.11</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemResourcesExtensionsPackageVersion>7.0.0-preview.2.22116.9</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
We've had this in place for about a year, and our version of S.S.C.PD has stuck as a result.  We should not be pinned to a preview version.