### PR TITLE
Pin Microsoft.CodeAnalysis version for API Compat to the 4.0.x stable package

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -5,10 +5,14 @@
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- We need to compare ISymbols in a special way (by name) and roslyn symbol comparers take more heuristics into consideration.-->
     <NoWarn>RS1024;$(NoWarn)</NoWarn>
+    <!-- We pin the code analysis version when not in source build as we need to support running on older
+    SDKs when the OOB package is used. -->
+    <_MicrosoftCodeAnalysisVersion>4.0.1</_MicrosoftCodeAnalysisVersion>
+    <_MicrosoftCodeAnalysisVersion Condition="'$(DotNetBuildFromSource)' == 'true'">$(MicrosoftCodeAnalysisPackageVersion)</_MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(_MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Porting #23321 to 6.0.3xx in order to have PackageValidation depend on a lower version of Roslyn in order to support being loaded by desktop MSBuild and older VS.

cc: @ericstj @carlossanlop 