### PR TITLE
Always detect if SelfContained was specified by the user

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -109,8 +109,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     Default SelfContained based on the RuntimeIdentifier, so projects don't have to explicitly set SelfContained.
     This avoids a breaking change from 1.0 behavior.
     -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
+  <PropertyGroup>
+    <!-- Detecting property presence is not harmful and can be done in an unconditioned way -->
     <_SelfContainedWasSpecified Condition="'$(SelfContained)' != ''">true</_SelfContainedWasSpecified>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
     <SelfContained Condition="'$(SelfContained)' == '' and '$(RuntimeIdentifier)' != ''">true</SelfContained>
     <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
     <_RuntimeIdentifierUsesAppHost Condition="$(RuntimeIdentifier.StartsWith('ios')) or $(RuntimeIdentifier.StartsWith('tvos')) or $(RuntimeIdentifier.StartsWith('maccatalyst')) or $(RuntimeIdentifier.StartsWith('android')) or $(RuntimeIdentifier.StartsWith('browser'))">false</_RuntimeIdentifierUsesAppHost>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -348,5 +348,30 @@ namespace Microsoft.NET.Build.Tests
             testRuntimePack.metadata["NuGetPackageId"].Should().Be("Microsoft.NETCore.App.Test.RuntimePack");
             testRuntimePack.metadata["NuGetPackageVersion"].Should().Be("1.0.42-abc");
         }
+
+        [Theory]
+        [InlineData("net6.0")]
+        public void It_can_publish_runtime_specific_apps_with_library_dependencies_self_contained(string targetFramework) {
+
+            // create a basic library and a basic app, reference the library from the app and then
+            // publish the app with a RID specified and self-contained.
+            // verify that no warnings about missing the --self-contained flag are emitted.
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+            var libProject = new TestProject("RidSelfContainedLib"){
+                IsExe = false,
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true
+            };
+            var createdLibProject = _testAssetsManager.CreateTestProject(libProject);
+            var appProject = new TestProject("RidSelfContainedApp") {
+                IsExe = true,
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true
+            };
+            appProject.ReferencedProjects.Add(libProject);
+            var createdAppProject = _testAssetsManager.CreateTestProject(appProject);
+            var publishCommand = new PublishCommand(createdAppProject);
+            publishCommand.Execute(new [] {"-property:SelfContained=true", "-property:_CommandLineDefinedSelfContained=true", $"-property:RuntimeIdentifier={rid}", "-property:_CommandLineDefinedRuntimeIdentifier=true" }).Should().Pass().And.NotHaveStdOutContaining("warning");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/24269 by moving the _SelfContainedWasSpecified property detection out of a conditioned PropertyGroup and into an always-evaluated PropertyGroup.

## Description

Users cannot correctly specify that they want a runtime-specific, self-contained application without warnings when building applications that reference other libraries. This is because in this scenario a sentinel property isn't set, and later that sentinel property is used to drive a build diagnostic. This appears to be a gap that we missed when tackling a bugfix that a few months ago: https://github.com/dotnet/sdk/pull/23999. For that fix, we moved to conditionally setting this flag via the CLI to inferring if the property was set through any means (which is good), but not in a way that was resilient to all kinds of property evaluations.  Now we unconditionally do this detection.

## Customer Impact

This particular kind of warning is often treated as an error by users in build scenarios, and so their builds fail. There's no user-accessible workaround that doesn't also surface undesirable side effects.

## Testing

Additional unit testing was added around the erroring reference pattern to safeguard against future regresssions.

## Risk

This is safe for two reasons: 

a) `_SelfContainedWasSpecified` is a private property that we don't have any contracts for, and
b) it's only used in one place - the RuntimeIdentifierInference targets where it is consumed in order to log an error message.

## Regression

Yes, it started appearing with 6.0.300 previews and slipped through the cracks.

