### PR TITLE
Replace rollForward in tools runtimeconfig

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -408,6 +408,11 @@
       <ReplacementString>"version": "$(MicrosoftNETCoreAppRuntimePackageVersion)"</ReplacementString>
     </PropertyGroup>
     <ItemGroup>
+      <TextReplacement>
+        <Include>"rollForward": "LatestMajor"</Include>
+        <ReplacementString>"rollForward": "Major"</ReplacementString>
+      </TextReplacement>
+
       <!-- Exclude F# from retargeting: https://github.com/dotnet/toolset/issues/2866 -->
       <!-- Exclude testhost from retargeting: https://github.com/dotnet/sdk/issues/24769 -->
       <ToolRuntimeConfigPath Include="$(OutputPath)/**/*.runtimeconfig.json"
@@ -418,6 +423,7 @@
     <ReplaceFileContents
       InputFiles="@(ToolRuntimeConfigPath)"
       DestinationFiles="@(ToolRuntimeConfigPath)"
+      ReplacementItems="@(TextReplacement)"
       ReplacementPatterns="$(ReplacementPattern)"
       ReplacementStrings="$(ReplacementString)" />
 


### PR DESCRIPTION
Tools like dotnet-format specify a rollForward of 'LatestMajor' which forces runtime change. Replace this rollForward with 'Major' which merely allows for a runtime change.