### PR TITLE
bump WarningLevel to 7 for .NET 7

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -18,7 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- If not specified and greater than or equal to .NET 5, default the AnalysisLevel to the the MAJ.MIN version -->
     <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
                               '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
-                              $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">$(_TargetFrameworkVersionWithoutV)</AnalysisLevel>
+                              $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">latest</AnalysisLevel>
 
 
     <!-- AnalysisLevel can also contain compound values with a prefix and suffix separated by a '-' character.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -20,12 +20,16 @@ Copyright (c) .NET Foundation. All rights reserved.
                               '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
                               $([MSBuild]::VersionEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">5.0</AnalysisLevel>
 
-    <!-- Automatically set AnalysisLevel if not specified -->
+    <!-- Automatically set AnalysisLevel if not specified based on TFM major version -->
     <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
                               (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
                                $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))) Or
-                               '$(AnalysisMode)' != '')">latest</AnalysisLevel>
+                               '$(AnalysisMode)' != '')">6.0</AnalysisLevel>
 
+    <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
+                               (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
+                                $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '7.0'))) Or
+                                '$(AnalysisMode)' != '')">7.0</AnalysisLevel>
 
     <!-- AnalysisLevel can also contain compound values with a prefix and suffix separated by a '-' character.
          The prefix indicates the core AnalysisLevel and the suffix indicates the bucket of
@@ -65,26 +69,23 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Enable the trim analyzer when any trimming settings are enabled. Warnings may suppressed based on other settings. -->
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</EnableTrimAnalyzer>
 
-    <!-- Enable the AOT analyzer when AOT is enabled. Warnings may suppressed based on other settings. -->
-    <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == '' And '$(PublishAot)' == 'true'">true</EnableAotAnalyzer>
-
-    <!-- Compiler warning level, defaulted to 4. We promote it to 5 if the user has set analysis level to 5 or higher
+    <!-- The compiler warning level is defaulted to 4. We promote it to 5 if the user has set analysis level to 5 or higher
          NOTE: at this time only the C# compiler supports warning waves -->
-    <WarningLevel Condition="'$(Language)' == 'C#'">5</WarningLevel>
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == ''">5</WarningLevel>
   </PropertyGroup>
 
   <!-- Set the default WarningLevel based on EffectiveAnalysisLevel
        For .NET 6 we want the Warning level to be 6 -->
   <PropertyGroup Condition="'$(EffectiveAnalysisLevel)' != '' And
                              $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '6.0'))">
-    <WarningLevel Condition="'$(Language)' == 'C#'">6</WarningLevel>
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == ''">6</WarningLevel>
   </PropertyGroup>
 
   <!-- Set the default WarningLevel based on EffectiveAnalysisLevel
        For .NET 7 we want the Warning level to be 7 -->
   <PropertyGroup Condition="'$(EffectiveAnalysisLevel)' != '' And
                              $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '7.0'))">
-    <WarningLevel Condition="'$(Language)' == 'C#'">7</WarningLevel>
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == ''">7</WarningLevel>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -15,21 +15,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Analysis level is a single property that can be used to control both the compiler warning waves
          and enable .NET analyzers. Valid values are 'none', 'latest', 'preview', or a version number  -->
 
-    <!-- Automatically set AnalysisLevel to 5 if targeting .net 5 and nothing else specified -->
+    <!-- If not specified and greater than or equal to .NET 5, default the AnalysisLevel to the the MAJ.MIN version -->
     <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
                               '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
-                              $([MSBuild]::VersionEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">5.0</AnalysisLevel>
+                              $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">$(_TargetFrameworkVersionWithoutV)</AnalysisLevel>
 
-    <!-- Automatically set AnalysisLevel if not specified based on TFM major version -->
-    <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
-                              (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
-                               $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))) Or
-                               '$(AnalysisMode)' != '')">6.0</AnalysisLevel>
-
-    <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
-                               (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
-                                $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '7.0'))) Or
-                                '$(AnalysisMode)' != '')">7.0</AnalysisLevel>
 
     <!-- AnalysisLevel can also contain compound values with a prefix and suffix separated by a '-' character.
          The prefix indicates the core AnalysisLevel and the suffix indicates the bucket of
