### PR TITLE
Support installing workload pack groups

### DIFF
--- a/src/Cli/dotnet/CliTransaction.cs
+++ b/src/Cli/dotnet/CliTransaction.cs
@@ -26,6 +26,10 @@ namespace Microsoft.DotNet.Cli
         //  Delegate called when rollback fails.  If set, exception will be passed to the delegate, but not rethrown
         public Action<Exception> RollbackFailed { get; set; }
 
+        public static void RunNew(Action<ITransactionContext> action)
+        {
+            new CliTransaction().Run(action);
+        }
 
         public void Run(Action<ITransactionContext> action, Action rollback)
         {
@@ -96,20 +100,6 @@ namespace Microsoft.DotNet.Cli
             {
                 CleanupActions.Add(action);
             }
-        }
-    }
-
-    //  Transaction context to use when there is no transaction
-    internal class NullTransactionContext : ITransactionContext
-    {
-        public void AddCleanupAction(Action action)
-        {
-
-        }
-
-        public void AddRollbackAction(Action action)
-        {
-
         }
     }
 

--- a/src/Cli/dotnet/Installer/Windows/WorkloadPackRecord.cs
+++ b/src/Cli/dotnet/Installer/Windows/WorkloadPackRecord.cs
@@ -3,7 +3,7 @@
 #nullable disable
 
 using System;
-
+using System.Collections.Generic;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 using NuGet.Versioning;
@@ -11,8 +11,10 @@ using NuGet.Versioning;
 namespace Microsoft.DotNet.Installer.Windows
 {
     /// <summary>
-    /// Represents a single workload pack installation record in the registry created
-    /// by a workload pack MSI.
+    /// Represents a workload pack installation record in the registry created
+    /// by a workload pack MSI.  This may represent either an individual workload pack
+    /// MSI, or a workload pack group MSI which is a single MSI that installs multiple
+    /// workload packs.
     /// </summary>
     internal class WorkloadPackRecord
     {
@@ -26,22 +28,29 @@ namespace Microsoft.DotNet.Installer.Windows
         }
 
         /// <summary>
-        /// The ID of the workload pack.
+        /// An identifier for the MSI.  If this is an MSI for a single workload pack, it will be the ID of the pack.
+        /// If it's an MSI with multiple workload packs (a workload pack group), then the ID will be the ID of the group.
+        /// This ID does NOT include the ".Msi.{HostArchitecture}" suffix
         /// </summary>
-        public WorkloadPackId PackId
+        public string MsiId
         {
             get;
             set;
         }
 
         /// <summary>
-        /// The semantic version of the workload pack.
+        /// The version of the workload pack installed by this MSI, or the version of the group of packs
         /// </summary>
-        public NuGetVersion PackVersion
+        public string MsiNuGetVersion
         {
             get;
             set;
         }
+
+        /// <summary>
+        /// The workload pack IDs and versions that are installed by this MSI
+        /// </summary>
+        public List<(WorkloadPackId id, NuGetVersion version)> InstalledPacks { get; set; } = new();
 
         /// <summary>
         /// The product code (GUID) of the workload pack MSI.

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
@@ -17,7 +18,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         IWorkloadInstaller GetWorkloadInstaller();
 
-        void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, DirectoryPath? offlineCache = null, bool isRollback = false);
+        void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null, bool isRollback = false);
 
         IWorkloadInstallationRecordRepository GetWorkloadInstallationRecordRepository();
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install
 {
@@ -16,7 +17,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         IWorkloadInstaller GetWorkloadInstaller();
 
-        void InstallWorkloadManifest(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null, bool isRollback = false);
+        void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, DirectoryPath? offlineCache = null, bool isRollback = false);
 
         IWorkloadInstallationRecordRepository GetWorkloadInstallationRecordRepository();
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
@@ -17,12 +17,14 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         IEnumerable<(
             ManifestId manifestId, 
-            ManifestVersion existingVersion, 
+            ManifestVersion existingVersion,
+            SdkFeatureBand existingFeatureBand,
             ManifestVersion newVersion,
-            Dictionary<WorkloadId, WorkloadDefinition> Workloads,
-            SdkFeatureBand newFeatureBand)> CalculateManifestUpdates();
+            SdkFeatureBand newFeatureBand,
+            Dictionary<WorkloadId, WorkloadDefinition> Workloads
+            )> CalculateManifestUpdates();
 
-        IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion, SdkFeatureBand newFeatureBand)>
+        IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, SdkFeatureBand existingFeatureBand, ManifestVersion newVersion,  SdkFeatureBand newFeatureBand)>
             CalculateManifestRollbacks(string rollbackDefinitionFilePath);
 
         Task<IEnumerable<string>> DownloadManifestPackagesAsync(bool includePreviews, DirectoryPath downloadPath);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 
@@ -18,9 +19,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             ManifestId manifestId, 
             ManifestVersion existingVersion, 
             ManifestVersion newVersion,
-            Dictionary<WorkloadId, WorkloadDefinition> Workloads)> CalculateManifestUpdates();
+            Dictionary<WorkloadId, WorkloadDefinition> Workloads,
+            SdkFeatureBand newFeatureBand)> CalculateManifestUpdates();
 
-        IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion)>
+        IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion, SdkFeatureBand newFeatureBand)>
             CalculateManifestRollbacks(string rollbackDefinitionFilePath);
 
         Task<IEnumerable<string>> DownloadManifestPackagesAsync(bool includePreviews, DirectoryPath downloadPath);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
@@ -16,15 +16,11 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         Task BackgroundUpdateAdvertisingManifestsWhenRequiredAsync();
 
         IEnumerable<(
-            ManifestId manifestId, 
-            ManifestVersion existingVersion,
-            SdkFeatureBand existingFeatureBand,
-            ManifestVersion newVersion,
-            SdkFeatureBand newFeatureBand,
+            ManifestVersionUpdate manifestUpdate,
             Dictionary<WorkloadId, WorkloadDefinition> Workloads
             )> CalculateManifestUpdates();
 
-        IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, SdkFeatureBand existingFeatureBand, ManifestVersion newVersion,  SdkFeatureBand newFeatureBand)>
+        IEnumerable<ManifestVersionUpdate>
             CalculateManifestRollbacks(string rollbackDefinitionFilePath);
 
         Task<IEnumerable<string>> DownloadManifestPackagesAsync(bool includePreviews, DirectoryPath downloadPath);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadPackInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadPackInstaller.cs
@@ -6,16 +6,15 @@ using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using System.Collections.Generic;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.DotNet.Cli;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install
 {
     internal interface IWorkloadPackInstaller : IInstaller
     {
-        void InstallWorkloadPacks(IEnumerable<PackInfo> packInfos, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null);
+        void InstallWorkloadPacks(IEnumerable<PackInfo> packInfos, SdkFeatureBand sdkFeatureBand, ITransactionContext transactionContext, DirectoryPath? offlineCache = null);
 
-        void RepairWorkloadPack(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null);
-
-        void RollBackWorkloadPackInstall(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null);
+        void RepairWorkloadPack(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, ITransactionContext transactionContext, DirectoryPath? offlineCache = null);
 
         void DownloadToOfflineCache(PackInfo packInfo, DirectoryPath offlineCache, bool includePreviews);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.Versioning;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
 using Microsoft.Win32;
 using Microsoft.Win32.Msi;
 using NuGet.Versioning;
@@ -81,11 +82,6 @@ namespace Microsoft.DotNet.Installer.Windows
         protected readonly IReporter Reporter;
 
         /// <summary>
-        /// Gets the set of currently installed workload pack records by querying the registry.
-        /// </summary>
-        protected IReadOnlyDictionary<string, List<WorkloadPackRecord>> WorkloadPackRecords => GetWorkloadPackRecords();
-
-        /// <summary>
         /// A service controller representing the Windows Update agent (wuaserv).
         /// </summary>
         protected readonly WindowsUpdateAgent UpdateAgent;
@@ -114,21 +110,24 @@ namespace Microsoft.DotNet.Installer.Windows
         /// Detect installed workload pack records. Only the default registry hive is searched. Finding a workload pack
         /// record does not necessarily guarantee that the MSI is installed.
         /// </summary>
-        private IReadOnlyDictionary<string, List<WorkloadPackRecord>> GetWorkloadPackRecords()
+        protected List<WorkloadPackRecord> GetWorkloadPackRecords()
         {
             Log?.LogMessage($"Detecting installed workload packs for {HostArchitecture}.");
-            Dictionary<string, List<WorkloadPackRecord>> workloadPackRecords = new Dictionary<string, List<WorkloadPackRecord>>();
+            List<WorkloadPackRecord> workloadPackRecords = new();
             using RegistryKey installedPacksKey = Registry.LocalMachine.OpenSubKey(@$"SOFTWARE\Microsoft\dotnet\InstalledPacks\{HostArchitecture}");
+
+            void SetRecordMsiProperties(WorkloadPackRecord record, RegistryKey key)
+            {
+                record.ProviderKeyName = (string)key.GetValue("DependencyProviderKey");
+                record.ProductCode = (string)key.GetValue("ProductCode");
+                record.ProductVersion = new Version((string)key.GetValue("ProductVersion"));
+                record.UpgradeCode = (string)key.GetValue("UpgradeCode");
+            }
 
             if (installedPacksKey != null)
             {
                 foreach (string packId in installedPacksKey.GetSubKeyNames())
                 {
-                    if (!workloadPackRecords.ContainsKey(packId))
-                    {
-                        workloadPackRecords[packId] = new List<WorkloadPackRecord>();
-                    }
-
                     using RegistryKey packKey = installedPacksKey.OpenSubKey(packId);
 
                     foreach (string packVersion in packKey.GetSubKeyNames())
@@ -137,22 +136,59 @@ namespace Microsoft.DotNet.Installer.Windows
 
                         WorkloadPackRecord record = new WorkloadPackRecord
                         {
-                            ProviderKeyName = (string)packVersionKey.GetValue("DependencyProviderKey"),
-                            PackId = new NET.Sdk.WorkloadManifestReader.WorkloadPackId(packId),
-                            PackVersion = new NuGetVersion(packVersion),
-                            ProductCode = (string)packVersionKey.GetValue("ProductCode"),
-                            ProductVersion = new Version((string)packVersionKey.GetValue("ProductVersion")),
-                            UpgradeCode = (string)packVersionKey.GetValue("UpgradeCode"),
+                            MsiId = packId,
+                            MsiNuGetVersion = packVersion,
                         };
 
-                        Log?.LogMessage($"Found workload pack record, Id: {record.PackId}, version: {record.PackVersion}, ProductCode: {record.ProductCode}, provider key: {record.ProviderKeyName}");
+                        SetRecordMsiProperties(record, packVersionKey);
 
-                        workloadPackRecords[packId].Add(record);
+                        record.InstalledPacks.Add((new WorkloadPackId(packId), new NuGetVersion(packVersion)));
+
+                        Log?.LogMessage($"Found workload pack record, Id: {packId}, version: {packVersion}, ProductCode: {record.ProductCode}, provider key: {record.ProviderKeyName}");
+
+                        workloadPackRecords.Add(record);
                     }
                 }
             }
 
-            return new ReadOnlyDictionary<string, List<WorkloadPackRecord>>(workloadPackRecords);
+            //  Workload pack group installation records are in a similar format as the pack installation records.  They use the "InstalledPackGroups" key,
+            //  and under the key for each pack group/version are keys for the workload pack IDs and versions that are in the pack gorup.
+            using RegistryKey installedPackGroupsKey = Registry.LocalMachine.OpenSubKey(@$"SOFTWARE\Microsoft\dotnet\InstalledPackGroups\{HostArchitecture}");
+            if (installedPackGroupsKey != null)
+            {
+                foreach (string packGroupId in installedPackGroupsKey.GetSubKeyNames())
+                {
+                    using RegistryKey packGroupKey = installedPackGroupsKey.OpenSubKey(packGroupId);
+                    foreach (string packGroupVersion in packGroupKey.GetSubKeyNames())
+                    {
+                        using RegistryKey packGroupVersionKey = packGroupKey.OpenSubKey(packGroupVersion);
+
+                        WorkloadPackRecord record = new WorkloadPackRecord
+                        {
+                            MsiId = packGroupId,
+                            MsiNuGetVersion = packGroupVersion
+                        };
+
+                        SetRecordMsiProperties(record, packGroupVersionKey);
+
+                        Log?.LogMessage($"Found workload pack group record, Id: {packGroupId}, version: {packGroupVersion}, ProductCode: {record.ProductCode}, provider key: {record.ProviderKeyName}");
+
+                        foreach (string packId in packGroupVersionKey.GetSubKeyNames())
+                        {
+                            using RegistryKey packIdKey = packGroupVersionKey.OpenSubKey(packId);
+                            foreach (string packVersion in packIdKey.GetSubKeyNames())
+                            {
+                                record.InstalledPacks.Add((new WorkloadPackId(packId), new NuGetVersion(packVersion)));
+                                Log?.LogMessage($"Found workload pack in group, Id: {packId}, version: {packVersion}");
+                            }
+                        }
+
+                        workloadPackRecords.Add(record);
+                    }
+                }
+            }
+
+            return workloadPackRecords;
         }
 
         /// <summary>
@@ -364,7 +400,7 @@ namespace Microsoft.DotNet.Installer.Windows
         protected string GetMsiLogName(WorkloadPackRecord record, InstallAction action)
         {
             return Path.Combine(Path.GetDirectoryName(Log.LogPath),
-                Path.GetFileNameWithoutExtension(Log.LogPath) + $"_{record.PackId}-{record.PackVersion}_{action}.log");
+                Path.GetFileNameWithoutExtension(Log.LogPath) + $"_{record.MsiId}-{record.MsiNuGetVersion}_{action}.log");
         }
 
         /// <summary>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.PackGroup.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.PackGroup.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
