### PR TITLE
Add default file inclusion support in .NET SDK for RESW and image files in WinAppSDK .NET projects.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -28,15 +28,24 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableWebSdkImplicitPackageVersions>false</EnableWebSdkImplicitPackageVersions>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <_ImageGlobs>**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif</_ImageGlobs>
+  </PropertyGroup>
 
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
     <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
     <EmbeddedResource Include="**/*.resx" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' " />
+    <!-- WindowsAppSdk is a NuGet delivered Windows SDK. Include only if the package is installed. -->
+    <Content Include="$(_ImageGlobs)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultContentItems)' != 'false' And '$(WindowsAppSdkFoundation)' == 'true' " />
+    <PRIResource Include="**/*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultPRIResourceItems)' != 'false' And '$(WindowsAppSdkFoundation)' == 'true' "/>
   </ItemGroup>
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultNoneItems)' == 'true' ">
     <None Include="**/*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <None Remove="**/*$(DefaultLanguageSourceExtension)" />
     <None Remove="**/*.resx" />
+    <!-- WindowsAppSdk is a NuGet delivered Windows SDK. Remove only if the package is installed. -->
+    <None Remove="$(_ImageGlobs)" Condition=" '$(WindowsAppSdkFoundation)' == 'true' "/>
+    <None Remove="**/*.resw" Condition=" '$(WindowsAppSdkFoundation)' == 'true' "/>
   </ItemGroup>
 
   <!-- Automatically reference NETStandard.Library or Microsoft.NETCore.App package if targeting the corresponding target framework.


### PR DESCRIPTION
This is for the feature request: https://github.com/dotnet/sdk/issues/24093
Please refer to it for a description of the change.

**How verified**
Setup:
1. Deleted contents of: https://github.com/microsoft/WindowsAppSDK/blob/main/dev/MRTCore/packaging/MrtCore.props
2. Added change to: C:\Program Files\dotnet\sdk\6.0.200\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.props
3. In VS 17.1, created a new WindowsAppSDK project from template (WAP based).

Cases:
1. New RESW file
2. RESW file added via UI from external folder
3. PNG file added via UI from external folder
4. RESW file copy pasted into project folder
5. JPG file copy pasted into project folder

Things I tested (for each of above):
1. Correct default value? Yes.
2. No project file modification by default? Yes.
3. Change of Build Action in UI to None:
  i. Worked? Yes.
  ii. Project file modification is correct? Yes.