### PR TITLE
Enable SingleFile and Trimming analyzers when Publishing a NativeAOT app

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -60,10 +60,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Intermediate step to enable ILLink.Analyzers so ILLink, Blazor, Xamarin, AOT, etc. can enable the same flags -->
     <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == '' And
-                                         '$(PublishSingleFile)' == 'true'">true</EnableSingleFileAnalyzer>
+                              ('$(PublishSingleFile)' == 'true'  Or '$(PublishAot)' == 'true')">true</EnableSingleFileAnalyzer>
 
     <!-- Enable the trim analyzer when any trimming settings are enabled. Warnings may suppressed based on other settings. -->
-    <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</EnableTrimAnalyzer>
+    <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And 
+                        ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true' Or '$(PublishAot)' == 'true')">true</EnableTrimAnalyzer>
 
     <!-- Enable the AOT analyzer when AOT is enabled. Warnings may suppressed based on other settings. -->
     <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == '' And '$(PublishAot)' == 'true'">true</EnableAotAnalyzer>


### PR DESCRIPTION
PublishAot should enable SingleFile and Trimming analyzers
Add SingleFile warning in the produced warnings
NativeAot_only_runs_when_switch_is_enabled now verifies for Trimming and SingleFile warnings