### PR TITLE
Assign names to arguments for nuget commands

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Cli
         private static Command GetDeleteCommand()
         {
             var deleteCommand = new Command("delete");
-            deleteCommand.AddArgument(new Argument<IEnumerable<string>>() { Arity = ArgumentArity.OneOrMore });
+            deleteCommand.AddArgument(new Argument<IEnumerable<string>>("package-paths") { Arity = ArgumentArity.OneOrMore });
             deleteCommand.AddOption(new Option<bool>("--force-english-output"));
             deleteCommand.AddOption(new Option<string>(new string[] { "-s", "--source" }));
             deleteCommand.AddOption(new Option<bool>("--non-interactive"));
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Cli
         {
             var localsCommand = new Command("locals");
 
-            localsCommand.AddArgument(new Argument<string>()
+            localsCommand.AddArgument(new Argument<string>("cache-locations")
                 .FromAmong(new string[] { "all", "http-cache", "global-packages", "plugins-cache", "temp" }));
 
             localsCommand.AddOption(new Option<bool>("--force-english-output"));
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Cli
         {
             var pushCommand = new Command("push");
 
-            pushCommand.AddArgument(new Argument<IEnumerable<string>>() { Arity = ArgumentArity.OneOrMore });
+            pushCommand.AddArgument(new Argument<IEnumerable<string>>("package-paths") { Arity = ArgumentArity.OneOrMore });
 
             pushCommand.AddOption(new Option<bool>("--force-english-output"));
             pushCommand.AddOption(new Option<string>(new string[] { "-s", "--source" }));
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Cli
             const string fingerprint = "--certificate-fingerprint";
             var verifyCommand = new Command("verify");
 
-            verifyCommand.AddArgument(new Argument<IEnumerable<string>>() { Arity = ArgumentArity.OneOrMore });
+            verifyCommand.AddArgument(new Argument<IEnumerable<string>>("package-paths") { Arity = ArgumentArity.OneOrMore });
 
             verifyCommand.AddOption(new Option<bool>("--all"));
             verifyCommand.AddOption(new ForwardedOption<IEnumerable<string>>(fingerprint)
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Cli
         {
             var trustCommand = new Command("trust");
 
-            trustCommand.AddArgument(new Argument<string>() { Arity = ArgumentArity.ZeroOrOne }
+            trustCommand.AddArgument(new Argument<string>("command") { Arity = ArgumentArity.ZeroOrOne }
                          .FromAmong(new string[] { "list", "author", "repository", "source", "certificate", "remove", "sync" }));
 
             trustCommand.AddOption(new Option<string>("--algorithm"));
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Cli
         {
             var signCommand = new Command("sign");
 
-            signCommand.AddArgument(new Argument<IEnumerable<string>>() { Arity = ArgumentArity.OneOrMore });
+            signCommand.AddArgument(new Argument<IEnumerable<string>>("package-paths") { Arity = ArgumentArity.OneOrMore });
 
             signCommand.AddOption(new Option<string>(new string[] { "-o", "--output" }));
             signCommand.AddOption(new Option<string>("--certificate-path"));

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Cli
         {
             var localsCommand = new Command("locals");
 
-            localsCommand.AddArgument(new Argument<string>("cache-locations")
+            localsCommand.AddArgument(new Argument<string>("folders")
                 .FromAmong(new string[] { "all", "http-cache", "global-packages", "plugins-cache", "temp" }));
 
             localsCommand.AddOption(new Option<bool>("--force-english-output"));


### PR DESCRIPTION
The arguments for the NuGet subcommands don't have names, which means help output shows unhelpful names like `<ienumerable'1>` for them instead of something descriptive.

To fix this, I've gone through each command in its raw form from the NuGet.CommandLine.XPlat.dll and duplicated what it shows for these arguments as much as possible.

Longer term this should go away with the transition to System.CommandLine from NuGet, but for now small tweaks like this seem acceptable.