### PR TITLE
Adding Package Validation support for cases where PackageId is different than AssemblyName

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.Compatibility/ValidatePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.Compatibility/ValidatePackage.cs
@@ -23,7 +23,6 @@ namespace Microsoft.DotNet.Compatibility
         [Required]
         public string RoslynAssembliesPath { get; set; }
 
-        [Required]
         public string AssemblyName { get; set; }
 
         public string RuntimeGraph { get; set; }

--- a/src/Compatibility/Microsoft.DotNet.Compatibility/ValidatePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.Compatibility/ValidatePackage.cs
@@ -23,6 +23,9 @@ namespace Microsoft.DotNet.Compatibility
         [Required]
         public string RoslynAssembliesPath { get; set; }
 
+        [Required]
+        public string AssemblyName { get; set; }
+
         public string RuntimeGraph { get; set; }
 
         public string NoWarn { get; set; }
@@ -96,7 +99,7 @@ namespace Microsoft.DotNet.Compatibility
                 }
             }
 
-            Package package = NupkgParser.CreatePackage(PackageTargetPath, runtimeGraph);
+            Package package = NupkgParser.CreatePackage(PackageTargetPath, runtimeGraph, AssemblyName);
             CompatibilityLogger logger = new(Log, CompatibilitySuppressionFilePath, GenerateCompatibilitySuppressionFile);
 
             new CompatibleTfmValidator(NoWarn, null, RunApiCompat, EnableStrictModeForCompatibleTfms, logger, apiCompatReferences).Validate(package);
@@ -104,7 +107,7 @@ namespace Microsoft.DotNet.Compatibility
 
             if (!DisablePackageBaselineValidation && !string.IsNullOrEmpty(BaselinePackageTargetPath))
             {
-                Package baselinePackage = NupkgParser.CreatePackage(BaselinePackageTargetPath, runtimeGraph);
+                Package baselinePackage = NupkgParser.CreatePackage(BaselinePackageTargetPath, runtimeGraph, AssemblyName);
                 new BaselinePackageValidator(baselinePackage, NoWarn, null, RunApiCompat, logger, apiCompatReferences).Validate(package);
             }
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/NupkgParser.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/NupkgParser.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.PackageValidation
                 packageDependencies.Add(item.TargetFramework, item.Packages);
             }
 
-            return new Package(packageId, version, packageReader.GetFiles()?.Where(t => t.EndsWith(assemblyName + ".dll")), packageDependencies, runtimeGraph);
+            return new Package(packageId, version, packageReader.GetFiles()?.Where(t => t.EndsWith((assemblyName ?? packageId) + ".dll")), packageDependencies, runtimeGraph);
         }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/NupkgParser.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/NupkgParser.cs
@@ -20,18 +20,19 @@ namespace Microsoft.DotNet.PackageValidation
         /// </summary>
         /// <param name="packagePath">The path to the package path.</param>
         /// <param name="runtimeGraph">The path to the the runtime graph.</param>
+        /// <param name="assemblyName">The name of the assembly to be used for API comparisons.</param>
         /// <returns>The package object.</returns>
-        public static Package CreatePackage(string packagePath, RuntimeGraph runtimeGraph)
+        public static Package CreatePackage(string packagePath, RuntimeGraph runtimeGraph, string assemblyName)
         {
             using (PackageArchiveReader packageReader = new PackageArchiveReader(packagePath))
             {
-                Package package = CreatePackage(packageReader, runtimeGraph);
+                Package package = CreatePackage(packageReader, runtimeGraph, assemblyName);
                 package.PackagePath = packagePath;
                 return package;
             }
         }
 
-        private static Package CreatePackage(PackageArchiveReader packageReader, RuntimeGraph runtimeGraph)
+        private static Package CreatePackage(PackageArchiveReader packageReader, RuntimeGraph runtimeGraph, string assemblyName)
         {
             NuspecReader nuspecReader = packageReader.NuspecReader;
             string packageId = nuspecReader.GetId();
@@ -44,7 +45,7 @@ namespace Microsoft.DotNet.PackageValidation
                 packageDependencies.Add(item.TargetFramework, item.Packages);
             }
 
-            return new Package(packageId, version, packageReader.GetFiles()?.Where(t => t.EndsWith(packageId + ".dll")), packageDependencies, runtimeGraph);
+            return new Package(packageId, version, packageReader.GetFiles()?.Where(t => t.EndsWith(assemblyName + ".dll")), packageDependencies, runtimeGraph);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
@@ -32,6 +32,7 @@
     <!-- PackageTargetPath isn't exposed by NuGet: https://github.com/NuGet/Home/issues/6671. -->
     <Microsoft.DotNet.Compatibility.ValidatePackage
       PackageTargetPath="$([MSBuild]::ValueOrDefault('$(PackageTargetPath)', '$([MSBuild]::NormalizePath('$(PackageOutputPath)', '$(PackageId).$(PackageVersion).nupkg'))'))"
+      AssemblyName="$(AssemblyName)"
       RuntimeGraph="$(RuntimeIdentifierGraphPath)"
       NoWarn="$(NoWarn)"
       RunApiCompat="$([MSBuild]::ValueOrDefault('$(RunApiCompat)', 'true'))"

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
@@ -45,7 +45,7 @@ namespace PackageValidationTests
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
-            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null, testProject.Name);
             new CompatibleFrameworkInPackageValidator(string.Empty, null, false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
             // TODO: add asserts for assembly and header metadata.
@@ -83,7 +83,7 @@ namespace PackageValidationTests
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
-            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null, testProject.Name);
             new CompatibleFrameworkInPackageValidator(string.Empty, null, false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/23646

As reported in the issue, we currently only run validation on the assemblies inside the package that have the same AssemblyName than the PackageId. This is not ideal since it is common for PackageId to be overwritten. With this change, we instead will fallback to use AssemblyName as the key to be used for detecting which assemblies should be validated. This is the release/6.0.3xx PR, I will also have one for main branch in a bit.

cc: @ericstj @Alex-Sob @iedeny @claudiamurialdo