### PR TITLE
Detect if a particular execution of the SDK is on a CI system or not

### DIFF
--- a/src/Cli/dotnet/Telemetry/CIEnvironmentDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/CIEnvironmentDetectorForTelemetry.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
 {
     internal class CIEnvironmentDetectorForTelemetry : ICIEnvironmentDetector
     {
-        // variables that will hold boolean values only
+        // Systems that provide boolean values only, so we can simply parse and check for true
         private static readonly string[] _booleanVariables = new string[] {
             // Azure Pipelines - https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#system-variables-devops-services
             "TF_BUILD",
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
             "CIRCLECI",
         };
 
+        // Systems where every variable must be present and not-null before returning true
         private static readonly string[][] _allNotNullVariables = new string[][] {
             // AWS CodeBuild - https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
             new string[]{ "CODEBUILD_BUILD_ID", "AWS_REGION" },
@@ -35,6 +36,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
             new string[]{ "BUILD_ID", "PROJECT_ID" }
         };
 
+        // Systems where the variable must be present and not-null
         private static readonly string[] _ifNonNullVariables = new string[] {
             // TeamCity - https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
             "TEAMCITY_VERSION",
@@ -62,7 +64,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
 
             foreach (var variable in _ifNonNullVariables)
             {
-                if (Environment.GetEnvironmentVariable(variable) is {} v)
+                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable)))
                 {
                     return true;
                 }

--- a/src/Cli/dotnet/Telemetry/CIEnvironmentDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/CIEnvironmentDetectorForTelemetry.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Cli.Telemetry
+{
+    internal class CIEnvironmentDetectorForTelemetry : ICIEnvironmentDetector
+    {
+        // variables that will hold boolean values
+        private static readonly string[] _booleanVariables = new string[] {
+            "TF_BUILD", // Azure Pipelines
+            "GITHUB_ACTIONS", // GitHub Actions
+            "APPVEYOR", // AppVeyor
+            "CI", // a general-use flag
+            "TRAVIS", // Travis CI
+            "CIRCLECI", // CircleCI
+        };
+
+        private static readonly string[][] _allNotNullVariables = new string[][] {
+            new string[]{ "CODEBUILD_BUILD_ID", "AWS_REGION" }, // AWS CodeBuild
+            new string[]{ "BUILD_ID", "BUILD_URL" }, // Jenkins
+            new string[]{ "BUILD_ID", "PROJECT_ID" } // Google Cloud Build
+        };
+
+        private static readonly string[] _ifNonNullVariables = new string[] {
+            "TEAMCITY_VERSION", // TeamCity
+            "JB_SPACE_API_URL" // JetBrains Space
+        };
+
+        public IsCIEnvironment IsCIEnvironment()
+        {
+            foreach (var booleanVariable in _booleanVariables)
+            {
+                if (bool.TryParse(Environment.GetEnvironmentVariable(booleanVariable), out bool envVar) && envVar)
+                {
+                    return Cli.Telemetry.IsCIEnvironment.True;
+                }
+            }
+
+            foreach (var variables in _allNotNullVariables) {
+                if (variables.All((variable) => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable))))
+                {
+                    return Cli.Telemetry.IsCIEnvironment.True;
+                }
+            }
+
+            foreach (var variable in _ifNonNullVariables) {
+                if(Environment.GetEnvironmentVariable(variable) is {} v) {
+                    return Cli.Telemetry.IsCIEnvironment.True;
+                }
+            }
+
+            return Cli.Telemetry.IsCIEnvironment.False;
+        }
+    }
+
+    internal enum IsCIEnvironment
+    {
+        True,
+        False
+    }
+}