@@ -45,8 +35,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- EffectiveAnalysisLevel is used to differentiate from user specified strings (such as 'none')
          and an implied numerical option (such as '4')-->
     <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'none' or '$(AnalysisLevelPrefix)' == 'none'">4.0</EffectiveAnalysisLevel>
-    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'latest' or '$(AnalysisLevelPrefix)' == 'latest'">6.0</EffectiveAnalysisLevel>
-    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'preview' or '$(AnalysisLevelPrefix)' == 'preview'">7.0</EffectiveAnalysisLevel>
+    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'latest' or '$(AnalysisLevelPrefix)' == 'latest'">7.0</EffectiveAnalysisLevel>
+    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'preview' or '$(AnalysisLevelPrefix)' == 'preview'">8.0</EffectiveAnalysisLevel>
 
     <!-- Set EffectiveAnalysisLevel to the value of AnalysisLevel if it is a version number -->
     <EffectiveAnalysisLevel Condition="'$(EffectiveAnalysisLevel)' == '' And
@@ -69,32 +59,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Enable the trim analyzer when any trimming settings are enabled. Warnings may suppressed based on other settings. -->
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</EnableTrimAnalyzer>
 
-    <!-- The compiler warning level is defaulted to 4. We promote it to 5 if the user has set analysis level to 5 or higher
-         NOTE: at this time only the C# compiler supports warning waves -->
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == ''">5</WarningLevel>
-  </PropertyGroup>
+    <!-- If the user specified 'preview' we want to pick a very high warning level to opt into the highest possible warning wave -->
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(AnalysisLevel)' == 'preview'">9999</WarningLevel>
+    <!-- NOTE: at this time only the C# compiler supports warning waves like this. -->
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == ''">$(_TargetFrameworkVersionWithoutV.Substring(0, 1))</WarningLevel>
 
-  <!-- Set the default WarningLevel based on EffectiveAnalysisLevel
-       For .NET 6 we want the Warning level to be 6 -->
-  <PropertyGroup Condition="'$(EffectiveAnalysisLevel)' != '' And
-                             $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '6.0'))">
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == ''">6</WarningLevel>
-  </PropertyGroup>
-
-  <!-- Set the default WarningLevel based on EffectiveAnalysisLevel
-       For .NET 7 we want the Warning level to be 7 -->
-  <PropertyGroup Condition="'$(EffectiveAnalysisLevel)' != '' And
-                             $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '7.0'))">
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == ''">7</WarningLevel>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">false</EnableNETAnalyzers>
 
     <!-- EnforceCodeStyleInBuild Allows code style analyzers to be disabled in bulk via msbuild if the user wants to -->
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">false</EnforceCodeStyleInBuild>
-    <!-- If the user specified 'preview' we want to pick a very high warning level to opt into the highest possible warning wave -->
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(AnalysisLevel)' == 'preview'">9999</WarningLevel>
   </PropertyGroup>
 
   <!-- Unconditionally import 'Microsoft.CodeAnalysis.NetAnalyzers.props' for all C# and VB projects for supporting https://github.com/dotnet/roslyn-analyzers/issues/3977 -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -15,11 +15,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Analysis level is a single property that can be used to control both the compiler warning waves
          and enable .NET analyzers. Valid values are 'none', 'latest', 'preview', or a version number  -->
 
-    <!-- If not specified and greater than or equal to .NET 5, default the AnalysisLevel to latest -->
+    <!-- If not specified and equal to the current most-recent TFM, default the AnalysisLevel to latest.
+         Otherwise, default AnalysisLevel to the TFM. We set 'latest' indirectly here because the
+         next chunk of logic handles user-defined prefix/suffix, which can also set 'latest', so
+         we choose to only do the 'latest' => actual value translation one time. -->
+    <_AnalysisLevelWasSet Condition="'$(AnalysisLevel)' == ''">true</_AnalysisLevelWasSet>
+    <!-- TODO: a test that automatically validates this would be great -->
+    <_LatestAnalysisLevel>7.0</_LatestAnalysisLevel>
     <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
                               '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
