### PR TITLE
[gh-23135] use parent path of manifest file path as rootConfigDirectory

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalInstaller.cs
@@ -78,7 +78,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                         new PackageLocation(
                             nugetConfig: configFile,
                             additionalFeeds: _sources,
-                            rootConfigDirectory: manifestFile.GetDirectoryPath()),
+                            // Fix https://github.com/dotnet/sdk/issues/23135
+                            rootConfigDirectory: manifestFile.GetDirectoryPath().GetParentPath()),
                         _packageId,
                         versionRange,
                         TargetFrameworkToInstall,


### PR DESCRIPTION
Fix gh-23135 using parent path of manifest file. 
I didn't figure out how to do a unit test that make sense unfortunately. 