### PR TITLE
Support suppressing transitive framework reference downloads, and other changes

### DIFF
--- a/src/Assets/TestProjects/WindowsFormsTestApp/Form1.Designer.cs
+++ b/src/Assets/TestProjects/WindowsFormsTestApp/Form1.Designer.cs
@@ -1,0 +1,38 @@
+﻿namespace WindowsFormsTestApp;
+
+partial class Form1
+{
+    /// <summary>
+    ///  Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary>
+    ///  Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    #region Windows Form Designer generated code
+
+    /// <summary>
+    ///  Required method for Designer support - do not modify
+    ///  the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        this.components = new System.ComponentModel.Container();
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        this.ClientSize = new System.Drawing.Size(800, 450);
+        this.Text = "Form1";
+    }
+
+    #endregion
+}

--- a/src/Assets/TestProjects/WindowsFormsTestApp/Form1.cs
+++ b/src/Assets/TestProjects/WindowsFormsTestApp/Form1.cs
@@ -1,0 +1,9 @@
+namespace WindowsFormsTestApp;
+
+public partial class Form1 : Form
+{
+    public Form1()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Assets/TestProjects/WindowsFormsTestApp/Program.cs
+++ b/src/Assets/TestProjects/WindowsFormsTestApp/Program.cs
@@ -1,0 +1,16 @@
+namespace WindowsFormsTestApp;
+
+static class Program
+{
+    /// <summary>
+    ///  The main entry point for the application.
+    /// </summary>
+    [STAThread]
+    static void Main()
+    {
+        // To customize application configuration such as set high DPI settings or default font,
+        // see https://aka.ms/applicationconfiguration.
+        ApplicationConfiguration.Initialize();
+        Application.Run(new Form1());
+    }    
+}

--- a/src/Assets/TestProjects/WindowsFormsTestApp/WindowsFormsTestApp.csproj
+++ b/src/Assets/TestProjects/WindowsFormsTestApp/WindowsFormsTestApp.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -841,7 +841,7 @@ You may need to build the project on another operating system or architecture, o
     <comment>{StrBegin="NETSDK1184: "}</comment>
   </data>
   <data name="UnknownFrameworkReference_MauiEssentials" xml:space="preserve">
-    <value>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</value>
+    <value>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</value>
     <comment>{StrBegin="NETSDK1185: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -833,15 +833,15 @@ You may need to build the project on another operating system or architecture, o
     <comment>{StrBegin="NETSDK1182: "}</comment>
   </data>
   <data name="TargetingPackNotRestored_TransitiveDisabled" xml:space="preserve">
-    <value>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</value>
+    <value>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</value>
     <comment>{StrBegin="NETSDK1183: "}</comment>
   </data>
   <data name="RuntimePackNotRestored_TransitiveDisabled" xml:space="preserve">
-    <value>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</value>
+    <value>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</value>
     <comment>{StrBegin="NETSDK1184: "}</comment>
   </data>
   <data name="UnknownFrameworkReference_MauiEssentials" xml:space="preserve">
-    <value>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</value>
+    <value>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</value>
     <comment>{StrBegin="NETSDK1185: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -832,4 +832,12 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</value>
     <comment>{StrBegin="NETSDK1182: "}</comment>
   </data>
+  <data name="TargetingPackNotRestored_TransitiveDisabled" xml:space="preserve">
+    <value>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</value>
+    <comment>{StrBegin="NETSDK1183: "}</comment>
+  </data>
+  <data name="RuntimePackNotRestored_TransitiveDisabled" xml:space="preserve">
+    <value>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</value>
+    <comment>{StrBegin="NETSDK1184: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -503,7 +503,7 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1099: "}</comment>
   </data>
   <data name="WindowsDesktopFrameworkRequiresWindows" xml:space="preserve">
-    <value>NETSDK1100: Windows is required to build Windows desktop applications.</value>
+    <value>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</value>
     <comment>{StrBegin="NETSDK1100: "}</comment>
   </data>
   <data name="ILLink_Info" xml:space="preserve">

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -840,4 +840,8 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</value>
     <comment>{StrBegin="NETSDK1184: "}</comment>
   </data>
+  <data name="UnknownFrameworkReference_MauiEssentials" xml:space="preserve">
+    <value>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</value>
+    <comment>{StrBegin="NETSDK1185: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: Balíček modulu runtime pro {0} se nestáhl. Zkuste spustit obnovení NuGet s identifikátorem RuntimeIdentifier {1}.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: odkazovaný projekt {0} je spustitelný soubor, který není samostatně obsažený.  Na spustitelný soubor, který není samostatně obsažený, nelze odkazovat pomocí samostatně obsaženého spustitelného souboru. Další informace najdete na https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: Targeting Pack {0} není nainstalovaný. Obnovte ho prosím a zkuste to znovu.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: Odkaz FrameworkReference {0} se nerozpoznal.</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: Sadu Microsoft.NET.Sdk.WindowsDesktop SDK už není nutné používat. Zvažte možnost změnit atribut SDK kořenového elementu Project na Microsoft.NET.Sdk.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: K sestavování desktopových aplikací pro Windows se vyžaduje systém Windows.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: K sestavování desktopových aplikací pro Windows se vyžaduje systém Windows.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: Das Laufzeitpaket für "{0}" wurde nicht heruntergeladen. Führen Sie eine NuGet-Wiederherstellung mit RuntimeIdentifier "{1}" aus.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: Das referenzierte Projekt „{0}“ ist keine eigenständige ausführbare Datei. Auf eine nicht eigenständige ausführbare Datei kann nicht von einer eigenständigen ausführbaren Datei verwiesen werden. Weitere Informationen finden Sie unter https://aka.ms/netsdk1150.</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: Das Paket zur Festlegung von Zielversionen "{0}" ist nicht installiert. Führen Sie eine Wiederherstellung durch, und versuchen Sie es noch mal.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: Windows ist zum Erstellen von Windows-Desktopanwendungen erforderlich.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: Windows ist zum Erstellen von Windows-Desktopanwendungen erforderlich.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: Die FrameworkReference "{0}" wurde nicht erkannt.</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: Es ist nicht länger erforderlich, das Microsoft.NET.Sdk.WindowsDesktop SDK zu verwenden. Erwägen Sie eine Änderung des Sdk-Attributs für das root-Projektelement in "Microsoft.NET.Sdk".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: No se reconoció el valor de FrameworkReference "{0}"</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: Ya no es necesario usar el SDK de Microsoft.NET.Sdk.WindowsDesktop. Puede cambiar el atributo Sdk del elemento del proyecto raíz a "Microsoft.NET.Sdk".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: Se requiere Windows para compilar las aplicaciones de escritorio de Windows.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: Se requiere Windows para compilar las aplicaciones de escritorio de Windows.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: no se descargó el paquete de tiempo de ejecución de {0}. Pruebe a ejecutar una restauración de NuGet con RuntimeIdentifier "{1}".</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: El proyecto al que se hace referencia '{0}' es un ejecutable no independiente. Un archivo ejecutable independiente no puede hacer referencia a un ejecutable que no es independiente.  Para obtener más información, consulte https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: El paquete de compatibilidad {0} no está instalado. Restáurelo y vuelva a intentarlo.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: le pack de runtime pour {0} n'a pas été téléchargé. Essayez d'exécuter une restauration NuGet avec le RuntimeIdentifier '{1}'.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: le projet référencé « {0} » est un exécutable qui n’est pas autonome.  Un exécutable non autonome ne peut pas être référencé par un exécutable autonome. Pour plus d’informations, voir https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: le pack de ciblage {0} n'est pas installé. Effectuez une restauration, puis réessayez.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: le FrameworkReference '{0}' n'a pas été reconnu</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: il n'est plus nécessaire d'utiliser le kit SDK Microsoft.NET.Sdk.WindowsDesktop. Remplacez l'attribut Sdk de l'élément racine Project par 'Microsoft.NET.Sdk'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: vous devez disposer de Windows pour générer des applications de bureau Windows.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: vous devez disposer de Windows pour générer des applications de bureau Windows.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: l'elemento FrameworkReference '{0}' non è stato riconosciuto</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: non è più necessario usare Microsoft.NET.Sdk.WindowsDesktop SDK. Provare a modificare l'attributo Sdk dell'elemento Project radice in 'Microsoft.NET.Sdk'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: per compilare applicazioni desktop di Windows è richiesto Windows.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: per compilare applicazioni desktop di Windows è richiesto Windows.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: il pacchetto di runtime per {0} non è stato scaricato. Provare a eseguire un ripristino NuGet con RuntimeIdentifier '{1}'.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: il progetto '{0}' a cui viene fatto riferimento è un eseguibile non autonomo. Non è possibile fare riferimento a un eseguibile non autonomo da un eseguibile autonomo. Per altre informazioni, vedere https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: il Targeting Pack {0} non è installato. Ripristinare e riprovare.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf~RF243dc495.TMP
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf~RF243dc495.TMP
@@ -1,205 +1,205 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
-        <target state="translated">NETSDK1076: AddResource는 정수 리소스 형식에만 사용할 수 있습니다.</target>
+        <target state="translated">NETSDK1076: è possibile usare AddResource solo con tipi di risorsa integer.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: 애플리케이션 구성 파일에는 루트 구성 요소가 있어야 합니다.</target>
+        <target state="translated">NETSDK1070: il file di configurazione dell'applicazione deve avere un elemento di configurazione radice.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCreationFailedWithRetry">
         <source>NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</source>
-        <target state="translated">NETSDK1113: apphost를 만들지 못했습니다(시도 횟수: {0}/{1}). {2}</target>
+        <target state="translated">NETSDK1113: non è stato possibile creare apphost (tentativo {0} di {1}): {2}</target>
         <note>{StrBegin="NETSDK1113: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="translated">NETSDK1074: 리소스를 추가하려면 빌드가 Windows(Nano Server 제외)에서 수행되어야 하므로 애플리케이션 호스트 실행 파일이 사용자 지정되지 않습니다.</target>
+        <target state="translated">NETSDK1074: l'eseguibile dell'host applicazione non verrà personalizzato perché per aggiungere risorse è necessario eseguire la compilazione in Windows (escluso Nano Server).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
       </trans-unit>
       <trans-unit id="AppHostHasBeenModified">
         <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: 애플리케이션 이름이 기록되는 위치를 표시하는 '{1}' 예상 자리 표시자 바이트 시퀀스가 포함되지 않아서 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
+        <target state="translated">NETSDK1029: non è possibile usare '{0}' come eseguibile host dell'applicazione perché non contiene la sequenza di byte segnaposto prevista '{1}' che indica dove verrà scritto il nome dell'applicazione.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
-        <target state="translated">NETSDK1078: Windows PE 파일이 아니므로 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
+        <target state="translated">NETSDK1078: non è possibile usare '{0}' come eseguibile dell'host applicazione perché non è un file di Windows PE.</target>
         <note>{StrBegin="NETSDK1078: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
         <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
-        <target state="translated">NETSDK1072: CUI(콘솔) 하위 시스템용 Windows 실행 파일이 아니므로 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
+        <target state="translated">NETSDK1072: non è possibile usare '{0}' come eseguibile dell'host applicazione perché non è un eseguibile Windows per il sottosistema CUI (Console).</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppHostSigningFailed">
         <source>NETSDK1177: Failed to sign apphost with error code {1}: {0}</source>
-        <target state="translated">NETSDK1177: apphost에 서명하지 못했습니다(오류 코드 {1}: {0})</target>
+        <target state="translated">NETSDK1177: impossibile firmare apphost con codice di errore {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: .NET Core 3.0 이상을 대상으로 할 경우 Microsoft.AspNetCore.All 패키지가 지원되지 않습니다. Microsoft.AspNetCore.App에 대한 FrameworkReference가 대신 사용되어야 하며, Microsoft.NET.Sdk.Web에 의해 암시적으로 포함됩니다.</target>
+        <target state="translated">NETSDK1079: il pacchetto Microsoft.AspNetCore.All non è supportato quando la destinazione è .NET Core 3.0 o versione successiva. È necessario un elemento FrameworkReference per Microsoft.AspNetCore.App, che verrà incluso in modo implicito da Microsoft.NET.Sdk.Web.</target>
         <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreUsesFrameworkReference">
         <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: .NET Core 3.0을 이상을 대상으로 할 경우 Microsoft.AspNetCore.App에 대한 PackageReference는 필요하지 않습니다. Microsoft.NET.Sdk.Web이 사용되는 경우 공유 프레임워크가 자동으로 참조됩니다. 그렇지 않은 경우 PackageReference를 FrameworkReference로 바꿔야 합니다.</target>
+        <target state="translated">NETSDK1080: non è necessario alcun elemento PackageReference per Microsoft.AspNetCore.App quando la destinazione è .NET Core 3.0 o versione successiva. Se si usa Microsoft.NET.Sdk.Web, il riferimento al framework condiviso verrà inserito automaticamente; in caso contrario, l'elemento PackageReference deve essere sostituito da un elemento FrameworkReference.</target>
         <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="translated">NETSDK1017: 자산을 처리하려면 먼저 자산 전처리기를 구성해야 합니다.</target>
+        <target state="translated">NETSDK1017: prima di elaborare le risorse, è necessario configurare il preprocessore di risorse.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingRuntimeIdentifier">
         <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요. 프로젝트의 RuntimeIdentifiers에 '{3}'을(를) 포함해야 할 수도 있습니다.</target>
+        <target state="translated">NETSDK1047: il file di risorse '{0}' non contiene una destinazione per '{1}'. Assicurarsi che il ripristino sia stato eseguito e che '{2}' sia stato incluso negli elementi TargetFramework del progetto. Potrebbe anche essere necessario includere '{3}' negli elementi RuntimeIdentifier del progetto.</target>
         <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingTarget">
         <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요.</target>
+        <target state="translated">NETSDK1005: il file di risorse '{0}' non contiene una destinazione per '{1}'. Assicurarsi che il ripristino sia stato eseguito e che '{2}' sia stato incluso negli elementi TargetFramework del progetto.</target>
         <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotFound">
         <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: 자산 파일 '{0}'을(를) 찾을 수 없습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
+        <target state="translated">NETSDK1004: il file di risorse '{0}' non è stato trovato. Per generare questo file, eseguire un ripristino del pacchetto NuGet.</target>
         <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
         <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: 프로젝트 자산 파일에 대한 경로가 설정되지 않았습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
+        <target state="translated">NETSDK1063: il percorso del file di risorse del progetto non è stato impostato. Per generare questo file, eseguire un ripristino del pacchetto NuGet.</target>
         <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFilePathNotRooted">
         <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: 자산 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
+        <target state="translated">NETSDK1006: il percorso dei file di risorse '{0}' non contiene una radice. Sono supportati solo percorsi completi.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: 가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>
+        <target state="translated">NETSDK1001: è necessario specificare almeno un framework di destinazione possibile.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotEmbedClsidMapIntoComhost">
         <source>NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="translated">NETSDK1092: 리소스를 추가하려면 빌드가 Windows(Nano Server 제외)에서 수행되어야 하므로 CLSIDMap을 COM 호스트에 포함할 수 없습니다.</target>
+        <target state="translated">NETSDK1092: non è possibile incorporare l'elemento CLSIDMap nell'host COM perché per aggiungere risorse è necessario eseguire la compilazione in Windows (escluso Nano Server).</target>
         <note>{StrBegin="NETSDK1092: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindApphostForRid">
         <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: {0}에 대한 앱 호스트를 찾을 수 없습니다. {0}이(가) 잘못된 RID(런타임 식별자)일 수 있습니다. RID에 대한 자세한 내용은 https://aka.ms/rid-catalog를 참조하세요.</target>
+        <target state="translated">NETSDK1065: non è possibile trovare l'host delle app per {0}. {0} potrebbe essere un identificatore di runtime (RID) non valido. Per altre informazioni sul RID, vedere https://aka.ms/rid-catalog.</target>
         <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindComhost">
         <source>NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</source>
-        <target state="translated">NETSDK1091: .NET Core COM 호스트를 찾을 수 없습니다. .NET Core COM 호스트는 Windows를 대상으로 할 경우 .NET Core 3.0 이상에서만 사용할 수 있습니다.</target>
+        <target state="translated">NETSDK1091: non è possibile trovare un host COM .NET Core. L'host COM .NET Core è disponibile solo in .NET Core 3.0 o versioni successive quando è destinato a Windows.</target>
         <note>{StrBegin="NETSDK1091: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindIjwhost">
         <source>NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</source>
-        <target state="translated">NETSDK1114: .NET Core IJW 호스트를 찾을 수 없습니다. .NET Core IJW 호스트는 Windows를 대상으로 할 경우 .NET Core 3.1 이상에서만 사용할 수 있습니다.</target>
+        <target state="translated">NETSDK1114: non è possibile trovare un host IJW .NET Core. L'host IJW .NET Core è disponibile solo in .NET Core 3.1 o versioni successive quando la destinazione è Windows.</target>
         <note>{StrBegin="NETSDK1114: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindProjectInfo">
         <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: '{0}'에 대한 프로젝트 정보를 찾을 수 없습니다. 프로젝트 참조가 없음을 나타낼 수 있습니다.</target>
+        <target state="translated">NETSDK1007: le informazioni del progetto per '{0}' non sono state trovate. Questo errore può indicare la mancanza di un riferimento al progetto.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: RuntimeIdentifier 플랫폼 '{0}'과(와) PlatformTarget '{1}'은(는) 호환되어야 합니다.</target>
+        <target state="translated">NETSDK1032: la piattaforma '{0}' di RuntimeIdentifier e quella '{1}' di PlatformTarget devono essere compatibili.</target>
         <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="translated">NETSDK1031: RuntimeIdentifier를 지정하지 않고 자체 포함 애플리케이션을 빌드하거나 게시할 수 없습니다. RuntimeIdentifier를 지정하거나 SelfContained를 false로 설정해야 합니다.</target>
+        <target state="translated">NETSDK1031: non è possibile compilare o pubblicare un'applicazione indipendente senza specificare un elemento RuntimeIdentifier. Specificare un elemento RuntimeIdentifier o impostare SelfContained su false.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
         <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="translated">NETSDK1097: RuntimeIdentifier를 지정하지 않고 애플리케이션을 단일 파일에 게시할 수 없습니다. RuntimeIdentifier를 지정하거나 PublishSingleFile을 false로 설정해야 합니다.</target>
+        <target state="translated">NETSDK1097: non è possibile pubblicare un'applicazione in un singolo file senza specificare un elemento RuntimeIdentifier. Specificare un elemento RuntimeIdentifier o impostare PublishSingleFile su false.</target>
         <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutAppHost">
         <source>NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1098: 애플리케이션 호스트를 사용하려면 단일 파일에 게시된 애플리케이션이 필요합니다. PublishSingleFile을 false로 설정하거나 UseAppHost를 true로 설정해야 합니다.</target>
+        <target state="translated">NETSDK1098: le applicazioni pubblicate in un singolo file sono necessarie per usare l'host dell'applicazione. Impostare PublishSingleFile su false o UseAppHost su true.</target>
         <note>{StrBegin="NETSDK1098: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutExecutable">
         <source>NETSDK1099: Publishing to a single-file is only supported for executable applications.</source>
-        <target state="translated">NETSDK1099: 실행 가능한 애플리케이션의 경우에만 단일 파일에 게시할 수 있습니다.</target>
+        <target state="translated">NETSDK1099: la pubblicazione in un singolo file è supportata solo per le applicazioni eseguibili.</target>
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
-        <target state="translated">NETSDK1134: 특정 RuntimeIdentifier를 사용한 솔루션 빌드는 지원되지 않습니다. 단일 RID에 대해 게시하려면 대신 개별 프로젝트 수준에서 RID를 지정하세요.</target>
+        <target state="translated">NETSDK1134: non è possibile compilare una soluzione con un parametro RuntimeIdentifier specifico. Per pubblicare per un singolo RID, specificare il RID a livello di singolo progetto.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
         <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="translated">NETSDK1135: SupportedOSPlatformVersion {0}은(는) TargetPlatformVersion {1}보다 높을 수 없습니다.</target>
+        <target state="translated">NETSDK1135: il valore di SupportedOSPlatformVersion {0} non può essere maggiore di quello di TargetPlatformVersion {1}.</target>
         <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>
-        <target state="translated">NETSDK1143: 단일 파일 번들에 모든 콘텐츠를 포함하면 네이티브 라이브러리도 포함됩니다. IncludeAllContentForSelfExtract가 true면 IncludeNativeLibrariesForSelfExtract는 false가 아니어야 합니다.</target>
+        <target state="translated">NETSDK1143: se si include tutto il contenuto in un unico bundle di file, verranno incluse anche le librerie native. Se IncludeAllContentForSelfExtract è true, IncludeNativeLibrariesForSelfExtract non deve essere false.</target>
         <note>{StrBegin="NETSDK1143: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeSymbolsInSingleFile">
         <source>NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</source>
-        <target state="translated">NETSDK1142: .NET5 이상을 게시할 때 단일 파일 번들에서 기호를 포함할 수 없습니다.</target>
+        <target state="translated">NETSDK1142: l'inclusione dei simboli in un unico bundle di file non è supportata quando si esegue la pubblicazione per .NET 5 o versioni successive.</target>
         <note>{StrBegin="NETSDK1142: "}</note>
       </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: TargetFramework 값 '{0}'을(를) 인식하지 못했습니다. 철자가 틀렸을 수 있습니다. 그렇지 않은 경우 TargetFrameworkIdentifier 및/또는 TargetFrameworkVersion 속성을 명시적으로 지정해야 합니다.</target>
+        <target state="translated">NETSDK1013: il valore {0}' di TargetFramework non è stato riconosciuto. È possibile che sia stato digitato in modo errato. In caso contrario, le proprietà TargetFrameworkIdentifier e/o TargetFrameworkVersion devono essere specificate in modo esplicito.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: 애플리케이션 호스트를 사용하려면 자체 포함 애플리케이션이 필요합니다. SelfContained를 false로 설정하거나 UseAppHost를 true로 설정하세요.</target>
+        <target state="translated">NETSDK1067: con le applicazioni complete è necessario usare l'host applicazione. Impostare SelfContained su false o UseAppHost su true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
         <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
-        <target state="translated">NETSDK1125: 단일 파일에 게시는 netcoreapp 대상에만 지원됩니다.</target>
+        <target state="translated">NETSDK1125: la pubblicazione in un file singolo è supportata solo per la destinazione netcoreapp.</target>
         <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="translated">AssemblyVersion '{1}'이(가) '{2}'보다 크기 때문에 '{0}'을(를) 선택합니다.</target>
+        <target state="translated">Verrà scelto '{0}' perché il valore di AssemblyVersion '{1}' è maggiore di '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingCopyLocalArbitrarily_Info">
         <source>Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</source>
-        <target state="translated">두 항목이 모두 로컬 복사이고 파일 및 어셈블리 버전이 같으므로 임의로 '{0}'을(를) 선택합니다.</target>
+        <target state="translated">Verrà scelto '{0}' in modo arbitrario perché entrambi gli elementi sono una copia locale e contengono versioni di file e assembly uguali.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingFileVersion_Info">
         <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="translated">파일 버전 '{1}'이(가) '{2}'보다 크기 때문에 '{0}'을(를) 선택합니다.</target>
+        <target state="translated">Verrà scelto '{0}' perché la versione del file '{1}' è maggiore di '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPlatformItem_Info">
         <source>Choosing '{0}' because it is a platform item.</source>
-        <target state="translated">플랫폼 항목이기 때문에 '{0}'을(를) 선택합니다.</target>
+        <target state="translated">Verrà scelto '{0}' perché è un elemento della piattaforma.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPreferredPackage_Info">
         <source>Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="translated">기본 설정되는 패키지에 있기 때문에 '{0}'을(를) 선택합니다.</target>
+        <target state="translated">Verrà scelto '{0}' perché proviene da un pacchetto preferito.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClsidMapConflictingGuids">
         <source>NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</source>
-        <target state="translated">NETSDK1089: '{0}' 및 '{1}' 형식이 GuidAttribute에 설정된 같은 CLSID '{2}'을(를) 포함합니다. 각 COMVisible 클래스는 해당 CLSID에 대해 고유한 guid를 포함해야 합니다.</target>
+        <target state="translated">NETSDK1089: per i tipi '{0}' e '{1}' è impostato lo stesso CLSID '{2}' nel relativo elemento GuidAttribute. Ogni classe COMVisible deve includere un GUID distinto per il CLSID.</target>
         <note>{StrBegin="NETSDK1089: "}
 {0} - The first type with the conflicting guid.
 {1} - The second type with the conflicting guid.
@@ -207,319 +207,319 @@
       </trans-unit>
       <trans-unit id="ClsidMapExportedTypesRequireExplicitGuid">
         <source>NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</source>
-        <target state="translated">NETSDK1088: COMVisible 클래스 '{0}'이(가) .NET Core에서 COM에 표시되려면 클래스의 CLSID가 포함된 GuidAttribute를 포함해야 합니다.</target>
+        <target state="translated">NETSDK1088: la classe COMVisible '{0}' deve includere un elemento GuidAttribute con il CLSID della classe da rendere visibile per COM in .NET Core.</target>
         <note>{StrBegin="NETSDK1088: "}
 {0} - The ComVisible class that doesn't have a GuidAttribute on it.</note>
       </trans-unit>
       <trans-unit id="ClsidMapInvalidAssembly">
         <source>NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</source>
-        <target state="translated">NETSDK1090: 제공된 어셈블리 '{0}'이(가) 잘못되었습니다. 해당 어셈블리에서 CLSIDMap을 생성할 수 없습니다.</target>
+        <target state="translated">NETSDK1090: l'assembly specificato '{0}' non è valido. Non può essere usato per generare un elemento CLSIDMap.</target>
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequires60">
         <source>NETSDK1167: Compression in a single file bundle is only supported when publishing for .NET6 or higher.</source>
-        <target state="translated">NETSDK1167: 단일 파일 번들에서 압축은 .NET6 이상에 게시할 때만 지원됩니다.</target>
+        <target state="translated">NETSDK1167: la compressione in un unico bundle di file è supportata solo quando si esegue la pubblicazione per .NET6 o versioni successive.</target>
         <note>{StrBegin="NETSDK1167: "}</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequiresSelfContained">
         <source>NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.</source>
-        <target state="translated">NETSDK1176: 자체 포함 애플리케이션이 게시된 경우 단일 파일 번들의 압축만 지원됩니다.</target>
+        <target state="translated">NETSDK1176: la compressione in un unico bundle di file è supportata solo quando si esegue la pubblicazione di un'applicazione indipendente.</target>
         <note>{StrBegin="NETSDK1176: "}</note>
       </trans-unit>
       <trans-unit id="ConflictingRuntimePackInformation">
         <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
 {1}</source>
-        <target state="translated">NETSDK1133: {0}에 사용할 수 있는 런타임 팩에 대해 충돌하는 정보가 있습니다.
+        <target state="translated">NETSDK1133: sono presenti informazioni in conflitto sui pacchetti di runtime disponibili per {0}:
 {1}</target>
         <note>{StrBegin="NETSDK1133: "}</note>
       </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: '{0}'의 콘텐츠 항목이 '{1}'을(를) 설정하지만, '{2}' 또는 '{3}'을(를) 제공하지 않습니다.</target>
+        <target state="translated">NETSDK1014: l'elemento di contenuto per '{0}' imposta '{1}', ma non fornisce '{2}' o '{3}'.</target>
         <note>{StrBegin="NETSDK1014: "}</note>
       </trans-unit>
       <trans-unit id="ContentPreproccessorParameterRequired">
         <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: 전처리된 콘텐츠를 사용하려면 '{0}' 작업에서 '{1}' 매개 변수의 값을 지정해야 합니다.</target>
+        <target state="translated">NETSDK1010: per poter utilizzare il contenuto pre-elaborato, è necessario assegnare un valore per il parametro '{1}' nell'attività '{0}'.</target>
         <note>{StrBegin="NETSDK1010: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesNotExist_Info">
         <source>Could not determine winner because '{0}' does not exist.</source>
-        <target state="translated">'{0}'이(가) 존재하지 않기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
+        <target state="translated">Non è stato possibile determinare la versione da usare perché '{0}' non esiste.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_EqualVersions_Info">
         <source>Could not determine winner due to equal file and assembly versions.</source>
-        <target state="translated">동일한 파일 및 어셈블리 버전으로 인해 적용되는 내용을 확인할 수 없습니다.</target>
+        <target state="translated">Non è stato possibile determinare la versione da usare perché le versioni dell'assembly e del file sono uguali.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NoFileVersion_Info">
         <source>Could not determine a winner because '{0}' has no file version.</source>
-        <target state="translated">'{0}'에 파일 버전이 없기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
+        <target state="translated">Non è stato possibile determinare la versione da usare perché non esiste alcuna versione del file per '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NotAnAssembly_Info">
         <source>Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="translated">'{0}'이(가) 어셈블리가 아니기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
+        <target state="translated">Non è stato possibile determinare la versione da usare perché '{0}' non è un assembly.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
         <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
-        <target state="translated">NETSDK1181: 팩 버전 가져오기 오류: {0} 팩이 워크로드 매니페스트에 없습니다.</target>
+        <target state="translated">NETSDK1181: errore durante il recupero della versione del pacchetto: il pacchetto '{0}' non era presente nei manifesti del carico di lavoro.</target>
         <note>{StrBegin="NETSDK1181: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: PlatformManifest가 존재하지 않기 때문에 '{0}'에서 로드할 수 없습니다.</target>
+        <target state="translated">NETSDK1042: non è stato possibile caricare PlatformManifest da '{0}' perché non esiste.</target>
         <note>{StrBegin="NETSDK1042: "}</note>
       </trans-unit>
       <trans-unit id="CppRequiresTFMVersion31">
         <source>NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</source>
-        <target state="translated">NETSDK1120: .NET Core를 대상으로 하는 C++/CLI 프로젝트에 'netcoreapp3.1' 이상의 대상 프레임워크가 필요합니다.</target>
+        <target state="translated">NETSDK1120: con i progetti C++/CLI destinati a .NET Core è il framework di destinazione deve essere impostato almeno su 'netcoreapp3.1'.</target>
         <note>{StrBegin="NETSDK1120: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2MissingRequiredMetadata">
         <source>NETSDK1158: Required '{0}' metadata missing on Crossgen2Tool item.</source>
-        <target state="translated">NETSDK1158: Crossgen2Tool 항목에 필요한 '{0}' 메타데이터가 없습니다.</target>
+        <target state="translated">NETSDK1158: nell'elemento Crossgen2Tool mancano i metadati richiesti di '{0}'.</target>
         <note>{StrBegin="NETSDK1158: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2RequiresSelfContained">
         <source>NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</source>
-        <target state="translated">NETSDK1126: Crossgen2를 사용한 ReadyToRun 게시는 자체 포함 애플리케이션에서만 지원됩니다.</target>
+        <target state="translated">NETSDK1126: la pubblicazione di ReadyToRun tramite Crossgen2 è supportata solo per le applicazioni autonome.</target>
         <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolExecutableNotFound">
         <source>NETSDK1155: Crossgen2Tool executable '{0}' not found.</source>
-        <target state="translated">NETSDK1155: Crossgen2Tool 실행 파일 '{0}'을(를) 찾을 수 없습니다.</target>
+        <target state="translated">NETSDK1155: l'eseguibile '{0}' di Crossgen2Tool non è stato trovato.</target>
         <note>{StrBegin="NETSDK1155: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolMissingWhenUseCrossgen2IsSet">
         <source>NETSDK1154: Crossgen2Tool must be specified when UseCrossgen2 is set to true.</source>
-        <target state="translated">NETSDK1154: UseCrossgen2가 true로 설정된 경우 Crossgen2Tool을 지정해야 합니다.</target>
+        <target state="translated">NETSDK1154: è necessario specificare Crossgen2Tool quando UseCrossgen2 è impostato su true.</target>
         <note>{StrBegin="NETSDK1154: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
-        <target state="translated">NETSDK1166: 복합 모드를 사용하여 Crossgen2를 사용하여 .NET 5에 게시할 때 기호를 내보낼 수 없습니다.</target>
+        <target state="translated">NETSDK1166: non è possibile creare simboli durante la pubblicazione per .NET 5 con Crossgen2 usando la modalità composita.</target>
         <note>{StrBegin="NETSDK1166: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolExecutableNotFound">
         <source>NETSDK1160: CrossgenTool executable '{0}' not found.</source>
-        <target state="translated">NETSDK1160: CrossgenTool 실행 파일 '{0}'을(를) 찾을 수 없습니다.</target>
+        <target state="translated">NETSDK1160: l'eseguibile '{0}' di CrossgenTool non è stato trovato.</target>
         <note>{StrBegin="NETSDK1160: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingInPDBCompilationMode">
         <source>NETSDK1153: CrossgenTool not specified in PDB compilation mode.</source>
-        <target state="translated">NETSDK1153: PDB 컴파일 모드에 CrossgenTool이 지정되지 않았습니다.</target>
+        <target state="translated">NETSDK1153: CrossgenTool non è stato specificato nella modalità di compilazione PDB.</target>
         <note>{StrBegin="NETSDK1153: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingWhenUseCrossgen2IsNotSet">
         <source>NETSDK1159: CrossgenTool must be specified when UseCrossgen2 is set to false.</source>
-        <target state="translated">NETSDK1159: UseCrossgen2가 false로 설정된 경우 CrossgenTool을 지정해야 합니다.</target>
+        <target state="translated">NETSDK1159: è necessario specificare CrossgenTool quando UseCrossgen2 è impostato su false.</target>
         <note>{StrBegin="NETSDK1159: "}</note>
       </trans-unit>
       <trans-unit id="DiaSymReaderLibraryNotFound">
         <source>NETSDK1161: DiaSymReader library '{0}' not found.</source>
-        <target state="translated">NETSDK1161: DiaSymReader 라이브러리 '{0}'을(를) 찾을 수 없습니다.</target>
+        <target state="translated">NETSDK1161: la libreria '{0}' di DiaSymReader non è stata trovata.</target>
         <note>{StrBegin="NETSDK1161: "}</note>
       </trans-unit>
       <trans-unit id="DotNetHostExecutableNotFound">
         <source>NETSDK1156: .NET host executable '{0}' not found.</source>
-        <target state="translated">NETSDK1156: .NET 호스트 실행 파일 '{0}'을(를) 찾을 수 없습니다.</target>
+        <target state="translated">NETSDK1156: l'eseguibile '{0}' dell'host .NET non è stato trovato.</target>
         <note>{StrBegin="NETSDK1156: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
         <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool가 netcoreapp2.1보다 낮은 대상 프레임워크를 지원하지 않습니다.</target>
+        <target state="translated">NETSDK1055: DotnetTool non supporta framework di destinazione di versioni precedenti a netcoreapp2.1.</target>
         <note>{StrBegin="NETSDK1055: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolOnlySupportNetcoreapp">
         <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: .NET Core만 지원합니다.</target>
+        <target state="translated">NETSDK1054: supporta solo .NET Core.</target>
         <note>{StrBegin="NETSDK1054: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateItemsError">
         <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: '{0}' 중복 항목이 포함되었습니다. .NET SDK에는 기본적으로 프로젝트 디렉터리의 '{0}' 항목이 포함됩니다. 프로젝트 파일에서 이러한 항목을 제거하거나, 프로젝트 파일에 해당 항목을 명시적으로 포함하려면 '{1}' 속성을 '{2}'(으)로 설정할 수 있습니다. 자세한 내용은 {4}을(를) 참조하세요. 중복 항목은 다음과 같습니다. {3}</target>
+        <target state="translated">NETSDK1022: sono stati inclusi '{0}' elementi duplicati. Per impostazione predefinita, .NET SDK include '{0}' elementi della directory del progetto. È possibile rimuovere tali elementi dal file di progetto oppure impostare la proprietà '{1}' su '{2}' se si vuole includerli implicitamente nel file di progetto. Per altre informazioni, vedere {4}. Gli elementi duplicati sono: {3}</target>
         <note>{StrBegin="NETSDK1022: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePreprocessorToken">
         <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: 전처리기 토큰 '{0}'의 값이 두 개 이상 지정되었습니다. '{1}'을(를) 값으로 선택합니다.</target>
+        <target state="translated">NETSDK1015: al token di preprocessore '{0}' è stato assegnato più di un valore. Come valore verrà scelto '{1}'.</target>
         <note>{StrBegin="NETSDK1015: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePublishOutputFiles">
         <source>NETSDK1152: Found multiple publish output files with the same relative path: {0}.</source>
-        <target state="translated">NETSDK1152: 상대 경로가 같은 여러 게시 출력 파일을 찾았습니다. {0}.</target>
+        <target state="translated">NETSDK1152: sono stati trovati più file di output di pubblicazione con lo stesso percorso relativo: {0}.</target>
         <note>{StrBegin="NETSDK1152: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateRuntimePackAsset">
         <source>NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="translated">NETSDK1110: 런타임 팩에 있는 두 개 이상 자산에 동일한 대상 하위 경로인 '{0}'이(가) 있습니다. https://aka.ms/dotnet-sdk-issue에서 .NET 팀에 이 오류를 보고하세요.</target>
+        <target state="translated">NETSDK1110: più di un asset nel pacchetto di runtime ha lo stesso percorso secondario di destinazione di '{0}'. Segnalare questo errore al team di .NET all'indirizzo: https://aka.ms/dotnet-sdk-issue.</target>
         <note>{StrBegin="NETSDK1110: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateTypeLibraryIds">
         <source>NETSDK1169: The same resource ID {0} was specified for two type libraries '{1}' and '{2}'. Duplicate type library IDs are not allowed.</source>
-        <target state="translated">NETSDK1169: 두 형식 라이브러리 '{1}' 및 '{2}'에 대해 동일한 리소스 ID {0}가 지정되었습니다. 중복 형식 라이브러리 ID는 허용되지 않습니다.</target>
+        <target state="translated">NETSDK1169: è stato specificato lo stesso ID di risorsa {0} per due librerie dei tipi '{1}' e '{2}'. Gli ID della libreria dei tipi duplicati non sono consentiti.</target>
         <note>{StrBegin="NETSDK1169: "}</note>
       </trans-unit>
       <trans-unit id="EncounteredConflict_Info">
         <source>Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="translated">'{0}'과(와) '{1}' 사이에 충돌이 발생했습니다.</target>
+        <target state="translated">È stato rilevato un conflitto tra '{0}' e '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">
         <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: '{0}'의 FrameworkList를 구문 분석하는 동안 오류가 발생했습니다. {1} '{2}'이(가) 잘못되었습니다.</target>
+        <target state="translated">NETSDK1051: si è verificato un errore durante l'analisi di FrameworkList da '{0}'. {1} '{2}' non è valido.</target>
         <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="translated">NETSDK1043: '{0}' 줄 {1}에서 PlatformManifest를 구문 분석하는 중 오류가 발생했습니다. 줄이 {2} 형식이어야 합니다.</target>
+        <target state="translated">NETSDK1043: si è verificato un errore durante l'analisi di PlatformManifest da '{0}' a riga {1}. Il formato delle righe deve essere {2}.</target>
         <note>{StrBegin="NETSDK1043: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="translated">NETSDK1044: '{0}' 줄 {1}에서 PlatformManifest를 구문 분석하는 중 오류가 발생했습니다. {2} '{3}'이(가) 잘못되었습니다.</target>
+        <target state="translated">NETSDK1044: si è verificato un errore durante l'analisi di PlatformManifest da '{0}' a riga {1}. Il valore {2} '{3}' non è valido.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">
         <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: 자산 파일 {0}을(를) 읽는 동안 오류가 발생했습니다.</target>
+        <target state="translated">NETSDK1060: errore durante la lettura del file di asset: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
       <trans-unit id="FailedToDeleteApphost">
         <source>NETSDK1111: Failed to delete output apphost: {0}</source>
-        <target state="translated">NETSDK1111: 출력 apphost를 삭제하지 못했습니다. {0}</target>
+        <target state="translated">NETSDK1111: non è stato possibile eliminare l'apphost di output: {0}</target>
         <note>{StrBegin="NETSDK1111: "}</note>
       </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: 리소스를 잠그지 못했습니다.</target>
+        <target state="translated">NETSDK1077: non è stato possibile bloccare la risorsa.</target>
         <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
       <trans-unit id="FileNameIsTooLong">
         <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: 제공한 파일 이름 '{0}'이(가) 1024바이트보다 깁니다.</target>
+        <target state="translated">NETSDK1030: il nome file specificato '{0}' supera 1024 byte</target>
         <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
       <trans-unit id="FolderAlreadyExists">
         <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: '{0}' 폴더가 이미 있습니다. 폴더를 삭제하거나 다른 ComposeWorkingDir을 제공하세요.</target>
+        <target state="translated">NETSDK1024: la cartella '{0}' esiste già. Eliminarla o specificare un elemento ComposeWorkingDir diverso</target>
         <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: 프레임워크 종속 애플리케이션 호스트는 'netcoreapp2.1' 이상의 대상 프레임워크가 필요합니다.</target>
+        <target state="translated">NETSDK1068: con l'host applicazione dipendente dal framework il framework di destinazione deve essere impostato almeno su 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1052: 프레임워크 목록 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
+        <target state="translated">NETSDK1052: il percorso '{0}' del file dell'elenco di framework non contiene una radice. Sono supportati solo percorsi completi.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceDuplicateError">
         <source>NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</source>
-        <target state="translated">NETSDK1087: 프로젝트에 '{0}'에 대한 여러 FrameworkReference 항목이 포함되었습니다.</target>
+        <target state="translated">NETSDK1087: nel progetto sono stati inclusi più elementi FrameworkReference per '{0}'.</target>
         <note>{StrBegin="NETSDK1087: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceOverrideWarning">
         <source>NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1086: '{0}'에 대한 FrameworkReference가 프로젝트에 포함되었습니다. 이는 .NET SDK에서 암시적으로 참조되며, 일반적으로 사용자가 프로젝트에서 참조할 필요가 없습니다. 자세한 내용은 {1}을(를) 참조하세요.</target>
+        <target state="translated">NETSDK1086: nel progetto è stato incluso un elemento FrameworkReference per '{0}'. Questo elemento viene usato come riferimento implicito da .NET SDK e non è in genere necessario farvi riferimento dal progetto. Per altre informazioni, vedere {1}</target>
         <note>{StrBegin="NETSDK1086: "}</note>
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
         <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: 확인된 파일의 이미지가 잘못되었거나, 메타데이터가 없거나, 파일 자체에 액세스할 수 없습니다. {0} {1}</target>
+        <target state="translated">NETSDK1049: il file risolto ha un'immagine danneggiata, non contiene metadati o è inaccessibile per altri motivi. {0} {1}</target>
         <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
       <trans-unit id="GlobalJsonSDKResolutionFailed">
         <source>NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</source>
-        <target state="translated">NETSDK1141: {0}에서 global.json에 지정된 .NET SDK 버전을 확인할 수 없습니다.</target>
+        <target state="translated">NETSDK1141: non è possibile risolvere la versione di .NET SDK come specificato nel file global.json presente in {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
         <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
-        <target state="translated">NETSDK1144: 어셈블리의 크기를 최적화하지 못했습니다. PublishTrimmed 속성을 false로 설정하여 최적화를 사용하지 않도록 설정할 수 있습니다.</target>
+        <target state="translated">NETSDK1144: l'ottimizzazione degli assembly per le dimensioni non è riuscita. È possibile disabilitare l'ottimizzazione impostando la proprietà PublishTrimmed su false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
-        <target state="translated">NETSDK1102: 선택한 게시 구성에서는 크기에 대한 어셈블리 최적화가 지원되지 않습니다. 자체 포함 앱을 게시하고 있는지 확인하세요.</target>
+        <target state="translated">NETSDK1102: l'ottimizzazione degli assembly per le dimensioni non è supportata per la configurazione di pubblicazione selezionata. Assicurarsi di pubblicare un'app indipendente.</target>
         <note>{StrBegin="NETSDK1102: "}</note>
       </trans-unit>
       <trans-unit id="ILLink_Info">
         <source>Optimizing assemblies for size, which may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</source>
-        <target state="translated">크기에 대한 어셈블리 최적화로 앱의 동작이 변경될 수 있습니다. 게시 후 테스트하세요. 참조: https://aka.ms/dotnet-illink</target>
+        <target state="translated">Verrà eseguita l'ottimizzazione degli assembly per le dimensioni. Questa operazione potrebbe comportare la modifica del comportamento dell'app. Assicurarsi di testarla dopo la pubblicazione. Vedere: https://aka.ms/dotnet-illink</target>
         <note />
       </trans-unit>
       <trans-unit id="IncorrectPackageRoot">
         <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: 패키지 루트 {0}이(가) 확인된 라이브러리 {1}에 대해 잘못 지정되었습니다.</target>
+        <target state="translated">NETSDK1020: la radice {0} del pacchetto specificata per la libreria risolta {1} non è corretta</target>
         <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectTargetFormat">
         <source>NETSDK1025: The target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: 제공한 대상 매니페스트 {0}이(가) 올바른 형식이 아닙니다.</target>
+        <target state="translated">NETSDK1025: il formato del manifesto di destinazione specificato {0} non è corretto</target>
         <note>{StrBegin="NETSDK1025: "}</note>
       </trans-unit>
       <trans-unit id="InputAssemblyNotFound">
         <source>NETSDK1163: Input assembly '{0}' not found.</source>
-        <target state="translated">NETSDK1163: 입력 어셈블리 '{0}'을(를) 찾을 수 없습니다.</target>
+        <target state="translated">NETSDK1163: l'assembly di input '{0}' non è stato trovato.</target>
         <note>{StrBegin="NETSDK1163: "}</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: 프레임워크 이름 '{0}'이(가) 잘못되었습니다.</target>
+        <target state="translated">NETSDK1003: nome di framework non valido: '{0}'.</target>
         <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="translated">NETSDK1058: ItemSpecToUse 매개 변수 값이 잘못되었습니다. '{0}'. 이 속성은 비워 두거나 'Left' 또는 'Right'로 설정해야 합니다.</target>
+        <target state="translated">NETSDK1058: valore non valido per il parametro ItemSpecToUse: '{0}'. Questa proprietà deve essere vuota o impostata su 'Left' o 'Right'</target>
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionString">
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</target>
+        <target state="translated">NETSDK1018: la stringa di versione '{0}' di NuGet non è valida.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidResourceUpdate">
         <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: 업데이트 핸들이 잘못되었습니다. 이 인스턴스는 추가 업데이트에 사용되지 않을 수 있습니다.</target>
+        <target state="translated">NETSDK1075: il punto di controllo dell'aggiornamento non è valido. Non è possibile usare questa istanza per ulteriori aggiornamenti.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="InvalidRollForwardValue">
         <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
-        <target state="translated">NETSDK1104: RollForward 값 '{0}'이(가) 잘못되었습니다. 허용되는 값은 {1}입니다.</target>
+        <target state="translated">NETSDK1104: il valore '{0}' di RollForward non è valido. I valori consentiti sono {1}.</target>
         <note>{StrBegin="NETSDK1104: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTargetPlatformVersion">
         <source>NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
 {2}</source>
-        <target state="translated">NETSDK1140: {0}은(는) {1}에 대한 유효한 TargetPlatformVersion이 아닙니다. 유효한 버전은 다음과 같습니다.
+        <target state="translated">NETSDK1140: {0} non è un valore valido di TargetPlatformVersion per or {1}. Le versioni valide includono:
 {2}</target>
         <note>{StrBegin="NETSDK1140: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibrary">
         <source>NETSDK1173: The provided type library '{0}' is in an invalid format.</source>
-        <target state="translated">NETSDK1173: 제공된 형식 라이브러리 '{0}'의 형식이 잘못되었습니다.</target>
+        <target state="translated">NETSDK1173: il formato della libreria dei tipi specificata '{0}' non è valido.</target>
         <note>{StrBegin="NETSDK1173: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibraryId">
         <source>NETSDK1170: The provided type library ID '{0}' for type libary '{1}' is invalid. The ID must be a positive integer less than 65536.</source>
-        <target state="translated">NETSDK1170: 형식 라이브러리 '{1}'에 대해 제공된 형식 라이브러리 ID '{0}'이(가) 잘못되었습니다. ID는 65536보다 작은 양의 정수여야 합니다.</target>
+        <target state="translated">NETSDK1170: l'ID '{0}' per la libreria dei tipi specificato '{1}' non è valido. L'ID deve essere un numero positivo intero inferiore a 65536.</target>
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
-        <target state="translated">NETSDK1157: JIT 라이브러리 '{0}'을(를) 찾을 수 없습니다.</target>
+        <target state="translated">NETSDK1157: la libreria '{0}' di JIT non è stata trovata.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="translated">NETSDK1061: {0} 버전 {1}을(를) 사용하여 프로젝트가 복원되었지만, 현재 설정에서는 버전 {2}을(를) 대신 사용합니다. 이 문제를 해결하려면 복원 및 후속 작업(예: 빌드 또는 게시)에 동일한 설정을 사용해야 합니다. 일반적으로 이 문제는 RuntimeIdentifier 속성이 빌드 또는 게시 중에 설정되었지만, 복원 중에는 설정되지 않은 경우에 발생할 수 있습니다. 자세한 내용은 https://aka.ms/dotnet-runtime-patch-selection을 참조하세요.</target>
+        <target state="translated">NETSDK1061: per il ripristino del progetto è stato usato {0} versione {1}, ma con le impostazioni correnti viene usata la versione {2}. Per risolvere il problema, assicurarsi di usare le stesse impostazioni per il ripristino e per le operazioni successive, quali compilazione o pubblicazione. In genere questo problema può verificarsi se la proprietà RuntimeIdentifier viene impostata durante la compilazione o la pubblicazione, ma non durante il ripristino. Per altre informazioni, vedere https://aka.ms/dotnet-runtime-patch-selection.</target>
         <note>{StrBegin="NETSDK1061: "}
 {0} - Package Identifier for platform package
 {1} - Restored version of platform package
@@ -527,401 +527,396 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="MissingItemMetadata">
         <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: '{1}' 항목 '{2}'에 '{0}' 메타데이터가 없습니다.</target>
+        <target state="translated">NETSDK1008: mancano i metadati di '{0}' sull'elemento '{2}' di '{1}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputPDBImagePath">
         <source>NETSDK1164: Missing output PDB path in PDB generation mode (OutputPDBImage metadata).</source>
-        <target state="translated">NETSDK1164: PDB 생성 모드(OutputPDBImage 메타데이터)에 출력 PDB 경로가 없습니다.</target>
+        <target state="translated">NETSDK1164: il percorso PDB di output non è presente nella modalità di generazione PDB (metadati di OutputPDBImage).</target>
         <note>{StrBegin="NETSDK1164: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputR2RImageFileName">
         <source>NETSDK1165: Missing output R2R image path (OutputR2RImage metadata).</source>
-        <target state="translated">NETSDK1165: 출력 R2R 이미지 경로(OutputR2RImage 메타데이터)가 없습니다.</target>
+        <target state="translated">NETSDK1165: il percorso dell'immagine R2R di output non è presente (metadati di OutputR2RImage).</target>
         <note>{StrBegin="NETSDK1165: "}</note>
       </trans-unit>
       <trans-unit id="MissingTypeLibraryId">
         <source>NETSDK1171: An integer ID less than 65536 must be provided for type library '{0}' because more than one type library is specified.</source>
-        <target state="translated">NETSDK1171: 두 개 이상의 형식 라이브러리가 지정되었기 때문에 형식 라이브러리 '{0}'에 대해 65536보다 작은 정수 ID를 제공해야 합니다.</target>
+        <target state="translated">NETSDK1171: un ID intero inferiore a 65536 deve essere fornito per la libreria dei tipi '{0}' perché è specificata più di una libreria dei tipi.</target>
         <note>{StrBegin="NETSDK1171: "}</note>
       </trans-unit>
       <trans-unit id="MultipleFilesResolved">
         <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: {0}에 대해 두 개 이상의 파일을 찾았습니다.</target>
+        <target state="translated">NETSDK1021: è stato trovato più di un file per {0}</target>
         <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: 이 프로젝트는 .NET Standard 1.5 이상을 대상으로 하는 라이브러리를 사용하며, 이 프로젝트는 해당 버전의 .NET Standard를 기본으로 제공하지 않는 .NET Framework 버전을 대상으로 합니다. 알려진 문제에 대해서는 https://aka.ms/net-standard-known-issues를 참조하세요. .NET Framework 4.7.2로 대상을 다시 지정해 보세요.</target>
+        <target state="translated">NETSDK1069: questo progetto usa una libreria destinata a .NET Standard 1.5 o versione successiva ed è destinato a una versione di .NET Framework che non include il supporto predefinito per tale versione di .NET Standard. Per un serie di problemi noti, visitare https://aka.ms/net-standard-known-issues. Provare a impostare come destinazione .NET Framework 4.7.2.</target>
         <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkWithoutUsingNETSdkDefaults">
         <source>NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</source>
-        <target state="translated">NETSDK1115: 현재 .NET SDK는 .NET SDK 기본값을 사용하지 않는 .NET Framework를 지원하지 않습니다. C++/CLI 프로젝트 CLRSupport 속성과 TargetFramework 사이의 불일치 때문일 수 있습니다.</target>
+        <target state="translated">NETSDK1115: l'istanza corrente di .NET SDK non supporta .NET Framework senza usare le impostazioni predefinite di .NET SDK. Il problema dipende probabilmente da una mancata corrispondenza tra la proprietà CLRSupport del progetto C++/CLI e TargetFramework.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
         <source>NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</source>
-        <target state="translated">NETSDK1182: Visual Studio 2019에서 .NET 6.0 이상을 대상으로 하는 것은 지원되지 않습니다.</target>
+        <target state="translated">NETSDK1182: la destinazione .NET 6.0 o versione successiva in Visual Studio 2019 non è supportata.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="translated">NETSDK1084: 지정된 RuntimeIdentifier '{0}'에 사용할 수 있는 애플리케이션 호스트가 없습니다.</target>
+        <target state="translated">NETSDK1084: non è disponibile alcun host applicazione per l'elemento RuntimeIdentifier specificato '{0}'.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
       <trans-unit id="NoBuildRequested">
         <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
-        <target state="translated">NETSDK1085: 'NoBuild' 속성이 true로 설정되었지만, 'Build' 대상이 호출되었습니다.</target>
+        <target state="translated">NETSDK1085: non è stata impostata alcuna proprietà 'NoBuild' su true, ma è stata chiamata la destinazione 'Build'.</target>
         <note>{StrBegin="NETSDK1085: "}</note>
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: '{0}' 프로젝트가 '{2}'을(를) 대상으로 합니다. '{1}'을(를) 대상으로 하는 프로젝트에서 참조할 수 없습니다.</target>
+        <target state="translated">NETSDK1002: il progetto '{0}' è destinato a '{2}'. Non può essere usato come riferimento in un progetto destinato a '{1}'.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackAvailable">
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="translated">NETSDK1082: 지정된 RuntimeIdentifier '{1}'에 사용할 수 있는 {0}용 런타임 팩이 없습니다.</target>
+        <target state="translated">NETSDK1082: non è disponibile alcun pacchetto di runtime per {0} per l'elemento RuntimeIdentifier specificato '{1}'.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackInformation">
         <source>NETSDK1132: No runtime pack information was available for {0}.</source>
-        <target state="translated">NETSDK1132: {0}에 사용할 수 있는 런타임 팩 정보가 없습니다.</target>
+        <target state="translated">NETSDK1132: non sono disponibili informazioni sui pacchetti di runtime per {0}.</target>
         <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
-        <target state="translated">NETSDK1128: COM 호스팅에서는 자체 포함 배포가 지원되지 않습니다.</target>
+        <target state="translated">NETSDK1128: l'hosting COM non supporta le distribuzioni complete.</target>
         <note>{StrBegin="NETSDK1128: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
-        <target state="translated">NETSDK1119: .NET Core를 대상으로 하는 C++/CLI 프로젝트는 EnableComHosting=true를 사용할 수 없습니다.</target>
+        <target state="translated">NETSDK1119: i progetti C++/CLI destinati a .NET Core non possono usare EnableComHosting=true.</target>
         <note>{StrBegin="NETSDK1119: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppNonDynamicLibraryDotnetCore">
         <source>NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</source>
-        <target state="translated">NETSDK1116: .NET Core를 대상으로 하는 C++/CLI 프로젝트는 동적 라이브러리여야 합니다.</target>
+        <target state="translated">NETSDK1116: i progetti C++/CLI destinati a .NET Core devono essere librerie dinamiche.</target>
         <note>{StrBegin="NETSDK1116: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPackDotnetCore">
         <source>NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</source>
-        <target state="translated">NETSDK1118: .NET Core를 대상으로 하는 C++/CLI 프로젝트를 압축할 수 없습니다.</target>
+        <target state="translated">NETSDK1118: i progetti C++/CLI destinati a .NET Core non possono essere compressi.</target>
         <note>{StrBegin="NETSDK1118: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPublishDotnetCore">
         <source>NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</source>
-        <target state="translated">NETSDK1117: dotnet core를 대상으로 하는 C++/CLI 프로젝트 게시를 지원하지 않습니다.</target>
+        <target state="translated">NETSDK1117: la pubblicazione di progetti C++/CLI destinati a .NET Core non è supportata.</target>
         <note>{StrBegin="NETSDK1117: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppSelfContained">
         <source>NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</source>
-        <target state="translated">NETSDK1121: .NET Core를 대상으로 하는 C++/CLI 프로젝트는 SelfContained=true를 사용할 수 없습니다.</target>
+        <target state="translated">NETSDK1121: i progetti C++/CLI destinati a .NET Core non possono usare SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
       <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
         <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</source>
-        <target state="translated">NETSDK1151: 참조된 프로젝트 '{0}'은(는) self-contained 실행 파일입니다. self-contained 실행 파일은 self-contained가 아닌 실행 파일에서 참조할 수 없습니다. 자세한 내용은 https://aka.ms/netsdk1151을 참조하세요</target>
+        <target state="translated">NETSDK1151: il progetto '{0}' a cui viene fatto riferimento è un eseguibile autonomo. Non è possibile fare riferimento a un eseguibile autonomo da un eseguibile non autonomo. Per altre informazioni, vedere https://aka.ms/netsdk1151</target>
         <note>{StrBegin="NETSDK1151: "}</note>
       </trans-unit>
       <trans-unit id="PDBGeneratorInputExecutableNotFound">
         <source>NETSDK1162: PDB generation: R2R executable '{0}' not found.</source>
-        <target state="translated">NETSDK1162: PDB 생성: R2R 실행 파일 '{0}'을(를) 찾을 수 없습니다.</target>
+        <target state="translated">NETSDK1162: generazione PDB: l'eseguibile '{0}' di R2R non è stato trovato.</target>
         <note>{StrBegin="NETSDK1162: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: 도구로서 팩은 자체 포함을 지원하지 않습니다.</target>
+        <target state="translated">NETSDK1053: la creazione di pacchetti come strumenti non prevede elementi autonomi.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
         <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
-        <target state="translated">NETSDK1146: PackAsTool은 설정 중인 TargetPlatformIdentifier를 지원하지 않습니다. 예를 들어, TargetFramework는 net5.0-windows를 사용할 수 없으며 net5.0만 지원합니다. 또한 PackAsTool은 .NET 5 이상을 대상으로 하는 경우 UseWPF 또는 UseWindowsForms를 지원하지 않습니다.</target>
+        <target state="translated">NETSDK1146: PackAsTool non supporta l'impostazione di TargetPlatformIdentifier. Ad esempio, TargetFramework non può essere essere impostato su net5.0-windows, ma solo su net5.0. PackAsTool non supporta neanche UseWPF o UseWindowsForms quando la destinazione è .NET 5 e versioni successive.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="translated">NETSDK1064: 패키지 {0}, 버전 {1}을(를) 찾을 수 없습니다. NuGet 복원 이후 삭제되었을 수 있습니다. 아니면, 최대 경로 길이 제한으로 인해 NuGet 복원이 부분적으로만 완료되었을 수 있습니다.</target>
+        <target state="translated">NETSDK1064: il pacchetto {0} versione {1} non è stato trovato. Potrebbe essere stato eliminato dopo il ripristino di NuGet. In caso contrario, il ripristino di NuGet potrebbe essere stato completato solo parzialmente, a causa delle restrizioni relative alla lunghezza massima del percorso.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceOverrideWarning">
         <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: '{0}'에 대한 PackageReference가 프로젝트에 포함되어 있습니다. 이 패키지는 .NET SDK에서 암시적으로 참조되며, 일반적으로 사용자가 프로젝트에서 참조할 필요가 없습니다. 자세한 내용은 {1}을(를) 참조하세요.</target>
+        <target state="translated">NETSDK1023: nel progetto è stato incluso un riferimento al pacchetto per '{0}'. Questo pacchetto viene usato come riferimento implicito da .NET SDK e non è in genere necessario farvi riferimento dal progetto. Per altre informazioni, vedere {1}</target>
         <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceVersionNotRecommended">
         <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: '{0}'에 대한 PackageReference에서 `{1}`의 버전을 지정했습니다. 이 패키지의 버전을 지정하지 않는 것이 좋습니다. 자세한 내용은 https://aka.ms/sdkimplicitrefs를 참조하세요.</target>
+        <target state="translated">NETSDK1071: in un elemento PackageReference che fa riferimento a '{0}' è specificata la versione di `{1}`. È consigliabile non specificare la versione di questo pacchetto. Per altre informazioni, vedere https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
         <source>NETSDK1174: Placeholder</source>
-        <target state="translated">NETSDK1174: 자리 표시자</target>
+        <target state="translated">NETSDK1174: Placeholder</target>
         <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: '{0}' 프로젝트의 자산이 사용되었지만, '{1}'에서 해당 MSBuild 프로젝트 경로를 찾을 수 없습니다.</target>
+        <target state="translated">NETSDK1011: le risorse vengono utilizzate dal progetto '{0}', ma non è stato trovato alcun percorso di progetto MSBuild corrispondente in '{1}'.</target>
         <note>{StrBegin="NETSDK1011: "}</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
         <source>NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: '{0}' 도구가 현재 .NET SDK에 포함되어 있습니다. 이 경고를 해결하는 방법은 https://aka.ms/dotnetclitools-in-box를 참조하세요.</target>
+        <target state="translated">NETSDK1059: lo strumento '{0}' è ora incluso in .NET SDK. Per informazioni sulla risoluzione di questo avviso, vedere (https://aka.ms/dotnetclitools-in-box).</target>
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
         <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: 프로젝트 도구(DotnetCliTool)는 .NET Core 2.2 이하를 대상으로 하는 경우만 지원합니다.</target>
+        <target state="translated">NETSDK1093: gli strumenti del progetto (DotnetCliTool) supportano come destinazione solo .NET Core 2.2 e versioni precedenti.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1122: ReadyToRun 컴파일은 .NET Core 3.0 이상에서만 지원되므로 건너뜁니다.</target>
+        <target state="translated">NETSDK1122: la compilazione eseguita con ReadyToRun verrà ignorata perché è supportata solo per .NET Core 3.0 o versioni successive.</target>
         <note>{StrBegin="NETSDK1122: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1123: 애플리케이션을 단일 파일에 게시하려면 .NET Core 3.0 이상이 필요합니다.</target>
+        <target state="translated">NETSDK1123: per la pubblicazione di un'applicazione in un file singolo è richiesto .NET Core 3.0 o versioni successive.</target>
         <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="PublishTrimmedRequiresVersion30">
         <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1124: 어셈블리를 트리밍하려면 .NET Core 3.0 이상이 필요합니다.</target>
+        <target state="translated">NETSDK1124: per il trimming degli assembly è richiesto .NET Core 3.0 o versioni successive.</target>
         <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="PublishUnsupportedWithoutTargetFramework">
         <source>NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</source>
-        <target state="translated">NETSDK1129: 대상 프레임워크를 지정하지 않고 'Publish' 대상을 사용할 수 없습니다. 현재 프로젝트가 여러 프레임워크를 대상으로 하므로 게시된 애플리케이션의 프레임워크를 지정해야 합니다.</target>
+        <target state="translated">NETSDK1129: la destinazione 'Publish' non è supportata se non viene specificato un framework di destinazione. Il progetto corrente è destinato a più framework, di conseguenza è necessario specificare il framework per l'applicazione pubblicata.</target>
         <note>{StrBegin="NETSDK1129: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>
-        <target state="translated">NETSDK1096: 성능 향상을 위해 어셈블리를 최적화하지 못했습니다. 오류가 발생하는 어셈블리를 최적화에서 제외하거나 PublishReadyToRun 속성을 false로 설정할 수 있습니다.</target>
+        <target state="translated">NETSDK1096: l'ottimizzazione degli assembly per le prestazioni non è riuscita. È possibile escludere gli assembly in errore dall'ottimizzazione oppure impostare la proprietà PublishReadyToRun su false.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
         <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
-        <target state="translated">일부 ReadyToRun 컴파일에서 잠재적인 종속성 누락을 나타내는 경고를 발생했습니다. 종속성 누락으로 인해 런타임 오류가 잠재적으로 발생할 수 있습니다. 경고를 표시하려면 PublishReadyToRunShowWarnings 속성을 true로 설정하세요.</target>
+        <target state="translated">Alcune compilazioni eseguite con la proprietà ReadyToRun hanno restituito avvisi per indicare potenziali dipendenze mancanti. Le dipendenze mancanti potrebbero causare errori di runtime. Per visualizzare gli avvisi, impostare la proprietà PublishReadyToRunShowWarnings su true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
-        <target state="translated">NETSDK1094: 성능 향상을 위해 어셈블리를 최적화할 수 없습니다. 유효한 런타임 패키지를 찾을 수 없습니다. PublishReadyToRun 속성을 false로 설정하거나, 게시할 때 지원되는 런타임 식별자를 사용하세요.</target>
+        <target state="translated">NETSDK1094: non è possibile ottimizzare gli assembly per le prestazioni perché non è stato trovato alcun pacchetto di runtime valido. Impostare la proprietà PublishReadyToRun su false oppure usare un identificatore di runtime supportato durante la pubblicazione.</target>
         <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunTargetNotSupportedError">
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
-        <target state="translated">NETSDK1095: 선택한 대상 플랫폼 또는 아키텍처의 경우 성능 향상을 위해 어셈블리를 최적화할 수 없습니다. 지원되는 런타임 식별자를 사용하고 있는지 확인하거나 PublishReadyToRun 속성을 false로 설정하세요.</target>
+        <target state="translated">NETSDK1095: l'ottimizzazione degli assembly per le prestazioni non è supportata per la piattaforma o l'architettura di destinazione selezionata. Verificare di usare un identificatore di runtime supportato oppure impostare la proprietà PublishReadyToRun su false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
       </trans-unit>
       <trans-unit id="RollForwardRequiresVersion30">
         <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1103: RollForward 설정은 .NET Core 3.0 이상에서만 지원됩니다.</target>
+        <target state="translated">NETSDK1103: l'impostazione RollForward è supportata solo in .NET Core 3.0 o versione successiva.</target>
         <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="translated">NETSDK1083: 지정된 RuntimeIdentifier '{0}'을(를) 인식할 수 없습니다.</target>
+        <target state="translated">NETSDK1083: l'elemento RuntimeIdentifier '{0}' specificato non è riconosciuto.</target>
         <note>{StrBegin="NETSDK1083: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: RuntimeIdentifier 지정</target>
+        <target state="translated">NETSDK1028: specificare un elemento RuntimeIdentifier</target>
         <note>{StrBegin="NETSDK1028: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeListNotFound">
         <source>NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="translated">NETSDK1109: 런타임 목록 파일 '{0}'을(를) 찾을 수 없습니다. https://aka.ms/dotnet-sdk-issue에서 .NET 팀에 이 오류를 보고하세요.</target>
+        <target state="translated">NETSDK1109: il file di elenco di runtime '{0}' non è stato trovato. Segnalare questo errore al team di .NET all'indirizzo: https://aka.ms/dotnet-sdk-issue.</target>
         <note>{StrBegin="NETSDK1109: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotDownloaded">
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
-        <target state="translated">NETSDK1112: {0}용 런타임 팩이 다운로드되지 않았습니다. RuntimeIdentifier '{1}'을(를) 사용하여 NuGet 복원을 실행해 보세요.</target>
+        <target state="translated">NETSDK1112: il pacchetto di runtime per {0} non è stato scaricato. Provare a eseguire un ripristino NuGet con RuntimeIdentifier '{1}'.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
-        <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
-        <target state="translated">NETSDK1150: 참조된 프로젝트 '{0}'은(는) self-contained가 아닌 실행 파일입니다. self-contained가 아닌  실행 파일은 self-contained 실행 파일에서 참조할 수 없습니다. 자세한 내용은 https://aka.ms/netsdk1150을 참조하세요</target>
+        <target state="translated">NETSDK1150: il progetto '{0}' a cui viene fatto riferimento è un eseguibile non autonomo. Non è possibile fare riferimento a un eseguibile non autonomo da un eseguibile autonomo. Per altre informazioni, vedere https://aka.ms/netsdk1150</target>
         <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionShouldBeUsedWithRuntime">
         <source>NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</source>
-        <target state="translated">NETSDK1179: '--runtime'을 사용하는 경우 '--no-self-contained' 또는 '--no-self-contained' 옵션 중 하나가 필요합니다.</target>
+        <target state="translated">NETSDK1179: quando si usa '--runtime' è necessaria una delle opzioni '--self-contained' o '--no-self-contained'.</target>
         <note>{StrBegin="NETSDK1179: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: GenerateRuntimeConfigurationFiles에 대해 'AdditionalProbingPaths'가 지정되었지만 'RuntimeConfigDevPath'가 비어 있어서 건너뜁니다.</target>
+        <target state="translated">NETSDK1048: per GenerateRuntimeConfigurationFiles è stato specificato 'AdditionalProbingPaths', ma questo valore verrà ignorato perché 'RuntimeConfigDevPath' è vuoto.</target>
         <note>{StrBegin="NETSDK1048: "}</note>
       </trans-unit>
       <trans-unit id="TargetFrameworkIsEol">
         <source>NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
-        <target state="translated">NETSDK1138: 대상 프레임워크 '{0}'은(는) 지원되지 않으며 향후 보안 업데이트를 받을 수 없습니다. 지원 정책에 대한 자세한 내용은 {1}을(를) 참조하세요.</target>
+        <target state="translated">NETSDK1138: il framework di destinazione '{0}' non è più supportato e non riceverà aggiornamenti della sicurezza in futuro. Per altre informazioni sui criteri di supporto, vedere {1}.</target>
         <note>{StrBegin="NETSDK1138: "}</note>
       </trans-unit>
       <trans-unit id="TargetFrameworkWithSemicolon">
         <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: TargetFramework 값 '{0}'이(가) 잘못되었습니다. 여러 대상을 지정하려면 'TargetFrameworks' 속성을 대신 사용하세요.</target>
+        <target state="translated">NETSDK1046: il valore '{0}' di TargetFramework non è valido. Per impostare più destinazioni, usare la proprietà 'TargetFrameworks'.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
       <trans-unit id="TargetingApphostPackMissingCannotRestore">
         <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
-        <target state="translated">NETSDK1145: {0} 팩이 설치되지 않았으며 NuGet 패키지 복원이 지원되지 않습니다. Visual Studio를 업그레이드하고, 특정 SDK 버전을 지정하는 경우 global.json을 제거하고, 최신 SDK를 설치하세요. 더 많은 옵션을 보려면 https://aka.ms/targeting-apphost-pack-missing을 방문하세요. 팩 형식: {0}, 팩 디렉터리: {1}, 대상 프레임워크: {2}, 팩 패키지 ID: {3}, 팩 패키지 버전: {4}</target>
+        <target state="translated">NETSDK1145: il pacchetto {0} non è installato e il ripristino del pacchetto NuGet non è supportato. Aggiornare Visual Studio, rimuovere global.json se specifica una determinata versione dell'SDK e disinstallare l'SDK più recente. Per altre opzioni, vedere https://aka.ms/targeting-apphost-pack-missing. Tipo del pacchetto: {0}. Directory del pacchetto: {1}. Framework di destinazione: {2}. ID pacchetto: {3}. Versione del pacchetto: {4}</target>
         <note>{StrBegin="NETSDK1145: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
-        <target state="translated">NETSDK1127: 타기팅 팩 {0}이(가) 설치되어 있지 않습니다. 복원한 후 다시 시도하세요.</target>
+        <target state="translated">NETSDK1127: il Targeting Pack {0} non è installato. Ripristinare e riprovare.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
-        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>
-        <target state="translated">NETSDK1175: 트리밍을 사용하도록 설정하면 Windows Forms이 지원되지 않거나 권장되지 않습니다. 자세한 내용은 https://aka.ms/dotnet-illink/windows-forms를 참조하세요.</target>
+        <target state="translated">NETSDK1175: quando il trimming è abilitato, Windows Form non è supportato o consigliato. Per altre informazioni, vedere https://aka.ms/dotnet-illink/windows-forms.</target>
         <note>{StrBegin="NETSDK1175: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWpfIsNotSupported">
         <source>NETSDK1168: WPF is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/wpf for more details.</source>
-        <target state="translated">NETSDK1168: 트리밍을 사용하도록 설정하면 WPF가 지원되지 않거나 권장되지 않습니다. 자세한 내용은 https://aka.ms/dotnet-illink/wpf로 이동하세요.</target>
+        <target state="translated">NETSDK1168: quando il trimming è abilitato, il WPF non è supportato o consigliato. Per altre informazioni, visitare https://aka.ms/dotnet-illink/wpf.</target>
         <note>{StrBegin="NETSDK1168: "}</note>
       </trans-unit>
       <trans-unit id="TypeLibraryDoesNotExist">
         <source>NETSDK1172: The provided type library '{0}' does not exist.</source>
-        <target state="translated">NETSDK1172: 제공된 형식 라이브러리 '{0}'이(가) 없습니다.</target>
+        <target state="translated">NETSDK1172: la libreria dei tipi specificata '{0}' non esiste.</target>
         <note>{StrBegin="NETSDK1172: "}</note>
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: '{0}'에 대해 확인된 경로를 찾을 수 없습니다.</target>
+        <target state="translated">NETSDK1016: il percorso risolto per '{0}' non è stato trovato.</target>
         <note>{StrBegin="NETSDK1016: "}</note>
       </trans-unit>
       <trans-unit id="UnableToUsePackageAssetsCache_Info">
         <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">I/O 오류로 인해 패키지 자산 캐시를 사용할 수 없습니다. 동일한 프로젝트가 두 번 이상 동시에 빌드되면 이 오류가 발생합니다. 성능이 저하될 수 있지만 빌드 결과는 영향을 받지 않습니다.</target>
+        <target state="translated">Non è possibile usare la cache delle risorse del pacchetto a causa dell'errore di I/O. Questo problema può verificarsi quando lo stesso progetto viene compilato più volte in parallelo. Può influire sulle prestazioni, ma non sul risultato della compilazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedFileType">
         <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: '{0}'에 대해 예기치 않은 파일 형식입니다. 형식이 '{1}'인 동시에 '{2}'입니다.</target>
+        <target state="translated">NETSDK1012: tipo di file imprevisto per '{0}'. Il tipo è sia '{1}' che '{2}'.</target>
         <note>{StrBegin="NETSDK1012: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference">
         <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: FrameworkReference '{0}'을(를) 인식할 수 없습니다.</target>
+        <target state="translated">NETSDK1073: l'elemento FrameworkReference '{0}' non è stato riconosciuto</target>
         <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_TransitiveDisabled">
+        <source>NETSDK1182: The FrameworkReference '{0}' was not recognized.  This may be because DOTNETSDK_DisableTransitiveFrameworkReferences was set to true.</source>
+        <target state="new">NETSDK1182: The FrameworkReference '{0}' was not recognized.  This may be because DOTNETSDK_DisableTransitiveFrameworkReferences was set to true.</target>
+        <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
-        <target state="translated">NETSDK1137: Microsoft.NET.Sdk.WindowsDesktop SDK를 더 이상 사용할 필요가 없습니다. 루트 프로젝트 요소의 SDK 특성을 'Microsoft.NET.Sdk'로 변경하세요.</target>
+        <target state="translated">NETSDK1137: non è più necessario usare Microsoft.NET.Sdk.WindowsDesktop SDK. Provare a modificare l'attributo Sdk dell'elemento Project radice in 'Microsoft.NET.Sdk'.</target>
         <note>{StrBegin="NETSDK1137: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: '{1}'에서 전처리기 토큰 '{0}'을(를) 인식할 수 없습니다.</target>
+        <target state="translated">NETSDK1009: token di preprocessore '{0}' non riconosciuto in '{1}'.</target>
         <note>{StrBegin="NETSDK1009: "}</note>
       </trans-unit>
       <trans-unit id="UnresolvedTargetingPack">
         <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="translated">NETSDK1081: {0}용 타기팅 팩을 찾을 수 없습니다. 프로젝트에서 NuGet 복원을 실행하여 이 문제를 해결할 수 있습니다.</target>
+        <target state="translated">NETSDK1081: il pacchetto di destinazione per {0} non è stato trovato. Per risolvere il problema, eseguire un ripristino NuGet sul progetto.</target>
         <note>{StrBegin="NETSDK1081: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0}은(는) 지원되지 않는 프레임워크입니다.</target>
+        <target state="translated">NETSDK1019: {0} è un framework non supportato.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: 프로젝트가 런타임 '{0}'을(를) 대상으로 하지만 런타임 관련 패키지를 확인하지 않았습니다. 이 런타임은 대상 프레임워크에서 지원되지 않을 수 있습니다.</target>
+        <target state="translated">NETSDK1056: il progetto è destinato al runtime '{0}' ma non ha risolto pacchetti specifici del runtime. È possibile che questo runtime non sia supportato dal framework di destinazione.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">
         <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: 이 프로젝트에서 사용하는 Microsoft.NET.Sdk 버전은 .NET Standard 1.5 이상을 대상으로 하는 라이브러리에 대한 참조를 지원할 수 없습니다. .NET Core SDK 버전 2.0 이상을 설치하세요.</target>
+        <target state="translated">NETSDK1050: la versione di Microsoft.NET.Sdk usata da questo progetto non è sufficiente per supportare i riferimenti alle librerie destinate a .NET Standard 1.5 o versione successiva. Installare la versione 2.0 o successiva di .NET Core SDK.</target>
         <note>{StrBegin="NETSDK1050: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetFrameworkVersion">
         <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: 현재 .NET SDK에서는 {0} {1}을(를) 대상으로 하는 것을 지원하지 않습니다. {0} {2} 이하를 대상으로 하거나 {0} {1}을(를) 지원하는 .NET SDK 버전을 사용하세요.</target>
+        <target state="translated">NETSDK1045: la versione corrente di .NET SDK non supporta {0} {1} come destinazione. Impostare come destinazione {0} {2} o una versione precedente oppure usare una versione di .NET SDK che supporta {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifier">
         <source>NETSDK1139: The target platform identifier {0} was not recognized.</source>
-        <target state="translated">NETSDK1139: 대상 플랫폼 식별자 {0}을(를) 인식할 수 없습니다.</target>
+        <target state="translated">NETSDK1139: l'identificatore di piattaforma di destinazione {0} non è stato riconosciuto.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
-        <target state="translated">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop을 사용하려면 Windows 데스크톱 애플리케이션을 빌드해야 합니다. 'UseWpf' 및 'UseWindowsForms'는 현재 SDK에서 지원하지 않습니다.</target>
+        <target state="translated">NETSDK1107: per compilare applicazioni desktop di Windows, è necessario Microsoft.NET.Sdk.WindowsDesktop. 'UseWpf' e 'UseWindowsForms' non sono supportati dall'SDK corrente.</target>
         <note>{StrBegin="NETSDK1107: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdk_Info">
         <source>You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">.NET의 미리 보기 버전을 사용 중입니다. 참조: https://aka.ms/dotnet-core-preview</target>
+        <target state="translated">Si sta usando una versione in anteprima di .NET. Vedere https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
-        <target state="translated">NETSDK1131: {0}을(를) 대상으로 지정하는 경우 WinMDExp로 관리형 Windows 메타데이터 구성 요소를 생성하는 것은 지원되지 않습니다.</target>
+        <target state="translated">NETSDK1131: la produzione di un componente Metadati Windows gestito con WinMDExp non è supportata quando la destinazione è {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
         <source>NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</source>
-        <target state="translated">NETSDK1130: {1}을(를) 참조할 수 없습니다. .NET 5 이상을 대상으로 하는 경우 Windows 메타데이터 구성 요소를 직접 참조하는 것은 지원되지 않습니다. 자세한 내용은 다음 링크를 참조하세요. https://aka.ms/netsdk1130</target>
+        <target state="translated">NETSDK1130: non è possibile fare riferimento a {1}. Il riferimento diretto a un componente di Metadati Windows quando la destinazione è .NET 5 o versione successiva non è supportato. Per altre informazioni, vedere https://aka.ms/netsdk1130</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WinMDTransitiveReferenceNotSupported">
         <source>NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</source>
-        <target state="translated">NETSDK1149: {0}은(는) 더 이상 .NET 5 이상에서 지원되지 않는 WinRT에 대한 기본 제공 지원을 사용하므로 참조할 수 없습니다.  .NET 5를 지원하는 업데이트된 버전의 구성 요소가 필요합니다. 자세한 내용은 다음 링크를 참조하세요. https://aka.ms/netsdk1149</target>
+        <target state="translated">NETSDK1149: non è possibile fare riferimento a {0} perché usa il supporto incorporato per WinRT, che non è più supportato in .NET 5 e versioni successive. È necessaria una versione aggiornata del componente che supporta .NET 5. Per altre informazioni, vedere https://aka.ms/netsdk1149</target>
         <note>{StrBegin="NETSDK1149: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
-        <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop을 사용하려면 'UseWpf' 또는 'UseWindowsForms'를 'true'로 설정해야 합니다.</target>
+        <target state="translated">NETSDK1106: con Microsoft.NET.Sdk.WindowsDesktop 'UseWpf' o 'UseWindowsForms' deve essere impostato su 'true'</target>
         <note>{StrBegin="NETSDK1106: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
         <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1105: Windows 데스크톱 애플리케이션은 .NET Core 3.0 이상에서만 지원됩니다.</target>
+        <target state="translated">NETSDK1105: le applicazioni desktop di Windows sono supportate solo in .NET Core 3.0 o versioni successive.</target>
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: Windows 데스크톱 애플리케이션을 빌드하려면 Windows가 필요합니다.</target>
+        <target state="translated">NETSDK1100: per compilare applicazioni desktop di Windows è richiesto Windows.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">
         <source>NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</source>
-        <target state="translated">NETSDK1136: Windows Forms 또는 WPF를 사용하거나 그러한 작업을 수행하는 프로젝트 또는 패키지를 참조하는 경우 대상 플랫폼을 Windows로 설정해야 합니다(일반적으로 TargetFramework 속성에 '-windows' 포함).</target>
+        <target state="translated">NETSDK1136: la piattaforma di destinazione deve essere impostata su Windows, in genere includendo '-windows ' nella proprietà TargetFramework, quando si usa Windows Forms o WPF oppure si fa riferimento a progetti o pacchetti che lo usano.</target>
         <note>{StrBegin="NETSDK1136: "}</note>
       </trans-unit>
       <trans-unit id="WindowsSDKVersionConflicts">
         <source>NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</source>
-        <target state="translated">NETSDK1148: 참조된 어셈블리가 최신 버전의 Microsoft.Windows.SDK.NET.dll을 사용하여 컴파일되었습니다. 이 어셈블리를 참조하려면 최신 .NET SDK로 업데이트하세요.</target>
+        <target state="translated">NETSDK1148: un assembly di riferimento è stato compilato con una versione più recente di Microsoft.Windows.SDK.NET.dll. Eseguire l'aggiornamento a un SDK .NET più recente per fare riferimento a questo assembly.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>
-        <target state="translated">NETSDK1178: 이 설치에서 사용 가능한 워크로드에 존재하지 않는 다음 워크로드 팩에 따라 프로젝트가 달라집니다. {0}
-다른 운영 체제나 아키텍처에서 프로젝트를 빌드하거나 .NET SDK를 업데이트해야 할 수 있습니다.</target>
+        <target state="translated">NETSDK1178: il progetto dipende dai pacchetti di carico di lavoro seguenti che non esistono in nessuno dei carichi di lavoro disponibili in questa installazione: {0}
+Potrebbe essere necessario compilare il progetto in un altro sistema operativo o architettura oppure aggiornare .NET SDK.</target>
         <note>{StrBegin="NETSDK1178: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotInstalled">
         <source>NETSDK1147: To build this project, the following workloads must be installed: {0}
 To install these workloads, run the following command: dotnet workload restore</source>
-        <target state="translated">NETSDK1147: 이 프로젝트를 빌드하려면 다음 워크로드를 설치해야 합니다. {0}
- 이러한 워크로드를 설치하려면 dotnet workload restore 명령을 실행합니다.</target>
+        <target state="translated">NETSDK1147: per compilare questo progetto devono essere installati i seguenti carichi di lavoro: {0}
+Per installare questi carichi di lavoro, eseguire il seguente comando: dotnet workload restore</target>
         <note>{StrBegin="NETSDK1147: "} LOCALIZATION: Do not localize "dotnet workload restore"</note>
       </trans-unit>
     </body>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: FrameworkReference '{0}' は認識されませんでした</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: Microsoft.NET.Sdk.WindowsDesktop SDK を使用する必要はなくなりました。ルート プロジェクト要素の SDK 属性を 'Microsoft.NET.Sdk' に変更することをご検討ください。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: Windows デスクトップ アプリケーションを構築するには Windows が必要です。</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: Windows デスクトップ アプリケーションを構築するには Windows が必要です。</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: {0} のランタイム パックがダウンロードされませんでした。RuntimeIdentifier '{1}' で NuGet 復元を実行してみてください。</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: 参照先プロジェクト '{0}' は自己完結型以外の実行可能ファイルです。 自己完結型以外の実行可能ファイルは、自己完結型の実行可能ファイルでは参照できません。詳細については、「https://aka.ms/netsdk1150」を参照してください</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: ターゲット パック {0} がインストールされていません。復元して、もう一度お試しください。</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: Windows 데스크톱 애플리케이션을 빌드하려면 Windows가 필요합니다.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: Windows 데스크톱 애플리케이션을 빌드하려면 Windows가 필요합니다.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: FrameworkReference '{0}'을(를) 인식할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: Microsoft.NET.Sdk.WindowsDesktop SDK를 더 이상 사용할 필요가 없습니다. 루트 프로젝트 요소의 SDK 특성을 'Microsoft.NET.Sdk'로 변경하세요.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: Nie pobrano pakietu wykonawczego dla: {0}. Spróbuj uruchomić przywracanie NuGet z użyciem wartości RuntimeIdentifier „{1}”.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: Projekt „{0}”, do którego istnieje odwołanie, jest niesamodzielnym plikiem wykonywalnym.  Niesamodzielny plik wykonywalny nie może być przywoływany przez samodzielny plik wykonywalny. Aby uzyskać więcej informacji, zobacz: https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: Pakiet docelowy {0} nie jest zainstalowany. Wykonaj przywrócenie i spróbuj ponownie.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: Do tworzenia aplikacji klasycznych systemu Windows wymagany jest system Windows.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: Do tworzenia aplikacji klasycznych systemu Windows wymagany jest system Windows.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: Nie rozpoznano elementu FrameworkReference „{0}”</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: Nie trzeba już używać zestawu SDK Microsoft.NET.Sdk.WindowsDesktop. Rozważ zmianę atrybutu Sdk głównego elementu Project na „Microsoft.NET.Sdk”.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: o Windows é necessário para compilar aplicativos da área de trabalho do Windows.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: o Windows é necessário para compilar aplicativos da área de trabalho do Windows.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: o pacote de tempo de execução para {0} não foi baixado. Tente executar uma restauração do NuGet com o RuntimeIdentifier '{1}'.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: O projeto referenciado '{0}' é um executável não autossuficiente.  Um executável não autossuficiente não pode ser referenciado por um executável autossuficiente. Para mais informações, consulte https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: o pacote de direcionamento do {0} não está instalado. Restaure e tente novamente.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: o FrameworkReference '{0}' não foi reconhecido</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: não é mais necessário usar o SDK do Microsoft.NET.Sdk.WindowsDesktop. Considere alterar o atributo SDK do elemento de Projeto raiz para 'Microsoft.NET.Sdk'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: элемент FrameworkReference "{0}" не распознан</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: больше не нужно использовать пакет SDK Microsoft.NET.Sdk.WindowsDesktop. Попробуйте изменить атрибут пакета SDK корневого элемента проекта на "Microsoft.NET.Sdk".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: для создания классических приложений Windows требуется ОС Windows.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: для создания классических приложений Windows требуется ОС Windows.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: пакет среды выполнения для {0} не был скачан. Попробуйте выполнить восстановление NuGet с помощью RuntimeIdentifier "{1}".</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: проект "{0}", на который указывает ссылка, является неавтономным исполняемым файлом.  Автономный исполняемый файл не может ссылаться на неавтономный исполняемый файл. Дополнительные сведения см. на странице https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: пакет нацеливания {0} не установлен. Выполните восстановление и повторите попытку.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: {0} için çalışma zamanı paketi indirilmedi. '{1}' RuntimeIdentifier ile bir NuGet geri yüklemesi çalıştırmayı deneyin.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: Başvurulan '{0}' projesi bağımsız olmayan bir yürütülebilir dosyadır. Bağımsız olmayan bir yürütülebilir dosyaya, bağımsız bir yürütülebilir dosya tarafından başvurulamaz.  Daha fazla bilgi için bkz. https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: {0} hedefleme paketi yüklü değil. Lütfen geri yükleyip yeniden deneyin.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: Windows masaüstü uygulamalarını oluşturmak için Windows gereklidir.</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: Windows masaüstü uygulamalarını oluşturmak için Windows gereklidir.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: FrameworkReference '{0}' tanınmadı</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: Artık Microsoft.NET.Sdk.WindowsDesktop SDK'sinin kullanılması gerekmiyor. Kök proje öğesinin Sdk özniteliğini 'Microsoft.NET.Sdk' olarak değiştirmeyi düşünün.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: 未识别 FrameworkReference“{0}”</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: 不再需要使用 Microsoft.NET.Sdk.WindowsDesktop SDK。请考虑将根项目元素的 Sdk 属性更改为 "Microsoft.NET.Sdk"。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: 未下载 {0} 的运行时包。请尝试使用 RuntimeIdentifier“{1}”运行 NuGet 还原。</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: 引用的项目“{0}”是非自包含的可执行文件。非自包含可执行文件不能由自包含可执行文件引用。如需获取更多信息，请访问 https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: 未安装目标包 {0}。请还原并重试。</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: 需使用 Windows 才能构建 Windows 桌面应用程序。</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: 需使用 Windows 才能构建 Windows 桌面应用程序。</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -740,6 +740,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1112: 未下載 {0} 的執行階段套件。請嘗試使用 RuntimeIdentifier '{1}' 執行 NuGet 還原。</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
+      <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1184: "}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: 參照的專案 '{0}' 是非獨立式可執行檔。獨立式可執行檔無法參照非獨立式可執行檔。如需詳細資料，請參閱 https://aka.ms/netsdk1150</target>
@@ -774,6 +779,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="translated">NETSDK1127: 未安裝目標套件 {0}。請還原後再試一次。</target>
         <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -741,8 +741,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
-        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1184: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
@@ -781,8 +781,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
-        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available.  This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <source>NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
+        <target state="new">NETSDK1183: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
@@ -821,8 +821,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
-        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -820,6 +820,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1073: 無法辨識 FrameworkReference '{0}'</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
+      <trans-unit id="UnknownFrameworkReference_MauiEssentials">
+        <source>NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
+        <target state="new">NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <note>{StrBegin="NETSDK1185: "}</note>
+      </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
         <target state="translated">NETSDK1137: 不再有必要使用 Microsoft.NET.Sdk.WindowsDesktop SDK。請考慮將根 Project 元素的 SDK 屬性變更為 'Microsoft.NET.Sdk'。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -901,8 +901,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
-        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
-        <target state="translated">NETSDK1100: 需要 Windows 才能建置 Windows 桌面應用程式。</target>
+        <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
+        <target state="needs-review-translation">NETSDK1100: 需要 Windows 才能建置 Windows 桌面應用程式。</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
@@ -337,6 +337,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 runtimeFrameworks: new[] {new MockTaskItem("RuntimeFramework1", new Dictionary<string, string>()) },
                 generateErrorForMissingTargetingPacks: true,
                 nuGetRestoreSupported: true,
+                disableTransitiveFrameworkReferences: false,
             netCoreTargetingPackRoot: "netCoreTargetingPackRoot",
             projectLanguage: "C#");
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
@@ -37,6 +37,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             1066,
             1101,
             1108,
+            1180,
         };
 
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -58,6 +58,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool EnableRuntimePackDownload { get; set; }
 
+        public bool EnableWindowsTargeting { get; set; }
+
         public bool DisableTransitiveFrameworkReferenceDownloads { get; set; }
 
         public ITaskItem[] FrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
@@ -146,7 +148,8 @@ namespace Microsoft.NET.Build.Tasks
 
                 // Handle Windows-only frameworks on non-Windows platforms
                 if (knownFrameworkReference.IsWindowsOnly &&
-                    !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                    !EnableWindowsTargeting)
                 {
                     // It is an error to reference the framework from non-Windows
                     if (!windowsOnlyErrorLogged && frameworkReference != null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -305,7 +305,7 @@ namespace Microsoft.NET.Build.Tasks
                         }
                     }
 
-                    ProcessRuntimeIdentifier(hasRuntimePackAlwaysCopyLocal ? "any" : RuntimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
+                    ProcessRuntimeIdentifier(string.IsNullOrEmpty(RuntimeIdentifier) ? "any" : RuntimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
                         unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, EnableRuntimePackDownload && useRuntimePackAndDownloadIfNecessary,
                         wasReferencedDirectly: frameworkReference != null);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -58,6 +58,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool EnableRuntimePackDownload { get; set; }
 
+        public bool DisableTransitiveFrameworkReferenceDownloads { get; set; }
+
         public ITaskItem[] FrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
 
         public ITaskItem[] KnownFrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
@@ -219,7 +221,10 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 else
                 {
-                    if (EnableTargetingPackDownload)
+                    //  If transitive framework reference downloads are disabled, then don't download targeting packs where there isn't
+                    //  a direct framework reference
+                    if (EnableTargetingPackDownload &&
+                        !(DisableTransitiveFrameworkReferenceDownloads && frameworkReference == null))
                     {
                         //  Download targeting pack
                         TaskItem packageToDownload = new TaskItem(knownFrameworkReference.TargetingPackName);
@@ -298,7 +303,8 @@ namespace Microsoft.NET.Build.Tasks
                     }
 
                     ProcessRuntimeIdentifier(hasRuntimePackAlwaysCopyLocal ? "any" : RuntimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
-                        unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, EnableRuntimePackDownload && useRuntimePackAndDownloadIfNecessary);
+                        unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, EnableRuntimePackDownload && useRuntimePackAndDownloadIfNecessary,
+                        wasReferencedDirectly: frameworkReference != null);
 
                     processedPrimaryRuntimeIdentifier = true;
                 }
@@ -316,7 +322,8 @@ namespace Microsoft.NET.Build.Tasks
                         //  Pass in null for the runtimePacks list, as for these runtime identifiers we only want to
                         //  download the runtime packs, but not use the assets from them
                         ProcessRuntimeIdentifier(runtimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack: null,
-                            unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks: null, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary);
+                            unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks: null, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
+                            wasReferencedDirectly: frameworkReference != null);
                     }
                 }
 
@@ -452,7 +459,8 @@ namespace Microsoft.NET.Build.Tasks
             List<ITaskItem> runtimePacks,
             List<ITaskItem> packagesToDownload,
             string isTrimmable,
-            bool addRuntimePackAndDownloadIfNecessary)
+            bool addRuntimePackAndDownloadIfNecessary,
+            bool wasReferencedDirectly)
         {
             var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
             var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = selectedRuntimePack.RuntimePackRuntimeIdentifiers.Split(';');
@@ -523,7 +531,7 @@ namespace Microsoft.NET.Build.Tasks
                         runtimePacks.Add(runtimePackItem);
                     }
 
-                    if (runtimePackPath == null)
+                    if (runtimePackPath == null && (wasReferencedDirectly || !DisableTransitiveFrameworkReferenceDownloads))
                     {
                         TaskItem packageToDownload = new TaskItem(runtimePackName);
                         packageToDownload.SetMetadata(MetadataKeys.Version, resolvedRuntimePackVersion);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -22,6 +22,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool DesignTimeBuild { get; set; }
 
+        public bool DisableTransitiveFrameworkReferenceDownloads { get; set; }
+
         [Output]
         public ITaskItem[] RuntimePackAssets { get; set; }
 
@@ -66,8 +68,16 @@ namespace Microsoft.NET.Build.Tasks
                         //  Don't treat this as an error if we are doing a design-time build.  This is because the design-time
                         //  build needs to succeed in order to get the right information in order to run a restore to download
                         //  the runtime pack.
-                        Log.LogError(Strings.RuntimePackNotDownloaded, runtimePack.ItemSpec,
-                            runtimePack.GetMetadata(MetadataKeys.RuntimeIdentifier));
+
+                        if (DisableTransitiveFrameworkReferenceDownloads)
+                        {
+                            Log.LogError(Strings.RuntimePackNotRestored_TransitiveDisabled, runtimePack.ItemSpec);
+                        }
+                        else
+                        {
+                            Log.LogError(Strings.RuntimePackNotDownloaded, runtimePack.ItemSpec,
+                                runtimePack.GetMetadata(MetadataKeys.RuntimeIdentifier));
+                        }
                     }
                     continue;
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -26,6 +26,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool NuGetRestoreSupported { get; set; } = true;
 
+        public bool DisableTransitiveFrameworkReferenceDownloads { get; set; }
+
         public string NetCoreTargetingPackRoot { get; set; }
 
         public string ProjectLanguage { get; set; }
@@ -78,12 +80,17 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                results = Resolve(inputs, Log, BuildEngine4);
+                results = Resolve(inputs, BuildEngine4);
 
                 if (s_allowCacheLookup)
                 {
                     BuildEngine4?.RegisterTaskObject(cacheKey, results, RegisteredTaskObjectLifetime.AppDomain, allowEarlyCollection: true);
                 }
+            }
+
+            foreach (var error in results.Errors)
+            {
+                Log.LogError(error);
             }
 
             ReferencesToAdd = results.ReferencesToAdd;
@@ -100,16 +107,18 @@ namespace Microsoft.NET.Build.Tasks
                         RuntimeFrameworks,
                         GenerateErrorForMissingTargetingPacks,
                         NuGetRestoreSupported,
+                        DisableTransitiveFrameworkReferenceDownloads,
                         NetCoreTargetingPackRoot,
                         ProjectLanguage);
 
-        private static ResolvedAssetsCacheEntry Resolve(StronglyTypedInputs inputs, Logger log, IBuildEngine4 buildEngine)
+        private static ResolvedAssetsCacheEntry Resolve(StronglyTypedInputs inputs, IBuildEngine4 buildEngine)
         {
             List<TaskItem> referencesToAdd = new List<TaskItem>();
             List<TaskItem> analyzersToAdd = new List<TaskItem>();
             List<TaskItem> platformManifests = new List<TaskItem>();
             List<TaskItem> packageConflictOverrides = new List<TaskItem>();
             List<string> preferredPackages = new List<string>();
+            List<string> errors = new List<string>();
 
             var resolvedTargetingPacks = inputs.ResolvedTargetingPacks
                 .ToDictionary(
@@ -129,24 +138,28 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         if (!foundTargetingPack)
                         {
-                            log.LogError(Strings.UnknownFrameworkReference, frameworkReference.Name);
+                            errors.Add(string.Format(Strings.UnknownFrameworkReference, frameworkReference.Name));
                         }
                         else
                         {
-                            if (inputs.NuGetRestoreSupported)
+                            if (inputs.DisableTransitiveFrameworkReferences)
                             {
-                                log.LogError(Strings.TargetingPackNeedsRestore, frameworkReference.Name);
+                                errors.Add(string.Format(Strings.TargetingPackNotRestored_TransitiveDisabled, frameworkReference.Name));
+                            }
+                            else if (inputs.NuGetRestoreSupported)
+                            {
+                                errors.Add(string.Format(Strings.TargetingPackNeedsRestore, frameworkReference.Name));
                             }
                             else
                             {
-                                log.LogError(
+                                errors.Add(string.Format(
                                     Strings.TargetingApphostPackMissingCannotRestore,
                                     "Targeting",
                                     $"{inputs.NetCoreTargetingPackRoot}\\{targetingPack.NuGetPackageId ?? ""}",
                                     targetingPack.TargetFramework ?? "",
                                     targetingPack.NuGetPackageId ?? "",
                                     targetingPack.NuGetPackageVersion ?? ""
-                                    );
+                                    ));
                             }
                         }
                     }
@@ -229,6 +242,7 @@ namespace Microsoft.NET.Build.Tasks
                 UsedRuntimeFrameworks = inputs.RuntimeFrameworks.Where(rf => frameworkReferenceNames.Contains(rf.FrameworkName))
                     .Select(rf => rf.Item)
                     .ToArray(),
+                Errors = errors.ToArray(),
             };
             return newCacheEntry;
         }
@@ -446,6 +460,7 @@ namespace Microsoft.NET.Build.Tasks
             public RuntimeFramework[] RuntimeFrameworks {get; private set;}
             public bool GenerateErrorForMissingTargetingPacks {get; private set;}
             public bool NuGetRestoreSupported {get; private set;}
+            public bool DisableTransitiveFrameworkReferences { get; private set; }
             public string NetCoreTargetingPackRoot {get; private set;}
             public string ProjectLanguage {get; private set;}
 
@@ -455,6 +470,7 @@ namespace Microsoft.NET.Build.Tasks
                 ITaskItem[] runtimeFrameworks,
                 bool generateErrorForMissingTargetingPacks,
                 bool nuGetRestoreSupported,
+                bool disableTransitiveFrameworkReferences,
                 string netCoreTargetingPackRoot,
                 string projectLanguage)
             {
@@ -473,6 +489,7 @@ namespace Microsoft.NET.Build.Tasks
                 RuntimeFrameworks = runtimeFrameworks.Select(item => new RuntimeFramework(item.ItemSpec, item.GetMetadata(MetadataKeys.FrameworkName), item)).ToArray();
                 GenerateErrorForMissingTargetingPacks = generateErrorForMissingTargetingPacks;
                 NuGetRestoreSupported = nuGetRestoreSupported;
+                DisableTransitiveFrameworkReferences = disableTransitiveFrameworkReferences;
                 NetCoreTargetingPackRoot = netCoreTargetingPackRoot;
                 ProjectLanguage = projectLanguage;
             }
@@ -500,6 +517,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 cacheKeyBuilder.AppendLine($"{nameof(GenerateErrorForMissingTargetingPacks)}={GenerateErrorForMissingTargetingPacks}");
                 cacheKeyBuilder.AppendLine($"{nameof(NuGetRestoreSupported)}={NuGetRestoreSupported}");
+                cacheKeyBuilder.AppendLine($"{nameof(DisableTransitiveFrameworkReferences)}={DisableTransitiveFrameworkReferences}");
 
                 cacheKeyBuilder.AppendLine($"{nameof(NetCoreTargetingPackRoot)}={NetCoreTargetingPackRoot}");
 
@@ -661,6 +679,7 @@ namespace Microsoft.NET.Build.Tasks
             public string PackageConflictPreferredPackages;
             public ITaskItem[] PackageConflictOverrides;
             public ITaskItem[] UsedRuntimeFrameworks;
+            public string[] Errors;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -138,7 +138,15 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         if (!foundTargetingPack)
                         {
-                            errors.Add(string.Format(Strings.UnknownFrameworkReference, frameworkReference.Name));
+                            if (frameworkReference.Name.Equals("Microsoft.Maui.Essentials", StringComparison.OrdinalIgnoreCase))
+                            {
+                                errors.Add(Strings.UnknownFrameworkReference_MauiEssentials);
+                            }
+                            else
+                            {
+                                errors.Add(string.Format(Strings.UnknownFrameworkReference, frameworkReference.Name));
+                            }
+                            
                         }
                         else
                         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -311,7 +311,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ResolveRuntimePackAssets Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'"
                               FrameworkReferences="@(FrameworkReference)"
-                              ResolvedRuntimePacks="@(_CrossgenRuntimePack)">
+                              ResolvedRuntimePacks="@(_CrossgenRuntimePack)"
+                              DisableTransitiveFrameworkReferenceDownloads="$(DisableTransitiveFrameworkReferenceDownloads)">
       <Output TaskParameter="RuntimePackAssets" ItemName="CrossgenResolvedAssembliesToPublish" />
     </ResolveRuntimePackAssets>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -106,6 +106,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 TargetLatestRuntimePatchIsDefault="$(_TargetLatestRuntimePatchIsDefault)"
                                 EnableTargetingPackDownload="$(EnableTargetingPackDownload)"
                                 EnableRuntimePackDownload="$(EnableRuntimePackDownload)"
+                                DisableTransitiveFrameworkReferenceDownloads="$(DisableTransitiveFrameworkReferenceDownloads)"
                                 KnownCrossgen2Packs="@(KnownCrossgen2Pack)"
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
                                 NetCoreRoot="$(NetCoreRoot)"
@@ -359,6 +360,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 RuntimeFrameworks="@(RuntimeFramework)"
                                 GenerateErrorForMissingTargetingPacks="$(GenerateErrorForMissingTargetingPacks)"
                                 NuGetRestoreSupported="$(_NuGetRestoreSupported)"
+                                DisableTransitiveFrameworkReferenceDownloads="$(DisableTransitiveFrameworkReferenceDownloads)"
                                 NetCoreTargetingPackRoot="$(NetCoreTargetingPackRoot)">
       <Output TaskParameter="ReferencesToAdd" ItemName="Reference" />
       <Output TaskParameter="AnalyzersToAdd" ItemName="Analyzer" />
@@ -428,7 +430,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                               ResolvedRuntimePacks="@(ResolvedRuntimePack)"
                               UnavailableRuntimePacks="@(UnavailableRuntimePack)"
                               SatelliteResourceLanguages="$(SatelliteResourceLanguages)"
-                              DesignTimeBuild="$(DesignTimeBuild)">
+                              DesignTimeBuild="$(DesignTimeBuild)"
+                              DisableTransitiveFrameworkReferenceDownloads="$(DisableTransitiveFrameworkReferenceDownloads)">
       <Output TaskParameter="RuntimePackAssets" ItemName="RuntimePackAsset" />
     </ResolveRuntimePackAssets>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -106,6 +106,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 TargetLatestRuntimePatchIsDefault="$(_TargetLatestRuntimePatchIsDefault)"
                                 EnableTargetingPackDownload="$(EnableTargetingPackDownload)"
                                 EnableRuntimePackDownload="$(EnableRuntimePackDownload)"
+                                EnableWindowsTargeting="$(EnableWindowsTargeting)"
                                 DisableTransitiveFrameworkReferenceDownloads="$(DisableTransitiveFrameworkReferenceDownloads)"
                                 KnownCrossgen2Packs="@(KnownCrossgen2Pack)"
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -673,10 +673,7 @@ namespace FrameworkReferenceTest
             resolvedVersions.AppHostPack["AppHost"].Should().Be("3.0.0-apphostversion");
         }
 
-        //  Transitive framework references require NuGet support, which isn't currently
-        //  in the full Framework MSBuild we use in CI, so only run these tests for
-        //  core MSBuild for now
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        [Fact]
         public void TransitiveFrameworkReferenceFromProjectReference()
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenTransitiveFrameworkReferencesAreDisabled.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenTransitiveFrameworkReferencesAreDisabled.cs
@@ -1,0 +1,194 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Collections;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenTransitiveFrameworkReferencesAreDisabled : SdkTest
+    {
+        public GivenTransitiveFrameworkReferencesAreDisabled(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TargetingPacksAreNotDownloadedIfNotDirectlyReferenced(bool referenceAspNet)
+        {
+            TestPackagesNotDownloaded(referenceAspNet, selfContained: false);
+        }
+
+        [Fact]
+        public void RuntimePacksAreNotDownloadedIfNotDirectlyReferenced()
+        {
+            TestPackagesNotDownloaded(referenceAspNet: false, selfContained: true);
+        }
+
+        void TestPackagesNotDownloaded(bool referenceAspNet, bool selfContained, [CallerMemberName] string testName = null)
+        {
+            string nugetPackagesFolder = _testAssetsManager.CreateTestDirectory(testName, identifier: "packages_" + referenceAspNet).Path;
+
+            var testProject = new TestProject(testName)
+            {
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true,
+            };
+
+            if (selfContained)
+            {
+                testProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid();
+                testProject.AdditionalProperties["SelfContained"] = "true";
+            }
+            else
+            {
+                //  Don't use AppHost in order to avoid additional download to packages folder
+                testProject.AdditionalProperties["UseAppHost"] = "False";
+            }
+
+            if (referenceAspNet)
+            {
+                testProject.FrameworkReferences.Add("Microsoft.AspNetCore.App");
+            }
+
+            testProject.AdditionalProperties["DisableTransitiveFrameworkReferenceDownloads"] = "True";
+            testProject.AdditionalProperties["RestorePackagesPath"] = nugetPackagesFolder;
+
+            //  Set packs folder to nonexistant folder so the project won't use installed targeting or runtime packs
+            testProject.AdditionalProperties["NetCoreTargetingPackRoot"] = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testName, identifier: referenceAspNet.ToString());
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var expectedPackages = new List<string>()
+            {
+                "microsoft.netcore.app.ref"
+            };
+
+            if (selfContained)
+            {
+                expectedPackages.Add("microsoft.netcore.app.runtime.**RID**");
+                expectedPackages.Add("microsoft.netcore.app.host.**RID**");
+            }
+
+            if (referenceAspNet)
+            {
+                expectedPackages.Add("microsoft.aspnetcore.app.ref");
+            }
+
+            Directory.EnumerateDirectories(nugetPackagesFolder)
+                .Select(Path.GetFileName)
+                .Select(package =>
+                {
+                    if (package.Contains(".runtime.") || (package.Contains(".host.")))
+                    {
+                        //  Replace RuntimeIdentifier, which should be the last dotted segment in the package name, with "**RID**"
+                        package = package.Substring(0, package.LastIndexOf('.') + 1) + "**RID**";
+                    }
+
+                    return package;
+                })
+                .Should().BeEquivalentTo(expectedPackages);
+        }
+
+        [Fact]
+        public void TransitiveFrameworkReferenceGeneratesError()
+        {
+            string nugetPackagesFolder = _testAssetsManager.CreateTestDirectory(identifier: "packages").Path;
+
+            var referencedProject = new TestProject()
+            {
+                Name = "ReferencedProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+            };
+
+            referencedProject.FrameworkReferences.Add("Microsoft.AspNetCore.App");
+
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true,
+            };
+
+            //  Don't use AppHost in order to avoid additional download to packages folder
+            testProject.AdditionalProperties["UseAppHost"] = "False";
+
+            testProject.AdditionalProperties["DisableTransitiveFrameworkReferenceDownloads"] = "True";
+            testProject.AdditionalProperties["RestorePackagesPath"] = nugetPackagesFolder;
+
+            //  Set packs folder to nonexistant folder so the project won't use installed targeting or runtime packs
+            testProject.AdditionalProperties["NetCoreTargetingPackRoot"] = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            testProject.ReferencedProjects.Add(referencedProject);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And.HaveStdOutContaining("NETSDK1183:");
+        }
+
+        [Fact]
+        public void TransitiveFrameworkReferenceGeneratesRuntimePackError()
+        {
+            string nugetPackagesFolder = _testAssetsManager.CreateTestDirectory(identifier: "packages").Path;
+
+            var referencedProject = new TestProject()
+            {
+                Name = "ReferencedProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+            };
+
+            referencedProject.FrameworkReferences.Add("Microsoft.AspNetCore.App");
+
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true,
+            };
+
+            testProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid();
+            testProject.AdditionalProperties["SelfContained"] = "true";
+
+            testProject.AdditionalProperties["DisableTransitiveFrameworkReferenceDownloads"] = "True";
+            testProject.AdditionalProperties["RestorePackagesPath"] = nugetPackagesFolder;
+
+            testProject.ReferencedProjects.Add(referencedProject);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And.HaveStdOutContaining("NETSDK1184:");
+        }
+
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -97,6 +97,44 @@ namespace Microsoft.NET.Build.Tests
                 .HaveStdOutContaining(Strings.WindowsDesktopFrameworkRequiresWindows);
         }
 
+        [PlatformSpecificFact(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.FreeBSD)]
+        public void AppTargetingWindows10CanBuildOnNonWindows()
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework + "-windows10.0.19041.0",
+                IsWinExe = true
+            };
+            testProject.AdditionalProperties["EnableWindowsTargeting"] = "true";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            new BuildCommand(testAsset)
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
+        [PlatformSpecificFact(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.FreeBSD)]
+        public void WindowsFormsAppCanBuildOnNonWindows()
+        {
+            var testDirectory = _testAssetsManager.CreateTestDirectory();
+
+            new DotnetCommand(Log, "new", "winforms")
+                .WithWorkingDirectory(testDirectory.Path)
+                .WithEnvironmentVariable("EnableWindowsTargeting", "true")
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetBuildCommand(Log)
+                .WithWorkingDirectory(testDirectory.Path)
+                .WithEnvironmentVariable("EnableWindowsTargeting", "true")
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
         [WindowsOnlyRequiresMSBuildVersionFact("16.8.0")]
         public void It_builds_on_windows_with_the_windows_desktop_sdk_5_0_with_ProjectSdk_set()
         {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -118,17 +118,10 @@ namespace Microsoft.NET.Build.Tests
         [PlatformSpecificFact(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.FreeBSD)]
         public void WindowsFormsAppCanBuildOnNonWindows()
         {
-            var testDirectory = _testAssetsManager.CreateTestDirectory();
+            var testInstance = _testAssetsManager.CopyTestAsset("WindowsFormsTestApp")
+                .WithSource();
 
-            new DotnetCommand(Log, "new", "winforms")
-                .WithWorkingDirectory(testDirectory.Path)
-                .WithEnvironmentVariable("EnableWindowsTargeting", "true")
-                .Execute()
-                .Should()
-                .Pass();
-
-            new DotnetBuildCommand(Log)
-                .WithWorkingDirectory(testDirectory.Path)
+            new BuildCommand(Log, testInstance.Path)
                 .WithEnvironmentVariable("EnableWindowsTargeting", "true")
                 .Execute()
                 .Should()


### PR DESCRIPTION
- Adds support for a `DisableTransitiveFrameworkReferenceDownloads` property.  If set to true, targeting and runtime packs will not be downloaded unless there is a corresponding FrameworkReference in the project being built (instead of the default behavior, which is to download all of them because they might be needed for a transitive framework reference).  This should make testing internal builds easier, as we plan to put the base runtime packs in a workload, and setting this property will mean that the ASP.NET and WindowsDesktop runtime packs won't always need to be downloaded from special build-specific feeds.
- Adds a specific error message when the Microsoft.Maui.Essentials framework reference is not recognized: "NETSDK1185: This project depends on Maui Essentials through a project or NuGet package reference.  To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary)."  This was the [outcome](https://github.com/dotnet/sdk/issues/24205#issuecomment-1101668900) of our discussion on how to handle the Maui transitive framework references.  However, note that the Maui KnownFrameworkReferences are currently set to `Pack="false" PrivateAssets="All"` (see [here](https://github.com/dotnet/maui/blob/744966449e4bd6c9935442984069a71aff1586cc/src/Workload/Microsoft.Maui.Sdk/Sdk/Sdk.targets#L22-L23)), so these framework reference don't flow to referencing projects at all.
- Adds support for building Windows projects on other operating systems if an `EnableWindowsTargeting` property is set to true.  This should help address dotnet/sdk#3592 and dotnet/sdk#23306.  The reason this was disabled in the first place was because we download all targeting packs (and runtime packs for self-contained builds) for the current target framework whether they are needed or not, because they might be brought in by a transitive framework reference.  We didn't want to ship the Windows targeting packs with the non-Windows SDK builds, but we also didn't want a vanilla Console or ASP.NET app to automatically download these targeting and runtime packs the first time you build.  The new property enables them to only be downloaded if you opt in.
- Supports RID-specific "RuntimePackAlwaysCopyLocal" runtime packs.  This should help support framework-dependent Maui apps targeting Windows: dotnet/maui#7170