+
+namespace Microsoft.DotNet.Workloads.Workload.Install
+{
+    internal partial class NetSdkMsiInstallerClient
+    {
+        class WorkloadPackGroupJson
+        {
+            public string GroupPackageId { get; set; }
+            public string GroupPackageVersion { get; set; }
+
+            public List<WorkloadPackJson> Packs { get; set; } = new List<WorkloadPackJson>();
+        }
+
+        class WorkloadPackJson
+        {
+            public string PackId { get; set; }
+
+            public string PackVersion { get; set; }
+        }
+
+        Dictionary<(string packId, string packVersion), List<WorkloadPackGroupJson>> GetWorkloadPackGroups()
+        {
+            Dictionary<(string packId, string packVersion), List<WorkloadPackGroupJson>> ret = new();
+
+            var manifests = _workloadResolver.GetInstalledManifests();
+            foreach (var manifest in manifests)
+            {
+                var packGroupFile = Path.Combine(manifest.ManifestDirectory, "WorkloadPackGroups.json");
+                if (File.Exists(packGroupFile))
+                {
+                    var packGroups = JsonSerializer.Deserialize<IList<WorkloadPackGroupJson>>(File.ReadAllText(packGroupFile));
+                    foreach (var packGroup in packGroups)
+                    {
+                        foreach (var packJson in packGroup.Packs)
+                        {
+                            var pack = (packId: packJson.PackId, packVersion: packJson.PackVersion);
+                            if (!ret.TryGetValue(pack, out var groupsWithPack))
+                            {
+                                groupsWithPack = new();
+                                ret[pack] = groupsWithPack;
+                            }
+                            groupsWithPack.Add(packGroup);
+                        }
+                    }
+                }
+            }
+
+            return ret;
+        }
+
+        List<AcquirableMsi> GetMsisToInstall(IEnumerable<PackInfo> packInfos)
+        {
+            List<AcquirableMsi> msisToInstall = new();
+            HashSet<(string packId, string packVersion)> packsProcessed = new();
+
+            var groupsForPacks = GetWorkloadPackGroups();
+
+            foreach (var pack in packInfos)
+            {
+                if (packsProcessed.Contains((pack.Id, pack.Version)))
+                {
+                    continue;
+                }
+
+                if (groupsForPacks.TryGetValue((pack.Id, pack.Version), out var groups))
+                {
+                    var group = groups.First();
+                    msisToInstall.Add(new AcquirableMsi($"{group.GroupPackageId}.Msi.{HostArchitecture}", group.GroupPackageVersion));
+                    foreach (var packFromGroup in group.Packs)
+                    {
+                        packsProcessed.Add((packFromGroup.PackId, packFromGroup.PackVersion));
+                    }
+                }
+                else
+                {
+                    msisToInstall.Add(AcquirableMsi.FromPackInfo(pack));
+                    packsProcessed.Add((pack.Id, pack.Version));
+                }
+            }
+
+            return msisToInstall;
+        }
+
+        class AcquirableMsi
+        {
+            /// <summary>
+            /// The ID of the NuGet package containing the MSI to install
+            /// </summary>
+            public string NuGetPackageId { get; }
+
+            public string NuGetPackageVersion { get; }
+
+            public AcquirableMsi(string nuGetPackageId, string nuGetPackageVersion)
+            {
+                NuGetPackageId = nuGetPackageId;
+                NuGetPackageVersion = nuGetPackageVersion;
+            }
+
+            public static AcquirableMsi FromPackInfo(PackInfo packInfo)
+            {
+                return new(GetMsiPackageId(packInfo), packInfo.Version);
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.PackGroup.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.PackGroup.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Cli;
 using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install
@@ -33,6 +34,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         Dictionary<(string packId, string packVersion), List<WorkloadPackGroupJson>> GetWorkloadPackGroups()
         {
             Dictionary<(string packId, string packVersion), List<WorkloadPackGroupJson>> ret = new();
+
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_DISABLE_PACK_GROUPS)))
+            {
+                //  If workload pack groups are disabled via environment variable, then just return an empty Dictionary
+                return ret;
+            }
 
             var manifests = _workloadResolver.GetInstalledManifests();
             foreach (var manifest in manifests)

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -249,7 +249,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         public IWorkloadInstaller GetWorkloadInstaller() => throw new InvalidOperationException($"{GetType()} is not a workload installer.");
 
-        public void InstallWorkloadManifest(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null, bool isRollback = false)
+        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, DirectoryPath? offlineCache = null, bool isRollback = false)
         {
             try
             {
@@ -258,13 +258,13 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 // Rolling back a manifest update after a successful install is essentially a downgrade, which is blocked so we have to
                 // treat it as a special case and is different from the install failing and rolling that back, though depending where the install
                 // failed, it may have removed the old product already.
-                Log?.LogMessage($"Installing manifest: Id: {manifestId}, version: {manifestVersion}, feature band: {sdkFeatureBand}, rollback: {isRollback}.");
+                Log?.LogMessage($"Installing manifest: Id: {manifestUpdate.ManifestId}, version: {manifestUpdate.NewVersion}, feature band: {manifestUpdate.NewFeatureBand}, rollback: {isRollback}.");
 
                 // Resolve the package ID for the manifest payload package
-                string msiPackageId = WorkloadManifestUpdater.GetManifestPackageId(sdkFeatureBand, manifestId, InstallType.Msi).ToString();
-                string msiPackageVersion = $"{manifestVersion}";
+                string msiPackageId = WorkloadManifestUpdater.GetManifestPackageId(new SdkFeatureBand(manifestUpdate.NewFeatureBand), manifestUpdate.ManifestId, InstallType.Msi).ToString();
+                string msiPackageVersion = $"{manifestUpdate.NewVersion}";
 
-                Log?.LogMessage($"Resolving {manifestId} ({manifestVersion}) to {msiPackageId} ({msiPackageVersion}).");
+                Log?.LogMessage($"Resolving {manifestUpdate.ManifestId} ({manifestUpdate.NewVersion}) to {msiPackageId} ({msiPackageVersion}).");
 
                 // Retrieve the payload from the MSI package cache.
                 MsiPayload msi = GetCachedMsiPayload(msiPackageId, msiPackageVersion, offlineCache);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -163,21 +163,13 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         }
 
         public IEnumerable<(
-            ManifestId manifestId,
-            ManifestVersion existingVersion,
-            SdkFeatureBand existingFeatureBand,
-            ManifestVersion newVersion,
-            SdkFeatureBand newFeatureBand,
+            ManifestVersionUpdate manifestUpdate,
             Dictionary<WorkloadId, WorkloadDefinition> Workloads
             )>
             CalculateManifestUpdates()
         {
             var manifestUpdates =
-                new List<(ManifestId manifestId,
-                    ManifestVersion existingVersion,
-                    SdkFeatureBand existingFeatureBand,
-                    ManifestVersion newVersion,
-                    SdkFeatureBand newFeatureBand,
+                new List<(ManifestVersionUpdate manifestUpdate,
                     Dictionary<WorkloadId, WorkloadDefinition> Workloads)>();
             var currentManifestIds = GetInstalledManifestIds();
             foreach (var manifestId in currentManifestIds)
@@ -192,8 +184,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 if (advertisingManifestVersionAndWorkloads != null &&
                     advertisingManifestVersionAndWorkloads.Value.ManifestVersion.CompareTo(currentManifestVersion.Item1) > 0)
                 {
-                    manifestUpdates.Add((manifestId, currentManifestVersion.Item1, currentManifestVersion.Item2,
-                        advertisingManifestVersionAndWorkloads.Value.ManifestVersion, advertisingManifestVersionAndWorkloads.Value.ManifestFeatureBand,
+                    manifestUpdates.Add((new ManifestVersionUpdate(manifestId, currentManifestVersion.manifestVersion, currentManifestVersion.sdkFeatureBand.ToString(),
+                        advertisingManifestVersionAndWorkloads.Value.ManifestVersion, advertisingManifestVersionAndWorkloads.Value.ManifestFeatureBand.ToString()),
                         advertisingManifestVersionAndWorkloads.Value.Workloads));
                 }
             }
@@ -215,7 +207,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        public IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, SdkFeatureBand existingFeatureBand, ManifestVersion newVersion, SdkFeatureBand newFeatureBand)> CalculateManifestRollbacks(string rollbackDefinitionFilePath)
+        public IEnumerable<ManifestVersionUpdate> CalculateManifestRollbacks(string rollbackDefinitionFilePath)
         {
             var currentManifestIds = GetInstalledManifestIds();
             var manifestRollbacks = ParseRollbackDefinitionFile(rollbackDefinitionFilePath);
@@ -231,7 +223,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 .Select(manifest =>
                 {
                     var installedManifestInfo = GetInstalledManifestVersion(manifest.id);
-                    return (manifest.id, installedManifestInfo.manifestVersion, installedManifestInfo.sdkFeatureBand, manifest.version, manifest.featureBand);
+                    return new ManifestVersionUpdate(manifest.id, installedManifestInfo.manifestVersion, installedManifestInfo.sdkFeatureBand.ToString(),
+                        manifest.version, manifest.featureBand.ToString());
                 });
 
             return manifestUpdates;

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -166,16 +166,19 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             ManifestId manifestId,
             ManifestVersion existingVersion,
             ManifestVersion newVersion,
-            Dictionary<WorkloadId, WorkloadDefinition> Workloads)> CalculateManifestUpdates()
+            Dictionary<WorkloadId, WorkloadDefinition> Workloads,
+            SdkFeatureBand newFeatureBand)>
+            CalculateManifestUpdates()
         {
             var manifestUpdates =
                 new List<(ManifestId, ManifestVersion, ManifestVersion,
-                    Dictionary<WorkloadId, WorkloadDefinition> Workloads)>();
+                    Dictionary<WorkloadId, WorkloadDefinition> Workloads, SdkFeatureBand newFeatureBand)>();
             var currentManifestIds = GetInstalledManifestIds();
             foreach (var manifestId in currentManifestIds)
             {
                 var currentManifestVersion = GetInstalledManifestVersion(manifestId);
                 var advertisingManifestVersionAndWorkloads = GetAdvertisingManifestVersionAndWorkloads(manifestId);
+                SdkFeatureBand newFeatureBand = new SdkFeatureBand(Product.Version);
                 if (advertisingManifestVersionAndWorkloads == null)
                 {
                     continue;
@@ -186,7 +189,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 {
                     manifestUpdates.Add((manifestId, currentManifestVersion,
                         advertisingManifestVersionAndWorkloads.Value.ManifestVersion,
-                        advertisingManifestVersionAndWorkloads.Value.Workloads));
+                        advertisingManifestVersionAndWorkloads.Value.Workloads,
+                        newFeatureBand));
                 }
             }
 
@@ -207,7 +211,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        public IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion)> CalculateManifestRollbacks(string rollbackDefinitionFilePath)
+        public IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion, SdkFeatureBand newFeatureBand)> CalculateManifestRollbacks(string rollbackDefinitionFilePath)
         {
             var currentManifestIds = GetInstalledManifestIds();
             var manifestRollbacks = ParseRollbackDefinitionFile(rollbackDefinitionFilePath);

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -154,8 +154,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 _workloadManifestUpdater.CalculateManifestUpdates();
 
             List<UpdateAvailableEntry> updateList = new();
-            foreach ((ManifestId _, ManifestVersion existingVersion, SdkFeatureBand existingFeatureBand, ManifestVersion newVersion, SdkFeatureBand newFeatureBand,
-                Dictionary<WorkloadId, WorkloadDefinition> workloads) in manifestsToUpdate)
+            foreach ((ManifestVersionUpdate manifestUpdate, Dictionary<WorkloadId, WorkloadDefinition> workloads) in manifestsToUpdate)
             {
                 foreach ((WorkloadId WorkloadId, WorkloadDefinition workloadDefinition) in
                     workloads)
@@ -163,8 +162,8 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                     if (installedWorkloads.Contains(new WorkloadId(WorkloadId.ToString())))
                     {
                         //  TODO: Potentially show existing and new feature bands
-                        updateList.Add(new UpdateAvailableEntry(existingVersion.ToString(),
-                            newVersion.ToString(),
+                        updateList.Add(new UpdateAvailableEntry(manifestUpdate.ExistingVersion.ToString(),
+                            manifestUpdate.NewVersion.ToString(),
                             workloadDefinition.Description, WorkloadId.ToString()));
                     }
                 }

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -150,12 +150,11 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         {
             HashSet<WorkloadId> installedWorkloads = installedList.ToHashSet();
             _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews).Wait();
-            IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion,
-                Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestsToUpdate =
+            var manifestsToUpdate =
                 _workloadManifestUpdater.CalculateManifestUpdates();
 
             List<UpdateAvailableEntry> updateList = new();
-            foreach ((ManifestId _, ManifestVersion existingVersion, ManifestVersion newVersion,
+            foreach ((ManifestId _, ManifestVersion existingVersion, SdkFeatureBand existingFeatureBand, ManifestVersion newVersion, SdkFeatureBand newFeatureBand,
                 Dictionary<WorkloadId, WorkloadDefinition> workloads) in manifestsToUpdate)
             {
                 foreach ((WorkloadId WorkloadId, WorkloadDefinition workloadDefinition) in
@@ -163,6 +162,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 {
                     if (installedWorkloads.Contains(new WorkloadId(WorkloadId.ToString())))
                     {
+                        //  TODO: Potentially show existing and new feature bands
                         updateList.Add(new UpdateAvailableEntry(existingVersion.ToString(),
                             newVersion.ToString(),
                             workloadDefinition.Description, WorkloadId.ToString()));

--- a/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommand.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Repair
 
                 foreach (var packId in packsToInstall)
                 {
-                    installer.RepairWorkloadPack(packId, sdkFeatureBand);
+                    installer.RepairWorkloadPack(packId, sdkFeatureBand, new NullTransactionContext());
                 }
             }
             else

--- a/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommand.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Repair
 
                 foreach (var packId in packsToInstall)
                 {
-                    installer.RepairWorkloadPack(packId, sdkFeatureBand, new NullTransactionContext());
+                    CliTransaction.RunNew(context => installer.RepairWorkloadPack(packId, sdkFeatureBand, context));
                 }
             }
             else

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -203,7 +203,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
 
                         foreach (var manifestUpdate in manifestsToUpdate)
                         {
-                            _workloadInstaller.InstallWorkloadManifest(manifestUpdate, offlineCache, rollback);
+                            _workloadInstaller.InstallWorkloadManifest(manifestUpdate, context, offlineCache, rollback);
                         }
 
                         _workloadResolver.RefreshWorkloadManifests();
@@ -211,16 +211,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                         workloadPackToUpdate = GetUpdatablePacks(installer);
 
                         installer.InstallWorkloadPacks(workloadPackToUpdate, sdkFeatureBand, context, offlineCache);
-
                     },
                     rollback: () => {
-                        foreach (var manifestUpdate in manifestsToUpdate)
-                        {
-                            var manifestUpdateRollback = new ManifestVersionUpdate(manifestUpdate.ManifestId, manifestUpdate.NewVersion, manifestUpdate.NewFeatureBand, manifestUpdate.ExistingVersion, manifestUpdate.ExistingFeatureBand);
-                            _workloadInstaller.InstallWorkloadManifest(manifestUpdateRollback, offlineCache: null, isRollback: true);
-                        }
-
-                        //  InstallWorkloadPacks implementation should already be using transaction and rolling back if needed
+                        //  Nothing to roll back at this level, InstallWorkloadManifest and InstallWorkloadPacks handle the transaction rollback
                     });
             }
             else

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache).Wait();
             
             var manifestsToUpdate = string.IsNullOrWhiteSpace(_fromRollbackDefinition) ?
-                _workloadManifestUpdater.CalculateManifestUpdates().Select(m => (m.manifestId, m.existingVersion, m.newVersion)) :
+                _workloadManifestUpdater.CalculateManifestUpdates().Select(m => (m.manifestId, m.existingVersion, m.newVersion, featureBand)) :
                 _workloadManifestUpdater.CalculateManifestRollbacks(_fromRollbackDefinition);
 
             UpdateWorkloadsWithInstallRecord(workloadIds, featureBand, manifestsToUpdate, offlineCache);
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
         private void UpdateWorkloadsWithInstallRecord(
             IEnumerable<WorkloadId> workloadIds,
             SdkFeatureBand sdkFeatureBand,
-            IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion)> manifestsToUpdate,
+            IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion, SdkFeatureBand sdkFeatureBand)> manifestsToUpdate,
             DirectoryPath? offlineCache = null)
         {
             if (_workloadInstaller.GetInstallationUnit().Equals(InstallationUnit.Packs))

--- a/src/Common/EnvironmentVariableNames.cs
+++ b/src/Common/EnvironmentVariableNames.cs
@@ -10,5 +10,6 @@ namespace Microsoft.DotNet.Cli
         public static readonly string WORKLOAD_MANIFEST_ROOTS = "DOTNETSDK_WORKLOAD_MANIFEST_ROOTS";
         public static readonly string WORKLOAD_UPDATE_NOTIFY_DISABLE = "DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE";
         public static readonly string WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS = "DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS";
+        public static readonly string WORKLOAD_DISABLE_PACK_GROUPS = "DOTNET_CLI_WORKLOAD_DISABLE_PACK_GROUPS";
     }
 }

