### PR TITLE
Switch the last non-helix test over to running on helix.

### DIFF
--- a/eng/runHelixAndNonHelixInParallel.ps1
+++ b/eng/runHelixAndNonHelixInParallel.ps1
@@ -33,8 +33,6 @@
         "/p:_CustomHelixTargetQueue=$customHelixTargetQueue") + $additionalParameters
 
         parallel {
-            Write-Output "&'$engfolderPath\runTestsCannotRunOnHelix.ps1' $runTestsCannotRunOnHelixArgs"
-            Invoke-Expression "&'$engfolderPath\runTestsCannotRunOnHelix.ps1' $runTestsCannotRunOnHelixArgs"
             Write-Output "&'$engfolderPath\common\build.ps1' $runTestsOnHelixArgs"
             Invoke-Expression "&'$engfolderPath\common\build.ps1' $runTestsOnHelixArgs"
         }

--- a/eng/runHelixAndNonHelixInParallelNonWindows.ps1
+++ b/eng/runHelixAndNonHelixInParallelNonWindows.ps1
@@ -14,7 +14,6 @@
       return
   }
 
-  $runTestsCannotRunOnHelixArgs = ("-configuration", $configuration, "-ci", $officialBuildIdArgs) + $additionalMSBuildParameters.Split(' ')
   $runTestsOnHelixArgs = ("-configuration", $configuration,
     "-ci",
   "-restore",
@@ -23,7 +22,7 @@
   "/bl:$buildSourcesDirectory/artifacts/log/$configuration/TestInHelix.binlog",
   "/p:_CustomHelixTargetQueue=$customHelixTargetQueue") + $additionalMSBuildParameters.Split(' ')
 
