### PR TITLE
Servicing F#

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,7 +120,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->
-    <MicrosoftFSharpCompilerPackageVersion>12.0.3-beta.22219.3</MicrosoftFSharpCompilerPackageVersion>
+    <MicrosoftFSharpCompilerPackageVersion>12.0.4-beta.22253.3</MicrosoftFSharpCompilerPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -436,7 +436,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             Directory.GetFiles(installRecordPath).Count().Should().Be(2);
         }
 
-        [Fact]
+        [Fact(Skip="Disable tests that might be updating workload manifest")]
         public void HideManifestUpdateCheckWhenVerbosityIsQuiet()
         {
             var command = new DotnetCommand(Log);
@@ -451,7 +451,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         }
 
 
-        [Theory]
+        [Theory(Skip="Disable tests that might be updating workload manifest")]
         [InlineData("--verbosity:minimal")]
         [InlineData("--verbosity:normal")]
         public void HideManifestUpdatesWhenVerbosityIsMinimalOrNormal(string verbosityFlag)
@@ -467,7 +467,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 .NotHaveStdOutContaining(Workloads.Workload.Install.LocalizableStrings.AdManifestUpdated);
         }
 
-        [Theory]
+        [Theory(Skip="Disable tests that might be updating workload manifest")]
         [InlineData("--verbosity:detailed")]
         [InlineData("--verbosity:diagnostic")]
         public void ShowManifestUpdatesWhenVerbosityIsDetailedOrDiagnostic(string verbosityFlag)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/fsharp/issues/13043 - Codegen Regression - function within recursive function results in null reference exception

This issue was reported last week by an F# Customer

**Impact**
The scenario is an important one it occurs when a function returns a lambda and has type annotation. It impacts developers who use this style of functional programming. In Don's words " If they use this .... they will use it a lot and will be affected by this bug"

**Description**
The bug was added to the project in this release of Visual Studio, we added a feature that vastly improved the debugging experience of F# ... the word vastly underestimates the improvement it is great. However, we were over eager adding debug breakpoints. 

The bug is that the compiler emits a debug point for the type annotation portion of the code when a lambda is defined with a return type annotation. Obviously that is nonsense, this debug point was then used in further code generation creating code that will generate System.NullReferenceException at runtime. Example code triggering this behavior is:

```fsharp
let doThing: string -> unit = fun name -> Console.WriteLine name
           ^--------------^
                      ^--------- this is the bad part
```

It is embarrassing that we had no tests that provoked this error, neither don nor I routinely write code this way. In main we have added test cases that verify the fix, validate the IL and verify the optimized and non optimized code gen.

This cherry-pick doesn't contain the test cases because they rely on test framework features that have been added since this branch was closed to insertions.

**Risk**
Very low ... the fix is to remove the single line of code that causes the problem and was added when the improved debugging feature was added. This only effects code matching this particular usage pattern

**Testing**
we have added additional automated testing.

Reviews: @KevinRansom , @dsyme , @vzarytovskii