--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -47,7 +47,7 @@
        2 different ways of doing things
   -->
   <ItemGroup>
-    <Compile Include="..\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\**\*.cs" LinkBase="Microsoft.DotNet.SdkResolver"/>
+    <Compile Include="..\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\**\*.cs" LinkBase="Microsoft.NET.Sdk.WorkloadManifestReader"/>
     <Compile Include="..\Resolvers\Microsoft.DotNet.MSBuildSdkResolver\FXVersion.cs" LinkBase="Microsoft.DotNet.SdkResolver"/>
     <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common"/>
     <Compile Include="$(RepoRoot)src\Common\WorkloadFileBasedInstall.cs" LinkBase="Common"/>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestId.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestId.cs
@@ -3,9 +3,9 @@
 
 using System;
 
-namespace Microsoft.DotNet.Workloads.Workload.Install
+namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
-    internal struct ManifestId : IEquatable<ManifestId>, IComparable<ManifestId>
+    public struct ManifestId : IEquatable<ManifestId>, IComparable<ManifestId>
     {
         private string _id;
 
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             return string.Compare(ToString(), other.ToString(), StringComparison.Ordinal);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ManifestId id && Equals(id);
         }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
@@ -4,9 +4,9 @@
 using System;
 using Microsoft.DotNet.MSBuildSdkResolver;
 
