### PR TITLE
Replace hardcoded error string in source with string from resources

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -728,7 +728,7 @@ namespace Microsoft.NET.Build.Tasks
             var packInfo = _workloadResolver.TryGetPackInfo(new WorkloadPackId(packID));
             if (packInfo == null)
             {
-                Log.LogError("NETSDKZZZZ: Error getting pack version: Pack '{0}' was not present in workload manifests.", packID);
+                Log.LogError(Strings.CouldNotGetPackVersionFromWorkloadManifests, packID);
                 return packVersion;
             }
             return packInfo.Version;


### PR DESCRIPTION
Noticed that this string was still hardcoded with `NETSDKZZZZ` error code while looking at https://github.com/dotnet/sdk/issues/25370 even though we have a proper resource.