--- a/src/Cli/dotnet/Telemetry/CIEnvironmentDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/CIEnvironmentDetectorForTelemetry.cs
@@ -9,57 +9,66 @@ namespace Microsoft.DotNet.Cli.Telemetry
 {
     internal class CIEnvironmentDetectorForTelemetry : ICIEnvironmentDetector
     {
-        // variables that will hold boolean values
+        // variables that will hold boolean values only
         private static readonly string[] _booleanVariables = new string[] {
-            "TF_BUILD", // Azure Pipelines
-            "GITHUB_ACTIONS", // GitHub Actions
-            "APPVEYOR", // AppVeyor
-            "CI", // a general-use flag
-            "TRAVIS", // Travis CI
-            "CIRCLECI", // CircleCI
+            // Azure Pipelines - https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#system-variables-devops-services
+            "TF_BUILD",
+            // GitHub Actions - https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+            "GITHUB_ACTIONS",
+            // AppVeyor - https://www.appveyor.com/docs/environment-variables/
+            "APPVEYOR",
+            // A general-use flag - Many of the major players support this: AzDo, GitHub, GitLab, AppVeyor, Travis CI, CircleCI.
+            // Given this, we could potentially remove all of these other options?
+            "CI",
+            // Travis CI - https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+            "TRAVIS",
+            // CircleCI - https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+            "CIRCLECI",
         };
 
         private static readonly string[][] _allNotNullVariables = new string[][] {
-            new string[]{ "CODEBUILD_BUILD_ID", "AWS_REGION" }, // AWS CodeBuild
-            new string[]{ "BUILD_ID", "BUILD_URL" }, // Jenkins
-            new string[]{ "BUILD_ID", "PROJECT_ID" } // Google Cloud Build
+            // AWS CodeBuild - https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+            new string[]{ "CODEBUILD_BUILD_ID", "AWS_REGION" },
+            // Jenkins - https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+            new string[]{ "BUILD_ID", "BUILD_URL" },
+            // Google Cloud Build - https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_default_substitutions
+            new string[]{ "BUILD_ID", "PROJECT_ID" }
         };
 
         private static readonly string[] _ifNonNullVariables = new string[] {
-            "TEAMCITY_VERSION", // TeamCity
-            "JB_SPACE_API_URL" // JetBrains Space
+            // TeamCity - https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
+            "TEAMCITY_VERSION",
+            // JetBrains Space - https://www.jetbrains.com/help/space/automation-environment-variables.html#general
+            "JB_SPACE_API_URL"
         };
 
-        public IsCIEnvironment IsCIEnvironment()
+        public bool IsCIEnvironment()
         {
             foreach (var booleanVariable in _booleanVariables)
             {
                 if (bool.TryParse(Environment.GetEnvironmentVariable(booleanVariable), out bool envVar) && envVar)
                 {
-                    return Cli.Telemetry.IsCIEnvironment.True;
+                    return true;
                 }
             }
 
-            foreach (var variables in _allNotNullVariables) {
+            foreach (var variables in _allNotNullVariables)
+            {
                 if (variables.All((variable) => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable))))
                 {
-                    return Cli.Telemetry.IsCIEnvironment.True;
+                    return true;
                 }
             }
 
-            foreach (var variable in _ifNonNullVariables) {
-                if(Environment.GetEnvironmentVariable(variable) is {} v) {
-                    return Cli.Telemetry.IsCIEnvironment.True;
+            foreach (var variable in _ifNonNullVariables)
+            {
+                if (Environment.GetEnvironmentVariable(variable) is {} v)
+                {
+                    return true;
                 }
             }
 
-            return Cli.Telemetry.IsCIEnvironment.False;
+            return false;
         }
-    }
-
-    internal enum IsCIEnvironment
-    {
-        True,
-        False
     }
 }

--- a/src/Cli/dotnet/Telemetry/ICIEnvironmentDetector.cs
+++ b/src/Cli/dotnet/Telemetry/ICIEnvironmentDetector.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Cli.Telemetry
+{
+    internal interface ICIEnvironmentDetector
+    {
+        IsCIEnvironment IsCIEnvironment();
+    }
+}

--- a/src/Cli/dotnet/Telemetry/ICIEnvironmentDetector.cs
+++ b/src/Cli/dotnet/Telemetry/ICIEnvironmentDetector.cs
@@ -5,6 +5,6 @@ namespace Microsoft.DotNet.Cli.Telemetry
 {
     internal interface ICIEnvironmentDetector
     {
-        IsCIEnvironment IsCIEnvironment();
+        bool IsCIEnvironment();
     }
 }

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -18,16 +18,19 @@ namespace Microsoft.DotNet.Cli.Telemetry
             Func<string, string> hasher = null,
             Func<string> getMACAddress = null,
             IDockerContainerDetector dockerContainerDetector = null,
-            IUserLevelCacheWriter userLevelCacheWriter = null)
+            IUserLevelCacheWriter userLevelCacheWriter = null,
+            ICIEnvironmentDetector ciEnvironmentDetector = null)
         {
             _getCurrentDirectory = getCurrentDirectory ?? Directory.GetCurrentDirectory;
             _hasher = hasher ?? Sha256Hasher.Hash;
             _getMACAddress = getMACAddress ?? MacAddressGetter.GetMacAddress;
             _dockerContainerDetector = dockerContainerDetector ?? new DockerContainerDetectorForTelemetry();
             _userLevelCacheWriter = userLevelCacheWriter ?? new UserLevelCacheWriter();
+            _ciEnvironmentDetector = ciEnvironmentDetector ?? new CIEnvironmentDetectorForTelemetry();
         }
 
         private readonly IDockerContainerDetector _dockerContainerDetector;
