### PR TITLE
[dotnet-watch] Skip dotnet watch flaky test 602xx

### DIFF
--- a/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             Assert.Equal(messagePrefix + " --no-restore -- wait", message.Trim());
         }
 
-        [CoreMSBuildOnlyFact]
+        [Fact(Skip = "https://github.com/dotnet/sdk/issues/24406")]
         public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings()
         {
             var testAsset = _testAssetsManager.CopyTestAsset("WatchAppWithLaunchSettings")


### PR DESCRIPTION
Run_WithHotReloadEnabled_ReadsLaunchSettings seems to fail often, so skip it for now and we can investigate later.