### PR TITLE
Add EnableAotAnalyzer support into SDK

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -64,6 +64,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Enable the trim analyzer when any trimming settings are enabled. Warnings may suppressed based on other settings. -->
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</EnableTrimAnalyzer>
+    
+    <!-- Enable the AOT analyzer when any AOT settings are enabled. Warnings may supressed based on other settings. -->
+    <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == '' And '$(PublishAot)' == 'true'">true</EnableAotAnalyzer>
 
     <!-- Compiler warning level, defaulted to 4. We promote it to 5 if the user has set analysis level to 5 or higher
          NOTE: at this time only the C# compiler supports warning waves -->
@@ -92,7 +95,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)..\analyzers\build\Microsoft.CodeAnalysis.NetAnalyzers.targets"
           Condition="$(EnableNETAnalyzers)" />
   <Import Project="$(MSBuildThisFileDirectory)..\analyzers\build\Microsoft.NET.ILLink.Analyzers.props"
-          Condition="'$(EnableSingleFileAnalyzer)' == 'true' Or '$(EnableTrimAnalyzer)' == 'true'" />
+          Condition="'$(EnableSingleFileAnalyzer)' == 'true' Or '$(EnableTrimAnalyzer)' == 'true' Or '$(EnableAotAnalyzer)' == 'true'" />
 
   <Import Project="$(MSBuildThisFileDirectory)..\codestyle\cs\build\Microsoft.CodeAnalysis.CSharp.CodeStyle.targets"
           Condition="$(EnforceCodeStyleInBuild) And '$(Language)' == 'C#'" />
