### PR TITLE
[release/6.0.3xx] Fix FSharp publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -58,6 +58,26 @@
     </CreateProperty>
   </Target>
 
+  <!-- FSharp needs to push different packages to nuget.org depending on whether the SDK is preview or not,
+       To achieve this, we find the FSharp compiler package, then the stable or non-stable FSharp.Core and Compiler service
+       package contained within, depending on the stability switch of the SDK. The SDK then treats these packages as its own outputs,
+       whch means they get automatically pushed on release day. -->
+  <PropertyGroup>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);_ResolvePublishFSharpNuGetPackages</PublishDependsOnTargets>
+  </PropertyGroup>
+    
+  <Target Name="_ResolvePublishFSharpNuGetPackages">
+    <PropertyGroup>
+        <FSharpCorePath Condition="'$(DotNetFinalVersionKind)'!='release'">Shipping</FSharpCorePath>
+        <FSharpCorePath Condition="'$(DotNetFinalVersionKind)'=='release'">Release</FSharpCorePath>
+    </PropertyGroup>
+    <ItemGroup>
+        <FSharpPackagesToPush Include="$(NuGetPackageRoot)\Microsoft.FSharp.Compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Core.*.nupkg"/>
+        <FSharpPackagesToPush Include="$(NuGetPackageRoot)\Microsoft.FSharp.Compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Compiler.Service.*.nupkg" />
+        <ItemsToPushToBlobFeed Include="@(FSharpPackagesToPush)" />
+    </ItemGroup>
+  </Target>
+ 
   <!-- We use a separate target to publish this to blob storage so that we can push this to
        a relative path inside the blob storage. -->
   <Target Name="PublishToolsetAssets" DependsOnTargets="ReadToolsetVersion" BeforeTargets="Publish">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,6 +12,9 @@
   <PropertyGroup>
     <VersionPrefix>6.0.300</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <!-- Enable to remove prerelease label. -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -70,17 +70,4 @@
       <Analyzer Remove="@(Analyzer)"/>
     </ItemGroup>
   </Target>
-
-  <Target Name="_ResolvePublishFSharpNuGetPackages"
-       AfterTargets="CoreCompile">
-
-    <PropertyGroup>
-        <FSharpCorePath Condition="'$(DotNetFinalVersionKind)'!='release'">Shipping</FSharpCorePath>
-        <FSharpCorePath Condition="'$(DotNetFinalVersionKind)'=='release'">Release</FSharpCorePath>
-    </PropertyGroup>
-    <ItemGroup>
-        <ItemsToPushToBlobFeed Include="$(PkgMicrosoft_FSharp_Compiler)\contentFiles\$(FSharpCorePath)\FSharp.Core.*.nupkg"/>
-        <ItemsToPushToBlobFeed Include="$(PkgMicrosoft_FSharp_Compiler)\contentFiles\$(FSharpCorePath)\FSharp.Compiler.Service.*.nupkg" />
-    </ItemGroup>
- </Target>
 </Project>


### PR DESCRIPTION
- Move the FSharp package publishing targets to eng/Publishing.props
- Use PublishDependsOnTargets to ensure it's run first
- Don't use Pkg* property to find the FSharp compiler package, since this is not available during Publish
- Add stabilization property