-                              $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">latest</AnalysisLevel>
-
+                              $([MSBuild]::VersionEquals($(_TargetFrameworkVersionWithoutV), '$(_LatestAnalysisLevel)'))">latest</AnalysisLevel>
+    <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
+                              '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
+                              $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">$(_TargetFrameworkVersionWithoutV)</AnalysisLevel>
 
     <!-- AnalysisLevel can also contain compound values with a prefix and suffix separated by a '-' character.
          The prefix indicates the core AnalysisLevel and the suffix indicates the bucket of
@@ -35,7 +43,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- EffectiveAnalysisLevel is used to differentiate from user specified strings (such as 'none')
          and an implied numerical option (such as '4')-->
     <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'none' or '$(AnalysisLevelPrefix)' == 'none'">4.0</EffectiveAnalysisLevel>
-    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'latest' or '$(AnalysisLevelPrefix)' == 'latest'">7.0</EffectiveAnalysisLevel>
+    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'latest' or '$(AnalysisLevelPrefix)' == 'latest'">$(_LatestAnalysisLevel)</EffectiveAnalysisLevel>
     <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'preview' or '$(AnalysisLevelPrefix)' == 'preview'">8.0</EffectiveAnalysisLevel>
 
     <!-- Set EffectiveAnalysisLevel to the value of AnalysisLevel if it is a version number -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -80,6 +80,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WarningLevel Condition="'$(Language)' == 'C#'">6</WarningLevel>
   </PropertyGroup>
 
+  <!-- Set the default WarningLevel based on EffectiveAnalysisLevel
+       For .NET 7 we want the Warning level to be 7 -->
+  <PropertyGroup Condition="'$(EffectiveAnalysisLevel)' != '' And
+                             $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '7.0'))">
+    <WarningLevel Condition="'$(Language)' == 'C#'">7</WarningLevel>
+  </PropertyGroup>
+
   <PropertyGroup>
     <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">false</EnableNETAnalyzers>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Analysis level is a single property that can be used to control both the compiler warning waves
          and enable .NET analyzers. Valid values are 'none', 'latest', 'preview', or a version number  -->
 
-    <!-- If not specified and greater than or equal to .NET 5, default the AnalysisLevel to the the MAJ.MIN version -->
+    <!-- If not specified and greater than or equal to .NET 5, default the AnalysisLevel to latest -->
     <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
                               '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
                               $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">latest</AnalysisLevel>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -60,7 +60,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</EnableTrimAnalyzer>
 
     <!-- If the user specified 'preview' we want to pick a very high warning level to opt into the highest possible warning wave -->
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(AnalysisLevel)' == 'preview'">9999</WarningLevel>
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(AnalysisLevel)' == 'preview'">9999</WarningLevel>
     <!-- NOTE: at this time only the C# compiler supports warning waves like this. -->
     <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == ''">$(_TargetFrameworkVersionWithoutV.Substring(0, 1))</WarningLevel>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -76,6 +76,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Enable the trim analyzer when any trimming settings are enabled. Warnings may suppressed based on other settings. -->
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</EnableTrimAnalyzer>
 
+    <!-- Enable the AOT analyzer when AOT is enabled. Warnings may suppressed based on other settings. -->
+    <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == '' And '$(PublishAot)' == 'true'">true</EnableAotAnalyzer>
+
     <!-- EnforceCodeStyleInBuild Allows code style analyzers to be disabled in bulk via msbuild if the user wants to -->
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">false</EnforceCodeStyleInBuild>
   </PropertyGroup>
@@ -85,6 +88,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">false</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">false</EnforceCodeStyleInBuild>
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == ''">false</EnableTrimAnalyzer>
+    <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == ''">false</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == ''">false</EnableSingleFileAnalyzer>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -43,6 +43,15 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        '$(AnalysisLevelPrefix)' != ''">$(AnalysisLevelPrefix)</EffectiveAnalysisLevel>
     <EffectiveAnalysisLevel Condition="'$(EffectiveAnalysisLevel)' == '' And
                                        '$(AnalysisLevel)' != ''">$(AnalysisLevel)</EffectiveAnalysisLevel>
