### PR TITLE
Add back build retry

### DIFF
--- a/eng/BuildConfiguration/build-configuration.json
+++ b/eng/BuildConfiguration/build-configuration.json
@@ -1,5 +1,5 @@
 {
-   "RetryCountLimit":0,
+   "RetryCountLimit":1,
    "RetryByPipeline":{
       "RetryStages":[
          {


### PR DESCRIPTION
I turned on test retry but that won't retry non-helix tests. Since we still have a lot of helix tests, adding back build retry (which will run after test retry). This will hopefully increase our PR success rate until I can get more tests move to helix.