### PR TITLE
Allow file changes from tar as it's just a warning

### DIFF
--- a/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
+++ b/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
         protected override string GenerateCommandLineCommands()
         {
-            return $"--warning:no-file-changed {GetDestinationArchive()} {GetSourceSpecification()}";
+            return $"--warning=no-file-changed {GetDestinationArchive()} {GetSourceSpecification()}";
         }
 
         private string GetSourceSpecification()

--- a/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
+++ b/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
@@ -43,8 +43,9 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {
             int returnCode = base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
-
-            if (IgnoreExitCode)
+            
+            // returnCode 1 indicates files changed during tar which is just a warning
+            if (IgnoreExitCode || returnCode == 1)
             {
                 returnCode = 0;
             }
@@ -110,7 +111,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
         protected override string GenerateCommandLineCommands()
         {
-            return $"--warning=no-file-changed {GetDestinationArchive()} {GetSourceSpecification()}";
+            return $"{GetDestinationArchive()} {GetSourceSpecification()}";
         }
 
         private string GetSourceSpecification()

--- a/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
+++ b/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
         protected override string GenerateCommandLineCommands()
         {
-            return $"{GetDestinationArchive()} {GetSourceSpecification()}";
+            return $"--warning:no-file-changed {GetDestinationArchive()} {GetSourceSpecification()}";
         }
 
         private string GetSourceSpecification()

--- a/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
+++ b/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         {
             int returnCode = base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
             
-            // returnCode 1 indicates files changed during tar which is just a warning
+            // returnCode 1 indicates that files changed during tar. In our case, it is likely being overwritten by another copy of the same file, so we can safely ignore this warning.
             if (IgnoreExitCode || returnCode == 1)
             {
                 returnCode = 0;


### PR DESCRIPTION
I kept seeing tar errors in our builds. it turns out that tar returning 1 means the files changed during execution. Let's allow that to be more reliable in our builds as I think this is from helix and non-helix together.

The version of tar we use doesn't support the --warning flag for this so map a returncode of 1 back to zero. In parallel, I'm digging into how our version of tar is determined.