### PR TITLE
[release/6.0.3xx] changed names of `dotnet new` providers

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/BuiltInTemplatePackageProviderFactory.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/BuiltInTemplatePackageProviderFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Tools.New
     {
         public static readonly Guid FactoryId = new Guid("{4B11226E-4594-43A4-B843-EB97447B6455}");
 
-        public string DisplayName => "BuiltIn SDK packages";
+        public string DisplayName => ".NET SDK";
 
         public Guid Id { get => FactoryId; }
 

--- a/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProviderFactory.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProviderFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Tools.New
 
         public Guid Id => FactoryId;
 
-        public string DisplayName => "OptionalWorkloads";
+        public string DisplayName => "Optional workloads";
 
         public ITemplatePackageProvider CreateProvider(IEngineEnvironmentSettings settings)
         {


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/24565 to 6.0.3xx