@@ -115,7 +118,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!-- ILLinker Analyzers -->
-  <ItemGroup Condition="'$(EnableSingleFileAnalyzer)' == 'true' Or '$(EnableTrimAnalyzer)' == 'true'">
+  <ItemGroup Condition="'$(EnableSingleFileAnalyzer)' == 'true' Or '$(EnableTrimAnalyzer)' == 'true' Or '$(EnableAotAnalyzer)' == 'true'">
     <Analyzer
       Include="$(MSBuildThisFileDirectory)..\analyzers\ILLink.*.dll"
       IsImplicitlyDefined="true" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -64,9 +64,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Enable the trim analyzer when any trimming settings are enabled. Warnings may suppressed based on other settings. -->
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</EnableTrimAnalyzer>
-    
-    <!-- Enable the AOT analyzer when any AOT settings are enabled. Warnings may supressed based on other settings. -->
-    <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == '' And '$(PublishAot)' == 'true'">true</EnableAotAnalyzer>
 
     <!-- Compiler warning level, defaulted to 4. We promote it to 5 if the user has set analysis level to 5 or higher
          NOTE: at this time only the C# compiler supports warning waves -->

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -1,0 +1,156 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+using static Microsoft.NET.Publish.Tests.PublishTestUtils;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishAnAotApp : SdkTest
+    {
+        private readonly string RuntimeIdentifier = $"/p:RuntimeIdentifier={RuntimeInformation.RuntimeIdentifier}";
+
+        public GivenThatWeWantToPublishAnAotApp(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void ILLink_analyzer_warnings_are_produced(string targetFramework)
+        {
+            var projectName = "ILLinkAnalyzerWarningsApp";
+            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
+            testProject.AdditionalProperties["PublishAot"] = "true";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute(RuntimeIdentifier)
+                .Should().Pass()
+                .And.HaveStdOutContaining("(8,9): warning IL3050")
+                .And.HaveStdOutContaining("(18,12): warning IL3052");
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void ILLink_linker_analyzer_warnings_are_not_produced(string targetFramework)
+        {
+            var projectName = "ILLinkAnalyzerWarningsApp";
+            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
+            // Inactive linker settings should have no effect on the aot analyzer,
+            // unless PublishTrimmed is also set.
+            testProject.AdditionalProperties["PublishAot"] = "true";
+            testProject.AdditionalProperties["SuppressTrimAnalysisWarnings"] = "false";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute(RuntimeIdentifier)
+                .Should().Pass()
+                .And.NotHaveStdOutContaining("IL2026");
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void ILLink_analyzer_warnings_are_produced_using_EnableAotAnalyzer(string targetFramework)
+        {
+            var projectName = "ILLinkAnalyzerWarningsApp";
+            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
+            testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute(RuntimeIdentifier)
+                .Should().Pass()
+                .And.HaveStdOutContaining("(8,9): warning IL3050")
+                .And.HaveStdOutContaining("(18,12): warning IL3052");
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void ILLink_analyzer_can_treat_warnings_as_errors(string targetFramework)
+        {
+            var projectName = "ILLinkAnalyzerWarningsApp";
+            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
+            testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
+            testProject.AdditionalProperties["WarningsAsErrors"] = "IL3050";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute(RuntimeIdentifier)
+                .Should().Fail()
+                .And.HaveStdOutContaining("(8,9): error IL3050")
+                .And.HaveStdOutContaining("(18,12): warning IL3052");
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void ILLink_analyzer_can_ignore_warnings(string targetFramework)
+        {
+            var projectName = "ILLinkAnalyzerWarningsApp";
+            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
+            testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
+            testProject.AdditionalProperties["WarningsAsErrors"] = "IL3050";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute(RuntimeIdentifier, "/p:NoWarn=IL3050", "/p:WarnAsError=IL3050")
+                .Should().Pass()
+                .And.HaveStdOutContaining("(18,12): warning IL3052");
+        }
+
+        private TestProject CreateTestProjectWithAnalyzerWarnings(string targetFramework, string projectName, bool isExecutable)
+        {
+            var testProject = new TestProject()
+            {
+                Name = projectName,
+                TargetFrameworks = targetFramework,
+                IsExe = isExecutable
+            };
+
+            testProject.SourceFiles[$"{projectName}.cs"] = @"
+using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
+class C
+{
+    static void Main()
+    {
+        ProduceAotAnalysisWarning();
+        ProduceLinkerAnalysisWarning();
+    }
+
+    [RequiresDynamicCode(""Aot analysis warning"")]
+    static void ProduceAotAnalysisWarning()
+    {
+    }
+
+    [RequiresDynamicCode(""Aot analysis warning"")]
+    static C() {}
+
+    [RequiresUnreferencedCode(""Linker analysis warning"")]
+    static void ProduceLinkerAnalysisWarning()
+    {
+    }
+}";
+
+            return testProject;
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        [InlineData(LatestTfm)]
         public void ILLink_aot_analyzer_warnings_are_produced(string targetFramework)
         {
             var projectName = "ILLinkAotAnalyzerWarningsApp";
@@ -46,7 +46,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        [InlineData(LatestTfm)]
         public void ILLink_linker_warnings_not_produced_if_not_set(string targetFramework)
         {
             var projectName = "ILLinkAotAnalyzerWarningsApp";
@@ -62,41 +62,6 @@ namespace Microsoft.NET.Publish.Tests
                 .Execute(RuntimeIdentifier)
                 .Should().Pass()
                 .And.NotHaveStdOutContaining("IL2026");
-        }
-
-        [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [InlineData(ToolsetInfo.CurrentTargetFramework)]
-        public void ILLink_aot_analyzer_can_treat_warnings_as_errors(string targetFramework)
-        {
-            var projectName = "ILLinkAotAnalyzerWarningsApp";
-            var testProject = CreateTestProjectWithAotAnalyzerWarnings(targetFramework, projectName, true);
-            testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
-            testProject.AdditionalProperties["WarningsAsErrors"] = "IL3050";
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand
-                .Execute(RuntimeIdentifier)
-                .Should().Fail()
-                .And.HaveStdOutContaining("(8,9): error IL3050")
-                .And.HaveStdOutContaining("(18,12): warning IL3052");
-        }
-
-        [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [InlineData(ToolsetInfo.CurrentTargetFramework)]
-        public void ILLink_aot_analyzer_can_ignore_warnings(string targetFramework)
-        {
-            var projectName = "ILLinkAotAnalyzerWarningsApp";
-            var testProject = CreateTestProjectWithAotAnalyzerWarnings(targetFramework, projectName, true);
-            testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
-            testProject.AdditionalProperties["WarningsAsErrors"] = "IL3050";
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand
-                .Execute(RuntimeIdentifier, "/p:NoWarn=IL3050", "/p:WarnAsError=IL3050")
-                .Should().Pass()
-                .And.HaveStdOutContaining("(18,12): warning IL3052");
         }
 
         private TestProject CreateTestProjectWithAotAnalyzerWarnings(string targetFramework, string projectName, bool isExecutable)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var projectName = "ILLinkAnalyzerWarningsApp";
             var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
-            testProject.AdditionalProperties["PublishAot"] = "true";
+            testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
             // Inactive linker settings should have no effect on the aot analyzer,
             // unless PublishTrimmed is also set.
-            testProject.AdditionalProperties["PublishAot"] = "true";
+            testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
             testProject.AdditionalProperties["SuppressTrimAnalysisWarnings"] = "false";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -62,23 +62,6 @@ namespace Microsoft.NET.Publish.Tests
                 .Execute(RuntimeIdentifier)
                 .Should().Pass()
                 .And.NotHaveStdOutContaining("IL2026");
-        }
-
-        [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [InlineData(ToolsetInfo.CurrentTargetFramework)]
-        public void ILLink_analyzer_warnings_are_produced_using_EnableAotAnalyzer(string targetFramework)
-        {
-            var projectName = "ILLinkAnalyzerWarningsApp";
-            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
-            testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand
-                .Execute(RuntimeIdentifier)
-                .Should().Pass()
-                .And.HaveStdOutContaining("(8,9): warning IL3050")
-                .And.HaveStdOutContaining("(18,12): warning IL3052");
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
@@ -142,7 +125,9 @@ class C
     }
 
     [RequiresDynamicCode(""Aot analysis warning"")]
-    static C() {}
+    static C()
+    {
+    }
 
     [RequiresUnreferencedCode(""Linker analysis warning"")]
     static void ProduceLinkerAnalysisWarning()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -30,10 +30,10 @@ namespace Microsoft.NET.Publish.Tests
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
-        public void ILLink_analyzer_warnings_are_produced(string targetFramework)
+        public void ILLink_aot_analyzer_warnings_are_produced(string targetFramework)
         {
-            var projectName = "ILLinkAnalyzerWarningsApp";
-            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
+            var projectName = "ILLinkAotAnalyzerWarningsApp";
+            var testProject = CreateTestProjectWithAotAnalyzerWarnings(targetFramework, projectName, true);
             testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -47,10 +47,10 @@ namespace Microsoft.NET.Publish.Tests
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
-        public void ILLink_linker_analyzer_warnings_are_not_produced(string targetFramework)
+        public void ILLink_linker_warnings_not_produced_if_not_set(string targetFramework)
         {
-            var projectName = "ILLinkAnalyzerWarningsApp";
-            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
+            var projectName = "ILLinkAotAnalyzerWarningsApp";
+            var testProject = CreateTestProjectWithAotAnalyzerWarnings(targetFramework, projectName, true);
             // Inactive linker settings should have no effect on the aot analyzer,
             // unless PublishTrimmed is also set.
             testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
@@ -66,10 +66,10 @@ namespace Microsoft.NET.Publish.Tests
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
-        public void ILLink_analyzer_can_treat_warnings_as_errors(string targetFramework)
+        public void ILLink_aot_analyzer_can_treat_warnings_as_errors(string targetFramework)
         {
-            var projectName = "ILLinkAnalyzerWarningsApp";
-            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
+            var projectName = "ILLinkAotAnalyzerWarningsApp";
+            var testProject = CreateTestProjectWithAotAnalyzerWarnings(targetFramework, projectName, true);
             testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
             testProject.AdditionalProperties["WarningsAsErrors"] = "IL3050";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -84,10 +84,10 @@ namespace Microsoft.NET.Publish.Tests
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
-        public void ILLink_analyzer_can_ignore_warnings(string targetFramework)
+        public void ILLink_aot_analyzer_can_ignore_warnings(string targetFramework)
         {
-            var projectName = "ILLinkAnalyzerWarningsApp";
-            var testProject = CreateTestProjectWithAnalyzerWarnings(targetFramework, projectName, true);
+            var projectName = "ILLinkAotAnalyzerWarningsApp";
+            var testProject = CreateTestProjectWithAotAnalyzerWarnings(targetFramework, projectName, true);
             testProject.AdditionalProperties["EnableAotAnalyzer"] = "true";
             testProject.AdditionalProperties["WarningsAsErrors"] = "IL3050";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -99,7 +99,7 @@ namespace Microsoft.NET.Publish.Tests
                 .And.HaveStdOutContaining("(18,12): warning IL3052");
         }
 
-        private TestProject CreateTestProjectWithAnalyzerWarnings(string targetFramework, string projectName, bool isExecutable)
+        private TestProject CreateTestProjectWithAotAnalyzerWarnings(string targetFramework, string projectName, bool isExecutable)
         {
             var testProject = new TestProject()
             {


### PR DESCRIPTION
Add EnableAotAnalyzer support into SDK
 - Set EnableAotAnalyzer if PublishAot is set
 - Import Microsoft.NET.ILLink.Analyzers.props if EnableAotAnalyzer is set
 - Import ILLink Analyzers if EnableAotAnalyzer is set

Add tests in SDK