### PR TITLE
Detect arm64 hostfxr.dll

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.NativeWrapper
         {
             string basePath = Path.GetDirectoryName(typeof(Interop).Assembly.Location);
             string architecture = IntPtr.Size == 8 ? "x64" : "x86";
-            architecture = dllFileName.Equals("hostfxr", StringComparison.OrdinalIgnoreCase) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : architecture;
+            architecture = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : architecture;
             string dllPath = Path.Combine(basePath, architecture, $"{dllFileName}.dll");
 
             // return value is intentionally ignored as we let the subsequent P/Invokes fail naturally.

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -40,6 +40,7 @@ namespace Microsoft.DotNet.NativeWrapper
         {
             string basePath = Path.GetDirectoryName(typeof(Interop).Assembly.Location);
             string architecture = IntPtr.Size == 8 ? "x64" : "x86";
+            architecture = dllFileName.Equals("hostfxr", StringComparison.OrdinalIgnoreCase) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : architecture;
             string dllPath = Path.Combine(basePath, architecture, $"{dllFileName}.dll");
 
             // return value is intentionally ignored as we let the subsequent P/Invokes fail naturally.


### PR DESCRIPTION
Help msbuild understand when it should load an arm64 hostfxr. I verified this works locally on an arm64 machine.

The check arm64 folder check should only run when finding `hostfxr`, otherwise we crash later in the build.