+        private readonly ICIEnvironmentDetector _ciEnvironmentDetector;
         private Func<string> _getCurrentDirectory;
         private Func<string, string> _hasher;
         private Func<string> _getMACAddress;
@@ -54,6 +57,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
 
         private const string MachineIdCacheKey = "MachineId";
         private const string IsDockerContainerCacheKey = "IsDockerContainer";
+        private const string CI = "Continuous Integration";
 
         public Dictionary<string, string> GetTelemetryCommonProperties()
         {
@@ -67,6 +71,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 {ProductVersion, Product.Version},
                 {TelemetryProfile, Environment.GetEnvironmentVariable(TelemetryProfileEnvironmentVariable)},
                 {DockerContainer, _userLevelCacheWriter.RunWithCache(IsDockerContainerCacheKey, () => _dockerContainerDetector.IsDockerContainer().ToString("G") )},
+                {CI, _ciEnvironmentDetector.IsCIEnvironment().ToString("G") },
                 {CurrentPathHash, _hasher(_getCurrentDirectory())},
                 {MachineIdOld, _userLevelCacheWriter.RunWithCache(MachineIdCacheKey, GetMachineId)},
                 // we don't want to recalcuate a new id for every new SDK version. Reuse the same path accross versions.

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -52,12 +52,13 @@ namespace Microsoft.DotNet.Cli.Telemetry
         private const string LibcRelease = "Libc Release";
         private const string LibcVersion = "Libc Version";
 
+        private const string CI = "Continuous Integration";
+
         private const string TelemetryProfileEnvironmentVariable = "DOTNET_CLI_TELEMETRY_PROFILE";
         private const string CannotFindMacAddress = "Unknown";
 
         private const string MachineIdCacheKey = "MachineId";
         private const string IsDockerContainerCacheKey = "IsDockerContainer";
-        private const string CI = "Continuous Integration";
 
         public Dictionary<string, string> GetTelemetryCommonProperties()
         {
@@ -71,7 +72,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 {ProductVersion, Product.Version},
                 {TelemetryProfile, Environment.GetEnvironmentVariable(TelemetryProfileEnvironmentVariable)},
                 {DockerContainer, _userLevelCacheWriter.RunWithCache(IsDockerContainerCacheKey, () => _dockerContainerDetector.IsDockerContainer().ToString("G") )},
-                {CI, _ciEnvironmentDetector.IsCIEnvironment().ToString("G") },
+                {CI, _ciEnvironmentDetector.IsCIEnvironment().ToString() },
                 {CurrentPathHash, _hasher(_getCurrentDirectory())},
                 {MachineIdOld, _userLevelCacheWriter.RunWithCache(MachineIdCacheKey, GetMachineId)},
                 // we don't want to recalcuate a new id for every new SDK version. Reuse the same path accross versions.

--- a/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -72,6 +72,13 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
+        public void TelemetryCommonPropertiesShouldReturnIsCIDetection()
+        {
+            var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
+            unitUnderTest.GetTelemetryCommonProperties()["Continuous Integration"].Should().BeOneOf("True", "False");
+        }
+
+        [Fact]
         public void TelemetryCommonPropertiesShouldContainKernelVersion()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());

--- a/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -172,11 +172,16 @@ namespace Microsoft.DotNet.Tests
             new object[] { new Dictionary<string, string> { { "CIRCLECI", "true"} }, true },
 
             new object[] { new Dictionary<string, string> { { "CODEBUILD_BUILD_ID", "hi" }, { "AWS_REGION", "hi" } }, true },
+            new object[] { new Dictionary<string, string> { { "CODEBUILD_BUILD_ID", "hi" } }, false },
             new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" }, { "BUILD_URL", "hi" } }, true },
+            new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" } }, false },
             new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" }, { "PROJECT_ID", "hi" } }, true },
+            new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" } }, false },
 
             new object[] { new Dictionary<string, string> { { "TEAMCITY_VERSION", "hi" } }, true },
+            new object[] { new Dictionary<string, string> { { "TEAMCITY_VERSION", "" } }, false },
             new object[] { new Dictionary<string, string> { { "JB_SPACE_API_URL", "hi" } }, true },
+            new object[] { new Dictionary<string, string> { { "JB_SPACE_API_URL", "" } }, false },
 
             new object[] { new Dictionary<string, string> { { "SomethingElse", "hi" } }, false },
         };

