### PR TITLE
update exception message for invalid rollback file

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -331,6 +331,6 @@
     <value>Checking for updated workload manifests.</value>
   </data>
   <data name="InvalidVersionForWorkload" xml:space="preserve">
-    <value>Error parsing version for workload {0}: Invalid version {1}.</value>
+    <value>Error parsing version '{1}' for workload manifest ID '{0}'</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -330,4 +330,7 @@
   <data name="CheckForUpdatedWorkloadManifests" xml:space="preserve">
     <value>Checking for updated workload manifests.</value>
   </data>
+  <data name="InvalidVersionForWorkload" xml:space="preserve">
+    <value>Error parsing version for workload {0}: Invalid version {1}.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -3,24 +3,23 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.Cli.Utils;
-using Microsoft.NET.Sdk.WorkloadManifestReader;
 using System.IO;
 using System.Linq;
-using Microsoft.DotNet.Cli.NuGetPackageDownloader;
-using Microsoft.DotNet.ToolPackage;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.MSBuildSdkResolver;
+using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.Extensions.EnvironmentAbstractions;
-using NuGet.Versioning;
-using Microsoft.DotNet.Configurer;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
 using NuGet.Common;
-using System.Text.Json;
-using System.Runtime.InteropServices;
-using Microsoft.DotNet.Cli;
-using System.Net;
-using System.Net.Http;
-using Microsoft.DotNet.MSBuildSdkResolver;
+using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install
 {
@@ -473,7 +472,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     SdkFeatureBand manifestFeatureBand;
                     var parts = manifest.Value.Split('/');
                     
-                    string manifestVersionString = (parts[0]).ToString();
+                    string manifestVersionString = (parts[0]);
                     if (!FXVersion.TryParse(manifestVersionString, out FXVersion version))
                     {
                         if (string.IsNullOrWhiteSpace(manifestVersionString))

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -480,7 +480,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         {
                             throw new ArgumentNullException(nameof(manifestVersionString));
                         }
-                        //throw new FormatException($"Error parsing version for workload {manifest.Key}: Invalid version {manifestVersionString}.");
                         throw new FormatException(String.Format(LocalizableStrings.InvalidVersionForWorkload, manifest.Key, manifestVersionString));
                     }
                     manifestVersion = new ManifestVersion(parts[0]);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -474,14 +474,15 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     var parts = manifest.Value.Split('/');
                     
                     string manifestVersionString = (parts[0]).ToString();
-                    if (!FXVersion.TryParse(manifestVersionString, out FXVersion _version))
+                    if (!FXVersion.TryParse(manifestVersionString, out FXVersion version))
                     {
                         if (string.IsNullOrWhiteSpace(manifestVersionString))
                         {
                             throw new ArgumentNullException(nameof(manifestVersionString));
                         }
                         throw new FormatException(String.Format(LocalizableStrings.InvalidVersionForWorkload, manifest.Key, manifestVersionString));
-                    }
+                    } 
+
                     manifestVersion = new ManifestVersion(parts[0]);
                     if (parts.Length == 1)
                     {

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -20,6 +20,7 @@ using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli;
 using System.Net;
 using System.Net.Http;
+using Microsoft.DotNet.MSBuildSdkResolver;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install
 {
@@ -471,6 +472,17 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     ManifestVersion manifestVersion;
                     SdkFeatureBand manifestFeatureBand;
                     var parts = manifest.Value.Split('/');
+                    
+                    string manifestVersionString = (parts[0]).ToString();
+                    FXVersion _version;
+                    if (!FXVersion.TryParse(manifestVersionString, out _version))
+                    {
+                        if (string.IsNullOrWhiteSpace(manifestVersionString))
+                        {
+                            throw new ArgumentNullException(nameof(manifestVersionString));
+                        }
+                        throw new FormatException($"Error parsing version for workload {manifest.Key}: Invalid version {manifestVersionString}.");
+                    }
                     manifestVersion = new ManifestVersion(parts[0]);
                     if (parts.Length == 1)
                     {

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -475,10 +475,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     string manifestVersionString = (parts[0]);
                     if (!FXVersion.TryParse(manifestVersionString, out FXVersion version))
                     {
-                        if (string.IsNullOrWhiteSpace(manifestVersionString))
-                        {
-                            throw new ArgumentNullException(nameof(manifestVersionString));
-                        }
                         throw new FormatException(String.Format(LocalizableStrings.InvalidVersionForWorkload, manifest.Key, manifestVersionString));
                     } 
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -474,14 +474,14 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     var parts = manifest.Value.Split('/');
                     
                     string manifestVersionString = (parts[0]).ToString();
-                    FXVersion _version;
-                    if (!FXVersion.TryParse(manifestVersionString, out _version))
+                    if (!FXVersion.TryParse(manifestVersionString, out FXVersion _version))
                     {
                         if (string.IsNullOrWhiteSpace(manifestVersionString))
                         {
                             throw new ArgumentNullException(nameof(manifestVersionString));
                         }
-                        throw new FormatException($"Error parsing version for workload {manifest.Key}: Invalid version {manifestVersionString}.");
+                        //throw new FormatException($"Error parsing version for workload {manifest.Key}: Invalid version {manifestVersionString}.");
+                        throw new FormatException(String.Format(LocalizableStrings.InvalidVersionForWorkload, manifest.Key, manifestVersionString));
                     }
                     manifestVersion = new ManifestVersion(parts[0]);
                     if (parts.Length == 1)

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Nedostatečná oprávnění pro spuštění serveru</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">Soubor nastavení v balíčku NuGet úlohy je neplatný: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Unzureichende Berechtigungen zum Starten des Servers.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">Die Einstellungsdatei im NuGet-Paket der Workload ist ungültig: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Insuficientes privilegios para iniciar el servidor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">El archivo de configuración del paquete NuGet de la carga de trabajo no es válido: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Privilèges insuffisants pour démarrer le serveur</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">Le fichier de paramètres situé dans le package NuGet de la charge de travail n'est pas valide : {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Privilegio insufficiente per l'avvio del server.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">Il file di impostazioni nel pacchetto NuGet del carico di lavoro non è valido: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -122,6 +122,11 @@
         <target state="translated">サーバーを起動するための十分な特権がありません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">ワークロードの NuGet パッケージ内の設定ファイルが無効です: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -122,6 +122,11 @@
         <target state="translated">서버를 시작할 권한이 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">워크로드의 NuGet 패키지에 있는 설정 파일이 잘못되었습니다. {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Niewystarczające uprawnienia do uruchomienia serwera.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">Plik ustawień w pakiecie NuGet obciążenia jest nieprawidłowy: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Privilégio insuficiente para iniciar o servidor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">O arquivo de configurações no pacote NuGet da carga de trabalho é inválido: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Недостаточно разрешений для запуска сервера.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">Недопустимый файл параметров в пакете NuGet рабочей нагрузки: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Sunucuyu başlatmak için yeterli ayrıcalığa sahip değilsiniz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">İş yükünün NuGet paketindeki ayar dosyası geçersiz: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -122,6 +122,11 @@
         <target state="translated">权限不足，无法启动服务器。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">工作负载的 NuGet 包中的设置文件无效: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -122,6 +122,11 @@
         <target state="translated">權限不足，無法啟動伺服器。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionForWorkload">
+        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
+        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="translated">工作負載的 NuGet 套件設定檔案無效: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionForWorkload">
-        <source>Error parsing version for workload {0}: Invalid version {1}.</source>
-        <target state="new">Error parsing version for workload {0}: Invalid version {1}.</target>
+        <source>Error parsing version '{1}' for workload manifest ID '{0}'</source>
+        <target state="new">Error parsing version '{1}' for workload manifest ID '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidWorkloadConfiguration">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.DotNet.MSBuildSdkResolver;
+using Strings = Microsoft.NET.Sdk.Localization.Strings;
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
@@ -14,7 +15,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         {
             if (!FXVersion.TryParse(version, out _version))
             {
-                throw new ArgumentNullException(nameof(version));
+                throw new ArgumentException(Strings.InvalidManifestVersion, version);     
             }
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         {
             if (!FXVersion.TryParse(version, out _version))
             {
-                throw new ArgumentNullException(nameof(version));
+                throw new ArgumentNullException($"Invalid version {version}.");
             }
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         {
             if (!FXVersion.TryParse(version, out _version))
             {
-                throw new Exception($"Error parsing version for workload : Invalid version {version}.");
+                throw new ArgumentNullException(nameof(version));
             }
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersion.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         {
             if (!FXVersion.TryParse(version, out _version))
             {
-                throw new ArgumentNullException($"Invalid version {version}.");
+                throw new Exception($"Error parsing version for workload : Invalid version {version}.");
             }
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
@@ -186,4 +186,7 @@
   <data name="CyclicWorkloadRedirect" xml:space="preserve">
     <value>Cyclic workload redirect '{0}' in manifest '{1}' [{2}]</value>
   </data>
+  <data name="InvalidManifestVersion" xml:space="preserve">
+    <value>Invalid version: {0}</value>
+  </data>
 </root>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Dokument předčasně ukončen</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">Nebyla nalezena závislost manifestu úlohy {0} požadovaná manifestem {1} [{2}].</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Dokument ist unvollständig.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">Die Workloadmanifestabhängigkeit „{0}“, die vom Manifest „{1}“ [{2}] benötigt wird, wurde nicht gefunden.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">El documento finalizó antes de tiempo</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">No se ha encontrado la dependencia del manifiesto de carga de trabajo '{0}' requerida por el manifiesto '{1}' [{2}]</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Fin prématurée du document</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">La dépendance de manifeste de charge de travail « {0} » requise par le manifeste « {1} » [{2}] est introuvable</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Il documento è stato interrotto prima del completamento</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">La dipendenza del manifesto del carico di lavoro '{0}' richiesta dal manifesto '{1}' [{2}] non è stata trovata</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">ドキュメントが途中で終了しました</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">マニフェスト '{1}' [{2}] で必要なワークロード マニフェストの依存関係 '{0}' が見つかりません</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">문서가 중간에 끝났습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">매니페스트 '{1}' [{2}]에 필요한 워크로드 매니페스트 종속성 '{0}'을(를) 찾지 못했습니다</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Dokument zakończony przedwcześnie</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">Nie znaleziono zależności manifestu obciążenia „{0}” wymaganej przez manifest „{1}” [{2}]</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">O documento terminou prematuramente</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">Não foi possível encontrar a dependência do manifesto de carga de trabalho '{0}' exigida pelo manifesto '{1}' [{2}]</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Документ завершен преждевременно</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">Не найдена зависимость манифеста рабочей нагрузки "{0}", необходимая для манифеста "{1}" [{2}]</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Belge zamanından önce sonlandırıldı</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">{1}' [{2}] bildirimi için gereken '{0}' iş yükü bildirimi bağımlılığı bulunamadı</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">文档过早结束</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">未找到清单“{1}”[{2}] 所需的工作负载清单依赖项“{0}”</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">文件已提前結束</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidManifestVersion">
+        <source>Invalid version: {0}</source>
+        <target state="new">Invalid version: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestDependencyMissing">
         <source>Did not find workload manifest dependency '{0}' required by manifest '{1}' [{2}]</source>
         <target state="translated">找不到資訊清單 '{1}' [{2}] 所需的工作負載資訊清單相依性 '{0}'</target>

--- a/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -409,12 +409,9 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             Directory.CreateDirectory(userProfileDir);
 
             var sdkFeatureVersion = "6.0.200";
-            var workloadResolver = WorkloadResolver.CreateForTests(new MockManifestProvider(new[] { _manifestPath }), dotnetRoot, userLocal: false, userProfileDir);
-            var nugetDownloader = new MockNuGetPackageDownloader(dotnetRoot);
-            
+           
             var mockRollbackFileContent = @"{""mock.workload"":""6.0.0.15/6.0.100""}";
             var rollbackFilePath = Path.Combine(testDirectory, "rollback.json");
-            var manifestUpdater = new MockWorkloadManifestUpdater();
             File.WriteAllText(rollbackFilePath, mockRollbackFileContent);
             
             var updateParseResult = Parser.Instance.Parse(new string[] { "dotnet", "workload", "update", "--from-rollback-file", rollbackFilePath });

--- a/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -22,6 +22,7 @@ using Microsoft.DotNet.Cli.Workload.Install.Tests;
 using Microsoft.DotNet.Workloads.Workload.Update;
 using Microsoft.DotNet.Cli.Utils;
 using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
+using System;
 
 namespace Microsoft.DotNet.Cli.Workload.Update.Tests
 {
@@ -395,6 +396,34 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             packInstaller.InstalledManifests[1].manifestUpdate.NewFeatureBand.Should().Be("6.0.300");
             packInstaller.InstalledManifests[2].manifestUpdate.NewFeatureBand.Should().Be("6.0.100");
             packInstaller.InstalledManifests[0].offlineCache.Should().Be(null);
+        }
+
+        [Fact]
+        public void GivenInvalidVersionInRollbackFileItErrors()
+        {
+            _reporter.Clear();
+            
+            var testDirectory = _testAssetsManager.CreateTestDirectory().Path;
+            var dotnetRoot = Path.Combine(testDirectory, "dotnet");
+            var userProfileDir = Path.Combine(testDirectory, "user-profile");
+            Directory.CreateDirectory(userProfileDir);
+
+            var sdkFeatureVersion = "6.0.200";
+            var workloadResolver = WorkloadResolver.CreateForTests(new MockManifestProvider(new[] { _manifestPath }), dotnetRoot, userLocal: false, userProfileDir);
+            var nugetDownloader = new MockNuGetPackageDownloader(dotnetRoot);
+            
+            var mockRollbackFileContent = @"{""mock.workload"":""6.0.0.15/6.0.100""}";
+            var rollbackFilePath = Path.Combine(testDirectory, "rollback.json");
+            var manifestUpdater = new MockWorkloadManifestUpdater();
+            File.WriteAllText(rollbackFilePath, mockRollbackFileContent);
+            
+            var updateParseResult = Parser.Instance.Parse(new string[] { "dotnet", "workload", "update", "--from-rollback-file", rollbackFilePath });
+            
+            var updateCommand = new WorkloadUpdateCommand(updateParseResult, reporter: _reporter, userProfileDir: userProfileDir, dotnetDir: dotnetRoot, version: sdkFeatureVersion, tempDirPath: testDirectory);
+
+            var exception = Assert.Throws<GracefulException>(() => updateCommand.Execute());
+            exception.InnerException.Should().BeOfType<FormatException>();
+            exception.InnerException.Message.Should().Contain(string.Format(Workloads.Workload.Install.LocalizableStrings.InvalidVersionForWorkload, "mock.workload", "6.0.0.15"));
         }
 
         internal (string, WorkloadUpdateCommand, MockPackWorkloadInstaller, IWorkloadResolver, MockWorkloadManifestUpdater, MockNuGetPackageDownloader) GetTestInstallers(


### PR DESCRIPTION
Fixes #24680

Run `dotnet workload update --from-rollback-file rollback.json` where rollback.json has the following contents:

```
{
    "microsoft.net.sdk.android": "31.0.300-rc.1.35/6.0.300",
    "microsoft.net.sdk.ios": "15.4.100-rc.1.104/6.0.300",
    "microsoft.net.sdk.maccatalyst": "15.4.100-rc.1.104/6.0.300",
    "microsoft.net.sdk.macos": "12.3.100-rc.1.104/6.0.300",
    "microsoft.net.sdk.maui": "6.0.300-rc.1.5299/6.0.300",
    "microsoft.net.sdk.tvos": "15.4.100-rc.1.104/6.0.300",
    "microsoft.net.workload.mono.toolchain": "6.0.0.15/6.0.100",
    "microsoft.net.workload.emscripten": "6.0.0/6.0.100"
}
```

Original Message:

`Workload update failed: Value cannot be null. (Parameter 'version')`

New Message:
`Workload update failed: Value cannot be null. (Parameter 'Invalid version 6.0.0.15.')`