+
+    <!-- Set WarningLevel based on all we know about the project -->
+    <!-- NOTE: at this time only the C# compiler supports warning waves like this. -->
+    <!-- If the user specified 'preview' we want to pick a very high warning level to opt into the highest possible warning wave -->
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(AnalysisLevel)' == 'preview'">9999</WarningLevel>
+    <!-- The CSharp.props used to hard-code WarningLevel to 4, so to maintain parity with .NET Framework projects we do that here. -->
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETFramework' ">4</WarningLevel>
+    <!-- .NET projects, however, can float up to their TFM's major version -->
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">$(_TargetFrameworkVersionWithoutV.Substring(0, 1))</WarningLevel>
   </PropertyGroup>
 
   <!-- Enable Analyzers based on EffectiveAnalysisLevel -->
@@ -59,15 +68,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Enable the trim analyzer when any trimming settings are enabled. Warnings may suppressed based on other settings. -->
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</EnableTrimAnalyzer>
 
-    <!-- If the user specified 'preview' we want to pick a very high warning level to opt into the highest possible warning wave -->
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(AnalysisLevel)' == 'preview'">9999</WarningLevel>
-    <!-- NOTE: at this time only the C# compiler supports warning waves like this. -->
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == ''">$(_TargetFrameworkVersionWithoutV.Substring(0, 1))</WarningLevel>
-
-    <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">false</EnableNETAnalyzers>
-
     <!-- EnforceCodeStyleInBuild Allows code style analyzers to be disabled in bulk via msbuild if the user wants to -->
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <!-- Establish good defaults for scenarios where no EffectiveAnalysisLevel was set (e.g. .NETFramework) -->
+  <PropertyGroup Condition="'$(EffectiveAnalysisLevel)' == '' Or ('$(EffectiveAnalysisLevel)' != '' And $([MSBuild]::VersionLessThanOrEquals($(EffectiveAnalysisLevel), '4.0')))">
+    <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">false</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">false</EnforceCodeStyleInBuild>
+    <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == ''">false</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == ''">false</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <!-- Unconditionally import 'Microsoft.CodeAnalysis.NetAnalyzers.props' for all C# and VB projects for supporting https://github.com/dotnet/roslyn-analyzers/issues/3977 -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -19,9 +19,12 @@ Copyright (c) .NET Foundation. All rights reserved.
          Otherwise, default AnalysisLevel to the TFM. We set 'latest' indirectly here because the
          next chunk of logic handles user-defined prefix/suffix, which can also set 'latest', so
          we choose to only do the 'latest' => actual value translation one time. -->
-    <_AnalysisLevelWasSet Condition="'$(AnalysisLevel)' == ''">true</_AnalysisLevelWasSet>
-    <!-- TODO: a test that automatically validates this would be great -->
+
+    <_NoneAnalysisLevel>4.0</_NoneAnalysisLevel>
+    <!-- When the base TFM of the platform bumps, these must be bumped as well. Preview should always be the 'next' TFM. -->
     <_LatestAnalysisLevel>7.0</_LatestAnalysisLevel>
+    <_PreviewAnalysisLevel>8.0</_PreviewAnalysisLevel>
+
     <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
                               '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
                               $([MSBuild]::VersionEquals($(_TargetFrameworkVersionWithoutV), '$(_LatestAnalysisLevel)'))">latest</AnalysisLevel>
@@ -42,9 +45,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- EffectiveAnalysisLevel is used to differentiate from user specified strings (such as 'none')
          and an implied numerical option (such as '4')-->
-    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'none' or '$(AnalysisLevelPrefix)' == 'none'">4.0</EffectiveAnalysisLevel>
+    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'none' or '$(AnalysisLevelPrefix)' == 'none'">$(_NoneAnalysisLevel)</EffectiveAnalysisLevel>
     <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'latest' or '$(AnalysisLevelPrefix)' == 'latest'">$(_LatestAnalysisLevel)</EffectiveAnalysisLevel>