-  $runTests = ("&'$PSScriptRoot/runTestsCannotRunOnHelix.sh' $runTestsCannotRunOnHelixArgs", "&'$PSScriptRoot/common/build.sh' $runTestsOnHelixArgs")
+  $runTests = ("&'$PSScriptRoot/common/build.sh' $runTestsOnHelixArgs")
 
   $runTests | ForEach-Object -Parallel { Invoke-Expression $_}
 

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -234,7 +234,8 @@ namespace Microsoft.DotNet.Cli
         {
             var dotnetRootPath = Path.GetDirectoryName(Environment.ProcessPath);
             // When running under test the path does not always contain "dotnet" and Product.Version is empty.
-            dotnetRootPath = Path.GetFileName(dotnetRootPath).Contains("dotnet") || Path.GetFileName(dotnetRootPath).Contains("x64") ? dotnetRootPath : Path.Combine(dotnetRootPath, "dotnet");
+            // The sdk folder is /d/ when run on helix because of space issues
+            dotnetRootPath = Path.GetFileName(dotnetRootPath).Contains("dotnet") || Path.GetFileName(dotnetRootPath).Contains("x64") || Path.GetFileName(dotnetRootPath).Equals("d") ? dotnetRootPath : Path.Combine(dotnetRootPath, "dotnet");
             var ridFileName = "NETCoreSdkRuntimeIdentifierChain.txt";
             string runtimeIdentifierChainPath = string.IsNullOrEmpty(Product.Version) ?
                 Path.Combine(Directory.GetDirectories(Path.Combine(dotnetRootPath, "sdk"))[0], ridFileName) :

--- a/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -27,12 +27,6 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         public ITaskItem[] XUnitProjects { get; set; }
 
         /// <summary>
-        /// The path of a list of test projects partial name that cannot be run in Helix. 
-        /// </summary>
-        [Required]
-        public string TestProjectExclusionListPath { get; set; }
-
-        /// <summary>
         /// The path to the dotnet executable on the Helix agent. Defaults to "dotnet"
         /// </summary>
         public string PathToDotnet { get; set; } = "dotnet";
@@ -79,14 +73,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         /// <returns></returns>
         private async Task ExecuteAsync()
         {
-            var testExclusion = File.ReadAllLines(TestProjectExclusionListPath)
-                .Select(l => l.Trim())
-                .Where(l => !string.IsNullOrWhiteSpace(l));
-
-            var xUnitProjectsCanRunInHelix
-                = XUnitProjects.Where(p => !testExclusion.Any(p.ItemSpec.Contains));
-
-            XUnitWorkItems = (await Task.WhenAll(xUnitProjectsCanRunInHelix.Select(PrepareWorkItem)))
+            XUnitWorkItems = (await Task.WhenAll(XUnitProjects.Select(PrepareWorkItem)))
                 .SelectMany(i => i)
                 .Where(wi => wi != null)
                 .ToArray();

--- a/src/Tests/Microsoft.DotNet.ShellShim.Tests/WindowsEnvironmentPathTests.cs
+++ b/src/Tests/Microsoft.DotNet.ShellShim.Tests/WindowsEnvironmentPathTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
             var mockEnvironmentPathEditor = new MockEnvironmentPathEditor(_mockPathInternal);
             _windowsEnvironmentPath = new WindowsEnvironmentPath(
                 _toolsPath,
-                CliFolderPathCalculator.WindowsNonExpandedToolsShimPath,
+                @"%USERPROFILE%\.dotnet\tools",
                 mockEnvironmentProvider,
                 mockEnvironmentPathEditor,
                 _reporter

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -239,6 +239,7 @@ namespace Microsoft.NET.TestFramework
             configuration = commandLine.SDKRepoConfiguration ?? configuration;
 
             string dotnetInstallDirFromEnvironment = Environment.GetEnvironmentVariable("DOTNET_INSTALL_DIR");
+            string dotnetCLIHomeFromEnvironment = Environment.GetEnvironmentVariable("DOTNET_CLI_HOME");
 
             string dotnetRoot;
 
@@ -253,6 +254,10 @@ namespace Microsoft.NET.TestFramework
             else if (!string.IsNullOrEmpty(dotnetInstallDirFromEnvironment))
             {
                 dotnetRoot = dotnetInstallDirFromEnvironment;
+            }
+            else if  (!string.IsNullOrEmpty(dotnetCLIHomeFromEnvironment))
+            {
+                dotnetRoot = dotnetCLIHomeFromEnvironment;
             }
             else
             {

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -239,7 +239,6 @@ namespace Microsoft.NET.TestFramework
             configuration = commandLine.SDKRepoConfiguration ?? configuration;
 
             string dotnetInstallDirFromEnvironment = Environment.GetEnvironmentVariable("DOTNET_INSTALL_DIR");
-            string dotnetCLIHomeFromEnvironment = Environment.GetEnvironmentVariable("DOTNET_CLI_HOME");
 
             string dotnetRoot;
 
@@ -254,10 +253,6 @@ namespace Microsoft.NET.TestFramework
             else if (!string.IsNullOrEmpty(dotnetInstallDirFromEnvironment))
             {
                 dotnetRoot = dotnetInstallDirFromEnvironment;
-            }
-            else if  (!string.IsNullOrEmpty(dotnetCLIHomeFromEnvironment))
-            {
-                dotnetRoot = dotnetCLIHomeFromEnvironment;
             }
             else
             {

--- a/src/Tests/dotnet-new.Tests/NewCommandTests.cs
+++ b/src/Tests/dotnet-new.Tests/NewCommandTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.New.Tests
         [Fact]
         public void WhenSwitchIsSkippedThenItPrintsError()
         {
-            var cmd = new DotnetCommand(Log).Execute("new", "Web1.1");
+            var cmd = new DotnetCommand(Log).Execute("new", "Web1.1", "--debug:ephemeral-hive");
 
             cmd.ExitCode.Should().NotBe(0);
 
@@ -34,14 +34,14 @@ namespace Microsoft.DotNet.New.Tests
         public void ItCanCreateTemplate()
         {
             var tempDir = _testAssetsManager.CreateTestDirectory();
-            var cmd = new DotnetCommand(Log).Execute("new", "console", "-o", tempDir.Path);
+            var cmd = new DotnetCommand(Log).Execute("new", "console", "-o", tempDir.Path, "--debug:ephemeral-hive");
             cmd.Should().Pass();
         }
 
         [Fact]
         public void ItCanShowHelp()
         {
-            var cmd = new DotnetCommand(Log).Execute("new", "--help");
+            var cmd = new DotnetCommand(Log).Execute("new", "--help", "--debug:ephemeral-hive");
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("Usage:")
                 .And.HaveStdOutContaining("dotnet new [command] [options]");
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.New.Tests
         [Fact]
         public void ItCanShowHelpForTemplate()
         {
-            var cmd = new DotnetCommand(Log).Execute("new", "classlib", "--help");
+            var cmd = new DotnetCommand(Log).Execute("new", "classlib", "--help", "--debug:ephemeral-hive");
             cmd.Should().Pass()
                 .And.NotHaveStdOutContaining("Usage: new [options]")
                 .And.HaveStdOutContaining("Class Library (C#)")

--- a/src/Tests/dotnet-pack.Tests/PackTests.cs
+++ b/src/Tests/dotnet-pack.Tests/PackTests.cs
@@ -249,7 +249,7 @@ namespace Microsoft.DotNet.Pack.Tests
 
             string dir = "pkgs";
 
-            new DotnetCommand(Log, "new", "console", "-o", rootPath, "--no-restore")
+            new DotnetCommand(Log, "new", "console", "-o", rootPath, "--no-restore", "--debug:ephemeral-hive")
                 .WithWorkingDirectory(rootPath)
                 .Execute()
                 .Should()

--- a/src/Tests/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
+++ b/src/Tests/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
@@ -80,7 +80,7 @@ Options:
             try
             {
                 string [] newArgs = new[] { "classlib", "-o", projDir.Path, "--no-restore" };
-                new DotnetCommand(Log, "new")
+                new DotnetCommand(Log, "new","--debug:ephemeral-hive")
                     .WithWorkingDirectory(projDir.Path)
                     .Execute(newArgs)
                 .Should().Pass();

--- a/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.Restore.Test
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
             string[] newArgs = new[] { "console", "-o", rootPath, "--no-restore" };
-            new DotnetCommand(Log, "new")
+            new DotnetCommand(Log, "new","--debug:ephemeral-hive")
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
                 .Should()

--- a/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.Restore.Test
             var rootPath = _testAssetsManager.CreateTestDirectory().Path;
 
             string[] newArgs = new[] { "console", "-o", rootPath, "--no-restore" };
-            new DotnetCommand(Log, "new")
+            new DotnetCommand(Log, "new", "--debug:ephemeral-hive")
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
                 .Should()

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         {
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("net5.0")]
         [InlineData("net6.0")]
         public void ItShouldSetDotnetRootToDirectoryOfMuxer(string targetFramework)

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -233,7 +233,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             string [] args = new string[] { "--packages", dir };
 
             string [] newArgs = new string[] { "console", "-o", rootPath, "--no-restore" };
-            new DotnetCommand(Log, "new")
+            new DotnetCommand(Log, "new","--debug:ephemeral-hive")
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
                 .Should()

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            new DotnetCommand(Log, "new", "sln")
+            new DotnetCommand(Log, "new", "sln", "--debug:ephemeral-hive")
                 .WithWorkingDirectory(testAsset.TestRoot)
                 .Execute()
                 .Should()

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -37,7 +37,8 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             _manifestPath = Path.Combine(_testAssetsManager.GetAndValidateTestProjectDirectory("SampleManifest"), "Sample.json");
         }
 
-        [Fact]
+        // These two tests hit an IOException when run in helix on non-windows
+        [WindowsOnlyFact]
         public void GivenWorkloadInstallItErrorsOnFakeWorkloadName()
         {
             var command = new DotnetCommand(Log);
@@ -51,7 +52,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 .HaveStdErrContaining(String.Format(Workloads.Workload.Install.LocalizableStrings.WorkloadNotRecognized, "fake"));
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void ItErrorUsingSkipManifestAndRollback()
         {
             var command = new DotnetCommand(Log);

--- a/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Tests.Commands
             };
 
             var reporter = new BufferedReporter();
-            CompleteCommand.RunWithReporter(new[] { "dotnet new " }, reporter).Should().Be(0);
+            CompleteCommand.RunWithReporter(new[] { "dotnet new --debug:ephemeral-hive " }, reporter).Should().Be(0);
             reporter.Lines.OrderBy(c => c).Should().Contain(expected.OrderBy(c => c));
         }
 

--- a/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -85,7 +85,8 @@ namespace Microsoft.DotNet.Tests.Commands
             reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
         }
 
-        [Fact]
+        // this test in helix errors accessing the template hive  but this test doesn't work with the ephemeral hive
+        [WindowsOnlyFact]
         public void GivenNewCommandItDisplaysCompletions()
         {
             var expected = new[] {
@@ -102,7 +103,7 @@ namespace Microsoft.DotNet.Tests.Commands
             };
 
             var reporter = new BufferedReporter();
-            CompleteCommand.RunWithReporter(new[] { "dotnet new --debug:ephemeral-hive " }, reporter).Should().Be(0);
+            CompleteCommand.RunWithReporter(new[] { "dotnet new " }, reporter).Should().Be(0);
             reporter.Lines.OrderBy(c => c).Should().Contain(expected.OrderBy(c => c));
         }
 

--- a/src/Tests/dotnet.Tests/GivenThatTheUserRequestsHelp.cs
+++ b/src/Tests/dotnet.Tests/GivenThatTheUserRequestsHelp.cs
@@ -26,7 +26,7 @@ namespace dotnet.Tests
         [InlineData("clean -h")]
         [InlineData("list -h")]
         [InlineData("msbuild -h")]
-        [InlineData("new -h")]
+        [InlineData("new -h --debug:ephemeral-hive")]
         [InlineData("nuget -h")]
         [InlineData("pack -h")]
         [InlineData("publish -h")]

--- a/src/Tests/dotnet.Tests/dotnet.Tests.csproj
+++ b/src/Tests/dotnet.Tests/dotnet.Tests.csproj
@@ -1,4 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -163,4 +168,6 @@
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/Tests/testsProjectCannotRunOnHelixList.txt
+++ b/src/Tests/testsProjectCannotRunOnHelixList.txt
@@ -1,1 +1,0 @@
-dotnet.Tests

--- a/src/Tests/xunit-runner/XUnitRunner.targets
+++ b/src/Tests/xunit-runner/XUnitRunner.targets
@@ -77,7 +77,6 @@
 
     <SDKCustomCreateXUnitWorkItemsWithTestExclusion
         XUnitProjects="@(SDKCustomXUnitProject)"
-        TestProjectExclusionListPath="$(reporoot)/src/Tests/testsProjectCannotRunOnHelixList.txt"
         IsPosixShell="$(IsPosixShell)"
         XUnitArguments="$(SDKCustomXUnitArgument)"
         XUnitWorkItemTimeout="$(XUnitWorkItemTimeout)">


### PR DESCRIPTION
Moving over the dotnet-test project into helix and stop calling the run non-helix tests. This is the largest single project and has the most churn.
In the future, we need to remove the run helix test script altogether and just trigger test execution directly from the yml files.

What changes are included:

- Remove call to the cannot run on helix scripts
- Change common options to handle a /d/ dotnet root path for getting the runtime id
- Remove test exclusion file
- Change the windows path tests to pass in the user profile unexpanded path as otherwise it was picking up an expanded path
- Add the ephemeral hive for dotnet new scenarios as non-windows file locations appear to be more locked down
- Change the dotnet root muxer test to only run on windows. On linux, I found that the test toolset code would pick up the CLI HOME environment variables which was /private/tmp/... but the test itself was running dotnet from /tmp/. I didn't find any alternative solution (I tried changed how our tests determines dotnet root but that broke every test). 
  - I could try changing CLI home in the helix script?
- Two workload error tests threw IOException on non-windows as the metadata folder was inaccessible. I disabled on windows
  - we could try modifying the code to either catch that exception (which may just throw a different exception) or move the metadata check to a different location.
- One of the dotnet new completion tests on non-windows failed when I used the ephemeral hive. 
  - Don't have an alternative suggestion on fixing.