### PR TITLE
Clarify NuGet version conflicts

### DIFF
--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="dotnet-format" Version="$(DotnetFormatVersion)" GeneratePathProperty="true" ExcludeAssets="All" />
     <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="NuGet.Build.Tasks.Console" Version="$(NuGetBuildTasksConsolePackageVersion)" />
+    <PackageReference Include="NuGet.Common" Version="$(NuGetCommonPackageVersion)" /><!-- Keeps this from being bumped by transitive refs (templating) -->
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverPackageVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)" ExcludeAssets="All" />
     <PackageReference Include="Microsoft.TestPlatform.Build" Version="$(MicrosoftTestPlatformBuildPackageVersion)" />


### PR DESCRIPTION
When transitive dependencies on NuGet packages get higher versions than directly
referenced in this repo, the build can succeed but cause NuGet restore operations
to fail with a confusing MissingMethodException on

    NuGet.RuntimeModel.JsonObjectWriter..ctor(Newtonsoft.Json.JsonWriter)

Directly referencing NuGet.Common here doesn't prevent that but does shift the
error to restore time instead of execution time, where it is much clearer.