-namespace Microsoft.DotNet.Workloads.Workload.Install
+namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
-    internal class ManifestVersion : IEquatable<ManifestVersion>, IComparable<ManifestVersion>
+    public class ManifestVersion : IEquatable<ManifestVersion>, IComparable<ManifestVersion>
     {
         private FXVersion _version;
 
@@ -18,17 +18,17 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        public bool Equals(ManifestVersion other)
+        public bool Equals(ManifestVersion? other)
         {
-            return ToString().Equals(other.ToString());
+            return ToString().Equals(other?.ToString());
         }
 
-        public int CompareTo(ManifestVersion other)
+        public int CompareTo(ManifestVersion? other)
         {
-            return FXVersion.Compare(_version, other._version);
+            return FXVersion.Compare(_version, other?._version);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ManifestVersion version && Equals(version);
         }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersionUpdate.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersionUpdate.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
     public class ManifestVersionUpdate : IEquatable<ManifestVersionUpdate>, IComparable<ManifestVersionUpdate>
     {
-        public ManifestVersionUpdate(ManifestId manifestId, ManifestVersion? existingVersion, string? existingFeatureBand, ManifestVersion newVersion, string newFeatureBand)
+        public ManifestVersionUpdate(ManifestId manifestId, ManifestVersion? existingVersion, string? existingFeatureBand, ManifestVersion? newVersion, string? newFeatureBand)
         {
             ManifestId = manifestId;
             ExistingVersion = existingVersion;
@@ -24,8 +24,14 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         public ManifestId ManifestId { get; }
         public ManifestVersion? ExistingVersion { get; }
         public string? ExistingFeatureBand { get; }
-        public ManifestVersion NewVersion { get; }
-        public string NewFeatureBand { get; }
+        public ManifestVersion? NewVersion { get; }
+        public string? NewFeatureBand { get; }
+
+        //  Returns an object representing an undo of this manifest update
+        public ManifestVersionUpdate Reverse()
+        {
+            return new ManifestVersionUpdate(ManifestId, NewVersion, NewFeatureBand, ExistingVersion, ExistingFeatureBand);
+        }
 
         public int CompareTo(ManifestVersionUpdate? other)
         {
@@ -61,7 +67,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             return EqualityComparer<ManifestId>.Default.Equals(ManifestId, other.ManifestId) &&
                 EqualityComparer<ManifestVersion?>.Default.Equals(ExistingVersion, other.ExistingVersion) &&
                 string.Equals(ExistingFeatureBand, other.ExistingFeatureBand, StringComparison.Ordinal) &&
-                EqualityComparer<ManifestVersion>.Default.Equals(NewVersion, other.NewVersion) &&
+                EqualityComparer<ManifestVersion?>.Default.Equals(NewVersion, other.NewVersion) &&
                 string.Equals(NewFeatureBand, other.NewFeatureBand, StringComparison.Ordinal);
         }
 
@@ -79,8 +85,8 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             hashCode = hashCode * -1521134295 + ManifestId.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<ManifestVersion?>.Default.GetHashCode(ExistingVersion);
             hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(ExistingFeatureBand);
-            hashCode = hashCode * -1521134295 + EqualityComparer<ManifestVersion>.Default.GetHashCode(NewVersion);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(NewFeatureBand);
+            hashCode = hashCode * -1521134295 + EqualityComparer<ManifestVersion?>.Default.GetHashCode(NewVersion);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(NewFeatureBand);
             return hashCode;
 #endif
         }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersionUpdate.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersionUpdate.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NET.Sdk.WorkloadManifestReader
+{
+    public class ManifestVersionUpdate : IEquatable<ManifestVersionUpdate>, IComparable<ManifestVersionUpdate>
+    {
+        public ManifestVersionUpdate(ManifestId manifestId, ManifestVersion? existingVersion, string? existingFeatureBand, ManifestVersion newVersion, string newFeatureBand)
+        {
+            ManifestId = manifestId;
+            ExistingVersion = existingVersion;
+            ExistingFeatureBand = existingFeatureBand;
+            NewVersion = newVersion;
+            NewFeatureBand = newFeatureBand;
+        }
+
+        public ManifestId ManifestId { get; }
+        public ManifestVersion? ExistingVersion { get; }
+        public string? ExistingFeatureBand { get; }
+        public ManifestVersion NewVersion { get; }
+        public string NewFeatureBand { get; }
+
+        public int CompareTo(ManifestVersionUpdate? other)
+        {
+            if (other == null) return 1;
+            int ret = ManifestId.CompareTo(other.ManifestId);
+            if (ret != 0) return ret;
+            
+            if (ExistingVersion == null && other.ExistingVersion != null) return -1;
+            if (ExistingVersion != null && other.ExistingVersion == null) return 1;
+            if (ExistingVersion != null)
+            {
+                ret = ExistingVersion.CompareTo(other.ExistingVersion);
+                if (ret != 0) return ret;
+            }
+
+            ret = string.Compare(ExistingFeatureBand, other.ExistingFeatureBand, StringComparison.Ordinal);
+            if (ret != 0) return ret;
+
+            if (NewVersion == null && other.NewVersion != null) return -1;
+            if (NewVersion != null && other.NewVersion == null) return 1;
+            if (NewVersion != null)
+            {
+                ret = NewVersion.CompareTo(other.NewVersion);
+                if (ret != 0) return ret;
+            }
+
+            ret = string.Compare(NewFeatureBand, other.NewFeatureBand, StringComparison.Ordinal);
+            return ret;
+        }
+        public bool Equals(ManifestVersionUpdate? other)
+        {
+            if (other == null) return false;
+            return EqualityComparer<ManifestId>.Default.Equals(ManifestId, other.ManifestId) &&
+                EqualityComparer<ManifestVersion?>.Default.Equals(ExistingVersion, other.ExistingVersion) &&
+                string.Equals(ExistingFeatureBand, other.ExistingFeatureBand, StringComparison.Ordinal) &&
+                EqualityComparer<ManifestVersion>.Default.Equals(NewVersion, other.NewVersion) &&
+                string.Equals(NewFeatureBand, other.NewFeatureBand, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ManifestVersionUpdate id && Equals(id);
+        }
+
+        public override int GetHashCode()
+        {
+#if NETCOREAPP3_1_OR_GREATER
+            return HashCode.Combine(ManifestId, ExistingVersion, ExistingFeatureBand, NewVersion, NewFeatureBand);
+#else
+            int hashCode = 1601069575;
+            hashCode = hashCode * -1521134295 + ManifestId.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<ManifestVersion?>.Default.GetHashCode(ExistingVersion);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(ExistingFeatureBand);
+            hashCode = hashCode * -1521134295 + EqualityComparer<ManifestVersion>.Default.GetHashCode(NewVersion);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(NewFeatureBand);
+            return hashCode;
+#endif
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadPackBundleTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadPackBundleTests.cs
@@ -1,0 +1,200 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Collections;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.NET.TestFramework;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Sdk.WorkloadManifestReader.Tests
+{
+    public class WorkloadPackBundleTests : SdkTest
+    {
+        public WorkloadPackBundleTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+
+        [Fact]
+        public void TestGetManifestDirectories()
+        {
+            var manifestProvider = CreateManifestProvider();
+
+            var manifestDirectories = manifestProvider.GetManifestDirectories();
+            foreach (var manifestDirectory in manifestDirectories)
+            {
+                Log.WriteLine(manifestDirectory);
+            }
+        }
+
+        [Fact]
+        public void TestGetManifests()
+        {
+            var manifests = GetManifests();
+
+            foreach (var manifest in manifests)
+            {
+                Log.WriteLine(manifest.Id + "\t" + manifest.ManifestPath);
+            }
+        }
+
+        [Fact]
+        public void GetPackDefinitionLocations()
+        {
+            var definitionLocations = GetWorkloadPackDefinitionLocations(GetManifests());
+
+            StringBuilder sb = new StringBuilder(); ;
+            foreach (var kvp in definitionLocations)
+            {
+                sb.Append(kvp.Key + ": ");
+                sb.Append(string.Join(", ", kvp.Value));
+                Log.WriteLine(sb.ToString());
+                sb.Clear();
+            }
+
+            foreach (var kvp in definitionLocations)
+            {
+                kvp.Value.Count.Should().Be(1);
+            }
+        }
+
+        [Fact]
+        public void TestGetPackBundles()
+        {
+            var packBundles = GetPackBundles();
+            foreach (var bundle in packBundles)
+            {
+                Log.WriteLine(bundle.Workload.Id);
+                foreach (var pack in bundle.Packs)
+                {
+                    if (pack.Id != pack.ResolvedPackageId)
+                    {
+                        Log.WriteLine($"\t{pack.Id}\t{pack.Version}\t{pack.ResolvedPackageId}");
+                    }
+                    else
+                    {
+                        Log.WriteLine($"\t{pack.Id}\t{pack.Version}");
+                    }
+                }
+                foreach (var unavailablePack in bundle.UnavailablePacks)
+                {
+                    Log.WriteLine($"\tUnavailable: {unavailablePack}");
+                }
+            }
+        }
+
+
+        SdkDirectoryWorkloadManifestProvider CreateManifestProvider()
+        {
+            return new(TestContext.Current.ToolsetUnderTest.DotNetRoot, TestContext.Current.ToolsetUnderTest.SdkVersion, userProfileDir: null);
+        }
+
+        public IEnumerable<WorkloadManifest> GetManifests(SdkDirectoryWorkloadManifestProvider? manifestProvider = null)
+        {
+            manifestProvider ??= CreateManifestProvider();
+            List<WorkloadManifest> manifests = new List<WorkloadManifest>();
+            foreach (var readableManifest in manifestProvider.GetManifests())
+            {
+                if (readableManifest.ManifestId.Equals("Microsoft.NET.Sdk.TestWorkload"))
+                {
+                    //  Ignore test workload for this
+                    continue;
+                }
+                using (var stream = readableManifest.OpenManifestStream())
+                {
+                    var manifest = WorkloadManifestReader.ReadWorkloadManifest(readableManifest.ManifestId, stream, readableManifest.ManifestPath);
+                    manifests.Add(manifest);
+                }
+            }
+
+            return manifests;
+        }
+
+
+        //  Implementation here
+        Dictionary<WorkloadPackId, List<WorkloadId>> GetWorkloadPackDefinitionLocations(IEnumerable<WorkloadManifest> manifests)
+        {
+            var ret = new Dictionary<WorkloadPackId, List<WorkloadId>>();
+            foreach (var manifest in manifests)
+            {
+                foreach (var baseWorkload in manifest.Workloads.Values)
+                {
+                    if (baseWorkload is WorkloadDefinition workload && workload.Packs != null)
+                    {
+                        foreach (var pack in workload.Packs)
+                        {
+                            if (!ret.TryGetValue(pack, out List<WorkloadId>? workloadList))
+                            {
+                                workloadList = new List<WorkloadId>();
+                                ret[pack] = workloadList;
+                            }
+                            workloadList.Add(workload.Id);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        List<WorkloadPackBundle> GetPackBundles()
+        {
+            List<WorkloadPackBundle> bundles = new List<WorkloadPackBundle>();
+
+            var manifestProvider = CreateManifestProvider();
+            var manifests = GetManifests(manifestProvider);
+            var workloadResolver = WorkloadResolver.CreateForTests(manifestProvider, TestContext.Current.ToolsetUnderTest.DotNetRoot);
+
+            foreach (var manifest in manifests)
+            {
+                foreach (var workload in manifest.Workloads.Values.OfType<WorkloadDefinition>())
+                {
+                    if (workload.Packs == null || !workload.Packs.Any())
+                    {
+                        continue;
+                    }
+                    List<WorkloadResolver.PackInfo> packInfos = new List<WorkloadResolver.PackInfo>();
+                    List<WorkloadPackId> unavailablePacks = new List<WorkloadPackId>();
+                    foreach (var packId in workload.Packs)
+                    {
+                        var packInfo = workloadResolver.TryGetPackInfo(packId);
+                        if (packInfo == null)
+                        {
+                            unavailablePacks.Add(packId);
+                        }
+                        else
+                        {
+                            packInfos.Add(packInfo);
+                        }
+                    }
+                    WorkloadPackBundle bundle = new WorkloadPackBundle(workload, packInfos, unavailablePacks);
+                    bundles.Add(bundle);
+                }
+            }
+            
+
+            return bundles;
+        }
+
+        class WorkloadPackBundle
+        {
+            public WorkloadDefinition Workload { get; }
+            public List<WorkloadResolver.PackInfo> Packs { get; }
+            public List<WorkloadPackId> UnavailablePacks { get; }
+
+            public WorkloadPackBundle(WorkloadDefinition workload, List<WorkloadResolver.PackInfo> packs, List<WorkloadPackId> unavailablePacks)
+            {
+                Workload = workload;
+                Packs = packs;
+                UnavailablePacks = unavailablePacks;
+            }
+        }
+    }
+}

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -505,39 +505,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             string.Join(" ", _reporter.Lines).Should().Contain(Workloads.Workload.Install.LocalizableStrings.CheckForUpdatedWorkloadManifests);
             string.Join(" ", _reporter.Lines).Should().Contain(String.Format(Workloads.Workload.Install.LocalizableStrings.CheckForUpdatedWorkloadManifests, "mock-manifest"));
         }
-
-        [Theory]
-        [InlineData(true, "6.0.100")]
-        [InlineData(true, "6.0.101")]
-        [InlineData(true, "6.0.102-preview1")]
-        [InlineData(false, "6.0.100")]
-        public void UpdateWorkloadVersionsWithRollbackFileAndDifferentFeatureBands(bool userLocal, string sdkVersion)
-        {
-            // TODO: update this test
-            var parseResult =
-                Parser.Instance.Parse(new string[] { "dotnet", "workload", "install", "xamarin-android" });
-            var manifestsToUpdate =
-                new (ManifestId manifestId,
-                ManifestVersion existingVersion,
-                SdkFeatureBand existingFeatureBand,
-                ManifestVersion newVersion,
-                SdkFeatureBand newFeatureBand,
-                Dictionary<WorkloadId, WorkloadDefinition> Workloads)[]
-                    {
-                        (new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), new SdkFeatureBand(sdkVersion), new ManifestVersion("2.0.0"), new SdkFeatureBand(sdkVersion),
-                            null),
-                    };
-            (_, var installManager, var installer, _, _, _) =
-                GetTestInstallers(parseResult, userLocal, sdkVersion, manifestUpdates: manifestsToUpdate);
-
-            installManager.InstallWorkloads(new List<WorkloadId>(), false); // Don't actually do any installs, just update manifests
-
-            installer.InstalledManifests[0].manifestId.Should().Be(manifestsToUpdate[0].manifestId);
-            installer.InstalledManifests[0].manifestVersion.Should().Be(manifestsToUpdate[0].newVersion);
-            installer.InstalledManifests[0].sdkFeatureBand.Should().Be(new SdkFeatureBand("6.0.100"));
-            installer.InstalledManifests[0].offlineCache.Should().Be(null);
-        }
-
+                
         private string AppendForUserLocal(string identifier, bool userLocal)
         {
             if (!userLocal)

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -167,10 +167,14 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var parseResult =
                 Parser.Instance.Parse(new string[] {"dotnet", "workload", "install", "xamarin-android"});
             var manifestsToUpdate =
-                new (ManifestId, ManifestVersion, ManifestVersion, Dictionary<WorkloadId, WorkloadDefinition>
-                    Workloads)[]
+                new (ManifestId manifestId,
+                ManifestVersion existingVersion,
+                SdkFeatureBand existingFeatureBand,
+                ManifestVersion newVersion,
+                SdkFeatureBand newFeatureBand,
+                Dictionary<WorkloadId, WorkloadDefinition> Workloads)[]
                     {
-                        (new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), new ManifestVersion("2.0.0"),
+                        (new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), new SdkFeatureBand(sdkVersion), new ManifestVersion("2.0.0"), new SdkFeatureBand(sdkVersion),
                             null),
                     };
             (_, var installManager, var installer, _, _, _) =
@@ -178,8 +182,8 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             installManager.InstallWorkloads(new List<WorkloadId>(), false); // Don't actually do any installs, just update manifests
 
-            installer.InstalledManifests[0].manifestId.Should().Be(manifestsToUpdate[0].Item1);
-            installer.InstalledManifests[0].manifestVersion.Should().Be(manifestsToUpdate[0].Item3);
+            installer.InstalledManifests[0].manifestId.Should().Be(manifestsToUpdate[0].manifestId);
+            installer.InstalledManifests[0].manifestVersion.Should().Be(manifestsToUpdate[0].newVersion);
             installer.InstalledManifests[0].sdkFeatureBand.Should().Be(new SdkFeatureBand("6.0.100"));
             installer.InstalledManifests[0].offlineCache.Should().Be(null);
         }
@@ -192,10 +196,14 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         public void GivenWorkloadInstallFromCacheItInstallsCachedManifest(bool userLocal, string sdkVersion)
         {
             var manifestsToUpdate =
-                new (ManifestId, ManifestVersion, ManifestVersion, Dictionary<WorkloadId, WorkloadDefinition>
-                    Workloads)[]
+                new (ManifestId manifestId,
+                ManifestVersion existingVersion,
+                SdkFeatureBand existingFeatureBand,
+                ManifestVersion newVersion,
+                SdkFeatureBand newFeatureBand,
+                Dictionary<WorkloadId, WorkloadDefinition> Workloads)[]
                     {
-                        (new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), new ManifestVersion("2.0.0"),
+                        (new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), new SdkFeatureBand(sdkVersion), new ManifestVersion("2.0.0"), new SdkFeatureBand(sdkVersion),
                             null)
                     };
             var cachePath = Path.Combine(_testAssetsManager.CreateTestDirectory(identifier: AppendForUserLocal("mockCache_", userLocal) + sdkVersion).Path,
@@ -209,8 +217,8 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             installManager.Execute();
 
-            installer.InstalledManifests[0].manifestId.Should().Be(manifestsToUpdate[0].Item1);
-            installer.InstalledManifests[0].manifestVersion.Should().Be(manifestsToUpdate[0].Item3);
+            installer.InstalledManifests[0].manifestId.Should().Be(manifestsToUpdate[0].manifestId);
+            installer.InstalledManifests[0].manifestVersion.Should().Be(manifestsToUpdate[0].newVersion);
             installer.InstalledManifests[0].sdkFeatureBand.Should().Be(new SdkFeatureBand("6.0.100"));
             installer.InstalledManifests[0].offlineCache.Should().Be(new DirectoryPath(cachePath));
         }
@@ -346,7 +354,12 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 string sdkVersion,
                 [CallerMemberName] string testName = "",
                 string failingWorkload = null,
-                IEnumerable<(ManifestId, ManifestVersion, ManifestVersion, Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestUpdates = null,
+                IEnumerable<(ManifestId manifestId,
+                    ManifestVersion existingVersion,
+                    SdkFeatureBand existingFeatureBand,
+                    ManifestVersion newVersion,
+                    SdkFeatureBand newFeatureBand,
+                    Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestUpdates = null,
                 string tempDirManifestPath = null)
         {
             _reporter.Clear();
@@ -474,10 +487,14 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var parseResult =
                Parser.Instance.Parse(new string[] { "dotnet", "workload", "install", verbosityFlag, "xamarin-android" });
             var manifestsToUpdate =
-                new (ManifestId, ManifestVersion, ManifestVersion, Dictionary<WorkloadId, WorkloadDefinition>
-                    Workloads)[]
+                new (ManifestId manifestId,
+                ManifestVersion existingVersion,
+                SdkFeatureBand existingFeatureBand,
+                ManifestVersion newVersion,
+                SdkFeatureBand newFeatureBand,
+                Dictionary<WorkloadId, WorkloadDefinition> Workloads)[]
                     {
-                        (new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), new ManifestVersion("2.0.0"),
+                        (new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), new SdkFeatureBand("6.0.300"), new ManifestVersion("2.0.0"), new SdkFeatureBand("6.0.300"),
                             null),
                     };
             (_, var installManager, var installer, _, _, _) =
@@ -487,6 +504,38 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             string.Join(" ", _reporter.Lines).Should().Contain(Workloads.Workload.Install.LocalizableStrings.CheckForUpdatedWorkloadManifests);
             string.Join(" ", _reporter.Lines).Should().Contain(String.Format(Workloads.Workload.Install.LocalizableStrings.CheckForUpdatedWorkloadManifests, "mock-manifest"));
+        }
+
+        [Theory]
+        [InlineData(true, "6.0.100")]
+        [InlineData(true, "6.0.101")]
+        [InlineData(true, "6.0.102-preview1")]
+        [InlineData(false, "6.0.100")]
+        public void UpdateWorkloadVersionsWithRollbackFileAndDifferentFeatureBands(bool userLocal, string sdkVersion)
+        {
+            // TODO: update this test
+            var parseResult =
+                Parser.Instance.Parse(new string[] { "dotnet", "workload", "install", "xamarin-android" });
+            var manifestsToUpdate =
+                new (ManifestId manifestId,
+                ManifestVersion existingVersion,
+                SdkFeatureBand existingFeatureBand,
+                ManifestVersion newVersion,
+                SdkFeatureBand newFeatureBand,
+                Dictionary<WorkloadId, WorkloadDefinition> Workloads)[]
+                    {
+                        (new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), new SdkFeatureBand(sdkVersion), new ManifestVersion("2.0.0"), new SdkFeatureBand(sdkVersion),
+                            null),
+                    };
+            (_, var installManager, var installer, _, _, _) =
+                GetTestInstallers(parseResult, userLocal, sdkVersion, manifestUpdates: manifestsToUpdate);
+
+            installManager.InstallWorkloads(new List<WorkloadId>(), false); // Don't actually do any installs, just update manifests
+
+            installer.InstalledManifests[0].manifestId.Should().Be(manifestsToUpdate[0].manifestId);
+            installer.InstalledManifests[0].manifestVersion.Should().Be(manifestsToUpdate[0].newVersion);
+            installer.InstalledManifests[0].sdkFeatureBand.Should().Be(new SdkFeatureBand("6.0.100"));
+            installer.InstalledManifests[0].offlineCache.Should().Be(null);
         }
 
         private string AppendForUserLocal(string identifier, bool userLocal)

--- a/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller();
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", "Xamarin.Android.Sdk", "8.4.7"), "Xamarin.Android.Sdk");
             var version = "6.0.100";
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
+            CliTransaction.RunNew(context => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), context));
 
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;
             mockNugetInstaller.DownloadCallParams.Count.Should().Be(1);
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller();
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Template, Path.Combine(dotnetRoot, "template-packs", "Xamarin.Android.Sdk.8.4.7.nupkg"), "Xamarin.Android.Sdk");
             var version = "6.0.100";
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
+            CliTransaction.RunNew(context => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), context));
 
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams.Count.Should().Be(1);
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams[0].ShouldBeEquivalentTo((new PackageId(packInfo.Id), new NuGetVersion(packInfo.Version), null as DirectoryPath?, null as PackageSourceLocation));
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var alias = "Xamarin.Android.BuildTools.Alias";
             var packInfo = CreatePackInfo("Xamarin.Android.BuildTools", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", alias, "8.4.7"), alias);
             var version = "6.0.100";
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
+            CliTransaction.RunNew(context => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), context));
 
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams.Count.Should().Be(1);
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams[0].ShouldBeEquivalentTo((new PackageId(alias), new NuGetVersion(packInfo.Version), null as DirectoryPath?, null as PackageSourceLocation));
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller(packageSourceLocation: packageSource);
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", "Xamarin.Android.Sdk", "8.4.7"), "Xamarin.Android.Sdk");
             var version = "6.0.100";
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
+            CliTransaction.RunNew(context => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), context));
 
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;
             mockNugetInstaller.DownloadCallParams.Count.Should().Be(1);
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Mock installing the pack
             Directory.CreateDirectory(packInfo.Path);
 
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
+            CliTransaction.RunNew(context => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), context));
 
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams.Count.Should().Be(0);
         }
