### PR TITLE
Set TargetFrameworkMonikerDisplayName for .NET Standard and .NET Core/.NET5+ projects.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
@@ -18,11 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'netstandard2.0'">.NET Standard 2.0</TargetFrameworkMonikerDisplayName>
     <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'netstandard2.1'">.NET Standard 2.1</TargetFrameworkMonikerDisplayName>
     <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'netcoreapp3.1'">.NET Core 3.1</TargetFrameworkMonikerDisplayName>
-    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netcoreapp5.0'">.NET 5.0</TargetFrameworkMonikerDisplayName>
-    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netcoreapp6.0'">.NET 6.0</TargetFrameworkMonikerDisplayName>
-    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'netcoreapp7.0'">.NET 7.0</TargetFrameworkMonikerDisplayName>
-    <!-- enable once .NET 8 development starts (and when the SDK adds support for it). -->
-    <!-- <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'netcoreapp8.0'">.NET 8.0</TargetFrameworkMonikerDisplayName> -->
+    <TargetFrameworkMonikerDisplayName Condition="''$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">.NET $(TargetFrameworkVersion)</TargetFrameworkMonikerDisplayName>
     <_TargetFrameworkDirectories />
     <FrameworkPathOverride />
     <TargetFrameworkDirectory />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
@@ -15,10 +15,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GetFrameworkPaths" />
 
   <PropertyGroup>
-    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'netstandard2.0'">.NET Standard 2.0</TargetFrameworkMonikerDisplayName>
-    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'netstandard2.1'">.NET Standard 2.1</TargetFrameworkMonikerDisplayName>
-    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'netcoreapp3.1'">.NET Core 3.1</TargetFrameworkMonikerDisplayName>
-    <TargetFrameworkMonikerDisplayName Condition="''$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">.NET $(TargetFrameworkVersion)</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 1.0)) and $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), 2.1))">.NET Standard $(TargetFrameworkVersion)</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 1.0)) and $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), 3.1))">.NET Core $(TargetFrameworkVersion)</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">.NET $(TargetFrameworkVersion)</TargetFrameworkMonikerDisplayName>
     <_TargetFrameworkDirectories />
     <FrameworkPathOverride />
     <TargetFrameworkDirectory />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
@@ -15,6 +15,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GetFrameworkPaths" />
 
   <PropertyGroup>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'netstandard2.0'">.NET Standard 2.0</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'netstandard2.1'">.NET Standard 2.1</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'netcoreapp3.1'">.NET Core 3.1</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netcoreapp5.0'">.NET 5.0</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netcoreapp6.0'">.NET 6.0</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'netcoreapp7.0'">.NET 7.0</TargetFrameworkMonikerDisplayName>
+    <!-- enable once .NET 8 development starts (and when the SDK adds support for it). -->
+    <!-- <TargetFrameworkMonikerDisplayName Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'netcoreapp8.0'">.NET 8.0</TargetFrameworkMonikerDisplayName> -->
     <_TargetFrameworkDirectories />
     <FrameworkPathOverride />
     <TargetFrameworkDirectory />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
@@ -15,9 +15,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GetFrameworkPaths" />
 
   <PropertyGroup>
-    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 1.0)) and $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), 2.1))">.NET Standard $(TargetFrameworkVersion)</TargetFrameworkMonikerDisplayName>
-    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 1.0)) and $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), 3.1))">.NET Core $(TargetFrameworkVersion)</TargetFrameworkMonikerDisplayName>
-    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">.NET $(TargetFrameworkVersion)</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 1.0)) and $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), 2.1))">.NET Standard $(_TargetFrameworkVersionWithoutV)</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 1.0)) and $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), 3.1))">.NET Core $(_TargetFrameworkVersionWithoutV)</TargetFrameworkMonikerDisplayName>
+    <TargetFrameworkMonikerDisplayName Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">.NET $(_TargetFrameworkVersionWithoutV)</TargetFrameworkMonikerDisplayName>
     <_TargetFrameworkDirectories />
     <FrameworkPathOverride />
     <TargetFrameworkDirectory />

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -2,19 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
-using Xunit;
-using FluentAssertions;
-using System.Runtime.InteropServices;
-using Xunit.Abstractions;
 using Microsoft.NET.TestFramework.ProjectConstruction;
-using System.Xml.Linq;
-using Xunit.Sdk;
-using System.Reflection;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -765,7 +762,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp2.1", ".NET Core 2.1")]
         [InlineData("netstandard2.1", ".NET Standard 2.1")]
         [InlineData("net5.0", ".NET 5.0")]
-        public void CheckTargetFrameworkDisplayName(string targetFrameworkVersion, string expectedVersion)
+        public void CheckTargetFrameworkDisplayName(string targetFrameworkVersion, string expectedFrameworkDisplayName)
         {
             TestProject libraryProject = new TestProject()
             {
@@ -808,7 +805,7 @@ class Program
                 .WithWorkingDirectory(Path.Combine(testAsset.Path, testProject.Name))
                 .Execute();
             result.Should().Pass();
-            result.StdOut.Should().Contain(expectedVersion);
+            result.StdOut.Should().Contain(expectedFrameworkDisplayName);
 
         }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -769,6 +769,7 @@ namespace Microsoft.NET.Build.Tests
                 Name = "LibraryProject",
                 TargetFrameworks = targetFrameworkVersion
             };
+            libraryProject.AdditionalProperties["NoWarn"] = "NETSDK1138";
             libraryProject.SourceFiles["Class.cs"] = @"
 public class LibraryClass{}
 ";
@@ -805,7 +806,7 @@ class Program
                 .WithWorkingDirectory(Path.Combine(testAsset.Path, testProject.Name))
                 .Execute();
             result.Should().Pass();
-            result.StdOut.Should().Contain(expectedFrameworkDisplayName);
+            result.StdOut.Should().Equals(expectedFrameworkDisplayName);
 
         }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -794,7 +794,7 @@ class Program
         Console.WriteLine(str);
     }
 }";
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFrameworkVersion);
             var buildCommand = new BuildCommand(testAsset);
             buildCommand.WithWorkingDirectory(testAsset.Path)
                 .Execute()


### PR DESCRIPTION
Fixes #10774.