### PR TITLE
Make enabling C++/CLI activation feature also enable native hosting

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -42,6 +42,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
     <AutoreleasePoolSupport Condition="'$(AutoreleasePoolSupport)' == ''">false</AutoreleasePoolSupport>
     <EnableCppCLIHostActivation Condition="'$(EnableCppCLIHostActivation)' == ''">false</EnableCppCLIHostActivation>
+    <!-- C++/CLI activation requires native hosting -->
+    <_EnableConsumingManagedCodeFromNativeHosting Condition="'$(EnableCppCLIHostActivation)' == 'true'">true</_EnableConsumingManagedCodeFromNativeHosting>
     <_EnableConsumingManagedCodeFromNativeHosting Condition="'$(_EnableConsumingManagedCodeFromNativeHosting)' == ''">false</_EnableConsumingManagedCodeFromNativeHosting>
     <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
   </PropertyGroup>
@@ -205,7 +207,7 @@ Copyright (c) .NET Foundation. All rights reserved.
    <Target Name="PrepareForILLink"
            DependsOnTargets="_ComputeManagedAssemblyToLink">
 
-    <!-- We print a message to the user to explain that trimming is 
+    <!-- We print a message to the user to explain that trimming is
          potentially problematic when warnings are suppressed. -->
     <NETSdkInformation Condition="'$(PublishTrimmed)' == 'true' And '$(SuppressTrimAnalysisWarnings)' == 'true'" ResourceName="ILLinkOptimizedAssemblies" />
 


### PR DESCRIPTION
With https://github.com/dotnet/runtime/pull/66486, C++/CLI activation also requires native hosting. This change enables native hosting if a user enables C++/CLI activation (`EnableCppCLIHostActivation=true`)

cc @agocke @AaronRobinsonMSFT @vitek-karas 