### PR TITLE
Fix unstable test

### DIFF
--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var msbuildPath = "<msbuildpath>";
             string[] args = new string[] { optionName, "<project>" };
             StoreCommand.FromArgs(args, msbuildPath)
-                .GetArgumentsToMSBuild().Should().Be($"{ExpectedPrefix}");
+                .GetArgumentsToMSBuild().Should().Contain($"{ExpectedPrefix}");
         }
 
         [Theory]


### PR DESCRIPTION
This test had an additional logger show up which is not really an issue in the test. Changes to a contains.