### PR TITLE
[release/6.0.3xx] Ensure stable property is set on asset manifest

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -92,6 +92,12 @@
       <ItemsToSignPostBuild Remove="@(ItemsToSignPostBuild)" />
       <ItemsToSignPostBuild Include="@(ToolsetAssetsToPublish->'%(Filename)%(Extension)')" />
     </ItemGroup>
+    
+    <PropertyGroup>
+      <IsStableBuild>false</IsStableBuild>
+      <IsStableBuild Condition="'$(DotNetFinalVersionKind)' == 'release'">true</IsStableBuild>
+    </PropertyGroup>
+    
 
     <MakeDir Directories="$(TempWorkingDirectory)"/>
 
@@ -113,7 +119,8 @@
       PublishFlatContainer="true"
       AssetManifestPath="$(SdkAssetsManifestFilePath)"
       AssetsTemporaryDirectory="$(TempWorkingDirectory)" 
-      PublishingVersion="3"/>
+      PublishingVersion="3"
+      IsStableBuild="$(IsStableBuild)" />
 
     <Copy
       SourceFiles="$(SdkAssetsManifestFilePath)"


### PR DESCRIPTION
For the custom push of fsharp packages, ensure that the task has the stable property set correctly. Without this, publishing will attempt to push stable packages to non-stable feeds and fail.