@@ -363,7 +363,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             var manifestUpdate = new ManifestVersionUpdate(manifestId, null, null, manifestVersion, featureBand.ToString());
 
-            installer.InstallWorkloadManifest(manifestUpdate, new NullTransactionContext());
+            CliTransaction.RunNew(context => installer.InstallWorkloadManifest(manifestUpdate, context));
 
             var mockNugetInstaller = nugetDownloader as MockNuGetPackageDownloader;
             mockNugetInstaller.DownloadCallParams.Count.Should().Be(1);
@@ -405,7 +405,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var nupkgPath = Path.Combine(cachePath, $"{packInfo.ResolvedPackageId}.{packInfo.Version}.nupkg");
             File.Create(nupkgPath);
 
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext(), new DirectoryPath(cachePath));
+            CliTransaction.RunNew(context => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), context, new DirectoryPath(cachePath)));
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;
             
             // We shouldn't download anything, use the cache
@@ -428,7 +428,8 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var version = "6.0.100";
             var cachePath = Path.Combine(dotnetRoot, "MockCache");
             
-            var exceptionThrown = Assert.Throws<Exception>(() => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext(), new DirectoryPath(cachePath)));
+            var exceptionThrown = Assert.Throws<Exception>(() =>
+                CliTransaction.RunNew(context => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), context, new DirectoryPath(cachePath))));
             exceptionThrown.Message.Should().Contain(packInfo.ResolvedPackageId);
             exceptionThrown.Message.Should().Contain(packInfo.Version);
             exceptionThrown.Message.Should().Contain(cachePath);

--- a/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller();
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", "Xamarin.Android.Sdk", "8.4.7"), "Xamarin.Android.Sdk");
             var version = "6.0.100";
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
 
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;
             mockNugetInstaller.DownloadCallParams.Count.Should().Be(1);
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller();
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Template, Path.Combine(dotnetRoot, "template-packs", "Xamarin.Android.Sdk.8.4.7.nupkg"), "Xamarin.Android.Sdk");
             var version = "6.0.100";
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
 
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams.Count.Should().Be(1);
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams[0].ShouldBeEquivalentTo((new PackageId(packInfo.Id), new NuGetVersion(packInfo.Version), null as DirectoryPath?, null as PackageSourceLocation));
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var alias = "Xamarin.Android.BuildTools.Alias";
             var packInfo = CreatePackInfo("Xamarin.Android.BuildTools", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", alias, "8.4.7"), alias);
             var version = "6.0.100";
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
 
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams.Count.Should().Be(1);
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams[0].ShouldBeEquivalentTo((new PackageId(alias), new NuGetVersion(packInfo.Version), null as DirectoryPath?, null as PackageSourceLocation));
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller(packageSourceLocation: packageSource);
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", "Xamarin.Android.Sdk", "8.4.7"), "Xamarin.Android.Sdk");
             var version = "6.0.100";
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
 
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;
             mockNugetInstaller.DownloadCallParams.Count.Should().Be(1);
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Mock installing the pack
             Directory.CreateDirectory(packInfo.Path);
 
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext());
 
             (nugetInstaller as MockNuGetPackageDownloader).DownloadCallParams.Count.Should().Be(0);
         }
