### PR TITLE
[release/6.0.1xx] Update runHelixAndNonHelixInParallel.ps1

### DIFF
--- a/eng/runHelixAndNonHelixInParallel.ps1
+++ b/eng/runHelixAndNonHelixInParallel.ps1
@@ -25,7 +25,6 @@
 
         $runTestsCannotRunOnHelixArgs = ("-configuration", $configuration, "-ci")
         $runTestsOnHelixArgs = ("-configuration", $configuration,
-        "-prepareMachine",
         "-ci",
         "-restore",
         "-test",
@@ -42,3 +41,11 @@
     }
 
     runHelixAndNonHelixInParallel -configuration $configuration -buildSourcesDirectory $buildSourcesDirectory -customHelixTargetQueue $customHelixTargetQueue -engfolderPath $PSScriptRoot -additionalParameters $additionalMSBuildParameters.Split(' ') 
+    
+  # An array of names of processes to stop on script exit
+  $processesToStopOnExit =  @('msbuild', 'dotnet', 'vbcscompiler')
+
+  Write-Host 'Stopping running build processes...'
+  foreach ($processName in $processesToStopOnExit) {
+    Get-Process -Name $processName -ErrorAction SilentlyContinue | Stop-Process
+  }


### PR DESCRIPTION
It was hard to pinpoint exactly from the logs but we determined that a timing issue in how the parallel scripts were launched was leading to one of the scripts preparing the machine after the other had started. The preparemachine step will stop all msbuild and dotnet processes which was what was leading to an error message (exited with code -1 but no errors)
