### PR TITLE
Fix broken blog post link

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// so that the next process will receive the same string[] args
         /// 
         /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// https://docs.microsoft.com/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// so that the next process will receive the same string[] args
         /// 
         /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// https://docs.microsoft.com/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// so that the next process will receive the same string[] args
         /// 
         /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// https://docs.microsoft.com/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// be to do this only for cmd metacharacters.
         /// 
         /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// https://docs.microsoft.com/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// be to do this only for cmd metacharacters.
         /// 
         /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// https://docs.microsoft.com/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>

--- a/src/RazorSdk/Tool/CommandLine/ArgumentEscaper.cs
+++ b/src/RazorSdk/Tool/CommandLine/ArgumentEscaper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool.CommandLineUtils
         /// receive the same string[] args.
         /// </summary>
         /// <remarks>
-        /// See https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+        /// See https://docs.microsoft.com/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
         /// </remarks>
         /// <param name="args">The arguments to concatenate.</param>
         /// <returns>The escaped arguments, concatenated.</returns>


### PR DESCRIPTION
The original link doesn't redirect to the new location of the post.