### PR TITLE
Refactor some workload APIs

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadPackInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadPackInstaller.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 {
     internal interface IWorkloadPackInstaller : IInstaller
     {
-        void InstallWorkloadPack(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null);
+        void InstallWorkloadPacks(IEnumerable<PackInfo> packInfos, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null);
 
         void RepairWorkloadPack(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -240,10 +240,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
                         workloadPackToInstall = GetPacksToInstall(workloadIds);
 
-                        foreach (var packId in workloadPackToInstall)
-                        {
-                            installer.InstallWorkloadPack(packId, sdkFeatureBand, offlineCache);
-                        }
+                        installer.InstallWorkloadPacks(workloadPackToInstall, sdkFeatureBand, offlineCache);
 
                         var recordRepo = _workloadInstaller.GetWorkloadInstallationRecordRepository();
                         newWorkloadInstallRecords = workloadIds.Except(recordRepo.GetInstalledWorkloads(sdkFeatureBand));

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -371,7 +371,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             using (FileStream fsSource = new FileStream(manifestPath, FileMode.Open, FileAccess.Read))
             {
-                var manifest = WorkloadManifestReader.ReadWorkloadManifest(manifestId.ToString(), fsSource);
+                var manifest = WorkloadManifestReader.ReadWorkloadManifest(manifestId.ToString(), fsSource, manifestPath);
                 return (new ManifestVersion(manifest.Version), manifest.Workloads.Values.OfType<WorkloadDefinition>().ToDictionary(w => w.Id));
             }
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadOptionsExtensions.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadOptionsExtensions.cs
@@ -33,12 +33,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 }
                 try
                 {
-                    foreach ((string manifestId, string informationalPath, Func<Stream> openManifestStream, Func<Stream> openLocalizationStream) in manifests)
+                    foreach (var readableManifest in manifests)
                     {
-                        using (var manifestStream = openManifestStream())
-                        using (var localizationStream = openLocalizationStream())
+                        using (var manifestStream = readableManifest.OpenManifestStream())
+                        using (var localizationStream = readableManifest.OpenLocalizationStream())
                         {
-                            var manifest = WorkloadManifestReader.ReadWorkloadManifest(manifestId, manifestStream, localizationStream, informationalPath);
+                            var manifest = WorkloadManifestReader.ReadWorkloadManifest(readableManifest.ManifestId, manifestStream, localizationStream, readableManifest.ManifestPath);
                         }
                     }
                 }

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -198,10 +198,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
 
                         workloadPackToUpdate = GetUpdatablePacks(installer);
 
-                        foreach (var packId in workloadPackToUpdate)
-                        {
-                            installer.InstallWorkloadPack(packId, sdkFeatureBand, offlineCache);
-                        }
+                        installer.InstallWorkloadPacks(workloadPackToUpdate, sdkFeatureBand, offlineCache);
+
                     },
                     rollback: () => {
                         try

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     /// </summary>
     public interface IWorkloadManifestProvider
     {
-        IEnumerable<(string manifestId, string? informationalPath, Func<Stream> openManifestStream, Func<Stream?> openLocalizationStream)> GetManifests();
+        IEnumerable<ReadableWorkloadManifest> GetManifests();
 
         IEnumerable<string> GetManifestDirectories();
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         IEnumerable<WorkloadResolver.WorkloadInfo> GetAvailableWorkloads();
         bool IsPlatformIncompatibleWorkload(WorkloadId workloadId);
         string GetManifestVersion(string manifestId);
-        IEnumerable<WorkloadResolver.ManifestInfo> GetInstalledManifests();
+        IEnumerable<WorkloadManifestInfo> GetInstalledManifests();
         string GetSdkFeatureBand();
         IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads);
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ReadableWorkloadManifest.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ReadableWorkloadManifest.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NET.Sdk.WorkloadManifestReader
+{
+    public class ReadableWorkloadManifest
+    {
+        public string ManifestId { get; }
+        public string ManifestPath { get; }
+
+        readonly Func<Stream> _openManifestStreamFunc;
+
+
+        readonly Func<Stream?> _openLocalizationStream;
+
+        public ReadableWorkloadManifest(string manifestId, string manifestPath, Func<Stream> openManifestStreamFunc, Func<Stream?> openLocalizationStream)
+        {
+            ManifestId = manifestId;
+            ManifestPath = manifestPath;
+            _openManifestStreamFunc = openManifestStreamFunc;
+            _openLocalizationStream = openLocalizationStream;
+        }
+
+        public Stream OpenManifestStream()
+        {
+            return _openManifestStreamFunc();
+        }
+
+        public Stream? OpenLocalizationStream()
+        {
+            return _openLocalizationStream();
+        }
+
+    }
+}

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -83,14 +83,14 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             }
         }
 