@@ -202,8 +202,12 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var version = "6.0.100";
             var (dotnetRoot, installer, nugetInstaller) = GetTestInstaller(failingInstaller: true);
             var packInfo = CreatePackInfo("Xamarin.Android.Sdk", "8.4.7", WorkloadPackKind.Sdk, Path.Combine(dotnetRoot, "packs", "Xamarin.Android.Sdk", "8.4.7"), "Xamarin.Android.Sdk");
-            
-            var exceptionThrown = Assert.Throws<Exception>(() => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version)));
+
+            var exceptionThrown = Assert.Throws<Exception>(() =>
+            {
+                var transaction = new CliTransaction();
+                transaction.Run(context => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), context));
+            });
             exceptionThrown.Message.Should().Be("Test Failure");
             var failingNugetInstaller = nugetInstaller as FailingNuGetPackageDownloader;
             // Nupkgs should be removed
@@ -399,7 +403,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var nupkgPath = Path.Combine(cachePath, $"{packInfo.ResolvedPackageId}.{packInfo.Version}.nupkg");
             File.Create(nupkgPath);
 
-            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new DirectoryPath(cachePath));
+            installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext(), new DirectoryPath(cachePath));
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;
             
             // We shouldn't download anything, use the cache
@@ -422,7 +426,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var version = "6.0.100";
             var cachePath = Path.Combine(dotnetRoot, "MockCache");
             
-            var exceptionThrown = Assert.Throws<Exception>(() => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new DirectoryPath(cachePath)));
+            var exceptionThrown = Assert.Throws<Exception>(() => installer.InstallWorkloadPacks(new[] { packInfo }, new SdkFeatureBand(version), new NullTransactionContext(), new DirectoryPath(cachePath)));
             exceptionThrown.Message.Should().Contain(packInfo.ResolvedPackageId);
             exceptionThrown.Message.Should().Contain(packInfo.Version);
             exceptionThrown.Message.Should().Contain(cachePath);

--- a/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -361,7 +361,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var manifestId = new ManifestId("test-manifest-1");
             var manifestVersion = new ManifestVersion("5.0.0");
 
-            installer.InstallWorkloadManifest(manifestId, manifestVersion, featureBand);
+            var manifestUpdate = new ManifestVersionUpdate(manifestId, null, null, manifestVersion, featureBand.ToString());
+
+            installer.InstallWorkloadManifest(manifestUpdate);
 
             var mockNugetInstaller = nugetDownloader as MockNuGetPackageDownloader;
             mockNugetInstaller.DownloadCallParams.Count.Should().Be(1);

--- a/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -363,7 +363,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             var manifestUpdate = new ManifestVersionUpdate(manifestId, null, null, manifestVersion, featureBand.ToString());
 
-            installer.InstallWorkloadManifest(manifestUpdate);
+            installer.InstallWorkloadManifest(manifestUpdate, new NullTransactionContext());
 
             var mockNugetInstaller = nugetDownloader as MockNuGetPackageDownloader;
             mockNugetInstaller.DownloadCallParams.Count.Should().Be(1);

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -147,16 +147,16 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var testDir = _testAssetsManager.CreateTestDirectory().Path;
             var featureBand = "6.0.100";
             var dotnetRoot = Path.Combine(testDir, "dotnet");
-            var expectedManifestUpdates = new (ManifestId, ManifestVersion, ManifestVersion)[] {
-                (new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), new ManifestVersion("4.0.0")),
-                (new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), new ManifestVersion("2.0.0")) };
+            var expectedManifestUpdates = new (ManifestId,  ManifestVersion, SdkFeatureBand, ManifestVersion, SdkFeatureBand)[] {
+                (new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), new SdkFeatureBand("6.0.100"), new ManifestVersion("4.0.0"), new SdkFeatureBand("6.0.100")),
+                (new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), new SdkFeatureBand("6.0.100"), new ManifestVersion("2.0.0"), new SdkFeatureBand("6.0.100")) };
 
             // Write mock manifests
             var installedManifestDir = Path.Combine(testDir, "dotnet", "sdk-manifests", featureBand);
             var adManifestDir = Path.Combine(testDir, ".dotnet", "sdk-advertising", featureBand);
             Directory.CreateDirectory(installedManifestDir);
             Directory.CreateDirectory(adManifestDir);
-            foreach ((var manifestId, var existingVersion, _) in expectedManifestUpdates)
+            foreach ((var manifestId, var existingVersion, var existingFeatureBand, _, _) in expectedManifestUpdates)
             {
                 Directory.CreateDirectory(Path.Combine(installedManifestDir, manifestId.ToString()));
                 File.WriteAllText(Path.Combine(installedManifestDir, manifestId.ToString(), _manifestFileName), GetManifestContent(existingVersion));

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -102,9 +102,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var testDir = _testAssetsManager.CreateTestDirectory().Path;
             var featureBand = "6.0.100";
             var dotnetRoot = Path.Combine(testDir, "dotnet");
-            var expectedManifestUpdates = new (ManifestId, ManifestVersion, ManifestVersion)[] {
-                (new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), new ManifestVersion("7.0.0")),
-                (new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), new ManifestVersion("4.0.0")) };
+            var expectedManifestUpdates = new ManifestVersionUpdate[] {
+                new ManifestVersionUpdate(new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), featureBand, new ManifestVersion("7.0.0"), featureBand),
+                new ManifestVersionUpdate(new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), featureBand, new ManifestVersion("4.0.0"), featureBand) };
             var expectedManifestNotUpdated = new ManifestId[] { new ManifestId("test-manifest-3"), new ManifestId("test-manifest-4") };
 
             // Write mock manifests
@@ -112,12 +112,12 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var adManifestDir = Path.Combine(testDir, ".dotnet", "sdk-advertising", featureBand);
             Directory.CreateDirectory(installedManifestDir);
             Directory.CreateDirectory(adManifestDir);
-            foreach ((var manifestId, var existingVersion, var newVersion) in expectedManifestUpdates)
+            foreach (ManifestVersionUpdate manifestUpdate in expectedManifestUpdates)
             {
-                Directory.CreateDirectory(Path.Combine(installedManifestDir, manifestId.ToString()));
-                File.WriteAllText(Path.Combine(installedManifestDir, manifestId.ToString(), _manifestFileName), GetManifestContent(existingVersion));
-                Directory.CreateDirectory(Path.Combine(adManifestDir, manifestId.ToString()));
-                File.WriteAllText(Path.Combine(adManifestDir, manifestId.ToString(), _manifestFileName), GetManifestContent(newVersion));
+                Directory.CreateDirectory(Path.Combine(installedManifestDir, manifestUpdate.ManifestId.ToString()));
+                File.WriteAllText(Path.Combine(installedManifestDir, manifestUpdate.ManifestId.ToString(), _manifestFileName), GetManifestContent(manifestUpdate.ExistingVersion));
+                Directory.CreateDirectory(Path.Combine(adManifestDir, manifestUpdate.ManifestId.ToString()));
+                File.WriteAllText(Path.Combine(adManifestDir, manifestUpdate.ManifestId.ToString(), _manifestFileName), GetManifestContent(manifestUpdate.NewVersion));
             }
             foreach (var manifest in expectedManifestNotUpdated)
             {
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 File.WriteAllText(Path.Combine(adManifestDir, manifest.ToString(), _manifestFileName), GetManifestContent(new ManifestVersion("5.0.0")));
             }
 
-            var manifestDirs = expectedManifestUpdates.Select(manifest => manifest.Item1)
+            var manifestDirs = expectedManifestUpdates.Select(manifest => manifest.ManifestId)
                 .Concat(expectedManifestNotUpdated)
                 .Select(manifest => Path.Combine(installedManifestDir, manifest.ToString(), _manifestFileName))
                 .ToArray();
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var installationRepo = new MockInstallationRecordRepository();
             var manifestUpdater = new WorkloadManifestUpdater(_reporter, workloadResolver, nugetDownloader, userProfileDir: Path.Combine(testDir, ".dotnet"), testDir, installationRepo);
 
-            var manifestUpdates = manifestUpdater.CalculateManifestUpdates().Select( m => (m.manifestId, m.existingVersion,m .newVersion));
+            var manifestUpdates = manifestUpdater.CalculateManifestUpdates().Select( m => m.manifestUpdate);
             manifestUpdates.Should().BeEquivalentTo(expectedManifestUpdates);
         }
 
@@ -147,26 +147,26 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var testDir = _testAssetsManager.CreateTestDirectory().Path;
             var featureBand = "6.0.100";
             var dotnetRoot = Path.Combine(testDir, "dotnet");
-            var expectedManifestUpdates = new (ManifestId,  ManifestVersion, SdkFeatureBand, ManifestVersion, SdkFeatureBand)[] {
-                (new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), new SdkFeatureBand("6.0.100"), new ManifestVersion("4.0.0"), new SdkFeatureBand("6.0.100")),
-                (new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), new SdkFeatureBand("6.0.100"), new ManifestVersion("2.0.0"), new SdkFeatureBand("6.0.100")) };
+            var expectedManifestUpdates = new ManifestVersionUpdate[] {
+                new ManifestVersionUpdate(new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), featureBand, new ManifestVersion("4.0.0"), featureBand),
+                new ManifestVersionUpdate(new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), featureBand, new ManifestVersion("2.0.0"), featureBand) };
 
             // Write mock manifests
             var installedManifestDir = Path.Combine(testDir, "dotnet", "sdk-manifests", featureBand);
             var adManifestDir = Path.Combine(testDir, ".dotnet", "sdk-advertising", featureBand);
             Directory.CreateDirectory(installedManifestDir);
             Directory.CreateDirectory(adManifestDir);
-            foreach ((var manifestId, var existingVersion, var existingFeatureBand, _, _) in expectedManifestUpdates)
+            foreach (var manifestUpdate in expectedManifestUpdates)
             {
-                Directory.CreateDirectory(Path.Combine(installedManifestDir, manifestId.ToString()));
-                File.WriteAllText(Path.Combine(installedManifestDir, manifestId.ToString(), _manifestFileName), GetManifestContent(existingVersion));
+                Directory.CreateDirectory(Path.Combine(installedManifestDir, manifestUpdate.ManifestId.ToString()));
+                File.WriteAllText(Path.Combine(installedManifestDir, manifestUpdate.ManifestId.ToString(), _manifestFileName), GetManifestContent(manifestUpdate.ExistingVersion));
             }
 
             var rollbackDefContent = JsonSerializer.Serialize(new Dictionary<string, string>() { { "test-manifest-1", "4.0.0" }, { "test-manifest-2", "2.0.0" } });
             var rollbackDefPath = Path.Combine(testDir, "testRollbackDef.txt");
             File.WriteAllText(rollbackDefPath, rollbackDefContent);
 
-            var manifestDirs = expectedManifestUpdates.Select(manifest => manifest.Item1)
+            var manifestDirs = expectedManifestUpdates.Select(manifest => manifest.ManifestId)
                 .Select(manifest => Path.Combine(installedManifestDir, manifest.ToString(), _manifestFileName))
                 .ToArray();
             var workloadManifestProvider = new MockManifestProvider(manifestDirs);

--- a/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
@@ -38,8 +38,16 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             FailingGarbageCollection = failingGarbageCollection;
         }
 
-        public void InstallWorkloadPacks(IEnumerable<PackInfo> packInfos, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null)
+        public void InstallWorkloadPacks(IEnumerable<PackInfo> packInfos, SdkFeatureBand sdkFeatureBand, ITransactionContext transactionContext, DirectoryPath? offlineCache = null)
         {
+            transactionContext.AddRollbackAction(() =>
+            {
+                if (FailingRollback)
+                {
+                    throw new Exception("Rollback failure");
+                }
+            });
+
             foreach (var packInfo in packInfos)
             {
                 InstalledPacks = InstalledPacks.Append(packInfo).ToList();
@@ -51,18 +59,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             }
         }
 
