### PR TITLE
Backport #24086 to release/5.0.4xx

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,6 @@
     <!-- Dependencies from https://github.com/dotnet/runtime -->
     <SystemCodeDomPackageVersion>5.0.0</SystemCodeDomPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>5.0.0</SystemTextEncodingCodePagesPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20307.4</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemResourcesExtensionsPackageVersion>5.0.0</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/GetPassword.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/GetPassword.cs
@@ -43,8 +43,12 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             string plainPWD = "";
             try
             {
-                Byte[] uncrypted = System.Security.Cryptography.ProtectedData.Unprotect(encryptedData, null, System.Security.Cryptography.DataProtectionScope.CurrentUser);
-                plainPWD = Encoding.Unicode.GetString(uncrypted);
+                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
+                    Byte[] uncrypted = System.Security.Cryptography.ProtectedData.Unprotect(encryptedData, null, System.Security.Cryptography.DataProtectionScope.CurrentUser);
+                    plainPWD = Encoding.Unicode.GetString(uncrypted);
+                } else {
+                    throw new PlatformNotSupportedException();
+                }
             }
             catch
             {


### PR DESCRIPTION
This backports the change in #24086 to release/5.0.4xx for servicing.

## Summary

Code-flow from dotnet/runtime brought in a dependency on System.Security.Cryptography.ProtectedData at some point. Separately, this repo took an explicit top-level dependency on that same library, which was kept up to date by arcade tooling. During the 5.0 cycle, the runtime-induced dependency stagnated and wasn't kept updated.  Because this entry was defined _after_ this repo's top-level dependency, the stagnant version was take as the version to use.

## Customer Impact

Fixes to this library that were introduced after `5.0.0-preview.7.20364.11` have not been made available on the 6.0.2xx releases.

## Regression?

No

## Testing

None

## Risk

Low - looking at the [history of the code](https://github.com/dotnet/runtime/commits/main/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs) since 5.0 preview time frames, very few changes have been made and the ones that have been made seem to be maintenance-related tasks.