### PR TITLE
Pin the compiler version in RSG to an exact version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -150,6 +150,7 @@
   <PropertyGroup Label="Manually updated">
     <!-- Dependencies from https://github.com/microsoft/MSBuildLocator -->
     <MicrosoftBuildLocatorPackageVersion>1.4.1</MicrosoftBuildLocatorPackageVersion>
+    <MicrosoftCodeAnalysisCSharpAnalyzerPinnedVersionPackageVersion>4.0.1</MicrosoftCodeAnalysisCSharpAnalyzerPinnedVersionPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/xliff-tasks -->

--- a/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
+++ b/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
@@ -11,8 +11,14 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Use a pinned version of the compiler unless building from source. This avoids issues where the source generator is unable to launch in VS because the compiler versions is older than the one in the SDK. -->
+    <RSG_MicrosoftCodeAnalysisCSharpPackageVersion Condition="'$(DotNetBuildFromSource)' != 'true'">$(MicrosoftCodeAnalysisCSharpAnalyzerPinnedVersionPackageVersion)</RSG_MicrosoftCodeAnalysisCSharpPackageVersion>
+    <RSG_MicrosoftCodeAnalysisCSharpPackageVersion Condition="'$(DotNetBuildFromSource)' == 'true'">$(MicrosoftCodeAnalysisCSharpPackageVersion)</RSG_MicrosoftCodeAnalysisCSharpPackageVersion>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RSG_MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal" Version="$(MicrosoftAspNetCoreRazorSourceGeneratorToolingInternalPackageVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

Sets the version of `Microsoft.CodeAnalysis.CSharp` referenced by the razor source generator to `4.0.1`. This ensures that it won't use newer Roslyn APIs and continue to be consumable in earlier VS releases.

Fixes https://github.com/dotnet/sdk/issues/23972

## Customer Impact

Customers using a newer version of the SDK on earlier version of Visual Studio are unable to run the razor source generator, and thus cannot successfully build any Razor/Blazor projects from within VS.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

No code changes, just references a lower version that will be available in VS at runtime.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