-        public IEnumerable<(string manifestId, string? informationalPath, Func<Stream> openManifestStream, Func<Stream?> openLocalizationStream)> GetManifests()
+        public IEnumerable<ReadableWorkloadManifest> GetManifests()
         {
             foreach (var workloadManifestDirectory in GetManifestDirectories())
             {
                 var workloadManifestPath = Path.Combine(workloadManifestDirectory, "WorkloadManifest.json");
                 var id = Path.GetFileName(workloadManifestDirectory);
 
-                yield return (
+                yield return new(
                     id,
                     workloadManifestPath,
                     () => File.OpenRead(workloadManifestPath),

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             _sdkVersionBand = sdkVersion;
         }
 
-        public IEnumerable<(string manifestId, string? informationalPath, Func<Stream> openManifestStream, Func<Stream?> openLocalizationStream)>
+        public IEnumerable<ReadableWorkloadManifest>
             GetManifests()
         {
             foreach (var workloadManifestDirectory in GetManifestDirectories())
@@ -37,7 +37,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     manifestId = manifestId.Substring(0, index);
                 }
 
-                yield return (
+                yield return new(
                     manifestId,
                     workloadManifestPath,
                     () => File.OpenRead(workloadManifestPath),

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifest.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifest.cs
@@ -12,12 +12,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     /// </summary>
     public class WorkloadManifest
     {
-        internal WorkloadManifest(string id, FXVersion version, string? description, string? informationalPath,  Dictionary<WorkloadId, BaseWorkloadDefinition> workloads, Dictionary<WorkloadPackId, WorkloadPack> packs, Dictionary<string, FXVersion>? dependsOnManifests)
+        internal WorkloadManifest(string id, FXVersion version, string? description, string manifestPath,  Dictionary<WorkloadId, BaseWorkloadDefinition> workloads, Dictionary<WorkloadPackId, WorkloadPack> packs, Dictionary<string, FXVersion>? dependsOnManifests)
         {
             Id = id;
             ParsedVersion = version;
             Description = description;
-            InformationalPath = informationalPath;
+            ManifestPath = manifestPath;
             Workloads = workloads;
             Packs = packs;
             DependsOnManifests = dependsOnManifests;
@@ -45,11 +45,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         public string? Description { get; }
 
-        /// <summary>
-        /// A path that indicates where the manifest was loaded from, for diagnostic purposes only.
-        /// Not guaranteed to be set or to be a valid filesystem path.
-        /// </summary>
-        public string? InformationalPath { get; }
+        public string ManifestPath { get; }
 
         public Dictionary<WorkloadId, BaseWorkloadDefinition> Workloads { get; }
         public Dictionary<WorkloadPackId, WorkloadPack> Packs { get; }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestInfo.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestInfo.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NET.Sdk.WorkloadManifestReader
+{
+    public class WorkloadManifestInfo
+    {
+        public WorkloadManifestInfo(string id, string version)
+        {
+            Id = id;
+            Version = version;
+        }
+
+        public string Id { get; }
+        public string Version { get; }
+    }
+}

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestInfo.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestInfo.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,10 +18,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             Id = id;
             Version = version;
             ManifestDirectory = manifestDirectory;
+            ManifestFeatureBand = Path.GetFileName(Path.GetDirectoryName(manifestDirectory))!;
         }
 
         public string Id { get; }
         public string Version { get; }
         public string ManifestDirectory { get; }
+        public string ManifestFeatureBand { get; }
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestInfo.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestInfo.cs
@@ -12,13 +12,15 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
     public class WorkloadManifestInfo
     {
-        public WorkloadManifestInfo(string id, string version)
+        public WorkloadManifestInfo(string id, string version, string manifestDirectory)
         {
             Id = id;
             Version = version;
+            ManifestDirectory = manifestDirectory;
         }
 
         public string Id { get; }
         public string Version { get; }
+        public string ManifestDirectory { get; }
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.NewtonsoftJson.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.NewtonsoftJson.cs
@@ -15,14 +15,14 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
     public partial class WorkloadManifestReader
     {
-        public static WorkloadManifest ReadWorkloadManifest(string manifestId, Stream manifestStream, Stream? localizationStream, string? informationalPath = null)
+        public static WorkloadManifest ReadWorkloadManifest(string manifestId, Stream manifestStream, Stream? localizationStream, string manifestPath)
         {
             using var textReader = new StreamReader(manifestStream, System.Text.Encoding.UTF8, true);
             using var jsonReader = new JsonTextReader(textReader);
 
             var manifestReader = new Utf8JsonStreamReader(jsonReader);
 
-            return ReadWorkloadManifest(manifestId, informationalPath, ReadLocalizationCatalog(localizationStream), ref manifestReader); ;
+            return ReadWorkloadManifest(manifestId, manifestPath, ReadLocalizationCatalog(localizationStream), ref manifestReader); ;
         }
 
         private static LocalizationCatalog? ReadLocalizationCatalog(Stream? localizationStream)

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.SystemTextJson.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.SystemTextJson.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
     public partial class WorkloadManifestReader
     {
-        public static WorkloadManifest ReadWorkloadManifest(string manifestId, Stream manifestStream, Stream? localizationStream, string? informationalPath = null)
+        public static WorkloadManifest ReadWorkloadManifest(string manifestId, Stream manifestStream, Stream? localizationStream, string manifestPath)
         {
             var readerOptions = new JsonReaderOptions
             {
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             var localizationCatalog = ReadLocalizationCatalog(localizationStream, readerOptions);
             var manifestReader = new Utf8JsonStreamReader(manifestStream, readerOptions);
 
-            return ReadWorkloadManifest(manifestId, informationalPath, localizationCatalog, ref manifestReader);
+            return ReadWorkloadManifest(manifestId, manifestPath, localizationCatalog, ref manifestReader);
         }
 
         private static LocalizationCatalog? ReadLocalizationCatalog(Stream? localizationStream, JsonReaderOptions readerOptions)

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.cs
@@ -17,8 +17,8 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
     public partial class WorkloadManifestReader
     {
-        public static WorkloadManifest ReadWorkloadManifest(string manifestId, System.IO.Stream manifestStream, string? informationalPath = null)
-            => ReadWorkloadManifest(manifestId, manifestStream, null, informationalPath);
+        public static WorkloadManifest ReadWorkloadManifest(string manifestId, System.IO.Stream manifestStream, string manifestPath)
+            => ReadWorkloadManifest(manifestId, manifestStream, null, manifestPath);
 
         private static void ConsumeToken(ref Utf8JsonStreamReader reader, JsonTokenType expected)
         {
@@ -85,7 +85,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             => throw new WorkloadManifestFormatException(Strings.DuplicateKeyAtOffset, key?.ToString() ?? throw new ArgumentNullException (nameof(key)), reader.TokenStartIndex);
 
         private static WorkloadManifest ReadWorkloadManifest(
-            string id, string? informationalPath,
+            string id, string manifestPath,
             LocalizationCatalog? localizationCatalog,
             ref Utf8JsonStreamReader reader)
         {
@@ -180,7 +180,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                             id,
                             version,
                             description,
-                            informationalPath,
+                            manifestPath,
                             workloads ?? new Dictionary<WorkloadId, BaseWorkloadDefinition> (),
                             packs ?? new Dictionary<WorkloadPackId, WorkloadPack> (),
                             dependsOn

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -683,19 +683,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             (_manifests.TryGetValue(manifestId, out WorkloadManifest? value)? value : null)?.Version
             ?? throw new Exception($"Manifest with id {manifestId} does not exist.");
 
-        public IEnumerable<ManifestInfo> GetInstalledManifests() => _manifests.Select(m => new ManifestInfo(m.Value.Id, m.Value.Version));
-
-        public class ManifestInfo
-        {
-            public ManifestInfo(string id, string version)
-            {
-                Id = id;
-                Version = version;
-            }
-
-            public string Id { get; }
-            public string Version { get; }
-        }
+        public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _manifests.Select(m => new WorkloadManifestInfo(m.Value.Id, m.Value.Version));
     }
 
     static class DictionaryExtensions

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -683,7 +683,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             (_manifests.TryGetValue(manifestId, out WorkloadManifest? value)? value : null)?.Version
             ?? throw new Exception($"Manifest with id {manifestId} does not exist.");
 
-        public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _manifests.Select(m => new WorkloadManifestInfo(m.Value.Id, m.Value.Version));
+        public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _manifests.Select(m => new WorkloadManifestInfo(m.Value.Id, m.Value.Version, Path.GetDirectoryName(m.Value.ManifestPath)!));
     }
 
     static class DictionaryExtensions

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -112,16 +112,16 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         private void LoadManifestsFromProvider(IWorkloadManifestProvider manifestProvider)
         {
-            foreach ((string manifestId, string? informationalPath, Func<Stream> openManifestStream, Func<Stream?> openLocalizationStream) in manifestProvider.GetManifests())
+            foreach (var readableManifest in manifestProvider.GetManifests())
             {
-                using (Stream manifestStream = openManifestStream())
-                using (Stream? localizationStream = openLocalizationStream())
+                using (Stream manifestStream = readableManifest.OpenManifestStream())
+                using (Stream? localizationStream = readableManifest.OpenLocalizationStream())
                 {
-                    var manifest = WorkloadManifestReader.ReadWorkloadManifest(manifestId, manifestStream, localizationStream, informationalPath);
-                    if (!_manifests.TryAdd(manifestId, manifest))
+                    var manifest = WorkloadManifestReader.ReadWorkloadManifest(readableManifest.ManifestId, manifestStream, localizationStream, readableManifest.ManifestPath);
+                    if (!_manifests.TryAdd(readableManifest.ManifestId, manifest))
                     {
-                        var existingManifest = _manifests[manifestId];
-                        throw new WorkloadManifestCompositionException(Strings.DuplicateManifestID, manifestProvider.GetType().FullName, manifestId, informationalPath, existingManifest.InformationalPath);
+                        var existingManifest = _manifests[readableManifest.ManifestId];
+                        throw new WorkloadManifestCompositionException(Strings.DuplicateManifestID, manifestProvider.GetType().FullName, readableManifest.ManifestId, readableManifest.ManifestPath, existingManifest.InformationalPath);
                     }
                 }
             }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -121,7 +121,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     if (!_manifests.TryAdd(readableManifest.ManifestId, manifest))
                     {
                         var existingManifest = _manifests[readableManifest.ManifestId];
-                        throw new WorkloadManifestCompositionException(Strings.DuplicateManifestID, manifestProvider.GetType().FullName, readableManifest.ManifestId, readableManifest.ManifestPath, existingManifest.InformationalPath);
+                        throw new WorkloadManifestCompositionException(Strings.DuplicateManifestID, manifestProvider.GetType().FullName, readableManifest.ManifestId, readableManifest.ManifestPath, existingManifest.ManifestPath);
                     }
                 }
             }
@@ -144,12 +144,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                         {
                             if (FXVersion.Compare(dependency.Value, resolvedDependency.ParsedVersion) > 0)
                             {
-                                throw new WorkloadManifestCompositionException(Strings.ManifestDependencyVersionTooLow, dependency.Key, resolvedDependency.Version, dependency.Value, manifest.Id, manifest.InformationalPath);
+                                throw new WorkloadManifestCompositionException(Strings.ManifestDependencyVersionTooLow, dependency.Key, resolvedDependency.Version, dependency.Value, manifest.Id, manifest.ManifestPath);
                             }
                         }
                         else
                         {
-                            throw new WorkloadManifestCompositionException(Strings.ManifestDependencyMissing, dependency.Key, manifest.Id, manifest.InformationalPath);
+                            throw new WorkloadManifestCompositionException(Strings.ManifestDependencyMissing, dependency.Key, manifest.Id, manifest.ManifestPath);
                     }
                     }
                 }
@@ -165,7 +165,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                         if (!_workloads.TryAdd(workload.Key, ((WorkloadDefinition)workload.Value, manifest)))
                         {
                             WorkloadManifest conflictingManifest = _workloads[workload.Key].manifest;
-                            throw new WorkloadManifestCompositionException(Strings.ConflictingWorkloadDefinition, workload.Key, manifest.Id, manifest.InformationalPath, conflictingManifest.Id, conflictingManifest.InformationalPath);
+                            throw new WorkloadManifestCompositionException(Strings.ConflictingWorkloadDefinition, workload.Key, manifest.Id, manifest.ManifestPath, conflictingManifest.Id, conflictingManifest.ManifestPath);
                         }
                     }
                 }
@@ -175,7 +175,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     if (!_packs.TryAdd(pack.Key, (pack.Value, manifest)))
                     {
                         WorkloadManifest conflictingManifest = _packs[pack.Key].manifest;
-                        throw new WorkloadManifestCompositionException(Strings.ConflictingWorkloadPack, pack.Key, manifest.Id, manifest.InformationalPath, conflictingManifest.Id, conflictingManifest.InformationalPath);
+                        throw new WorkloadManifestCompositionException(Strings.ConflictingWorkloadPack, pack.Key, manifest.Id, manifest.ManifestPath, conflictingManifest.Id, conflictingManifest.ManifestPath);
                     }
                 }
             }
@@ -196,7 +196,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                         if (!_workloads.TryAdd(redirect.Id, replacement))
                         {
                             WorkloadManifest conflictingManifest = _workloads[redirect.Id].manifest;
-                            throw new WorkloadManifestCompositionException(Strings.ConflictingWorkloadDefinition, redirect.Id, manifest.Id, manifest.InformationalPath, conflictingManifest.Id, conflictingManifest.InformationalPath);
+                            throw new WorkloadManifestCompositionException(Strings.ConflictingWorkloadDefinition, redirect.Id, manifest.Id, manifest.ManifestPath, conflictingManifest.Id, conflictingManifest.ManifestPath);
                         }
                         return true;
                     }
@@ -209,12 +209,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     var unresolved = unresolvedRedirects.Select(ur => redirects[ur]).Where(ur => !redirects.ContainsKey(ur.redirect.ReplaceWith)).FirstOrDefault();
                     if (unresolved is (WorkloadRedirect redirect, WorkloadManifest manifest))
                     {
-                        throw new WorkloadManifestCompositionException(Strings.UnresolvedWorkloadRedirect, redirect.ReplaceWith, redirect.Id, manifest.Id, manifest.InformationalPath);
+                        throw new WorkloadManifestCompositionException(Strings.UnresolvedWorkloadRedirect, redirect.ReplaceWith, redirect.Id, manifest.Id, manifest.ManifestPath);
                     }
                     else
                     {
                         var cyclic = redirects[unresolvedRedirects.First()];
-                        throw new WorkloadManifestCompositionException(Strings.CyclicWorkloadRedirect, cyclic.redirect.Id, cyclic.manifest.Id, cyclic.manifest.InformationalPath);
+                        throw new WorkloadManifestCompositionException(Strings.CyclicWorkloadRedirect, cyclic.redirect.Id, cyclic.manifest.Id, cyclic.manifest.ManifestPath);
                     }
                 }
             }
@@ -417,7 +417,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
                     if (_workloads.TryGetValue(baseWorkloadId) is not (WorkloadDefinition baseWorkload, WorkloadManifest baseWorkloadManifest))
                     {
-                        throw new WorkloadManifestCompositionException(Strings.MissingBaseWorkload, baseWorkloadId, workload.Id, manifest.Id, manifest.InformationalPath);
+                        throw new WorkloadManifestCompositionException(Strings.MissingBaseWorkload, baseWorkloadId, workload.Id, manifest.Id, manifest.ManifestPath);
                     }
 
                     // the workload's ID may not match the value we looked up if it's a redirect

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
@@ -28,11 +28,11 @@ namespace ManifestReaderTests
 
         public IEnumerable<string> GetManifestDirectories() => throw new NotImplementedException();
 
-        public IEnumerable<(string manifestId, string? informationalPath, Func<Stream> openManifestStream, Func<Stream?> openLocalizationStream)> GetManifests()
+        public IEnumerable<ReadableWorkloadManifest> GetManifests()
         {
             foreach (var filePath in _filePaths)
             {
-                yield return (
+                yield return new(
                     Path.GetFileNameWithoutExtension(filePath.manifest),
                     filePath.manifest,
                     () => new FileStream(filePath.manifest, FileMode.Open, FileAccess.Read),
@@ -51,10 +51,10 @@ namespace ManifestReaderTests
         public void Add(string id, string content) => _manifests.Add((id, Encoding.UTF8.GetBytes(content)));
         public IEnumerable<string> GetManifestDirectories() => throw new NotImplementedException();
 
-        public IEnumerable<(string manifestId, string? informationalPath, Func<Stream> openManifestStream, Func<Stream?> openLocalizationStream)> GetManifests()
-            => _manifests.Select(m => (
+        public IEnumerable<ReadableWorkloadManifest> GetManifests()
+            => _manifests.Select(m => new ReadableWorkloadManifest(
                 m.id,
-                (string?)null,
+                $@"C:\fake\{m.id}\WorkloadManifest.json",
                 (Func<Stream>)(() => new MemoryStream(m.content)),
                 (Func<Stream?>)(() => null)
             ));

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
@@ -37,7 +37,7 @@ namespace ManifestReaderTests
         {
             using (FileStream fsSource = new FileStream(ManifestPath, FileMode.Open, FileAccess.Read))
             {
-                var result = WorkloadManifestReader.ReadWorkloadManifest("Sample", fsSource);
+                var result = WorkloadManifestReader.ReadWorkloadManifest("Sample", fsSource, ManifestPath);
                 result.Version.Should().Be("5.0.0-preview1");
                 var xamAndroidId = new WorkloadPackId("Xamarin.Android.Sdk");
 
@@ -209,9 +209,10 @@ namespace ManifestReaderTests
         [Fact]
         public void WillNotLoadManifestWithNullAlias()
         {
-            using FileStream fsSource = new FileStream(GetSampleManifestPath("NullAliasError.json"), FileMode.Open, FileAccess.Read);
+            var manifestPath = GetSampleManifestPath("NullAliasError.json");
+            using FileStream fsSource = new FileStream(manifestPath, FileMode.Open, FileAccess.Read);
 
-            var ex = Assert.Throws<WorkloadManifestFormatException>(() => WorkloadManifestReader.ReadWorkloadManifest("NullAliasError", fsSource));
+            var ex = Assert.Throws<WorkloadManifestFormatException>(() => WorkloadManifestReader.ReadWorkloadManifest("NullAliasError", fsSource, manifestPath));
             Assert.Contains("Expected string value at offset", ex.Message);
         }
 

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -96,7 +96,7 @@ namespace ManifestReaderTests
                 = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "5.0.100", userProfileDir: null);
 
             Action a = () => sdkDirectoryWorkloadManifestProvider.GetManifests().Select(m => {
-                using (m.openManifestStream()) { }
+                using (m.OpenManifestStream()) { }
                 return true;
             }).ToList();
 
@@ -320,7 +320,7 @@ namespace ManifestReaderTests
 
         private IEnumerable<string> GetManifestContents(SdkDirectoryWorkloadManifestProvider manifestProvider)
         {
-            return manifestProvider.GetManifests().Select(manifest => new StreamReader(manifest.openManifestStream()).ReadToEnd());
+            return manifestProvider.GetManifests().Select(manifest => new StreamReader(manifest.OpenManifestStream()).ReadToEnd());
         }
 
         private class EnvironmentMock

--- a/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller();
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", "Xamarin.Android.Sdk", "8.4.7"), "Xamarin.Android.Sdk");
             var version = "6.0.100";
-            installer.InstallWorkloadPack(packInfo, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
 
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;
             mockNugetInstaller.DownloadCallParams.Count.Should().Be(1);
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller();
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Template, Path.Combine(dotnetRoot, "template-packs", "Xamarin.Android.Sdk.8.4.7.nupkg"), "Xamarin.Android.Sdk");
             var version = "6.0.100";
-            installer.InstallWorkloadPack(packInfo, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
 
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams.Count.Should().Be(1);
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams[0].ShouldBeEquivalentTo((new PackageId(packInfo.Id), new NuGetVersion(packInfo.Version), null as DirectoryPath?, null as PackageSourceLocation));
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var alias = "Xamarin.Android.BuildTools.Alias";
             var packInfo = CreatePackInfo("Xamarin.Android.BuildTools", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", alias, "8.4.7"), alias);
             var version = "6.0.100";
-            installer.InstallWorkloadPack(packInfo, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
 
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams.Count.Should().Be(1);
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams[0].ShouldBeEquivalentTo((new PackageId(alias), new NuGetVersion(packInfo.Version), null as DirectoryPath?, null as PackageSourceLocation));
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller(packageSourceLocation: packageSource);
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", "Xamarin.Android.Sdk", "8.4.7"), "Xamarin.Android.Sdk");
             var version = "6.0.100";
-            installer.InstallWorkloadPack(packInfo, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
 
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;
             mockNugetInstaller.DownloadCallParams.Count.Should().Be(1);
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Mock installing the pack
             Directory.CreateDirectory(packInfo.Path);
 
-            installer.InstallWorkloadPack(packInfo, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
 
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams.Count.Should().Be(0);
         }
@@ -203,7 +203,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller(failingInstaller: true);
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", "Xamarin.Android.Sdk", "8.4.7"), "Xamarin.Android.Sdk");
             
-            var exceptionThrown = Assert.Throws<Exception>(() => installer.InstallWorkloadPack(packInfo, new SdkFeatureBand(version)));
+            var exceptionThrown = Assert.Throws<Exception>(() => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version)));
             exceptionThrown.Message.Should().Be("Test Failure");
             var failingNugetInstaller = nugetInstaller as FailingNuGetPackageDownloader;
             // Nupkgs should be removed
@@ -399,7 +399,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var nupkgPath = Path.Combine(cachePath, $"{packInfo.ResolvedPackageId}.{packInfo.Version}.nupkg");
             File.Create(nupkgPath);
 
-            installer.InstallWorkloadPack(packInfo, new SdkFeatureBand(version), new DirectoryPath(cachePath));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new DirectoryPath(cachePath));
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;
             
             // We shouldn't download anything, use the cache
@@ -422,7 +422,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var version = "6.0.100";
             var cachePath = Path.Combine(dotnetRoot, "MockCache");
             
-            var exceptionThrown = Assert.Throws<Exception>(() => installer.InstallWorkloadPack(packInfo, new SdkFeatureBand(version), new DirectoryPath(cachePath)));
+            var exceptionThrown = Assert.Throws<Exception>(() => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new DirectoryPath(cachePath)));
             exceptionThrown.Message.Should().Contain(packInfo.ResolvedPackageId);
             exceptionThrown.Message.Should().Contain(packInfo.Version);
             exceptionThrown.Message.Should().Contain(cachePath);

--- a/src/Tests/dotnet-workload-install.Tests/MockManifestProvider.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockManifestProvider.cs
@@ -34,11 +34,11 @@ namespace ManifestReaderTests
             }
         }
 
-        public IEnumerable<(string manifestId, string informationalPath, Func<Stream> openManifestStream, Func<Stream> openLocalizationStream)> GetManifests()
+        public IEnumerable<ReadableWorkloadManifest> GetManifests()
             {
                 foreach ((var id, var path) in _manifests)
                 {
-                    yield return (
+                    yield return new(
                         id,
                         path,
                         () => File.OpenRead(path),

--- a/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
@@ -38,19 +38,22 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             FailingGarbageCollection = failingGarbageCollection;
         }
 
-        public void InstallWorkloadPack(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null)
+        public void InstallWorkloadPacks(IEnumerable<PackInfo> packInfos, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null)
         {
-            InstalledPacks = InstalledPacks.Append(packInfo).ToList();
-            CachePath = offlineCache?.Value;
-            if (packInfo.Id.ToString().Equals(FailingPack))
+            foreach (var packInfo in packInfos)
             {
-                throw new Exception($"Failing pack: {packInfo.Id}");
+                InstalledPacks = InstalledPacks.Append(packInfo).ToList();
+                CachePath = offlineCache?.Value;
+                if (packInfo.Id.ToString().Equals(FailingPack))
+                {
+                    throw new Exception($"Failing pack: {packInfo.Id}");
+                }
             }
         }
 
         public void RepairWorkloadPack(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null)
         {
-            InstallWorkloadPack(packInfo, sdkFeatureBand, offlineCache);
+            InstallWorkloadPacks(new[] { packInfo }, sdkFeatureBand, offlineCache);
         }
 
         public void RollBackWorkloadPackInstall(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null)

--- a/src/Tests/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/src/Tests/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public WorkloadResolver.PackInfo TryGetPackInfo(WorkloadPackId packId) => throw new NotImplementedException();
         public bool IsPlatformIncompatibleWorkload(WorkloadId workloadId) => throw new NotImplementedException();
         public string GetManifestVersion(string manifestId) => throw new NotImplementedException();
-        public IEnumerable<WorkloadResolver.ManifestInfo> GetInstalledManifests() => throw new NotImplementedException();
+        public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();

--- a/src/Tests/dotnet-workload-update.Tests/TempDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/dotnet-workload-update.Tests/TempDirectoryWorkloadManifestProviderTests.cs
@@ -66,11 +66,11 @@ namespace dotnet.Tests
 
             TempDirectoryWorkloadManifestProvider tempDirectoryWorkloadManifestProvider =
                 new TempDirectoryWorkloadManifestProvider(_manifestDirectory, mockWorkloadResolver.GetSdkFeatureBand());
-            IEnumerable<(string manifestId, string informationalPath, Func<Stream> openManifestStream, Func<Stream> openLocalizationStream)> manifest =
+            IEnumerable<ReadableWorkloadManifest> manifest =
                 tempDirectoryWorkloadManifestProvider.GetManifests();
-            manifest.First().manifestId.Should()
+            manifest.First().ManifestId.Should()
                 .NotBe("microsoft.net.workload.emscripten.manifest-6.0.100.6.0.0-preview.7.21377.2");
-            manifest.First().manifestId.Should()
+            manifest.First().ManifestId.Should()
                 .BeEquivalentTo("microsoft.net.workload.emscripten");
         }
 


### PR DESCRIPTION
Refactoring to support various things:

- Pass list of packs to pack installer, in order to support grouping workload packs (#21741)
- Save and provide path to workload manifest directory.  This will also support grouping workload packs, so that we can add additional information to the MSI-based workload manifest install about which packs are grouped together
- Add property to retrieve workload manifest feature band.  This will help support #23402 and #23403