### PR TITLE
Use System.Environment to obtain user HOME dir

### DIFF
--- a/src/Common/CliFolderPathCalculatorCore.cs
+++ b/src/Common/CliFolderPathCalculatorCore.cs
@@ -13,8 +13,7 @@ namespace Microsoft.DotNet.Configurer
     {
         public const string DotnetHomeVariableName = "DOTNET_CLI_HOME";
         public const string DotnetProfileDirectoryName = ".dotnet";
-
-        public static string PlatformHomeVariableName =>
+        public static readonly string PlatformHomeVariableName =
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "USERPROFILE" : "HOME";
 
         public static string? GetDotnetUserProfileFolderPath()
@@ -28,17 +27,19 @@ namespace Microsoft.DotNet.Configurer
             return Path.Combine(homePath, DotnetProfileDirectoryName);
         }
 
-        public static string? GetDotnetHomePath(Func<string, string?>? getEnvironmentVariable = null)
+        public static string? GetDotnetHomePath()
         {
-            getEnvironmentVariable ??= key => Environment.GetEnvironmentVariable(key);
-
-            var home = getEnvironmentVariable(DotnetHomeVariableName);
+            var home = Environment.GetEnvironmentVariable(DotnetHomeVariableName);
             if (string.IsNullOrEmpty(home))
             {
-                home = getEnvironmentVariable(PlatformHomeVariableName);
+                home = Environment.GetEnvironmentVariable(PlatformHomeVariableName);
                 if (string.IsNullOrEmpty(home))
                 {
-                    return null;
+                    home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                    if (string.IsNullOrEmpty(home))
+                    {
+                        return null;
+                    }
                 }
             }
 

--- a/src/RazorSdk/Tool/ServerCommand.cs
+++ b/src/RazorSdk/Tool/ServerCommand.cs
@@ -125,7 +125,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
 
         protected virtual FileStream WritePidFile()
         {
-            var path = GetPidFilePath(env => Environment.GetEnvironmentVariable(env));
+            var path = GetPidFilePath();
             return WritePidFile(path);
         }
 
@@ -167,12 +167,12 @@ namespace Microsoft.NET.Sdk.Razor.Tool
         }
 
         // Internal for testing.
-        internal virtual string GetPidFilePath(Func<string, string> getEnvironmentVariable)
+        internal static string GetPidFilePath()
         {
-            var path = getEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY");
+            var path = Environment.GetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY");
             if (string.IsNullOrEmpty(path))
             {
-                var homePath = CliFolderPathCalculatorCore.GetDotnetHomePath(getEnvironmentVariable);
+                var homePath = CliFolderPathCalculatorCore.GetDotnetHomePath();
                 if (homePath is null)
                 {
                     // Couldn't locate the user profile directory. Bail.

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerCommandTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerCommandTest.cs
@@ -61,22 +61,13 @@ namespace Microsoft.NET.Sdk.Razor.Tool
         public void GetPidFilePath_ReturnsCorrectDefaultPath()
         {
             // Arrange
-            var expectedPath = Path.Combine("homeDir", ".dotnet", "pids", "build");
-            var server = GetServerCommand();
+            var expectedPath = Path.Combine(".dotnet", "pids", "build");
 
             // Act
-            var directoryPath = server.GetPidFilePath(getEnvironmentVariable: env =>
-            {
-                if (env == "DOTNET_BUILD_PIDFILE_DIRECTORY")
-                {
-                    return null;
-                }
-
-                return "homeDir";
-            });
+            var directoryPath = ServerCommand.GetPidFilePath();
 
             // Assert
-            Assert.Equal(expectedPath, directoryPath);
+            Assert.EndsWith(expectedPath, directoryPath);
         }
 
         [Fact]
@@ -84,26 +75,19 @@ namespace Microsoft.NET.Sdk.Razor.Tool
         {
             // Arrange
             var expectedPath = "/Some/directory/path/";
-            var server = GetServerCommand();
+            Environment.SetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY", expectedPath);
+            try
+            {
+                // Act
+                var directoryPath = ServerCommand.GetPidFilePath();
 
-            // Act
-            var directoryPath = server.GetPidFilePath(getEnvironmentVariable: env => expectedPath);
-
-            // Assert
-            Assert.Equal(expectedPath, directoryPath);
-        }
-
-        [Fact]
-        public void GetPidFilePath_NullEnvironmentVariableValue_ReturnsNull()
-        {
-            // Arrange
-            var server = GetServerCommand();
-
-            // Act
-            var directoryPath = server.GetPidFilePath(getEnvironmentVariable: env => null);
-
-            // Assert
-            Assert.Null(directoryPath);
+                // Assert
+                Assert.Equal(expectedPath, directoryPath);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY", "");
+            }
         }
 
         private ServerCommand GetServerCommand(string pipeName = null)

--- a/src/Tests/dotnet.Tests/GivenThatDotNetRunsCommands.cs
+++ b/src/Tests/dotnet.Tests/GivenThatDotNetRunsCommands.cs
@@ -43,16 +43,16 @@ namespace Microsoft.DotNet.Tests
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void GivenAMissingHomeVariableItPrintsErrorMessage(string value)
+        public void GivenAMissingHomeVariableItExecutesHelpCommandSuccessfully(string value)
         {
             new DotnetCommand(Log)
                 .WithEnvironmentVariable(CliFolderPathCalculator.PlatformHomeVariableName, value)
                 .WithEnvironmentVariable(CliFolderPathCalculator.DotnetHomeVariableName, "")
                 .Execute("--help")
                 .Should()
-                .Fail()
+                .Pass()
                 .And
-                .HaveStdErrContaining(CliFolderPathCalculator.DotnetHomeVariableName);
+                .HaveStdOutContaining(LocalizableStrings.DotNetSdkInfo);
         }
 
         [Fact]


### PR DESCRIPTION
Using `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` to obtain user's home or profile directory is preferred over manually probing the environment variable.

Under linux base installation, e.g. container, if HOME is not set, `Environment.GetFolderPath(UserProfile)` will not give up right away. It fallback to POSIX `getpwuid(3)` API to obtain this path.

corehost was updated in https://github.com/dotnet/runtime/commit/cef245d28ae8d50f3bf0ad7adedc461cd45b085c (targeting .NET 7 release), which puts host on the same fallback plan as `Environment.GetFolderPath` and apphost/singlefilehost etc. do not complain if HOME is not set.

For SDK, before this change:

```sh
$ unset HOME
$ dotnet --help
The user's home directory could not be determined. Set the 'DOTNET_CLI_HOME' environment variable to specify the directory to use.
```

and with this change, it does not produce the error.