### PR TITLE
Add default file inclusion support in .NET SDK for RESW and image files in WinAppSDK .NET projects.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -29,22 +29,22 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <_ImageGlobs>**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif</_ImageGlobs>
+    <__WindowsAppSdkDefaultImageIncludes>**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif</__WindowsAppSdkDefaultImageIncludes>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
     <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
     <EmbeddedResource Include="**/*.resx" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' " />
-    <!-- WindowsAppSdk is a NuGet delivered Windows SDK. Include only if the package is installed. -->
-    <Content Include="$(_ImageGlobs)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultContentItems)' != 'false' And '$(WindowsAppSdkFoundation)' == 'true' " />
+    <!-- Microsoft.WindowsAppSDK is a NuGet delivered SDK. Include only if the package is installed (WindowsAppSdkFoundation is set by the Microsoft.WindowsAppSDK NuGet package). -->
+    <Content Include="$(__WindowsAppSdkDefaultImageIncludes)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultContentItems)' != 'false' And '$(WindowsAppSdkFoundation)' == 'true' " />
     <PRIResource Include="**/*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultPRIResourceItems)' != 'false' And '$(WindowsAppSdkFoundation)' == 'true' "/>
   </ItemGroup>
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultNoneItems)' == 'true' ">
     <None Include="**/*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <None Remove="**/*$(DefaultLanguageSourceExtension)" />
     <None Remove="**/*.resx" />
-    <!-- WindowsAppSdk is a NuGet delivered Windows SDK. Remove only if the package is installed. -->
-    <None Remove="$(_ImageGlobs)" Condition=" '$(WindowsAppSdkFoundation)' == 'true' "/>
+    <!-- Microsoft.WindowsAppSDK is a NuGet delivered SDK. Remove only if the package is installed (WindowsAppSdkFoundation is set by the Microsoft.WindowsAppSDK NuGet package). -->
+    <None Remove="$(__WindowsAppSdkDefaultImageIncludes)" Condition=" '$(WindowsAppSdkFoundation)' == 'true' "/>
     <None Remove="**/*.resw" Condition=" '$(WindowsAppSdkFoundation)' == 'true' "/>
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -28,15 +28,24 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableWebSdkImplicitPackageVersions>false</EnableWebSdkImplicitPackageVersions>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <_ImageGlobs>**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif</_ImageGlobs>
+  </PropertyGroup>
 
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
     <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
     <EmbeddedResource Include="**/*.resx" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' " />
+    <!-- WindowsAppSdk is a NuGet delivered Windows SDK. Include only if the package is installed. -->
+    <Content Include="$(_ImageGlobs)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultContentItems)' != 'false' And '$(WindowsAppSdkFoundation)' == 'true' " />
+    <PRIResource Include="**/*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultPRIResourceItems)' != 'false' And '$(WindowsAppSdkFoundation)' == 'true' "/>
   </ItemGroup>
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultNoneItems)' == 'true' ">
     <None Include="**/*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <None Remove="**/*$(DefaultLanguageSourceExtension)" />
     <None Remove="**/*.resx" />
