### PR TITLE
Next helix test move

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -23,9 +23,9 @@ FOR /F "tokens=*" %%g IN ('PowerShell -ExecutionPolicy ByPass [System.IO.Path]::
 set TestExecutionDirectory=%TEMP%\dotnetSdkTests\%RandomDirectoryName%
 set DOTNET_CLI_HOME=%TestExecutionDirectory%\.dotnet
 mkdir %TestExecutionDirectory%
-robocopy %HELIX_CORRELATION_PAYLOAD%\t\TestExecutionDirectoryFiles %TestExecutionDirectory%
+robocopy %HELIX_CORRELATION_PAYLOAD%\t\TestExecutionDirectoryFiles %TestExecutionDirectory% /s
 
 REM call dotnet new so the first run message doesn't interfere with the first test
-dotnet new
+dotnet new --debug:ephemeral-hive
 REM avoid potetial cocurrency issues when nuget is creating nuget.config
 dotnet nuget list source

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -12,9 +12,9 @@ export PATH=$DOTNET_ROOT:$PATH
 export TestExecutionDirectory=$(pwd)/testExecutionDirectory
 mkdir $TestExecutionDirectory
 export DOTNET_CLI_HOME=$TestExecutionDirectory/.dotnet
-cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionDirectory/
+cp -a -r $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionDirectory/
 
 # call dotnet new so the first run message doesn't interfere with the first test
-dotnet new
+dotnet new --debug:ephemeral-hive
 # avoid potetial concurrency issues when nuget is creating nuget.config
 dotnet nuget list source

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -12,7 +12,7 @@ export PATH=$DOTNET_ROOT:$PATH
 export TestExecutionDirectory=$(pwd)/testExecutionDirectory
 mkdir $TestExecutionDirectory
 export DOTNET_CLI_HOME=$TestExecutionDirectory/.dotnet
-cp -a -r $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionDirectory/
+cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionDirectory/
 
 # call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive

--- a/src/Tests/EndToEnd.Tests/EndToEnd.Tests.csproj
+++ b/src/Tests/EndToEnd.Tests/EndToEnd.Tests.csproj
@@ -1,4 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
   <PropertyGroup>
     <TargetFramework>$(ToolsetTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -8,4 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
   </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/Tests/UnitTests.proj
+++ b/src/Tests/UnitTests.proj
@@ -34,13 +34,13 @@
   <Target Name="CopyHelixFiles" AfterTargets="Publish">
 
     <ItemGroup>
-      <BuiltSdks Include="$(RepoRoot)\artifacts\bin\$(Configuration)\Sdks\**\*.*"/>
+      <BuiltSdks Include="$(reporoot)artifacts\bin\$(Configuration)\Sdks\**\*.*"/>
 
       <!-- All the following files are just to get full framework msbuild while avoid to duplicated arcade logic by copying
       arcade and run it -->
-      <Engfolder Include="$(RepoRoot)\eng\**\*.*"/>
-      <DotToolsFolder Include="$(RepoRoot)\.tools\**\*.*"/>
-      <GlobalJson Include="$(RepoRoot)\global.json"/>
+      <Engfolder Include="$(reporoot)eng\**\*.*"/>
+      <DotToolsFolder Include="$(reporoot).tools\**\*.*"/>
+      <GlobalJson Include="$(reporoot)global.json"/>
       <!-- Get full framework msbuild end -->
 
       <!-- include .dotnet folder. So there is no extra first run experience run during the test -->
@@ -52,14 +52,18 @@
       <TestExecutionDirectoryFiles Include="$(ArtifactsTmpDir)NuGet.config"/>
       <TestExecutionDirectoryFiles Include="$(ArtifactsTmpDir)Directory.Build.props"/>
       <TestExecutionDirectoryFiles Include="$(ArtifactsTmpDir)Directory.Build.targets"/>
+      <TestExecutionDirectoryFiles Include="$(RepoRoot)testAsset.props"/>
+      <TestExecutionDirectoryFiles Include="$(RepoRoot)eng\Versions.props">
+        <DestinationFolder>eng/</DestinationFolder>
+      </TestExecutionDirectoryFiles>
 
-      <FilesInHelixRoot Include="$(RepoRoot)\artifacts\tmp\$(Configuration)\NuGet.config"/>
-      <FilesInHelixRoot Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="$(RepoRoot)\build\RunTestsOnHelix.cmd"/>
-      <FilesInHelixRoot Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' " Include="$(RepoRoot)\build\RunTestsOnHelix.sh"/>
+      <FilesInHelixRoot Include="$(reporoot)artifacts\tmp\$(Configuration)\NuGet.config"/>
+      <FilesInHelixRoot Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="$(reporoot)build\RunTestsOnHelix.cmd"/>
+      <FilesInHelixRoot Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' " Include="$(reporoot)build\RunTestsOnHelix.sh"/>
     </ItemGroup>
 
     <PropertyGroup>
-      <HelixPayloadOnHost>$(RepoRoot)\artifacts\tmp\Helixpayload</HelixPayloadOnHost>
+      <HelixPayloadOnHost>$(reporoot)artifacts\tmp\Helixpayload</HelixPayloadOnHost>
     </PropertyGroup>
 
     <Copy SourceFiles="@(Engfolder)" DestinationFiles="@(Engfolder->'$(HelixPayloadOnHost)\eng\%(RecursiveDir)%(Filename)%(Extension)')" />
@@ -68,7 +72,7 @@
 
     <Copy SourceFiles="@(FilesInHelixRoot)" DestinationFiles="@(FilesInHelixRoot->'$(HelixPayloadOnHost)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
-    <Copy SourceFiles="@(TestExecutionDirectoryFiles)" DestinationFiles="@(TestExecutionDirectoryFiles->'$(HelixPayloadOnHost)\TestExecutionDirectoryFiles\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(TestExecutionDirectoryFiles)" DestinationFiles="@(TestExecutionDirectoryFiles->'$(HelixPayloadOnHost)\TestExecutionDirectoryFiles\%(RecursiveDir)%(DestinationFolder)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(DotnetCliHome)" DestinationFiles="@(DotnetCliHome->'$(HelixPayloadOnHost)\TestExecutionDirectoryFiles\.dotnet\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(Testpackages)" DestinationFiles="@(Testpackages->'$(HelixPayloadOnHost)\TestExecutionDirectoryFiles\Testpackages\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
@@ -78,11 +82,11 @@
     <PropertyGroup>
       <HelixPreCommands Condition="!$(IsPosixShell)">call %HELIX_CORRELATION_PAYLOAD%\t\RunTestsOnHelix.cmd $(TestFullMSBuild);$(HelixPreCommands)</HelixPreCommands>
       <HelixPreCommands Condition="$(IsPosixShell)">. $HELIX_CORRELATION_PAYLOAD/t/RunTestsOnHelix.sh;$(HelixPreCommands)</HelixPreCommands>
-      <TestDotnetRoot>$(RepoRoot)\artifacts\bin\redist\$(Configuration)\dotnet</TestDotnetRoot>
+      <TestDotnetRoot>$(reporoot)artifacts\bin\redist\$(Configuration)\dotnet</TestDotnetRoot>
       <TestDotnetVersion>$(Version)</TestDotnetVersion>
-      <MSBuildSdkResolverDir>$(RepoRoot)\artifacts\bin\Microsoft.DotNet.MSBuildSdkResolver</MSBuildSdkResolverDir>
-      <HelixStage0Targz>$(RepoRoot)\artifacts\tmp\HelixStage0.tar.gz</HelixStage0Targz>
-      <MicrosoftNETBuildExtensions>$(RepoRoot)\artifacts\bin\$(Configuration)\Sdks\Microsoft.NET.Build.Extensions</MicrosoftNETBuildExtensions>
+      <MSBuildSdkResolverDir>$(reporoot)artifacts\bin\Microsoft.DotNet.MSBuildSdkResolver</MSBuildSdkResolverDir>
+      <HelixStage0Targz>$(reporoot)artifacts\tmp\HelixStage0.tar.gz</HelixStage0Targz>
+      <MicrosoftNETBuildExtensions>$(reporoot)artifacts\bin\$(Configuration)\Sdks\Microsoft.NET.Build.Extensions</MicrosoftNETBuildExtensions>
     </PropertyGroup>
 
     <TarGzFileCreateFromDirectory
@@ -122,6 +126,6 @@
   <Target Name="CreateLocalHelixTestLayout" DependsOnTargets="AppendHelixPreCommand">
     <CreateLocalHelixTestLayout
         HelixCorrelationPayload="@(HelixCorrelationPayload)"
-        TestOutputDirectory="$(RepoRoot)\artifacts\bin\localHelixTestLayout" />
+        TestOutputDirectory="$(reporoot)artifacts\bin\localHelixTestLayout" />
   </Target>
 </Project>

--- a/src/Tests/UnitTests.proj
+++ b/src/Tests/UnitTests.proj
@@ -34,13 +34,13 @@
   <Target Name="CopyHelixFiles" AfterTargets="Publish">
 
     <ItemGroup>
-      <BuiltSdks Include="$(reporoot)artifacts\bin\$(Configuration)\Sdks\**\*.*"/>
+      <BuiltSdks Include="$(RepoRoot)artifacts\bin\$(Configuration)\Sdks\**\*.*"/>
 
       <!-- All the following files are just to get full framework msbuild while avoid to duplicated arcade logic by copying
       arcade and run it -->
-      <Engfolder Include="$(reporoot)eng\**\*.*"/>
-      <DotToolsFolder Include="$(reporoot).tools\**\*.*"/>
-      <GlobalJson Include="$(reporoot)global.json"/>
+      <Engfolder Include="$(RepoRoot)eng\**\*.*"/>
+      <DotToolsFolder Include="$(RepoRoot).tools\**\*.*"/>
+      <GlobalJson Include="$(RepoRoot)global.json"/>
       <!-- Get full framework msbuild end -->
 
       <!-- include .dotnet folder. So there is no extra first run experience run during the test -->
@@ -57,13 +57,13 @@
         <DestinationFolder>eng/</DestinationFolder>
       </TestExecutionDirectoryFiles>
 
-      <FilesInHelixRoot Include="$(reporoot)artifacts\tmp\$(Configuration)\NuGet.config"/>
-      <FilesInHelixRoot Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="$(reporoot)build\RunTestsOnHelix.cmd"/>
-      <FilesInHelixRoot Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' " Include="$(reporoot)build\RunTestsOnHelix.sh"/>
+      <FilesInHelixRoot Include="$(RepoRoot)artifacts\tmp\$(Configuration)\NuGet.config"/>
+      <FilesInHelixRoot Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="$(RepoRoot)build\RunTestsOnHelix.cmd"/>
+      <FilesInHelixRoot Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' " Include="$(RepoRoot)build\RunTestsOnHelix.sh"/>
     </ItemGroup>
 
     <PropertyGroup>
-      <HelixPayloadOnHost>$(reporoot)artifacts\tmp\Helixpayload</HelixPayloadOnHost>
+      <HelixPayloadOnHost>$(RepoRoot)artifacts\tmp\Helixpayload</HelixPayloadOnHost>
     </PropertyGroup>
 
     <Copy SourceFiles="@(Engfolder)" DestinationFiles="@(Engfolder->'$(HelixPayloadOnHost)\eng\%(RecursiveDir)%(Filename)%(Extension)')" />
@@ -82,11 +82,11 @@
     <PropertyGroup>
       <HelixPreCommands Condition="!$(IsPosixShell)">call %HELIX_CORRELATION_PAYLOAD%\t\RunTestsOnHelix.cmd $(TestFullMSBuild);$(HelixPreCommands)</HelixPreCommands>
       <HelixPreCommands Condition="$(IsPosixShell)">. $HELIX_CORRELATION_PAYLOAD/t/RunTestsOnHelix.sh;$(HelixPreCommands)</HelixPreCommands>
-      <TestDotnetRoot>$(reporoot)artifacts\bin\redist\$(Configuration)\dotnet</TestDotnetRoot>
+      <TestDotnetRoot>$(RepoRoot)artifacts\bin\redist\$(Configuration)\dotnet</TestDotnetRoot>
       <TestDotnetVersion>$(Version)</TestDotnetVersion>
-      <MSBuildSdkResolverDir>$(reporoot)artifacts\bin\Microsoft.DotNet.MSBuildSdkResolver</MSBuildSdkResolverDir>
-      <HelixStage0Targz>$(reporoot)artifacts\tmp\HelixStage0.tar.gz</HelixStage0Targz>
-      <MicrosoftNETBuildExtensions>$(reporoot)artifacts\bin\$(Configuration)\Sdks\Microsoft.NET.Build.Extensions</MicrosoftNETBuildExtensions>
+      <MSBuildSdkResolverDir>$(RepoRoot)artifacts\bin\Microsoft.DotNet.MSBuildSdkResolver</MSBuildSdkResolverDir>
+      <HelixStage0Targz>$(RepoRoot)artifacts\tmp\HelixStage0.tar.gz</HelixStage0Targz>
+      <MicrosoftNETBuildExtensions>$(RepoRoot)artifacts\bin\$(Configuration)\Sdks\Microsoft.NET.Build.Extensions</MicrosoftNETBuildExtensions>
     </PropertyGroup>
 
     <TarGzFileCreateFromDirectory
@@ -126,6 +126,6 @@
   <Target Name="CreateLocalHelixTestLayout" DependsOnTargets="AppendHelixPreCommand">
     <CreateLocalHelixTestLayout
         HelixCorrelationPayload="@(HelixCorrelationPayload)"
-        TestOutputDirectory="$(reporoot)artifacts\bin\localHelixTestLayout" />
+        TestOutputDirectory="$(RepoRoot)artifacts\bin\localHelixTestLayout" />
   </Target>
 </Project>

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -487,7 +487,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             Directory.GetFiles(installRecordPath).Count().Should().Be(2);
         }
 
-        [Fact(Skip="Disable tests that might be updating workload manifest")]
+        [Fact(Skip="https://github.com/dotnet/sdk/issues/25175")]
         public void HideManifestUpdateCheckWhenVerbosityIsQuiet()
         {
             var command = new DotnetCommand(Log);
@@ -502,7 +502,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         }
 
 
-        [Theory(Skip="Disable tests that might be updating workload manifest")]
+        [Theory(Skip="https://github.com/dotnet/sdk/issues/25175")]
         [InlineData("--verbosity:minimal")]
         [InlineData("--verbosity:normal")]
         public void HideManifestUpdatesWhenVerbosityIsMinimalOrNormal(string verbosityFlag)
@@ -518,7 +518,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 .NotHaveStdOutContaining(Workloads.Workload.Install.LocalizableStrings.AdManifestUpdated);
         }
 
