### PR TITLE
Adding Package Validation support for cases where PackageId is different than AssemblyName

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.Compatibility/ValidatePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.Compatibility/ValidatePackage.cs
@@ -23,6 +23,9 @@ namespace Microsoft.DotNet.Compatibility
         [Required]
         public string RoslynAssembliesPath { get; set; }
 
+        [Required]
+        public string AssemblyName { get; set; }
+
         public string RuntimeGraph { get; set; }
 
         public string NoWarn { get; set; }
@@ -96,7 +99,7 @@ namespace Microsoft.DotNet.Compatibility
                 }
             }
 
-            Package package = NupkgParser.CreatePackage(PackageTargetPath, runtimeGraph);
+            Package package = NupkgParser.CreatePackage(PackageTargetPath, runtimeGraph, AssemblyName);
             CompatibilityLogger logger = new(Log, CompatibilitySuppressionFilePath, GenerateCompatibilitySuppressionFile, NoWarn);
 
             new CompatibleTfmValidator(RunApiCompat, EnableStrictModeForCompatibleTfms, logger, apiCompatReferences).Validate(package);
@@ -104,7 +107,7 @@ namespace Microsoft.DotNet.Compatibility
 
             if (!DisablePackageBaselineValidation && !string.IsNullOrEmpty(BaselinePackageTargetPath))
             {
-                Package baselinePackage = NupkgParser.CreatePackage(BaselinePackageTargetPath, runtimeGraph);
+                Package baselinePackage = NupkgParser.CreatePackage(BaselinePackageTargetPath, runtimeGraph, AssemblyName);
                 new BaselinePackageValidator(baselinePackage, RunApiCompat, logger, apiCompatReferences).Validate(package);
             }
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/NupkgParser.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/NupkgParser.cs
@@ -20,18 +20,19 @@ namespace Microsoft.DotNet.PackageValidation
         /// </summary>
         /// <param name="packagePath">The path to the package path.</param>
         /// <param name="runtimeGraph">The path to the the runtime graph.</param>
+        /// <param name="assemblyName">The name of the assembly to be used for API comparisons.</param>
         /// <returns>The package object.</returns>
-        public static Package CreatePackage(string packagePath, RuntimeGraph runtimeGraph)
+        public static Package CreatePackage(string packagePath, RuntimeGraph runtimeGraph, string assemblyName)
         {
             using (PackageArchiveReader packageReader = new PackageArchiveReader(packagePath))
             {
-                Package package = CreatePackage(packageReader, runtimeGraph);
+                Package package = CreatePackage(packageReader, runtimeGraph, assemblyName);
                 package.PackagePath = packagePath;
                 return package;
             }
         }
 
-        private static Package CreatePackage(PackageArchiveReader packageReader, RuntimeGraph runtimeGraph)
+        private static Package CreatePackage(PackageArchiveReader packageReader, RuntimeGraph runtimeGraph, string assemblyName)
         {
             NuspecReader nuspecReader = packageReader.NuspecReader;
             string packageId = nuspecReader.GetId();
@@ -44,7 +45,7 @@ namespace Microsoft.DotNet.PackageValidation
                 packageDependencies.Add(item.TargetFramework, item.Packages);
             }
 
-            return new Package(packageId, version, packageReader.GetFiles()?.Where(t => t.EndsWith(packageId + ".dll")), packageDependencies, runtimeGraph);
+            return new Package(packageId, version, packageReader.GetFiles()?.Where(t => t.EndsWith(assemblyName + ".dll")), packageDependencies, runtimeGraph);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
@@ -32,6 +32,7 @@
     <!-- PackageTargetPath isn't exposed by NuGet: https://github.com/NuGet/Home/issues/6671. -->
     <Microsoft.DotNet.Compatibility.ValidatePackage
       PackageTargetPath="$([MSBuild]::ValueOrDefault('$(PackageTargetPath)', '$([MSBuild]::NormalizePath('$(PackageOutputPath)', '$(PackageId).$(PackageVersion).nupkg'))'))"
+      AssemblyName="$(AssemblyName)"
       RuntimeGraph="$(RuntimeIdentifierGraphPath)"
       NoWarn="$(NoWarn)"
       RunApiCompat="$([MSBuild]::ValueOrDefault('$(RunApiCompat)', 'true'))"

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
@@ -45,7 +45,7 @@ namespace PackageValidationTests
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
-            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null, testProject.Name);
             new CompatibleFrameworkInPackageValidator(false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
             // TODO: add asserts for assembly and header metadata.
@@ -83,7 +83,7 @@ namespace PackageValidationTests
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
-            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null, testProject.Name);
             new CompatibleFrameworkInPackageValidator(false, _log, null).Validate(package);
             Assert.NotEmpty(_log.errors);
 

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
-            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null, testProject.Name);
 
             // First we run without references. Without references, ApiCompat should not be able to see that class First
             // removed an interface due to it's base class removing that implementation. We validate that APICompat doesn't
@@ -192,7 +192,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
-            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null, testProject.Name);
 
             Dictionary<string, HashSet<string>> references = new()
             {
@@ -238,7 +238,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
-            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null, testProject.Name);
 
             Dictionary<string, HashSet<string>> references = new()
             {
@@ -284,7 +284,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
-            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null, testProject.Name);
 
             Dictionary<string, HashSet<string>> references = new()
             {
@@ -311,7 +311,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
             Assert.Equal(string.Empty, result.StdErr);
-            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null, testProject.Name);
 
             Dictionary<string, HashSet<string>> references = new()
             {
@@ -324,6 +324,30 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
                 Assert.Empty(log.errors.Where(e => e.Contains("CP1003")));
             else
                 Assert.NotEmpty(log.errors.Where(e => e.Contains("CP1003")));
+        }
+
+        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        public void ValidatePackageValidationRunsWhenAssemblyNameIsDifferentThanPackageId()
+        {
+            TestLogger log = new TestLogger();
+
+            string sourceCode = @"
+public class MyType
+{
+#if NETSTANDARD2_0
+  public void Foo() { }
+#endif
+}";
+
+            TestProject testProject = CreateTestProject(sourceCode, "netstandard2.0;net5.0");
+            TestAsset asset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
+            PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
+            var result = packCommand.Execute("/p:PackageId=MyAwesomePackage");
+            Assert.Equal(string.Empty, result.StdErr);
+            Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(packageId: "MyAwesomePackage"), null, testProject.Name);
+
+            new CompatibleFrameworkInPackageValidator(false, log, null).Validate(package);
+            Assert.NotEmpty(log.errors.Where(e => e.Contains("CP0002")));
         }
 
         private TestProject CreateTestProject(string sourceCode, string tfms, IEnumerable<TestProject> referenceProjects = null)


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/issues/23646

Same PR as https://github.com/dotnet/sdk/pull/24439, but this one is targeting main branch as opposed to 6.0.3xx branch.