+    <!-- WindowsAppSdk is a NuGet delivered Windows SDK. Remove only if the package is installed. -->
+    <None Remove="$(_ImageGlobs)" Condition=" '$(WindowsAppSdkFoundation)' == 'true' "/>
+    <None Remove="**/*.resw" Condition=" '$(WindowsAppSdkFoundation)' == 'true' "/>
   </ItemGroup>
 
   <!-- Automatically reference NETStandard.Library or Microsoft.NETCore.App package if targeting the corresponding target framework.

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -367,7 +367,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
-        public void It_does_not_include_source_or_resx_files_in_None()
+        public void It_does_not_include_items_in_any_group_if_group_specific_default_include_properties_are_false()
         {
             var testProject = new TestProject()
             {
@@ -378,9 +378,15 @@ namespace Microsoft.NET.Build.Tests
             testProject.AdditionalProperties["EnableDefaultCompileItems"] = "false";
             testProject.AdditionalProperties["EnableDefaultResourceItems"] = "false";
 
+            // Windows App SDK related
+            testProject.AdditionalProperties["WindowsAppSdkFoundation"] = "true";
+            testProject.AdditionalProperties["EnableDefaultContentItems"] = "false";
+            testProject.AdditionalProperties["EnableDefaultPRIResourceItems"] = "false";
+
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project =>
                 {
+                    // "Manual" include via project file modification.
                     var ns = project.Root.Name.Namespace;
                     XElement itemGroup = new XElement(ns + "ItemGroup");
                     project.Root.Add(itemGroup);
@@ -391,7 +397,10 @@ namespace Microsoft.NET.Build.Tests
 
             File.WriteAllText(Path.Combine(projectFolder, "ShouldBeIgnored.cs"), "!InvalidCSharp!");
             File.WriteAllText(Path.Combine(projectFolder, "Resources.resx"), "<Resource/>");
+            File.WriteAllText(Path.Combine(projectFolder, "ResourcesResw.resw"), "<root/>");
+            File.WriteAllText(Path.Combine(projectFolder, "TestImage.jpg"), "");
 
+            // Validate Compile items.
             var getCompileItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "Compile", GetValuesCommand.ValueType.Item);
             getCompileItemsCommand.Execute()
                 .Should()
@@ -401,6 +410,7 @@ namespace Microsoft.NET.Build.Tests
             RemoveGeneratedCompileItems(compileItems);
             compileItems.ShouldBeEquivalentTo(new[] { testProject.Name + ".cs" });
 
+            // Validate None items.
             var getNoneItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "None", GetValuesCommand.ValueType.Item);
             getNoneItemsCommand.Execute()
                 .Should()
@@ -409,6 +419,7 @@ namespace Microsoft.NET.Build.Tests
             getNoneItemsCommand.GetValues()
                 .Should().BeEmpty();
 
+            // Validate Resource items.
             var getResourceItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "Resource", GetValuesCommand.ValueType.Item);
             getResourceItemsCommand.Execute()
                 .Should()
@@ -417,6 +428,23 @@ namespace Microsoft.NET.Build.Tests
             getResourceItemsCommand.GetValues()
                 .Should().BeEmpty();
 
+            // Validate PRIResource items.
+            var getPRIResourceItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "PRIResource", GetValuesCommand.ValueType.Item);
+            getPRIResourceItemsCommand.Execute()
+                .Should()
+                .Pass();
+
+            getPRIResourceItemsCommand.GetValues()
+                .Should().BeEmpty();
+
+            // Validate Content items.
+            var getContentItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "Content", GetValuesCommand.ValueType.Item);
+            getContentItemsCommand.Execute()
+                .Should()
+                .Pass();
+
+            getContentItemsCommand.GetValues()
+                .Should().BeEmpty();
         }
 
         [Fact]
@@ -727,6 +755,112 @@ public class Class1
                 r.metadata["ExcludeAssets"].Should().BeEmpty();
                 r.metadata["IsImplicitlyDefined"].Should().BeEmpty();
             }