-        [Theory(Skip="Disable tests that might be updating workload manifest")]
+        [Theory(Skip="https://github.com/dotnet/sdk/issues/25175")]
         [InlineData("--verbosity:detailed")]
         [InlineData("--verbosity:diagnostic")]
         public void ShowManifestUpdatesWhenVerbosityIsDetailedOrDiagnostic(string verbosityFlag)

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -487,7 +487,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             Directory.GetFiles(installRecordPath).Count().Should().Be(2);
         }
 
-        [Fact]
+        [Fact(Skip="Disable tests that might be updating workload manifest")]
         public void HideManifestUpdateCheckWhenVerbosityIsQuiet()
         {
             var command = new DotnetCommand(Log);
@@ -502,7 +502,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         }
 
 
-        [Theory]
+        [Theory(Skip="Disable tests that might be updating workload manifest")]
         [InlineData("--verbosity:minimal")]
         [InlineData("--verbosity:normal")]
         public void HideManifestUpdatesWhenVerbosityIsMinimalOrNormal(string verbosityFlag)
@@ -518,7 +518,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 .NotHaveStdOutContaining(Workloads.Workload.Install.LocalizableStrings.AdManifestUpdated);
         }
 
-        [Theory]
+        [Theory(Skip="Disable tests that might be updating workload manifest")]
         [InlineData("--verbosity:detailed")]
         [InlineData("--verbosity:diagnostic")]
         public void ShowManifestUpdatesWhenVerbosityIsDetailedOrDiagnostic(string verbosityFlag)

--- a/src/Tests/testsProjectCannotRunOnHelixList.txt
+++ b/src/Tests/testsProjectCannotRunOnHelixList.txt
@@ -1,5 +1,4 @@
 Microsoft.DotNet.Cli.Utils.Tests
-EndToEnd.Tests
 Microsoft.DotNet.Tools.Tests.Utilities.Tests
 dotnet.Tests
 msbuild.Integration.Tests


### PR DESCRIPTION
Reduce the helix move to a single test group to limit the impact in the build and see if the main set of changes can get in.