### PR TITLE
Fix MSI workload garbage collection

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -105,6 +105,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 IEnumerable<WorkloadId> installedWorkloads = RecordRepository.GetInstalledWorkloads(_sdkFeatureBand);
                 Dictionary<(WorkloadPackId id, string version),PackInfo> expectedWorkloadPacks = installedWorkloads
                     .SelectMany(workload => _workloadResolver.GetPacksInWorkload(workload))
+                    .Distinct()
                     .Select(pack => _workloadResolver.TryGetPackInfo(pack))
                     .Where(pack => pack != null)
                     .ToDictionary(p => (new WorkloadPackId(p.ResolvedPackageId), p.Version));


### PR DESCRIPTION
### Description

Fixes bug garbage collecting workload packs in MSI-based install

### Customer impact

When installing or uninstalling workloads with `dotnet workload` commands, the following warning may be generated:

> Warning: Workload garbage collection failed with error: An item with the same key has already been added. Key: (Microsoft.Android.Sdk.Windows, 32.0.300-rc.2.27).

Additionally, if this occurs it will prevent workload packs which are no longer needed from being uninstalled.

### Regression

Yes, introduced in 6.0.300 with #24630.

### Risk

Low.  Adds a call to `.Distinct()` to deduplicate items before putting them in a dictionary.

### Testing

Repro'd issue and tested fix manually using Windows Sandbox.

We don't have automated tests for MSI-based installs, and I am following up to confirm what type of workload installation scenarios we have for our manual test passes and to make sure this scenario is covered.