--- a/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/src/Tests/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Xunit;
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Configurer;
@@ -146,6 +147,39 @@ namespace Microsoft.DotNet.Tests
                 unitUnderTest.GetTelemetryCommonProperties()["Libc Version"].Should().NotBeEmpty();
             }
         }
+
+        [Theory]
+        [MemberData(nameof(CITelemetryTestCases))]
+        public void CanDetectCIStatusForEnvVars(Dictionary<string, string> envVars, bool expected) {
+            try {
+                foreach (var (key, value) in envVars) {
+                    Environment.SetEnvironmentVariable(key, value);
+                }
+                new CIEnvironmentDetectorForTelemetry().IsCIEnvironment().Should().Be(expected);
+            } finally {
+                foreach (var (key, value) in envVars) {
+                    Environment.SetEnvironmentVariable(key, null);
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> CITelemetryTestCases => new List<object[]>{
+            new object[] { new Dictionary<string, string> { { "TF_BUILD", "true" } }, true },
+            new object[] { new Dictionary<string, string> { { "GITHUB_ACTIONS", "true" } }, true },
+            new object[] { new Dictionary<string, string> { { "APPVEYOR", "true"} }, true },
+            new object[] { new Dictionary<string, string> { { "CI", "true"} }, true },
+            new object[] { new Dictionary<string, string> { { "TRAVIS", "true"} }, true },
+            new object[] { new Dictionary<string, string> { { "CIRCLECI", "true"} }, true },
+
+            new object[] { new Dictionary<string, string> { { "CODEBUILD_BUILD_ID", "hi" }, { "AWS_REGION", "hi" } }, true },
+            new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" }, { "BUILD_URL", "hi" } }, true },
+            new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" }, { "PROJECT_ID", "hi" } }, true },
+
+            new object[] { new Dictionary<string, string> { { "TEAMCITY_VERSION", "hi" } }, true },
+            new object[] { new Dictionary<string, string> { { "JB_SPACE_API_URL", "hi" } }, true },
+
+            new object[] { new Dictionary<string, string> { { "SomethingElse", "hi" } }, false },
+        };
 
         private class NothingCache : IUserLevelCacheWriter
         {


### PR DESCRIPTION
This is an implementation of #23795 following the established patterns. I've added a test verifying the new field is populated, and attempted to fast-exit from the implementation. ~It _may_ also be useful to cache or lazily compute the value, since each telemetry event would add this new field. Repeated access should be zero-cost in the ideal case.~  Since this is only ever invoked once per invocation of the `dotnet` command, then cached into a reuseable Dictionary, no caching or laziness needs to be done in the implementation.

When this merges, we'll need to update [this list of collected data](https://docs.microsoft.com/en-us/dotnet/core/tools/telemetry#data-points) with a brief description of the new data point.