-        public void RepairWorkloadPack(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null)
+        public void RepairWorkloadPack(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, ITransactionContext context, DirectoryPath? offlineCache = null)
         {
-            InstallWorkloadPacks(new[] { packInfo }, sdkFeatureBand, offlineCache);
-        }
-
-        public void RollBackWorkloadPackInstall(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null)
-        {
-            if (FailingRollback)
-            {
-                throw new Exception("Rollback failure");
-            }
-            RolledBackPacks.Add(packInfo);
+            InstallWorkloadPacks(new[] { packInfo }, sdkFeatureBand, context, offlineCache);
         }
 
         public void GarbageCollectInstalledWorkloadPacks(DirectoryPath? offlineCache = null)

--- a/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
@@ -15,9 +15,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
     internal class MockPackWorkloadInstaller : IWorkloadPackInstaller
     {
         public IList<PackInfo> InstalledPacks;
-        public IList<PackInfo> RolledBackPacks = new List<PackInfo>();
-        public IList<(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache)> InstalledManifests = 
-            new List<(ManifestId, ManifestVersion, SdkFeatureBand, DirectoryPath?)>();
+        public List<PackInfo> RolledBackPacks = new List<PackInfo>();
+        public IList<(ManifestVersionUpdate manifestUpdate, DirectoryPath? offlineCache)> InstalledManifests = 
+            new List<(ManifestVersionUpdate manifestUpdate, DirectoryPath?)>();
         public IList<PackInfo> CachedPacks = new List<PackInfo>();
         public string CachePath;
         public bool GarbageCollectionCalled = false;
@@ -40,23 +40,27 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
         public void InstallWorkloadPacks(IEnumerable<PackInfo> packInfos, SdkFeatureBand sdkFeatureBand, ITransactionContext transactionContext, DirectoryPath? offlineCache = null)
         {
-            transactionContext.AddRollbackAction(() =>
+            transactionContext.Run(action: () =>
+            {
+                foreach (var packInfo in packInfos)
+                {
+                    InstalledPacks = InstalledPacks.Append(packInfo).ToList();
+                    CachePath = offlineCache?.Value;
+                    if (packInfo.Id.ToString().Equals(FailingPack))
+                    {
+                        throw new Exception($"Failing pack: {packInfo.Id}");
+                    }
+                }
+            },
+            rollback: () =>
             {
                 if (FailingRollback)
                 {
                     throw new Exception("Rollback failure");
                 }
-            });
 
-            foreach (var packInfo in packInfos)
-            {
-                InstalledPacks = InstalledPacks.Append(packInfo).ToList();
-                CachePath = offlineCache?.Value;
-                if (packInfo.Id.ToString().Equals(FailingPack))
-                {
-                    throw new Exception($"Failing pack: {packInfo.Id}");
-                }
-            }
+                RolledBackPacks.AddRange(packInfos);
+            });
         }
 
         public void RepairWorkloadPack(PackInfo packInfo, SdkFeatureBand sdkFeatureBand, ITransactionContext context, DirectoryPath? offlineCache = null)
@@ -88,9 +92,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             return InstallationRecordRepository;
         }
 
-        public void InstallWorkloadManifest(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null, bool isRollback = false)
+        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, DirectoryPath? offlineCache = null, bool isRollback = false)
         {
-            InstalledManifests.Add((manifestId, manifestVersion, sdkFeatureBand, offlineCache));
+            InstalledManifests.Add((manifestUpdate, offlineCache));
         }
 
         public void DownloadToOfflineCache(PackInfo pack, DirectoryPath cachePath, bool includePreviews)

--- a/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             return InstallationRecordRepository;
         }
 
-        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, DirectoryPath? offlineCache = null, bool isRollback = false)
+        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null, bool isRollback = false)
         {
             InstalledManifests.Add((manifestUpdate, offlineCache));
         }

--- a/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Workloads.Workload.Install;
+using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 
@@ -16,12 +17,27 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         public int CalculateManifestUpdatesCallCount = 0;
         public int DownloadManifestPackagesCallCount = 0;
         public int ExtractManifestPackagesToTempDirCallCount = 0;
-        private IEnumerable<(ManifestId, ManifestVersion, ManifestVersion, Dictionary<WorkloadId, WorkloadDefinition> Workloads)> _manifestUpdates;
+        private IEnumerable<(ManifestId manifestId,
+            ManifestVersion existingVersion,
+            SdkFeatureBand existingFeatureBand,
+            ManifestVersion newVersion,
+            SdkFeatureBand newFeatureBand,
+            Dictionary<WorkloadId, WorkloadDefinition> Workloads)> _manifestUpdates;
         private string _tempDirManifestPath;
 
-        public MockWorkloadManifestUpdater(IEnumerable<(ManifestId, ManifestVersion, ManifestVersion, Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestUpdates = null, string tempDirManifestPath = null)
+        public MockWorkloadManifestUpdater(IEnumerable<(ManifestId manifestId,
+            ManifestVersion existingVersion,
+            SdkFeatureBand existingFeatureBand,
+            ManifestVersion newVersion,
+            SdkFeatureBand newFeatureBand,
+            Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestUpdates = null, string tempDirManifestPath = null)
         {
-            _manifestUpdates = manifestUpdates ?? new List<(ManifestId, ManifestVersion, ManifestVersion, Dictionary<WorkloadId, WorkloadDefinition> Workloads)>();
+            _manifestUpdates = manifestUpdates ?? new List<(ManifestId manifestId,
+                ManifestVersion existingVersion,
+                SdkFeatureBand existingFeatureBand,
+                ManifestVersion newVersion,
+                SdkFeatureBand newFeatureBand,
+                Dictionary<WorkloadId, WorkloadDefinition> Workloads)>();
             _tempDirManifestPath = tempDirManifestPath;
         }
 
@@ -34,7 +50,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         public IEnumerable<(
             ManifestId manifestId,
             ManifestVersion existingVersion,
+            SdkFeatureBand existingFeatureBand,
             ManifestVersion newVersion,
+            SdkFeatureBand newFeatureBand,
             Dictionary<WorkloadId, WorkloadDefinition> Workloads)> CalculateManifestUpdates()
         {
             CalculateManifestUpdatesCallCount++;
@@ -64,7 +82,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         }
 
         public Task BackgroundUpdateAdvertisingManifestsWhenRequiredAsync() => throw new System.NotImplementedException();
-        public IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, ManifestVersion newVersion)> CalculateManifestRollbacks(string rollbackDefinitionFilePath) => throw new System.NotImplementedException();
+        public IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, SdkFeatureBand existingFeatureBand, ManifestVersion newVersion, SdkFeatureBand newFeatureBand)> CalculateManifestRollbacks(string rollbackDefinitionFilePath) => throw new System.NotImplementedException();
         public IEnumerable<WorkloadId> GetUpdatableWorkloadsToAdvertise(IEnumerable<WorkloadId> installedWorkloads) => throw new System.NotImplementedException();
         public void DeleteUpdatableWorkloadsFile() { }
     }

--- a/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
@@ -81,8 +82,12 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             return new string[] { "mock-manifest-url" };
         }
 
+        public IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, SdkFeatureBand existingFeatureBand, ManifestVersion newVersion, SdkFeatureBand newFeatureBand)> CalculateManifestRollbacks(string rollbackDefinitionFilePath)
+        {
+            return _manifestUpdates.Select(t => (t.manifestId, t.existingVersion, t.existingFeatureBand, t.newVersion, t.newFeatureBand));
+        }
+
         public Task BackgroundUpdateAdvertisingManifestsWhenRequiredAsync() => throw new System.NotImplementedException();
-        public IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, SdkFeatureBand existingFeatureBand, ManifestVersion newVersion, SdkFeatureBand newFeatureBand)> CalculateManifestRollbacks(string rollbackDefinitionFilePath) => throw new System.NotImplementedException();
         public IEnumerable<WorkloadId> GetUpdatableWorkloadsToAdvertise(IEnumerable<WorkloadId> installedWorkloads) => throw new System.NotImplementedException();
         public void DeleteUpdatableWorkloadsFile() { }
     }

--- a/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
@@ -18,26 +18,14 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         public int CalculateManifestUpdatesCallCount = 0;
         public int DownloadManifestPackagesCallCount = 0;
         public int ExtractManifestPackagesToTempDirCallCount = 0;
