### PR TITLE
Restrict default file inclusion of Windows App SDK files to only happen if specific properties are set

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -35,17 +35,17 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
     <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
     <EmbeddedResource Include="**/*.resx" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' " />
-    <!-- Microsoft.WindowsAppSDK is a NuGet delivered SDK. Include only if the package is installed (WindowsAppSdkFoundation is set by the Microsoft.WindowsAppSDK NuGet package). -->
-    <Content Include="$(__WindowsAppSdkDefaultImageIncludes)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultContentItems)' != 'false' And '$(WindowsAppSdkFoundation)' == 'true' " />
-    <PRIResource Include="**/*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultPRIResourceItems)' != 'false' And '$(WindowsAppSdkFoundation)' == 'true' "/>
+    <!-- Microsoft.WindowsAppSDK is a NuGet delivered SDK. EnableDefaultWindowsAppSdkContentItems and EnableDefaultWindowsAppSdkPRIResourceItems are overridable properties that the SDK will set to true by default. -->
+    <Content Include="$(__WindowsAppSdkDefaultImageIncludes)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultContentItems)' != 'false' And '$(EnableDefaultWindowsAppSdkContentItems)' == 'true' " />
+    <PRIResource Include="**/*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultPRIResourceItems)' != 'false' And '$(EnableDefaultWindowsAppSdkPRIResourceItems)' == 'true' "/>
   </ItemGroup>
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultNoneItems)' == 'true' ">
     <None Include="**/*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <None Remove="**/*$(DefaultLanguageSourceExtension)" />
     <None Remove="**/*.resx" />
-    <!-- Microsoft.WindowsAppSDK is a NuGet delivered SDK. Remove only if the package is installed (WindowsAppSdkFoundation is set by the Microsoft.WindowsAppSDK NuGet package). -->
-    <None Remove="$(__WindowsAppSdkDefaultImageIncludes)" Condition=" '$(WindowsAppSdkFoundation)' == 'true' "/>
-    <None Remove="**/*.resw" Condition=" '$(WindowsAppSdkFoundation)' == 'true' "/>
+    <!-- Microsoft.WindowsAppSDK is a NuGet delivered SDK. EnableDefaultWindowsAppSdkContentItems and EnableDefaultWindowsAppSdkPRIResourceItems are overridable properties that the SDK will set to true by default. -->
+    <None Remove="$(__WindowsAppSdkDefaultImageIncludes)" Condition=" '$(EnableDefaultWindowsAppSdkContentItems)' == 'true' "/>
+    <None Remove="**/*.resw" Condition=" '$(EnableDefaultWindowsAppSdkPRIResourceItems)' == 'true' "/>
   </ItemGroup>
 
   <!-- Automatically reference NETStandard.Library or Microsoft.NETCore.App package if targeting the corresponding target framework.

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -379,7 +379,8 @@ namespace Microsoft.NET.Build.Tests
             testProject.AdditionalProperties["EnableDefaultResourceItems"] = "false";
 
             // Windows App SDK related
-            testProject.AdditionalProperties["WindowsAppSdkFoundation"] = "true";
+            testProject.AdditionalProperties["EnableDefaultWindowsAppSdkContentItems"] = "true";
+            testProject.AdditionalProperties["EnableDefaultWindowsAppSdkPRIResourceItems"] = "true";
             testProject.AdditionalProperties["EnableDefaultContentItems"] = "false";
             testProject.AdditionalProperties["EnableDefaultPRIResourceItems"] = "false";
 
@@ -768,7 +769,8 @@ public class Class1
             };
 
             // Windows App SDK
-            testProject.AdditionalProperties["WindowsAppSdkFoundation"] = "true";
+            testProject.AdditionalProperties["EnableDefaultWindowsAppSdkContentItems"] = "true";
+            testProject.AdditionalProperties["EnableDefaultWindowsAppSdkPRIResourceItems"] = "true";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             var projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);
@@ -819,7 +821,7 @@ public class Class1
                 IsExe = true,
             };
 
-            // Not setting the "WindowsAppSdkFoundation" property!
+            // Not setting the "EnableDefaultWindowsAppSdkContentItems" or "EnableDefaultWindowsAppSdkPRIResourceItems" properties!
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             var projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);


