### PR TITLE
Improve loading of Roslyn assemblies on validate package task (#22277)

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.Compatibility/Microsoft.DotNet.Compatibility.csproj
+++ b/src/Compatibility/Microsoft.DotNet.Compatibility/Microsoft.DotNet.Compatibility.csproj
@@ -6,7 +6,7 @@
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <!-- This package doesnot contain any lib or ref assemblies because its a tooling package.-->
     <NoWarn>$(NoWarn);NU5128</NoWarn>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
@@ -15,8 +15,9 @@
     <PropertyGroup Condition="'$(RoslynAssembliesPath)' == ''">
       <RoslynAssembliesPath>$(RoslynTargetsPath)</RoslynAssembliesPath>
       <_packageReferenceList>@(PackageReference)</_packageReferenceList>
-      <RoslynAssembliesPath Condition="'$(MSBuildProjectExtension)' == '.csproj' and $(_packageReferenceList.Contains('Microsoft.Net.Compilers.Toolset'))">$([System.IO.Path]::GetDirectoryName($(CSharpCoreTargetsPath)))</RoslynAssembliesPath>
-      <RoslynAssembliesPath Condition="'$(MSBuildProjectExtension)' == '.vbproj' and $(_packageReferenceList.Contains('Microsoft.Net.Compilers.Toolset'))">$([System.IO.Path]::GetDirectoryName($(VisualBasicCoreTargetsPath)))</RoslynAssembliesPath>
+      <!-- CSharpCoreTargetsPath and VisualBasicCoreTargetsPath point to the same location, Microsoft.CodeAnalysis.CSharp and Microsoft.CodeAnalysis.VisualBasic
+      are on the same directory as Microsoft.CodeAnalysis. So there is no need to distinguish between csproj or vbproj. -->
+      <RoslynAssembliesPath Condition="$(_packageReferenceList.Contains('Microsoft.Net.Compilers.Toolset'))">$([System.IO.Path]::GetDirectoryName($(CSharpCoreTargetsPath)))</RoslynAssembliesPath>
       <RoslynAssembliesPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$([System.IO.Path]::Combine('$(RoslynAssembliesPath)', bincore))</RoslynAssembliesPath>
     </PropertyGroup>
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/issues/22353

Porting #22277 to release/6.0

cc: @carlossanlop @ericstj @dagood 

After this change is in and we have a build for it, I will go ahead and create a PR in runtime to update the version of PackageValidation we use.