-        private IEnumerable<(ManifestId manifestId,
-            ManifestVersion existingVersion,
-            SdkFeatureBand existingFeatureBand,
-            ManifestVersion newVersion,
-            SdkFeatureBand newFeatureBand,
+        private IEnumerable<(ManifestVersionUpdate manifestUpdate,
             Dictionary<WorkloadId, WorkloadDefinition> Workloads)> _manifestUpdates;
         private string _tempDirManifestPath;
 
-        public MockWorkloadManifestUpdater(IEnumerable<(ManifestId manifestId,
-            ManifestVersion existingVersion,
-            SdkFeatureBand existingFeatureBand,
-            ManifestVersion newVersion,
-            SdkFeatureBand newFeatureBand,
+        public MockWorkloadManifestUpdater(IEnumerable<(ManifestVersionUpdate manifestUpdate,
             Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestUpdates = null, string tempDirManifestPath = null)
         {
-            _manifestUpdates = manifestUpdates ?? new List<(ManifestId manifestId,
-                ManifestVersion existingVersion,
-                SdkFeatureBand existingFeatureBand,
-                ManifestVersion newVersion,
-                SdkFeatureBand newFeatureBand,
+            _manifestUpdates = manifestUpdates ?? new List<(ManifestVersionUpdate manifestUpdate,
                 Dictionary<WorkloadId, WorkloadDefinition> Workloads)>();
             _tempDirManifestPath = tempDirManifestPath;
         }
@@ -49,11 +37,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         }
 
         public IEnumerable<(
-            ManifestId manifestId,
-            ManifestVersion existingVersion,
-            SdkFeatureBand existingFeatureBand,
-            ManifestVersion newVersion,
-            SdkFeatureBand newFeatureBand,
+            ManifestVersionUpdate manifestUpdate,
             Dictionary<WorkloadId, WorkloadDefinition> Workloads)> CalculateManifestUpdates()
         {
             CalculateManifestUpdatesCallCount++;
@@ -82,9 +66,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             return new string[] { "mock-manifest-url" };
         }
 
-        public IEnumerable<(ManifestId manifestId, ManifestVersion existingVersion, SdkFeatureBand existingFeatureBand, ManifestVersion newVersion, SdkFeatureBand newFeatureBand)> CalculateManifestRollbacks(string rollbackDefinitionFilePath)
+        public IEnumerable<ManifestVersionUpdate> CalculateManifestRollbacks(string rollbackDefinitionFilePath)
         {
-            return _manifestUpdates.Select(t => (t.manifestId, t.existingVersion, t.existingFeatureBand, t.newVersion, t.newFeatureBand));
+            return _manifestUpdates.Select(t => t.manifestUpdate);
         }
 
         public Task BackgroundUpdateAdvertisingManifestsWhenRequiredAsync() => throw new System.NotImplementedException();

--- a/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
+++ b/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
@@ -31,12 +31,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
         private WorkloadListCommand _workloadListCommand;
         private string _testDirectory;
 
-        private List<(ManifestId manifestId,
-            ManifestVersion existingVersion,
-            SdkFeatureBand existingFeatureBand,
-            ManifestVersion newVersion,
-            SdkFeatureBand newFeatureBand,
-            Dictionary<WorkloadId, WorkloadDefinition> Workloads)> _mockManifestUpdates;
+        private List<(ManifestVersionUpdate manifestUpdate, Dictionary<WorkloadId, WorkloadDefinition> Workloads)> _mockManifestUpdates;
 
         private MockNuGetPackageDownloader _nugetDownloader;
         private string _dotnetRoot;
@@ -50,15 +45,17 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             _testDirectory = _testAssetsManager.CreateTestDirectory(identifier: identifier).Path;
             _dotnetRoot = Path.Combine(_testDirectory, "dotnet");
             _nugetDownloader = new(_dotnetRoot);
-            
+            var currentSdkFeatureBand = new SdkFeatureBand(CurrentSdkVersion);
+
             _mockManifestUpdates = new()
             {
                 (
-                    new ManifestId("manifest1"),
-                    new ManifestVersion(CurrentSdkVersion),
-                    new SdkFeatureBand("6.0.300"),
-                    new ManifestVersion(UpdateAvailableVersion),
-                    new SdkFeatureBand("6.0.300"),
+                    new ManifestVersionUpdate(
+                        new ManifestId("manifest1"),
+                        new ManifestVersion(CurrentSdkVersion),
+                        currentSdkFeatureBand.ToString(),
+                        new ManifestVersion(UpdateAvailableVersion),
+                        currentSdkFeatureBand.ToString()),
                     new Dictionary<WorkloadId, WorkloadDefinition>
                     {
                         [new WorkloadId(InstallingWorkload)] = new(
@@ -69,11 +66,12 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                             WorkloadDefinitionKind.Dev, null, null, null)
                     }),
                 (
-                    new ManifestId("manifest-other"),
-                    new ManifestVersion(CurrentSdkVersion),
-                    new SdkFeatureBand("6.0.300"),
-                    new ManifestVersion("7.0.101"),
-                    new SdkFeatureBand("6.0.300"),
+                    new ManifestVersionUpdate(
+                        new ManifestId("manifest-other"),
+                        new ManifestVersion(CurrentSdkVersion),
+                        currentSdkFeatureBand.ToString(),
+                        new ManifestVersion("7.0.101"),
+                        currentSdkFeatureBand.ToString()),
                     new Dictionary<WorkloadId, WorkloadDefinition>
                     {
                         [new WorkloadId("other-manifest-workload")] = new(
@@ -82,11 +80,12 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                             WorkloadDefinitionKind.Dev, null, null, null)
                     }),
                 (
-                    new ManifestId("manifest-older-version"),
-                    new ManifestVersion(CurrentSdkVersion),
-                    new SdkFeatureBand("6.0.300"),
-                    new ManifestVersion("6.0.100"),
-                    new SdkFeatureBand("6.0.300"),
+                    new ManifestVersionUpdate(
+                        new ManifestId("manifest-older-version"),
+                        new ManifestVersion(CurrentSdkVersion),
+                        currentSdkFeatureBand.ToString(),
+                        new ManifestVersion("6.0.100"),
+                        currentSdkFeatureBand.ToString()),
                     new Dictionary<WorkloadId, WorkloadDefinition>
                     {
                         [new WorkloadId("other-manifest-workload")] = new(

--- a/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
+++ b/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
@@ -31,8 +31,12 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
         private WorkloadListCommand _workloadListCommand;
         private string _testDirectory;
 
-        private List<(ManifestId, ManifestVersion, ManifestVersion, Dictionary<WorkloadId, WorkloadDefinition>
-            Workloads)> _mockManifestUpdates;
+        private List<(ManifestId manifestId,
+            ManifestVersion existingVersion,
+            SdkFeatureBand existingFeatureBand,
+            ManifestVersion newVersion,
+            SdkFeatureBand newFeatureBand,
+            Dictionary<WorkloadId, WorkloadDefinition> Workloads)> _mockManifestUpdates;
 
         private MockNuGetPackageDownloader _nugetDownloader;
         private string _dotnetRoot;
@@ -46,13 +50,15 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             _testDirectory = _testAssetsManager.CreateTestDirectory(identifier: identifier).Path;
             _dotnetRoot = Path.Combine(_testDirectory, "dotnet");
             _nugetDownloader = new(_dotnetRoot);
-
+            
             _mockManifestUpdates = new()
             {
                 (
                     new ManifestId("manifest1"),
                     new ManifestVersion(CurrentSdkVersion),
+                    new SdkFeatureBand("6.0.300"),
                     new ManifestVersion(UpdateAvailableVersion),
+                    new SdkFeatureBand("6.0.300"),
                     new Dictionary<WorkloadId, WorkloadDefinition>
                     {
                         [new WorkloadId(InstallingWorkload)] = new(
@@ -65,7 +71,9 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 (
                     new ManifestId("manifest-other"),
                     new ManifestVersion(CurrentSdkVersion),
+                    new SdkFeatureBand("6.0.300"),
                     new ManifestVersion("7.0.101"),
+                    new SdkFeatureBand("6.0.300"),
                     new Dictionary<WorkloadId, WorkloadDefinition>
                     {
                         [new WorkloadId("other-manifest-workload")] = new(
@@ -76,7 +84,9 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 (
                     new ManifestId("manifest-older-version"),
                     new ManifestVersion(CurrentSdkVersion),
+                    new SdkFeatureBand("6.0.300"),
                     new ManifestVersion("6.0.100"),
+                    new SdkFeatureBand("6.0.300"),
                     new Dictionary<WorkloadId, WorkloadDefinition>
                     {
                         [new WorkloadId("other-manifest-workload")] = new(

--- a/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -343,7 +343,12 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             [CallerMemberName] string testName = "",
             string failingWorkload = null,
             string failingPack = null,
-            IEnumerable<(ManifestId, ManifestVersion, ManifestVersion, Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestUpdates = null,
+            IEnumerable<(ManifestId manifestId,
+                ManifestVersion existingVersion,
+                SdkFeatureBand existingFeatureBand,
+                ManifestVersion newVersion,
+                SdkFeatureBand newFeatureBand,
+                Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestUpdates = null,
             IList<WorkloadId> installedWorkloads = null,
             bool includeInstalledPacks = false)
         {

--- a/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -351,14 +351,10 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             var parseResult = Parser.Instance.Parse(new string[] { "dotnet", "workload", "update", "--from-rollback-file", "rollback.json" });
       
             var manifestsToUpdate =
-                new (ManifestId manifestId,
-                ManifestVersion existingVersion,
-                SdkFeatureBand existingFeatureBand,
-                ManifestVersion newVersion,
-                SdkFeatureBand newFeatureBand,
+                new (ManifestVersionUpdate manifestUpdate,
                 Dictionary<WorkloadId, WorkloadDefinition> Workloads)[]
                     {
-                        (new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), new SdkFeatureBand(existingSdkFeatureBand), new ManifestVersion("2.0.0"), new SdkFeatureBand(newSdkFeatureBand),
+                        (new ManifestVersionUpdate(new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), existingSdkFeatureBand, new ManifestVersion("2.0.0"), newSdkFeatureBand),
                             null),
                     };
 
@@ -366,9 +362,9 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
 
             updateCommand.UpdateWorkloads();
 
-            packInstaller.InstalledManifests[0].manifestId.Should().Be(manifestsToUpdate[0].manifestId);
-            packInstaller.InstalledManifests[0].manifestVersion.Should().Be(manifestsToUpdate[0].newVersion);
-            packInstaller.InstalledManifests[0].sdkFeatureBand.Should().Be(new SdkFeatureBand(newSdkFeatureBand));
+            packInstaller.InstalledManifests[0].manifestUpdate.ManifestId.Should().Be(manifestsToUpdate[0].manifestUpdate.ManifestId);
+            packInstaller.InstalledManifests[0].manifestUpdate.NewVersion.Should().Be(manifestsToUpdate[0].manifestUpdate.NewVersion);
+            packInstaller.InstalledManifests[0].manifestUpdate.NewFeatureBand.Should().Be(manifestsToUpdate[0].manifestUpdate.NewFeatureBand);
             packInstaller.InstalledManifests[0].offlineCache.Should().Be(null);
         }
 
@@ -378,18 +374,14 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             var parseResult = Parser.Instance.Parse(new string[] { "dotnet", "workload", "update", "--from-rollback-file", "rollback.json" });
 
             var manifestsToUpdate =
-                new (ManifestId manifestId,
-                ManifestVersion existingVersion,
-                SdkFeatureBand existingFeatureBand,
-                ManifestVersion newVersion,
-                SdkFeatureBand newFeatureBand,
+                new (ManifestVersionUpdate manifestUpdate,
                 Dictionary<WorkloadId, WorkloadDefinition> Workloads)[]
                     {
-                        (new ManifestId("mock-manifest-1"), new ManifestVersion("1.0.0"), new SdkFeatureBand("6.0.300"), new ManifestVersion("2.0.0"), new SdkFeatureBand("6.0.100"),
+                        (new ManifestVersionUpdate(new ManifestId("mock-manifest-1"), new ManifestVersion("1.0.0"), "6.0.300", new ManifestVersion("2.0.0"), "6.0.100"),
                             null),
-                        (new ManifestId("mock-manifest-2"), new ManifestVersion("1.0.0"), new SdkFeatureBand("6.0.100"), new ManifestVersion("2.0.0"), new SdkFeatureBand("6.0.300"),
+                        (new ManifestVersionUpdate(new ManifestId("mock-manifest-2"), new ManifestVersion("1.0.0"), "6.0.100", new ManifestVersion("2.0.0"), "6.0.300"),
                             null),
-                        (new ManifestId("mock-manifest-3"), new ManifestVersion("1.0.0"), new SdkFeatureBand("5.0.100"), new ManifestVersion("2.0.0"), new SdkFeatureBand("6.0.100"),
+                        (new ManifestVersionUpdate(new ManifestId("mock-manifest-3"), new ManifestVersion("1.0.0"), "5.0.100", new ManifestVersion("2.0.0"), "6.0.100"),
                             null),
                     };
 
@@ -397,11 +389,11 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
 
             updateCommand.UpdateWorkloads();
 
-            packInstaller.InstalledManifests[0].manifestId.Should().Be(manifestsToUpdate[0].manifestId);
-            packInstaller.InstalledManifests[0].manifestVersion.Should().Be(manifestsToUpdate[0].newVersion);
-            packInstaller.InstalledManifests[0].sdkFeatureBand.Should().Be(new SdkFeatureBand("6.0.100"));
-            packInstaller.InstalledManifests[1].sdkFeatureBand.Should().Be(new SdkFeatureBand("6.0.300"));
-            packInstaller.InstalledManifests[2].sdkFeatureBand.Should().Be(new SdkFeatureBand("6.0.100"));
+            packInstaller.InstalledManifests[0].manifestUpdate.ManifestId.Should().Be(manifestsToUpdate[0].manifestUpdate.ManifestId);
+            packInstaller.InstalledManifests[0].manifestUpdate.NewVersion.Should().Be(manifestsToUpdate[0].manifestUpdate.NewVersion);
+            packInstaller.InstalledManifests[0].manifestUpdate.NewFeatureBand.Should().Be("6.0.100");
+            packInstaller.InstalledManifests[1].manifestUpdate.NewFeatureBand.Should().Be("6.0.300");
+            packInstaller.InstalledManifests[2].manifestUpdate.NewFeatureBand.Should().Be("6.0.100");
             packInstaller.InstalledManifests[0].offlineCache.Should().Be(null);
         }
 
@@ -410,12 +402,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             [CallerMemberName] string testName = "",
             string failingWorkload = null,
             string failingPack = null,
-            IEnumerable<(ManifestId manifestId,
-                ManifestVersion existingVersion,
-                SdkFeatureBand existingFeatureBand,
-                ManifestVersion newVersion,
-                SdkFeatureBand newFeatureBand,
-                Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestUpdates = null,
+            IEnumerable<(ManifestVersionUpdate manifestUpdate, Dictionary<WorkloadId, WorkloadDefinition> Workloads)> manifestUpdates = null,
             IList<WorkloadId> installedWorkloads = null,
             bool includeInstalledPacks = false,
             string sdkVersion = "6.0.100",


### PR DESCRIPTION
- Supports installing workload pack group MSIs (#21741).  Creating the MSIs will be a separate update to the workload creation infrastructure in dotnet/arcade.
- Creates a `ManifestVersionUpdate` class to replace passing around tuples of 5 elements in a lot of places
- Switches to a new transaction infrastructure for workloads, to allow for more control of the ordering of messages and rollback actions, as well as making it explicit which installation methods should participate in the transaction (by taking an `ITransactionContext` parameter)

(This is rebased on top of #24545, so it also currently includes commits from that PR.)