+        }
+
+        [Fact]
+        public void It_includes_Windows_App_SDK_items_in_the_correct_groups_if_Windows_App_SDK_is_present()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "DontIncludeSourceFilesInNone",
+                TargetFrameworks = "net6.0",
+                IsExe = true,
+            };
+
+            // Windows App SDK
+            testProject.AdditionalProperties["WindowsAppSdkFoundation"] = "true";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);
+
+            File.WriteAllText(Path.Combine(projectFolder, "ResourcesResw.resw"), "<root/>");
+            string[] imageFiles = { "TestImage1.png", "TestImage2.bmp", "TestImage3.jpg", "TestImage4.dds", "TestImage5.tif", "TestImage6.tga", "TestImage7.gif" };
+            foreach (string fileName in imageFiles)
+            {
+                File.WriteAllText(Path.Combine(projectFolder, fileName), "");
+            }
+
+            // Validate None items.
+            var getNoneItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "None", GetValuesCommand.ValueType.Item);
+            getNoneItemsCommand.Execute()
+                .Should()
+                .Pass();
+
+            getNoneItemsCommand.GetValues()
+                .Should()
+                .BeEmpty();
+
+            // Validate PRIResource items.
+            var getPRIResourceItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "PRIResource", GetValuesCommand.ValueType.Item);
+            getPRIResourceItemsCommand.Execute()
+                .Should()
+                .Pass();
+
+            var getPRIResourceItems = getPRIResourceItemsCommand.GetValues();
+            getPRIResourceItems.ShouldBeEquivalentTo(new[] { "ResourcesResw.resw" });
+
+            // Validate Content items.
+            var getContentItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "Content", GetValuesCommand.ValueType.Item);
+            getContentItemsCommand.Execute()
+                .Should()
+                .Pass();
+
+            var getContentItems = getContentItemsCommand.GetValues();
+            getContentItems.ShouldBeEquivalentTo(imageFiles);
+        }
+
+        [Fact]
+        public void It_does_not_include_Windows_App_SDK_items_if_Windows_App_SDK_is_absent()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "DontIncludeSourceFilesInNone",
+                TargetFrameworks = "net6.0",
+                IsExe = true,
+            };
+
+            // Not setting the "WindowsAppSdkFoundation" property!
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);
+
+            File.WriteAllText(Path.Combine(projectFolder, "ResourcesResw.resw"), "<root/>");
+            List<string> imageFiles = new List<string>{ "TestImage1.png", "TestImage2.bmp", "TestImage3.jpg", "TestImage4.dds", "TestImage5.tif", "TestImage6.tga", "TestImage7.gif" };
+            foreach (string fileName in imageFiles)
+            {
+                File.WriteAllText(Path.Combine(projectFolder, fileName), "");
+            }
+
+            // Validate None items.
+            var getNoneItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "None", GetValuesCommand.ValueType.Item);
+            getNoneItemsCommand.Execute()
+                .Should()
+                .Pass();
+
+            var getNoneItems = getNoneItemsCommand.GetValues();
+            List<string> expectedFiles = imageFiles;
+            expectedFiles.Add("ResourcesResw.resw");
+            getNoneItems.ShouldBeEquivalentTo(expectedFiles.ToArray());
+
+            // Validate PRIResource items.
+            var getPRIResourceItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "PRIResource", GetValuesCommand.ValueType.Item);
+            getPRIResourceItemsCommand.Execute()
+                .Should()
+                .Pass();
+
+            getPRIResourceItemsCommand.GetValues()
+                .Should()
+                .BeEmpty();
+
+            // Validate Content items.
+            var getContentItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "Content", GetValuesCommand.ValueType.Item);
+            getContentItemsCommand.Execute()
+                .Should()
+                .Pass();
+
+            getContentItemsCommand.GetValues()
+                .Should()
+                .BeEmpty();
         }
 
         void RemoveGeneratedCompileItems(List<string> compileItems)


### PR DESCRIPTION
### Description
This is for the feature request: https://github.com/dotnet/sdk/issues/24093
Please refer to it for a description of the change.

### How verified
#### Automated
Added tests.

#### Manual
Tested these cases for WinUI, packaged console, packaged WPF and packaged WinForms:
1. New RESW file
2. RESW file added via UI from external folder
3. PNG file added via UI from external folder
4. RESW file copy pasted into project folder
5. JPG file copy pasted into project folder

Note: WPF + RESW doesn't work. The attempted inclusion is undone by automatic injection in the project file. By that, I mean that this is injected: removal from PRIResource and addition to None. That needs to be fixed separately, likely in the Windows App SDK. Tracked by https://github.com/microsoft/WindowsAppSDK/issues/2324.

Note 2: Tested with and without https://github.com/microsoft/WindowsAppSDK/blob/main/dev/MRTCore/packaging/MrtCore.props in the Windows App SDK NuGet package. So, that WAS change and this can coexist! In the long term though, the WAS change should be removed. I also confirmed that the string and image resources were not showing up twice in the PRI file.

Description of setup:
Used VS2022.
Modified .NET SDK install in C:\Program Files\dotnet\sdk\.