### PR TITLE
Move WebAssembly ProjectCapability to props file

### DIFF
--- a/src/BlazorWasmSdk/Sdk/Sdk.targets
+++ b/src/BlazorWasmSdk/Sdk/Sdk.targets
@@ -15,10 +15,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_BlazorWebAssemblyTargetsFile Condition="'$(_BlazorWebAssemblyTargetsFile)' == ''">$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets</_BlazorWebAssemblyTargetsFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectCapability Include="WebAssembly" />
-  </ItemGroup>
-
   <Import Project="$(_BlazorWebAssemblyTargetsFile)" />
 
 </Project>

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.props
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.props
@@ -40,6 +40,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <StaticWebAssetsAdditionalPublishPropertiesToRemove>$(StaticWebAssetsAdditionalPublishPropertiesToRemove);NoBuild;RuntimeIdentifier</StaticWebAssetsAdditionalPublishPropertiesToRemove>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectCapability Include="WebAssembly" />
+  </ItemGroup>
+
   <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.props" />
   <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.props" />
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.props" />


### PR DESCRIPTION
Both VS and dotnet-watch have heuristics that assumes that an ASP.NET Core app referencing
a BlazorWebAssembly app is a Blazor hosted app for hot reload purposes. They then attempt
to send deltas to the browser to update the WASM app.

We've seen a few cases of users attempting to build dual-mode Blazor apps where the client is
a Blazor WebAssembly app, but during development the app references blazor.server.js. In this event,
applying the delta results in a warning with no simple way for a user to tell VS / watch to
not treat this as a Blazor hosted app.

Detecting the client as Blazor WebAssembly is based on ProjectCapability. Removing this capability
should solve the issue here and we think this was a sufficient solution at this time. However,
the ProjectCapability is defined within the targets file which makes it difficult to remove it
from within the project. This change moves it to the props making that easier.

Contributes to https://github.com/dotnet/aspnetcore/issues/40527