### PR TITLE
Remove 'reflecting any global.json' from info label

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -149,7 +149,7 @@ Possible reasons for this include:
     <value>.NET SDK</value>
   </data>
   <data name="DotNetSdkInfoLabel" xml:space="preserve">
-    <value>.NET SDK (reflecting any global.json):</value>
+    <value>.NET SDK:</value>
   </data>
   <data name="DotNetRuntimeInfoLabel" xml:space="preserve">
     <value>Runtime Environment:</value>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
@@ -76,8 +76,8 @@ Mezi možné příčiny patří toto:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">Sada .NET SDK (s ohledem na libovolný soubor global.json):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">Sada .NET SDK (s ohledem na libovolný soubor global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
@@ -76,8 +76,8 @@ Mögliche Ursachen:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">.NET SDK (gemäß "global.json"):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">.NET SDK (gemäß "global.json"):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
@@ -76,8 +76,8 @@ Algunas de las posibles causas son :
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">SDK de .NET (que refleje cualquier global.json):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">SDK de .NET (que refleje cualquier global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
@@ -76,8 +76,8 @@ Raisons possibles :
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">SDK .NET (reflétant tous les fichiers global.json) :</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">SDK .NET (reflétant tous les fichiers global.json) :</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
@@ -76,8 +76,8 @@ Motivi possibili:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">.NET SDK (che rispecchia un qualsiasi file global.json):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">.NET SDK (che rispecchia un qualsiasi file global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
@@ -76,8 +76,8 @@ Possible reasons for this include:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">.NET SDK (global.json を反映):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">.NET SDK (global.json を反映):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
@@ -76,8 +76,8 @@ Possible reasons for this include:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">.NET SDK(global.json 반영):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">.NET SDK(global.json 반영):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
@@ -76,8 +76,8 @@ Możliwe przyczyny:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">Zestaw .NET SDK (odzwierciedlenie dowolnego pliku global.json):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">Zestaw .NET SDK (odzwierciedlenie dowolnego pliku global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
@@ -76,8 +76,8 @@ Possíveis motivos para isso incluem:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">SDK do .NET (refletindo qualquer global.json):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">SDK do .NET (refletindo qualquer global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
@@ -76,8 +76,8 @@ Possible reasons for this include:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">Пакет SDK для .NET (отражающий любой global.json):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">Пакет SDK для .NET (отражающий любой global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
@@ -76,8 +76,8 @@ Bunun nedeni şunlardan biri olabilir:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">.NET SDK (varsa global.json dosyasını yansıtır):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">.NET SDK (varsa global.json dosyasını yansıtır):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
@@ -76,8 +76,8 @@ Possible reasons for this include:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">.NET SDK (反映任何 global.json):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">.NET SDK (反映任何 global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
@@ -76,8 +76,8 @@ Possible reasons for this include:
         <note />
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
-        <source>.NET SDK (reflecting any global.json):</source>
-        <target state="translated">.NET SDK (反映任何 global.json):</target>
+        <source>.NET SDK:</source>
+        <target state="needs-review-translation">.NET SDK (反映任何 global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">


### PR DESCRIPTION
Remove `(reflecting any global.json)` from the SDK info label per https://github.com/dotnet/runtime/pull/67022#issuecomment-1077893846

cc @richlander 