### PR DESCRIPTION
**Issue**
Follow up change for https://github.com/dotnet/sdk/pull/24139

Both the Windows App SDK and the .NET SDK were doing the file inclusion. This wasn't an issue in testing the Windows App SDK scenarios, but it results in an error IF `EnableDefaultContentItems` is set to true (the duplicate items check is done only if that property is set to true). That property is generally not set to true, but MAUI does set it to true (and they use the Windows App SDK). That's how this was discovered.

This change ensures that the inclusion is not done twice. The properties `EnableDefaultWindowsAppSdkContentItems` and `EnableDefaultWindowsAppSdkPRIResourceItems` do not exist in the current Windows App SDK. They will be added in v1.1 where the file inclusion that's done there (broken solution) will also be removed.

It would be good to also require `EnableDefaultContentItems` and `EnableDefaultPRIResourceItems` to be true, rather than not false, but as it's late in the game, I'm keeping the change minimal.

**How verified**
Fixed tests and reran them. Tests that installed the Windows App SDK NuGet were considered but I think they're unnecessary.


## Approval template

### Customer impact

.NET Maui apps for Windows will fail to build.  We are not aware of a workaround.  The failure message will be similar to the following:

NETSDK1022: Duplicate 'Content' items were included. The .NET SDK includes 'Content' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultContentItems' property to 'false' if you want to explicitly include them in your project file. For more information, see [https://aka.ms/sdkimplicititems](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Faka.ms%2Fsdkimplicititems&data=04%7C01%7Cdaplaist%40microsoft.com%7C48d07fd7a5fb44e86c5208da16949440%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C637847124717620275%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=yybEbKx68NpbFP4I3AMIVzHfuI5rUISMS8l6f5V0OJY%3D&reserved=0). The duplicate items were: 'Resources\Embedded\dotnet_bot.png'; 'Resources\Images\books.png'; 'Resources\Images\calculator.png'; 'Resources\Images\card_background.png'; 'Resources\Images\coffee.png'; 'Resources\Images\header_background.png'; 'Resources\Images\mic.png'; 'Resources\Images\settings.png'; 'Resources\Images\cover1.jpg'; 'Resources\Images\flowerbuds.jpg'; 'Resources\Images\fruits.jpg'; 'Resources\Images\legumes.jpg'; 'Resources\Images\oasis.jpg'; 'Resources\Images\photo.jpg'; 'Resources\Images\vegetables.jpg'; 'Resources\Embedded\animated_heart.gif'; 'Resources\Images\animated_heart.gif' [C:\Projects\maui\src\Controls\samples\Controls.Sample\Maui.Controls.Sample.csproj]

### Description

Only include Windows App SDK content and PRI file globs if a new property (EnableDefaultWindowsAppSdkContentItems) is set.  This will be set by a future version of the Windows App SDK package.


### Regression

Yes, from previous release

The regression was introduced in https://github.com/dotnet/sdk/pull/24139.  We didn't catch it there because it doesn't happen with simple Windows App SDK projects, but does affect .NET Maui projects.

In a previous PR (https://github.com/dotnet/sdk/pull/24139), we added some Content file globs (default item includes) for the Windows APP SDK to the .NET SDK itself.  Previously, they were defined in the Windows App SDK NuGet package, but because of where NuGet .props files are evaluated, it wasn’t possible to get that logic in the right place in evaluation order to work well.  So we added them to the .NET SDK with a condition based on whether the Windows App SDK was being used.

However, currently those includes are still included in the Windows App SDK NuGet package itself.  This is now causing duplicate items to be included, which results in a build error.

This wasn’t caught in previous testing, because the check for these duplicate items only runs if EnableDefaultContentItems is set to true.  The conflicting includes were checking whether EnableDefaultContentItems was not set to true, so if the property was not set there would be duplicate items but the check and error for duplicate items wouldn’t be run.

However, in Maui scenarios, the Razor SDK is also used, and it sets EnableDefaultContentItems to true, which causes the error to be enabled.

### Risk

Low – the actual fix is low risk.  As with all changes at this point in the cycle, there is some schedule risk from doing a rebuild.

### Testing

There are some automated tests, but they don’t test a full Maui project.  We did manual testing of the fix with a Maui project that was broken by the previous change.