-    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'preview' or '$(AnalysisLevelPrefix)' == 'preview'">8.0</EffectiveAnalysisLevel>
+    <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'preview' or '$(AnalysisLevelPrefix)' == 'preview'">$(PreviewAnalysisLevel)</EffectiveAnalysisLevel>
 
     <!-- Set EffectiveAnalysisLevel to the value of AnalysisLevel if it is a version number -->
     <EffectiveAnalysisLevel Condition="'$(EffectiveAnalysisLevel)' == '' And

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.props
@@ -12,7 +12,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <WarningLevel Condition=" '$(WarningLevel)' == '' ">4</WarningLevel>
     <NoWarn Condition=" '$(NoWarn)' == '' ">1701;1702</NoWarn>
 
     <!-- Remove the line below once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -19,6 +19,7 @@ namespace Microsoft.NET.Build.Tests
     {
         private const string targetFrameworkNet6 = "net6.0";
         private const string targetFrameworkNet7 = "net7.0";
+        private const string targetFrameworkNetFramework472 = "net472";
 
         public GivenThatWeWantToFloatWarningLevels(ITestOutputHelper log) : base(log)
         {
@@ -26,8 +27,9 @@ namespace Microsoft.NET.Build.Tests
 
         [InlineData(targetFrameworkNet6, 6)]
         [InlineData(targetFrameworkNet7, 7)]
+        [InlineData(targetFrameworkNetFramework472, 4)]
         [RequiresMSBuildVersionTheory("16.8")]
-        public void It_defaults_WarningLevel_To_The_Current_TFM(string tfm, int warningLevel)
+        public void It_defaults_WarningLevel_To_The_Current_TFM_When_Net(string tfm, int warningLevel)
         {
             var testProject = new TestProject
             {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+using FluentAssertions;
+
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToFloatWarningLevels : SdkTest
+    {
+        private const string targetFrameworkNet6 = "net6.0";
+        private const string targetFrameworkNet7 = "net7.0";
+
+        public GivenThatWeWantToFloatWarningLevels(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [InlineData(targetFrameworkNet6, 6)]
+        [InlineData(targetFrameworkNet7, 7)]
+        [RequiresMSBuildVersionTheory("16.8")]
+        public void It_defaults_WarningLevel_To_The_Current_TFM(string tfm, int warningLevel)
+        {
+            var testProject = new TestProject
+            {
+                Name = "HelloWorld",
+                TargetFrameworks = tfm,
+                IsExe = true,
+                SourceFiles =
+                {
+                    ["Program.cs"] = @"
+                        using System;
+
+                        namespace ConsoleCore
+                        {
+                            class Program
+                            {
+                                static void Main()
+                                {
+                                }
+                            }
+                        }
+                    ",
+                }
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject, identifier: "warningLevelConsoleApp", targetExtension: ".csproj");
+
+            var buildCommand = new GetValuesCommand(
+                Log,
+                Path.Combine(testAsset.TestRoot, testProject.Name),
+                tfm, "WarningLevel")
+            {
+                DependsOnTargets = "Build"
+            };
+            var buildResult = buildCommand.Execute();
+            var computedWarningLevel = buildCommand.GetValues()[0];
+            buildResult.StdErr.Should().Be(string.Empty);
+            computedWarningLevel.Should().Be(warningLevel.ToString());
+        }
+
+        [InlineData(1, 1)]
+        [InlineData(null, 7)]
+        [RequiresMSBuildVersionTheory("16.8")]
+        public void It_always_accepts_user_defined_WarningLevel(int? warningLevel, int expectedWarningLevel)
+        {
+            var testProject = new TestProject
+            {
+                Name = "HelloWorld",
+                TargetFrameworks = "net7.0",
+                IsExe = true,
+                SourceFiles =
+                {
+                    ["Program.cs"] = @"
+                        using System;
+
+                        namespace ConsoleCore
+                        {
+                            class Program
+                            {
+                                static void Main()
+                                {
+                                }
+                            }
+                        }
+                    ",
+                }
+            };
+            testProject.AdditionalProperties.Add("WarningLevel", warningLevel?.ToString());
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject, identifier: "customWarningLevelConsoleApp", targetExtension: ".csproj");
+
+            var buildCommand = new GetValuesCommand(
+                Log,
+                Path.Combine(testAsset.TestRoot, testProject.Name),
+                "net7.0", "WarningLevel")
+            {
+                DependsOnTargets = "Build"
+            };
+            var buildResult = buildCommand.Execute();
+            var computedWarningLevel = buildCommand.GetValues()[0];
+            buildResult.StdErr.Should().Be(string.Empty);
+            computedWarningLevel.Should().Be(expectedWarningLevel.ToString());
+        }
+
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
-
 using FluentAssertions;
 
 using Microsoft.NET.TestFramework;
@@ -112,6 +111,59 @@ namespace Microsoft.NET.Build.Tests
             var computedWarningLevel = buildCommand.GetValues()[0];
             buildResult.StdErr.Should().Be(string.Empty);
             computedWarningLevel.Should().Be(expectedWarningLevel.ToString());
+        }
+
+        [InlineData(targetFrameworkNet6, "6.0")]
+        [InlineData(targetFrameworkNet7, "7.0")]
+        [InlineData(targetFrameworkNetFramework472, null)]
+        [RequiresMSBuildVersionTheory("16.8")]
+        public void It_defaults_AnalysisLevel_To_The_Current_TFM_When_NotLatestTFM(string tfm, string analysisLevel)
+        {
+            var testProject = new TestProject
+            {
+                Name = "HelloWorld",
+                TargetFrameworks = tfm,
+                IsExe = true,
+                SourceFiles =
+                {
+                    ["Program.cs"] = @"
+                        using System;
+
+                        namespace ConsoleCore
+                        {
+                            class Program
+                            {
+                                static void Main()
+                                {
+                                }
+                            }
+                        }
+                    ",
+                }
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject, identifier: "analysisLevelConsoleApp"+tfm, targetExtension: ".csproj");
+
+            var buildCommand = new GetValuesCommand(
+                Log,
+                Path.Combine(testAsset.TestRoot, testProject.Name),
+                tfm, "EffectiveAnalysisLevel")
+            {
+                DependsOnTargets = "Build"
+            };
+            var buildResult = buildCommand.Execute();
+
+                buildResult.StdErr.Should().Be(string.Empty);
+            if (analysisLevel == null)
+            {
+                buildCommand.GetValues().Should().BeEmpty();
+            }
+            else {
+                var computedEffectiveAnalysisLevel = buildCommand.GetValues()[0];
+                computedEffectiveAnalysisLevel.Should().Be(analysisLevel.ToString());
+            }
+            buildResult.StdErr.Should().Be(string.Empty);
         }
 
     }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -55,7 +55,7 @@ namespace Microsoft.NET.Build.Tests
             };
 
             var testAsset = _testAssetsManager
-                .CreateTestProject(testProject, identifier: "warningLevelConsoleApp", targetExtension: ".csproj");
+                .CreateTestProject(testProject, identifier: "warningLevelConsoleApp"+tfm, targetExtension: ".csproj");
 
             var buildCommand = new GetValuesCommand(
                 Log,


### PR DESCRIPTION
The C# compiler supports a warning wave of 7 now, and we should float that on like was done for .NET 6. This PR does that, in a slightly more maintainable way IMO.

The rules are:
* AnalysisLevel should track the current TFM if not specifed
* AnalysisLevel should be set to `latest` if the current TFM is the 'latest' TFM (as defined by a property that we need to bump)
* WarningLevel should track the current TFM if not specified
* WarningLevel shouldn't override the user-provided value
* WarningLevel should be set to 4 if the project is a .NET Framework project

Fixes https://github.com/dotnet/sdk/issues/21599 as well

cc @Youssef1313 via https://github.com/dotnet/templating/issues/4580