### PR TITLE
Update Microsoft.NET.Compatibility.Common.targets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Compatibility.Common.targets
@@ -3,7 +3,7 @@
   <UsingTask TaskName="Microsoft.DotNet.Compatibility.ValidatePackage" AssemblyFile="$(DotNetCompatibilityAssembly)" />
 
   <PropertyGroup>
-    <!--Add any custom targets that need to run before package validation to the following property-->
+    <!-- Add any custom targets that need to run before package validation to the following property. -->
     <RunPackageValidationDependsOn>_GetReferencePathFromInnerProjects;$(RunPackageValidationDependsOn)</RunPackageValidationDependsOn>
   </PropertyGroup>
 
@@ -45,32 +45,23 @@
       ReferencePaths="@(PackageValidationReferencePath)" />
   </Target>
 
-  <PropertyGroup>
-    <_GetReferencePathFromInnerProjectsDependsOn Condition="'$(IsCrossTargetingBuild)' != 'true'">_GetReferencePathForPackageValidation</_GetReferencePathFromInnerProjectsDependsOn>
-    <_GetReferencePathFromInnerProjectsDependsOn Condition="'$(IsCrossTargetingBuild)' == 'true'">_ComputeTargetFrameworkItems</_GetReferencePathFromInnerProjectsDependsOn>
-  </PropertyGroup>
-
   <Target Name="_GetReferencePathForPackageValidation"
           DependsOnTargets="ResolveReferences"
           Returns="@(_ReferencePathWithTargetFramework)">
     <ItemGroup>
-      <_ReferencePathWithTargetFramework Include="@(ReferencePath)"  TargetFramework="$(TargetFramework)" />
+      <_ReferencePathWithTargetFramework Include="@(ReferencePath)" TargetFramework="$(TargetFramework)" />
     </ItemGroup>
   </Target>
 
+  <!-- Depends on NuGet's _GetTargetFrameworksOutput target to calculate inner target frameworks. -->
   <Target Name="_GetReferencePathFromInnerProjects"
-          DependsOnTargets="$(_GetReferencePathFromInnerProjectsDependsOn)"
+          DependsOnTargets="_GetTargetFrameworksOutput"
           Condition="'$(RunPackageValidationWithoutReferences)' != 'true'">
-
-    <MSBuild Projects="@(_InnerBuildProjects)"
-             Condition="'$(IsCrossTargetingBuild)' == 'true'"
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="_GetReferencePathForPackageValidation"
-             Properties="BuildProjectReferences=false">
+             Properties="TargetFramework=%(_TargetFrameworks.Identity);
+                         BuildProjectReferences=false">
       <Output ItemName="PackageValidationReferencePath" TaskParameter="TargetOutputs" />
     </MSBuild>
-
-    <ItemGroup Condition="'$(IsCrossTargetingBuild)' != 'true'">
-      <PackageValidationReferencePath Include="@(_ReferencePathWithTargetFramework)" />
-    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/24943

Make sure that the `BuildProjectReferences` property  is set to false when the `NoBuild=true` property is set, to avoid the ResolveReferences target to build project references when it shouldn't.

Before this change, a non cross-targeting build avoided to use an MSBuild task to gather the project's references but as NuGet's Pack target itself already doesn't differentiate between if it's running as part of a cross targeting or a non-cross targeting build and always calls into an MSBuild task, this optimization isn't necessary in package validation. Instead, this change brings package validation in sync with how NuGet's Pack target invokes inner build projects to make sure that additional project evaluations are avoided.

As an alternative, an additional target could have been added that sets `BuildProjectReferences` to false [like GenAPI is doing](https://github.com/dotnet/arcade/blob/769455cb75153c025502d9800ea5f25afe15ea54/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets#L17-L22) but it feels wrong to me to diverge in behavior between NuGet and package validation as the latter already depends on the former in execution.