### PR TITLE
Add a fabricbot.json file to auto close issues with "Area-NuGet" label

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -92,7 +92,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Thanks for creating this issue! We believe this issue is related to NuGet tooling, which is maintained by the NuGet team. Thus, we closed this one and encourage you to raise this issue in the [NuGet repository](https://github.com/NuGet/Home) instead. Don’t forget to check out [NuGet’s contributing guide](https://github.com/NuGet/Home/blob/dev/CONTRIBUTING.md#before-submitting-an-issue) before submitting an issue!\n\nHappy Coding!"
+              "comment": "Thanks for creating this issue! We believe this issue is related to NuGet tooling, which is maintained by the NuGet team. Thus, we closed this one and encourage you to raise this issue in the [NuGet repository](https://github.com/NuGet/Home) instead. Don’t forget to check out [NuGet’s contributing guide](https://github.com/NuGet/Home/blob/dev/CONTRIBUTING.md#before-submitting-an-issue) before submitting an issue!\n\nIf you believe this issue was closed out of error, please comment to let us know.\n\nHappy Coding!"
             }
           },
           {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,106 @@
+[
+    {
+      "taskType": "trigger",
+      "capabilityId": "AutoMerge",
+      "subCapability": "AutoMerge",
+      "version": "1.0",
+      "config": {
+        "taskName": "Automatically merge pull requests",
+        "deleteBranches": true,
+        "removeLabelOnPush": true,
+        "mergeType": "squash",
+        "minMinutesOpen": "12",
+        "label": "Auto-Merge If Tests Pass",
+        "requireAllStatuses": true
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              16
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              16
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              16
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              16
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              16
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              16
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              16
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Area-NuGet"
+            }
+          }
+        ],
+        "taskName": "Auto close \"Area-NuGet\" issues and add a comment pointing to NuGet repo",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Thanks for creating this issue! We believe this issue is related to NuGet tooling, which is maintained by the NuGet team. Thus, we closed this one and encourage you to raise this issue in the [NuGet repository](https://github.com/NuGet/Home) instead. Don’t forget to check out [NuGet’s contributing guide](https://github.com/NuGet/Home/blob/dev/CONTRIBUTING.md#before-submitting-an-issue) before submitting an issue!\n\nHappy Coding!"
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      },
+      "disabled": false
+    }
+  ]


### PR DESCRIPTION
The MerlinBot team previously sent out the email "Heads up: Expect open PRs in your FabricBot enabled repos, onboarding you to config-as-code". So I export the configuration file from dotnet/sdk repo with the existing ruleset and the ruleset I added to auto close the issues with "Area-NuGet" label.

The new ruleset added by this PR is to do the following every 4pm(PST) for issues with "Area-NuGet" label:
1. Add a comment as following:

> Thanks for creating this issue! We believe this issue is related to NuGet tooling, which is maintained by the NuGet team. Thus, we closed this one and encourage you to raise this issue in the [NuGet repository](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FNuGet%2FHome&data=05%7C01%7CLiu.Heng%40microsoft.com%7C165fea0352f74bdd497308da22339327%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C637859902163765452%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=aNQqXqO0F9QCscWghuiljwEPRYvAIWNTU%2BTLxeZl85Q%3D&reserved=0) instead. Don’t forget to check out NuGet’s contributing guide before submitting an issue! 
> 
> If you believe this issue was closed out of error, please comment to let us know.
>  
> Happy Coding!

2. Close the issue.

So when the issue is closed by mistake, if customer is confident it’s not a NuGet issue, we encourage them to leave a comment. Or else, after they raise the issue in NuGet repo,  NuGet team finds that the issue is not related to NuGet tooling, then NuGet team will:
1.	Remove the Area-NuGet label from the original issue in dotnet/sdk repo
2.	Re-open the issue in dotnet/sdk repo
3.	Close the issue in NuGet/Home (if the customer filed a new one, although unlikely)
