### PR TITLE
Enable signature checks in the package downloader

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -170,7 +170,7 @@
     <FluentAssertionsJsonVersion>4.19.0</FluentAssertionsJsonVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.22212.5</MicrosoftDotNetXUnitExtensionsVersion>
     <MoqPackageVersion>4.8.2</MoqPackageVersion>
-    <MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>6.0.0-beta.21376.2</MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>
+    <MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>6.0.0-beta.22262.1</MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ExeExtension>.exe</ExeExtension>

--- a/src/Cli/dotnet/commands/dotnet-workload/SignCheck.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/SignCheck.cs
@@ -16,12 +16,18 @@ namespace Microsoft.DotNet.Workloads.Workload
         /// Determines whether dotnet is signed.
         /// </summary>
         /// <returns><see langword="true"/> if dotnet is signed; <see langword="false"/> otherwise.</returns>
-        public static bool IsDotNetSigned()
+        public static bool IsDotNetSigned() => IsSigned(s_dotnet);
+
+        /// <summary>
+        /// Determines whether the specified file is signed by a trusted organization.
+        /// </summary>
+        /// <returns><see langword="true"/> if file is signed; <see langword="false"/> otherwise.</returns>
+        internal static bool IsSigned(string path)
         {
             if (OperatingSystem.IsWindows())
             {
-                return AuthentiCode.IsSigned(s_dotnet) && 
-                    AuthentiCode.IsSignedByTrustedOrganization(s_dotnet, AuthentiCode.TrustedOrganizations);
+                return AuthentiCode.IsSigned(path) &&
+                    AuthentiCode.IsSignedByTrustedOrganization(path, AuthentiCode.TrustedOrganizations);
             }
 
             return false;

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
@@ -1,9 +1,14 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.IO;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.Common;
 
 namespace Microsoft.DotNet.Workloads.Workload
 {
@@ -13,6 +18,54 @@ namespace Microsoft.DotNet.Workloads.Workload
     internal abstract class WorkloadCommandBase : CommandBase
     {
         /// <summary>
+        /// The package downloader to use for acquiring NuGet packages.
+        /// </summary>
+        protected INuGetPackageDownloader PackageDownloader
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Provides basic output primitives for the command.
+        /// </summary>
+        protected IReporter Reporter
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Configuration options used by NuGet when performing a restore.
+        /// </summary>
+        protected RestoreActionConfig RestoreActionConfiguration
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Temporary directory used for downloading NuGet packages.
+        /// </summary>
+        protected DirectoryPath TempPackagesDirectory
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The path of the temporary temporary directory to use.
+        /// </summary>
+        protected string TempDirectoryPath
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The verbosity level to use when reporting output from the command.
+        /// </summary>
+        protected VerbosityOptions Verbosity
+        {
+            get;
+        }
+
+        /// <summary>
         /// Gets whether signatures for workload packages and installers should be verified.
         /// </summary>
         protected bool VerifySignatures
@@ -20,9 +73,47 @@ namespace Microsoft.DotNet.Workloads.Workload
             get;
         }
 
-        public WorkloadCommandBase(ParseResult parseResult) : base(parseResult)
+        /// <summary>
+        /// Initializes a new <see cref="WorkloadCommandBase"/> instance.
+        /// </summary>
+        /// <param name="parseResult">The results of parsing the command line.</param>
+        /// <param name="verbosityOptions">The command line option used to define the verbosity level.</param>
+        /// <param name="reporter">The reporter to use for output.</param>
+        /// <param name="tempDirPath">The directory to use for volatile output. If no value is specified, the commandline
+        /// option is used if present, otherwise the default temp directory used.</param>
+        /// <param name="nugetPackageDownloader">The package downloader to use for acquiring NuGet packages.</param>
+        public WorkloadCommandBase(ParseResult parseResult,
+            Option<VerbosityOptions> verbosityOptions = null,
+            IReporter reporter = null,
+            string tempDirPath = null,
+            INuGetPackageDownloader nugetPackageDownloader = null) : base(parseResult)
         {
             VerifySignatures = ShouldVerifySignatures(parseResult);
+
+            RestoreActionConfiguration = _parseResult.ToRestoreActionConfig();
+
+            Verbosity = verbosityOptions == null
+                ? parseResult.GetValueForOption(CommonOptions.VerbosityOption)
+                : parseResult.GetValueForOption(verbosityOptions);
+
+            ILogger nugetLogger = Verbosity.VerbosityIsDetailedOrDiagnostic() ? new NuGetConsoleLogger() : new NullLogger();
+
+            Reporter = reporter ?? Cli.Utils.Reporter.Output;
+
+            TempDirectoryPath = !string.IsNullOrWhiteSpace(tempDirPath)
+                ? tempDirPath
+                : !string.IsNullOrWhiteSpace(parseResult.GetValueForOption(WorkloadInstallCommandParser.TempDirOption))
+                ? parseResult.GetValueForOption(WorkloadInstallCommandParser.TempDirOption)
+                : Path.GetTempPath();
+
+            TempPackagesDirectory = new DirectoryPath(Path.Combine(TempDirectoryPath, "dotnet-sdk-advertising-temp"));
+
+            PackageDownloader = nugetPackageDownloader ?? new NuGetPackageDownloader(TempPackagesDirectory,
+                filePermissionSetter: null,
+                new FirstPartyNuGetPackageSigningVerifier(TempPackagesDirectory, nugetLogger),
+                nugetLogger,
+                restoreActionConfig: RestoreActionConfiguration,
+                verifySignatures: VerifySignatures);
         }
 
         /// <summary>
@@ -30,10 +121,10 @@ namespace Microsoft.DotNet.Workloads.Workload
         /// dotnet is signed, the skip option was specified, and whether a global policy enforcing verification
         /// was set.
         /// </summary>
-        /// <param name="parseResult"></param>
-        /// <returns></returns>
+        /// <param name="parseResult">The results of parsing the command line.</param>
+        /// <returns><see langword="true"/> if signatures of packages and installers should be verified.</returns>
         /// <exception cref="GracefulException" />
-        private bool ShouldVerifySignatures(ParseResult parseResult)
+        private static bool ShouldVerifySignatures(ParseResult parseResult)
         {
             if (!SignCheck.IsDotNetSigned())
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommandParser.cs
@@ -69,8 +69,6 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option<string> TempDirOption = new Option<string>("--temp-dir", LocalizableStrings.TempDirOptionDescription);
 
-        public static readonly Option<VerbosityOptions> VerbosityOption = CommonOptions.VerbosityOption;
-
         public static readonly Option<string> FromRollbackFileOption = new Option<string>("--from-rollback-file", Microsoft.DotNet.Workloads.Workload.Update.LocalizableStrings.FromRollbackDefinitionOptionDescription)
         {
             IsHidden = true
@@ -107,7 +105,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(IncludePreviewOption);
             command.AddOption(TempDirOption);
             command.AddWorkloadCommandNuGetRestoreActionConfigOptions();
-            command.AddOption(VerbosityOption);
+            command.AddOption(CommonOptions.VerbosityOption);
             command.AddOption(FromRollbackFileOption);
             command.AddOption(SkipSignCheckOption);
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -70,7 +70,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                                           filePermissionSetter: null,
                                           new FirstPartyNuGetPackageSigningVerifier(tempPackagesDir, new NullLogger()),
                                           new NullLogger(),
-                                          reporter);
+                                          reporter,
+                                          verifySignatures: SignCheck.IsDotNetSigned());
             var workloadRecordRepo = WorkloadInstallerFactory.GetWorkloadInstaller(reporter, new SdkFeatureBand(sdkVersion),
                 workloadResolver, Cli.VerbosityOptions.normal, userProfileDir, verifySignatures: false)
                 .GetWorkloadInstallationRecordRepository();

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -14,9 +14,7 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
-using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
-using NuGet.Common;
 using Product = Microsoft.DotNet.Cli.Utils.Product;
 
 namespace Microsoft.DotNet.Workloads.Workload.List
@@ -27,12 +25,8 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         private readonly string _dotnetPath;
         private readonly bool _includePreviews;
         private readonly bool _machineReadableOption;
-        private readonly INuGetPackageDownloader _nugetPackageDownloader;
-        private readonly IReporter _reporter;
         private readonly string _targetSdkVersion;
-        private readonly string _tempDirPath;
         private readonly string _userProfileDir;
-        private readonly VerbosityOptions _verbosity;
         private readonly IWorkloadManifestUpdater _workloadManifestUpdater;
         private readonly IWorkloadInstallationRecordRepository _workloadRecordRepo;
         private readonly IWorkloadResolver _workloadResolver;
@@ -48,22 +42,16 @@ namespace Microsoft.DotNet.Workloads.Workload.List
             INuGetPackageDownloader nugetPackageDownloader = null,
             IWorkloadManifestUpdater workloadManifestUpdater = null,
             IWorkloadResolver workloadResolver = null
-        ) : base(result)
+        ) : base(result, CommonOptions.HiddenVerbosityOption, reporter, tempDirPath, nugetPackageDownloader)
         {
-            _reporter = reporter ?? Reporter.Output;
             _machineReadableOption = result.GetValueForOption(WorkloadListCommandParser.MachineReadableOption);
-            _verbosity = result.GetValueForOption(WorkloadListCommandParser.VerbosityOption);
 
             _dotnetPath = dotnetDir ?? Path.GetDirectoryName(Environment.ProcessPath);
             ReleaseVersion currentSdkReleaseVersion = new(currentSdkVersion ?? Product.Version);
             _currentSdkFeatureBand = new SdkFeatureBand(currentSdkReleaseVersion);
-            
+
             _includePreviews = result.GetValueForOption(WorkloadListCommandParser.IncludePreviewsOption);
-            _tempDirPath = tempDirPath ??
-                           (string.IsNullOrWhiteSpace(
-                               result.GetValueForOption(WorkloadListCommandParser.TempDirOption))
-                               ? Path.GetTempPath()
-                               : result.GetValueForOption(WorkloadListCommandParser.TempDirOption));
+
             _targetSdkVersion = result.GetValueForOption(WorkloadListCommandParser.VersionOption);
             _userProfileDir = userProfileDir ?? CliFolderPathCalculator.DotnetUserProfileFolderPath;
             var workloadManifestProvider =
@@ -72,23 +60,16 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                         ? currentSdkReleaseVersion.ToString()
                         : _targetSdkVersion,
                     _userProfileDir);
-            DirectoryPath tempPackagesDir =
-                new(Path.Combine(_userProfileDir, "sdk-advertising-temp"));
-            NullLogger nullLogger = new NullLogger();
-            _nugetPackageDownloader = nugetPackageDownloader ??
-                                      new NuGetPackageDownloader(tempPackagesDir, null,
-                                          new FirstPartyNuGetPackageSigningVerifier(tempPackagesDir, nullLogger),
-                                          verboseLogger: nullLogger,
-                                          restoreActionConfig: _parseResult.ToRestoreActionConfig());
+
             _workloadResolver = workloadResolver ?? WorkloadResolver.Create(workloadManifestProvider, _dotnetPath, currentSdkReleaseVersion.ToString(), _userProfileDir);
 
             _workloadRecordRepo = workloadRecordRepo ??
-                WorkloadInstallerFactory.GetWorkloadInstaller(reporter, _currentSdkFeatureBand, _workloadResolver, _verbosity, _userProfileDir,
+                WorkloadInstallerFactory.GetWorkloadInstaller(reporter, _currentSdkFeatureBand, _workloadResolver, Verbosity, _userProfileDir,
                 VerifySignatures,
                 elevationRequired: false).GetWorkloadInstallationRecordRepository();
 
-            _workloadManifestUpdater = workloadManifestUpdater ?? new WorkloadManifestUpdater(_reporter,
-                _workloadResolver, _nugetPackageDownloader, _userProfileDir, _tempDirPath, _workloadRecordRepo);
+            _workloadManifestUpdater = workloadManifestUpdater ?? new WorkloadManifestUpdater(Reporter,
+                _workloadResolver, PackageDownloader, _userProfileDir, TempDirectoryPath, _workloadRecordRepo);
         }
 
         public override int Execute()
@@ -109,11 +90,11 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 ListOutput listOutput = new(installedList.Select(id => id.ToString()).ToArray(),
                     updateAvailable);
 
-                _reporter.WriteLine("==workloadListJsonOutputStart==");
-                _reporter.WriteLine(
+                Reporter.WriteLine("==workloadListJsonOutputStart==");
+                Reporter.WriteLine(
                     JsonSerializer.Serialize(listOutput,
-                        new JsonSerializerOptions {PropertyNamingPolicy = JsonNamingPolicy.CamelCase}));
-                _reporter.WriteLine("==workloadListJsonOutputEnd==");
+                        new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
+                Reporter.WriteLine("==workloadListJsonOutputEnd==");
             }
             else
             {
@@ -123,24 +104,24 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 {
                     VisualStudioWorkloads.GetInstalledWorkloads(_workloadResolver, _currentSdkFeatureBand, installedWorkloads);
                 }
-                
-                _reporter.WriteLine();
+
+                Reporter.WriteLine();
 
                 PrintableTable<KeyValuePair<string, string>> table = new();
                 table.AddColumn(LocalizableStrings.WorkloadIdColumn, workload => workload.Key);
                 table.AddColumn(LocalizableStrings.WorkloadSourceColumn, workload => workload.Value);
 
-                table.PrintRows(installedWorkloads.AsEnumerable(), l => _reporter.WriteLine(l));
+                table.PrintRows(installedWorkloads.AsEnumerable(), l => Reporter.WriteLine(l));
 
-                _reporter.WriteLine();
-                _reporter.WriteLine(LocalizableStrings.WorkloadListFooter);
-                _reporter.WriteLine();
+                Reporter.WriteLine();
+                Reporter.WriteLine(LocalizableStrings.WorkloadListFooter);
+                Reporter.WriteLine();
 
                 var updatableWorkloads = _workloadManifestUpdater.GetUpdatableWorkloadsToAdvertise(installedList).Select(workloadId => workloadId.ToString());
                 if (updatableWorkloads.Any())
                 {
-                    _reporter.WriteLine(string.Format(LocalizableStrings.WorkloadUpdatesAvailable, string.Join(" ", updatableWorkloads)));
-                    _reporter.WriteLine();
+                    Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadUpdatesAvailable, string.Join(" ", updatableWorkloads)));
+                    Reporter.WriteLine();
                 }
             }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommandParser.cs
@@ -14,8 +14,6 @@ namespace Microsoft.DotNet.Cli
         // arguments are a list of workload to be detected
         public static readonly Option<bool> MachineReadableOption = new Option<bool>("--machine-readable") {IsHidden = true};
 
-        public static readonly Option<VerbosityOptions> VerbosityOption = CommonOptions.HiddenVerbosityOption;
-
         public static readonly Option<string> VersionOption = WorkloadUpdateCommandParser.VersionOption;
 
         public static readonly Option<string> TempDirOption = 
@@ -35,7 +33,7 @@ namespace Microsoft.DotNet.Cli
         {
             var command = new Command("list", LocalizableStrings.CommandDescription);
             command.AddOption(MachineReadableOption);
-            command.AddOption(VerbosityOption);
+            command.AddOption(CommonOptions.HiddenVerbosityOption);
             command.AddOption(VersionOption);
             command.AddOption(TempDirOption);
             command.AddOption(IncludePreviewsOption);

--- a/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommand.cs
@@ -21,9 +21,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Repair
 {
     internal class WorkloadRepairCommand : WorkloadCommandBase
     {
-        private readonly IReporter _reporter;
         private readonly PackageSourceLocation _packageSourceLocation;
-        private readonly VerbosityOptions _verbosity;
         private readonly IInstaller _workloadInstaller;
         private IWorkloadResolver _workloadResolver;
         private readonly ReleaseVersion _sdkVersion;
@@ -39,10 +37,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Repair
             string tempDirPath = null,
             string version = null,
             string userProfileDir = null)
-            : base(parseResult)
+            : base(parseResult, reporter: reporter, nugetPackageDownloader: nugetPackageDownloader)
         {
-            _reporter = reporter ?? Reporter.Output;
-            _verbosity = parseResult.GetValueForOption(WorkloadRepairCommandParser.VerbosityOption);
             _dotnetPath = dotnetDir ?? Path.GetDirectoryName(Environment.ProcessPath);
             userProfileDir ??= CliFolderPathCalculator.DotnetUserProfileFolderPath;
             _sdkVersion = WorkloadOptionsExtensions.GetValidatedSdkVersion(parseResult.GetValueForOption(WorkloadRepairCommandParser.VersionOption), version, _dotnetPath, userProfileDir);
@@ -55,18 +51,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Repair
             var workloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(_dotnetPath, _sdkVersion.ToString(), userProfileDir);
             _workloadResolver = workloadResolver ?? WorkloadResolver.Create(workloadManifestProvider, _dotnetPath, _sdkVersion.ToString(), userProfileDir);
             var sdkFeatureBand = new SdkFeatureBand(_sdkVersion);
-            tempDirPath = tempDirPath ?? (string.IsNullOrWhiteSpace(parseResult.GetValueForOption(WorkloadInstallCommandParser.TempDirOption)) ?
-                Path.GetTempPath() :
-                parseResult.GetValueForOption(WorkloadInstallCommandParser.TempDirOption));
-            var tempPackagesDir = new DirectoryPath(Path.Combine(tempDirPath, "dotnet-sdk-advertising-temp"));
-            NullLogger nullLogger = new NullLogger();
-            nugetPackageDownloader ??= new NuGetPackageDownloader(
-                tempPackagesDir,
-                filePermissionSetter: null,
-                new FirstPartyNuGetPackageSigningVerifier(tempPackagesDir, nullLogger), nullLogger, restoreActionConfig: _parseResult.ToRestoreActionConfig());
+            
             _workloadInstaller = workloadInstaller ??
-                                 WorkloadInstallerFactory.GetWorkloadInstaller(_reporter, sdkFeatureBand,
-                                     _workloadResolver, _verbosity, userProfileDir, VerifySignatures, nugetPackageDownloader, dotnetDir, tempDirPath,
+                                 WorkloadInstallerFactory.GetWorkloadInstaller(Reporter, sdkFeatureBand,
+                                     _workloadResolver, Verbosity, userProfileDir, VerifySignatures, PackageDownloader, dotnetDir, TempDirectoryPath,
                                      _packageSourceLocation, _parseResult.ToRestoreActionConfig());
         }
 
@@ -74,25 +62,25 @@ namespace Microsoft.DotNet.Workloads.Workload.Repair
         {
             try
             {
-                _reporter.WriteLine();
+                Reporter.WriteLine();
 
                 var workloadIds = _workloadInstaller.GetWorkloadInstallationRecordRepository().GetInstalledWorkloads(new SdkFeatureBand(_sdkVersion));
 
                 if (!workloadIds.Any())
                 {
-                    _reporter.WriteLine(LocalizableStrings.NoWorkloadsToRepair);
+                    Reporter.WriteLine(LocalizableStrings.NoWorkloadsToRepair);
                     return 0;
                 }
 
-                _reporter.WriteLine(string.Format(LocalizableStrings.RepairingWorkloads, string.Join(" ", workloadIds)));
+                Reporter.WriteLine(string.Format(LocalizableStrings.RepairingWorkloads, string.Join(" ", workloadIds)));
 
                 ReinstallWorkloadsBasedOnCurrentManifests(workloadIds, new SdkFeatureBand(_sdkVersion));
 
-                WorkloadInstallCommand.TryRunGarbageCollection(_workloadInstaller, _reporter, _verbosity);
+                WorkloadInstallCommand.TryRunGarbageCollection(_workloadInstaller, Reporter, Verbosity);
 
-                _reporter.WriteLine();
-                _reporter.WriteLine(string.Format(LocalizableStrings.RepairSucceeded, string.Join(" ", workloadIds)));
-                _reporter.WriteLine();
+                Reporter.WriteLine();
+                Reporter.WriteLine(string.Format(LocalizableStrings.RepairSucceeded, string.Join(" ", workloadIds)));
+                Reporter.WriteLine();
             }
             catch (Exception e)
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommandParser.cs
@@ -17,8 +17,6 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option<string> VersionOption = WorkloadInstallCommandParser.VersionOption;
 
-        public static readonly Option<VerbosityOptions> VerbosityOption = CommonOptions.VerbosityOption;
-
         private static readonly Command Command = ConstructCommand();
 
         public static Command GetCommand()
@@ -33,7 +31,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(VersionOption);
             command.AddOption(ConfigOption);
             command.AddOption(SourceOption);
-            command.AddOption(VerbosityOption);
+            command.AddOption(CommonOptions.VerbosityOption);
             command.AddWorkloadCommandNuGetRestoreActionConfigOptions();
 
             command.SetHandler((parseResult) => new WorkloadRepairCommand(parseResult).Execute());

--- a/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
@@ -22,17 +22,15 @@ namespace Microsoft.DotNet.Workloads.Workload.Restore
     internal class WorkloadRestoreCommand : WorkloadCommandBase
     {
         private readonly ParseResult _result;
-        private readonly IReporter _reporter;
         private readonly IEnumerable<string> _slnOrProjectArgument;
 
         public WorkloadRestoreCommand(
             ParseResult result,
             IFileSystem fileSystem = null,
             IReporter reporter = null)
-            : base(result)
+            : base(result, reporter: reporter)
         {
             _result = result;
-            _reporter = reporter ?? Reporter.Output;
             _slnOrProjectArgument =
                 result.GetValueForArgument(RestoreCommandParser.SlnOrProjectArgument);
         }
@@ -41,7 +39,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Restore
         {
             var allProjects = DiscoverAllProjects(Directory.GetCurrentDirectory(), _slnOrProjectArgument).Distinct();
             List<WorkloadId> allWorkloadId = RunTargetToGetWorkloadIds(allProjects);
-            _reporter.WriteLine(string.Format(LocalizableStrings.InstallingWorkloads, string.Join(" ", allWorkloadId)));
+            Reporter.WriteLine(string.Format(LocalizableStrings.InstallingWorkloads, string.Join(" ", allWorkloadId)));
 
             var workloadInstallCommand = new WorkloadInstallCommand(_result,
                 workloadIds: allWorkloadId.Select(a => a.ToString()).ToList().AsReadOnly());
@@ -65,9 +63,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Restore
                 bool buildResult = project.Build(new[] {"_GetRequiredWorkloads"},
                     loggers: new ILogger[]
                     {
-                        new ConsoleLogger(_result
-                            .GetValueForOption(WorkloadInstallCommandParser.VerbosityOption)
-                            .ToLoggerVerbosity())
+                        new ConsoleLogger(Verbosity.ToLoggerVerbosity())
                     },
                     remoteLoggers: Enumerable.Empty<ForwardingLoggerRecord>(),
                     targetOutputs: out var targetOutputs);

--- a/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchCommand.cs
@@ -17,8 +17,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Search
 {
     internal class WorkloadSearchCommand : WorkloadCommandBase
     {
-        private readonly IReporter _reporter;
-        private readonly VerbosityOptions _verbosity;
         private readonly IWorkloadResolver _workloadResolver;
         private readonly ReleaseVersion _sdkVersion;
         private readonly string _workloadIdStub;
@@ -28,10 +26,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Search
             IReporter reporter = null,
             IWorkloadResolver workloadResolver = null,
             string version = null,
-            string userProfileDir = null) : base(result)
+            string userProfileDir = null) : base(result, CommonOptions.HiddenVerbosityOption, reporter)
         {
-            _reporter = reporter ?? Reporter.Output;
-            _verbosity = result.GetValueForOption(WorkloadSearchCommandParser.VerbosityOption);
             _workloadIdStub = result.GetValueForArgument(WorkloadSearchCommandParser.WorkloadIdStubArgument);
             var dotnetPath = Path.GetDirectoryName(Environment.ProcessPath);
             userProfileDir ??= CliFolderPathCalculator.DotnetUserProfileFolderPath;
@@ -55,9 +51,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Search
             table.AddColumn(LocalizableStrings.WorkloadIdColumnName, workload => workload.Id.ToString());
             table.AddColumn(LocalizableStrings.DescriptionColumnName, workload => workload.Description);
 
-            _reporter.WriteLine();
-            table.PrintRows(availableWorkloads, l => _reporter.WriteLine(l));
-            _reporter.WriteLine();
+            Reporter.WriteLine();
+            table.PrintRows(availableWorkloads, l => Reporter.WriteLine(l));
+            Reporter.WriteLine();
 
             return 0;
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchCommandParser.cs
@@ -18,8 +18,6 @@ namespace Microsoft.DotNet.Cli
                 Description = LocalizableStrings.WorkloadIdStubArgumentDescription
             };
 
-        public static readonly Option<VerbosityOptions> VerbosityOption = CommonOptions.HiddenVerbosityOption;
-
         public static readonly Option<string> VersionOption = WorkloadInstallCommandParser.VersionOption;
 
         private static readonly Command Command = ConstructCommand();
@@ -33,7 +31,7 @@ namespace Microsoft.DotNet.Cli
         {
             var command = new Command("search", LocalizableStrings.CommandDescription);
             command.AddArgument(WorkloadIdStubArgument);
-            command.AddOption(VerbosityOption);
+            command.AddOption(CommonOptions.HiddenVerbosityOption);
             command.AddOption(VersionOption);
 
             command.SetHandler((parseResult) => new WorkloadSearchCommand(parseResult).Execute());

--- a/src/Cli/dotnet/commands/dotnet-workload/uninstall/WorkloadUninstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/uninstall/WorkloadUninstallCommand.cs
@@ -22,7 +22,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Uninstall
 {
     internal class WorkloadUninstallCommand : WorkloadCommandBase
     {
-        private readonly IReporter _reporter;
         private readonly IReadOnlyCollection<WorkloadId> _workloadIds;
         private readonly IInstaller _workloadInstaller;
         private readonly ReleaseVersion _sdkVersion;
@@ -35,27 +34,26 @@ namespace Microsoft.DotNet.Workloads.Workload.Uninstall
             string dotnetDir = null,
             string version = null,
             string userProfileDir = null)
-            : base(parseResult)
+            : base(parseResult, reporter: reporter, nugetPackageDownloader: nugetPackageDownloader)
         {
-            _reporter = reporter ?? Reporter.Output;
             _workloadIds = parseResult.GetValueForArgument(WorkloadUninstallCommandParser.WorkloadIdArgument)
                 .Select(workloadId => new WorkloadId(workloadId)).ToList().AsReadOnly();
             var dotnetPath = dotnetDir ?? Path.GetDirectoryName(Environment.ProcessPath);
             userProfileDir = userProfileDir ?? CliFolderPathCalculator.DotnetUserProfileFolderPath;
             _sdkVersion = WorkloadOptionsExtensions.GetValidatedSdkVersion(parseResult.GetValueForOption(WorkloadUninstallCommandParser.VersionOption), version, dotnetPath, userProfileDir);
-            var verbosity = parseResult.GetValueForOption(WorkloadUninstallCommandParser.VerbosityOption);
+
             var workloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(dotnetPath, _sdkVersion.ToString(), userProfileDir);
             workloadResolver ??= WorkloadResolver.Create(workloadManifestProvider, dotnetPath, _sdkVersion.ToString(), userProfileDir);
-            nugetPackageDownloader ??= new NuGetPackageDownloader(new DirectoryPath(Path.GetTempPath()), filePermissionSetter: null, verboseLogger: new NullLogger());
+
             var sdkFeatureBand = new SdkFeatureBand(_sdkVersion);
-            _workloadInstaller = WorkloadInstallerFactory.GetWorkloadInstaller(_reporter, sdkFeatureBand, workloadResolver, verbosity, userProfileDir, VerifySignatures, nugetPackageDownloader, dotnetPath);
+            _workloadInstaller = WorkloadInstallerFactory.GetWorkloadInstaller(Reporter, sdkFeatureBand, workloadResolver, Verbosity, userProfileDir, VerifySignatures, PackageDownloader, dotnetPath);
         }
 
         public override int Execute()
         {
             try
             {
-                _reporter.WriteLine();
+                Reporter.WriteLine();
 
                 var featureBand = new SdkFeatureBand(_sdkVersion);
                 var installedWorkloads = _workloadInstaller.GetWorkloadInstallationRecordRepository().GetInstalledWorkloads(featureBand);
@@ -67,7 +65,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Uninstall
 
                 foreach (var workloadId in _workloadIds)
                 {
-                    _reporter.WriteLine(string.Format(LocalizableStrings.RemovingWorkloadInstallationRecord, workloadId));
+                    Reporter.WriteLine(string.Format(LocalizableStrings.RemovingWorkloadInstallationRecord, workloadId));
                     _workloadInstaller.GetWorkloadInstallationRecordRepository()
                         .DeleteWorkloadInstallationRecord(workloadId, featureBand);
                 }
@@ -87,9 +85,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Uninstall
                     }
                 }
 
-                _reporter.WriteLine();
-                _reporter.WriteLine(string.Format(LocalizableStrings.UninstallSucceeded, string.Join(" ", _workloadIds)));
-                _reporter.WriteLine();
+                Reporter.WriteLine();
+                Reporter.WriteLine(string.Format(LocalizableStrings.UninstallSucceeded, string.Join(" ", _workloadIds)));
+                Reporter.WriteLine();
             }
             catch (Exception e)
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/uninstall/WorkloadUninstallCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/uninstall/WorkloadUninstallCommandParser.cs
@@ -14,8 +14,6 @@ namespace Microsoft.DotNet.Cli
     {
         public static readonly Argument<IEnumerable<string>> WorkloadIdArgument = WorkloadInstallCommandParser.WorkloadIdArgument;
 
-        public static readonly Option<VerbosityOptions> VerbosityOption = WorkloadInstallCommandParser.VerbosityOption;
-        
         public static readonly Option<string> VersionOption = WorkloadInstallCommandParser.VersionOption;
 
         private static readonly Command Command = ConstructCommand();

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -18,7 +18,6 @@ using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
-using NuGet.Common;
 using NuGet.Versioning;
 using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
 
@@ -33,18 +32,14 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
         private readonly bool _printRollbackDefinitionOnly;
         private readonly string _fromRollbackDefinition;
         private readonly PackageSourceLocation _packageSourceLocation;
-        private readonly IReporter _reporter;
         private readonly bool _includePreviews;
         private readonly bool _fromPreviousSdk;
-        private readonly VerbosityOptions _verbosity;
         private readonly IInstaller _workloadInstaller;
         private IWorkloadResolver _workloadResolver;
-        private readonly INuGetPackageDownloader _nugetPackageDownloader;
         private readonly IWorkloadManifestUpdater _workloadManifestUpdater;
         private readonly ReleaseVersion _sdkVersion;
         private readonly string _userProfileDir;
         private readonly string _dotnetPath;
-        private readonly string _tempDirPath;
 
         public WorkloadUpdateCommand(
             ParseResult parseResult,
@@ -57,44 +52,36 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             string userProfileDir = null,
             string tempDirPath = null,
             string version = null)
-            : base(parseResult)
+            : base(parseResult, reporter: reporter, tempDirPath: tempDirPath, nugetPackageDownloader: nugetPackageDownloader)
         {
             _printDownloadLinkOnly =
                 parseResult.GetValueForOption(WorkloadUpdateCommandParser.PrintDownloadLinkOnlyOption);
             _fromCacheOption = parseResult.GetValueForOption(WorkloadUpdateCommandParser.FromCacheOption);
-            _reporter = reporter ?? Reporter.Output;
             _includePreviews = parseResult.GetValueForOption(WorkloadUpdateCommandParser.IncludePreviewsOption);
             _fromPreviousSdk = parseResult.GetValueForOption(WorkloadUpdateCommandParser.FromPreviousSdkOption);
             _adManifestOnlyOption = parseResult.GetValueForOption(WorkloadUpdateCommandParser.AdManifestOnlyOption);
             _downloadToCacheOption = parseResult.GetValueForOption(WorkloadUpdateCommandParser.DownloadToCacheOption);
-            _verbosity = parseResult.GetValueForOption(WorkloadUpdateCommandParser.VerbosityOption);
             _dotnetPath = dotnetDir ?? Path.GetDirectoryName(Environment.ProcessPath);
             _userProfileDir = userProfileDir ?? CliFolderPathCalculator.DotnetUserProfileFolderPath;
             _sdkVersion = WorkloadOptionsExtensions.GetValidatedSdkVersion(parseResult.GetValueForOption(WorkloadUpdateCommandParser.VersionOption), version, _dotnetPath, _userProfileDir);
-            _tempDirPath = tempDirPath ?? (string.IsNullOrWhiteSpace(parseResult.GetValueForOption(WorkloadUpdateCommandParser.TempDirOption)) ?
-                Path.GetTempPath() :
-                parseResult.GetValueForOption(WorkloadUpdateCommandParser.TempDirOption));
+
             _printRollbackDefinitionOnly = parseResult.GetValueForOption(WorkloadUpdateCommandParser.PrintRollbackOption);
             _fromRollbackDefinition = parseResult.GetValueForOption(WorkloadUpdateCommandParser.FromRollbackFileOption);
 
             var configOption = parseResult.GetValueForOption(WorkloadUpdateCommandParser.ConfigOption);
             var sourceOption = parseResult.GetValueForOption<string[]>(WorkloadUpdateCommandParser.SourceOption);
             _packageSourceLocation = string.IsNullOrEmpty(configOption) && (sourceOption == null || !sourceOption.Any()) ? null :
-                new PackageSourceLocation(string.IsNullOrEmpty(configOption) ? null : new FilePath(configOption), sourceFeedOverrides:  sourceOption);
+                new PackageSourceLocation(string.IsNullOrEmpty(configOption) ? null : new FilePath(configOption), sourceFeedOverrides: sourceOption);
 
             var workloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(_dotnetPath, _sdkVersion.ToString(), _userProfileDir);
             _workloadResolver = workloadResolver ?? WorkloadResolver.Create(workloadManifestProvider, _dotnetPath, _sdkVersion.ToString(), _userProfileDir);
             var sdkFeatureBand = new SdkFeatureBand(_sdkVersion);
-            var restoreActionConfig = _parseResult.ToRestoreActionConfig();
-            _workloadInstaller = workloadInstaller ?? WorkloadInstallerFactory.GetWorkloadInstaller(_reporter,
-                sdkFeatureBand, _workloadResolver, _verbosity, _userProfileDir, VerifySignatures, nugetPackageDownloader,
-                dotnetDir, _tempDirPath, packageSourceLocation: _packageSourceLocation, restoreActionConfig,
+
+            _workloadInstaller = workloadInstaller ?? WorkloadInstallerFactory.GetWorkloadInstaller(Reporter,
+                sdkFeatureBand, _workloadResolver, Verbosity, _userProfileDir, VerifySignatures, PackageDownloader,
+                dotnetDir, TempDirectoryPath, packageSourceLocation: _packageSourceLocation, RestoreActionConfiguration,
                 elevationRequired: !_printDownloadLinkOnly && !_printRollbackDefinitionOnly && string.IsNullOrWhiteSpace(_downloadToCacheOption));
-            var tempPackagesDir = new DirectoryPath(Path.Combine(_tempDirPath, "dotnet-sdk-advertising-temp"));
-            _nugetPackageDownloader = nugetPackageDownloader ?? new NuGetPackageDownloader(tempPackagesDir,
-                filePermissionSetter: null, new FirstPartyNuGetPackageSigningVerifier(tempPackagesDir, _verbosity.VerbosityIsDetailedOrDiagnostic() ? new NuGetConsoleLogger() : new NullLogger()),
-                _verbosity.VerbosityIsDetailedOrDiagnostic() ? new NuGetConsoleLogger() : new NullLogger(), restoreActionConfig: restoreActionConfig);
-            _workloadManifestUpdater = workloadManifestUpdater ?? new WorkloadManifestUpdater(_reporter, _workloadResolver, _nugetPackageDownloader, _userProfileDir, _tempDirPath, 
+            _workloadManifestUpdater = workloadManifestUpdater ?? new WorkloadManifestUpdater(Reporter, _workloadResolver, PackageDownloader, _userProfileDir, TempDirectoryPath,
                 _workloadInstaller.GetWorkloadInstallationRecordRepository(), _packageSourceLocation);
         }
 
@@ -115,23 +102,23 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             {
                 var packageUrls = GetUpdatablePackageUrlsAsync(_includePreviews).GetAwaiter().GetResult();
 
-                _reporter.WriteLine("==allPackageLinksJsonOutputStart==");
-                _reporter.WriteLine(JsonSerializer.Serialize(packageUrls));
-                _reporter.WriteLine("==allPackageLinksJsonOutputEnd==");
+                Reporter.WriteLine("==allPackageLinksJsonOutputStart==");
+                Reporter.WriteLine(JsonSerializer.Serialize(packageUrls));
+                Reporter.WriteLine("==allPackageLinksJsonOutputEnd==");
             }
             else if (_adManifestOnlyOption)
             {
                 _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews, string.IsNullOrWhiteSpace(_fromCacheOption) ? null : new DirectoryPath(_fromCacheOption)).Wait();
-                _reporter.WriteLine();
-                _reporter.WriteLine(LocalizableStrings.WorkloadUpdateAdManifestsSucceeded);
+                Reporter.WriteLine();
+                Reporter.WriteLine(LocalizableStrings.WorkloadUpdateAdManifestsSucceeded);
             }
             else if (_printRollbackDefinitionOnly)
             {
                 var manifests = _workloadResolver.GetInstalledManifests().ToDictionary(m => m.Id, m => m.Version + "/" + m.ManifestFeatureBand, StringComparer.OrdinalIgnoreCase);
 
-                _reporter.WriteLine("==workloadRollbackDefinitionJsonOutputStart==");
-                _reporter.WriteLine(JsonSerializer.Serialize(manifests));
-                _reporter.WriteLine("==workloadRollbackDefinitionJsonOutputEnd==");
+                Reporter.WriteLine("==workloadRollbackDefinitionJsonOutputStart==");
+                Reporter.WriteLine(JsonSerializer.Serialize(manifests));
+                Reporter.WriteLine("==workloadRollbackDefinitionJsonOutputEnd==");
             }
             else
             {
@@ -151,26 +138,26 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
 
         public void UpdateWorkloads(bool includePreviews = false, DirectoryPath? offlineCache = null)
         {
-            _reporter.WriteLine();
+            Reporter.WriteLine();
             var featureBand =
                 new SdkFeatureBand(string.Join('.', _sdkVersion.Major, _sdkVersion.Minor, _sdkVersion.SdkFeatureBand));
 
             var workloadIds = GetUpdatableWorkloads();
             _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache).Wait();
-            
+
             var manifestsToUpdate = string.IsNullOrWhiteSpace(_fromRollbackDefinition) ?
                 _workloadManifestUpdater.CalculateManifestUpdates().Select(m => m.manifestUpdate) :
                 _workloadManifestUpdater.CalculateManifestRollbacks(_fromRollbackDefinition);
 
             UpdateWorkloadsWithInstallRecord(workloadIds, featureBand, manifestsToUpdate, offlineCache);
 
-            WorkloadInstallCommand.TryRunGarbageCollection(_workloadInstaller, _reporter, _verbosity, offlineCache);
+            WorkloadInstallCommand.TryRunGarbageCollection(_workloadInstaller, Reporter, Verbosity, offlineCache);
 
             _workloadManifestUpdater.DeleteUpdatableWorkloadsFile();
 
-            _reporter.WriteLine();
-            _reporter.WriteLine(string.Format(LocalizableStrings.UpdateSucceeded, string.Join(" ", workloadIds)));
-            _reporter.WriteLine();
+            Reporter.WriteLine();
+            Reporter.WriteLine(string.Format(LocalizableStrings.UpdateSucceeded, string.Join(" ", workloadIds)));
+            Reporter.WriteLine();
         }
 
         private void UpdateWorkloadsWithInstallRecord(
@@ -188,12 +175,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
 
                 transaction.RollbackStarted = () =>
                 {
-                    _reporter.WriteLine(LocalizableStrings.RollingBackInstall);
+                    Reporter.WriteLine(LocalizableStrings.RollingBackInstall);
                 };
                 // Don't hide the original error if roll back fails, but do log the rollback failure
                 transaction.RollbackFailed = ex =>
                 {
-                    _reporter.WriteLine(string.Format(LocalizableStrings.RollBackFailedMessage, ex.Message));
+                    Reporter.WriteLine(string.Format(LocalizableStrings.RollBackFailedMessage, ex.Message));
                 };
 
                 transaction.Run(
@@ -212,7 +199,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
 
                         installer.InstallWorkloadPacks(workloadPackToUpdate, sdkFeatureBand, context, offlineCache);
                     },
-                    rollback: () => {
+                    rollback: () =>
+                    {
                         //  Nothing to roll back at this level, InstallWorkloadManifest and InstallWorkloadPacks handle the transaction rollback
                     });
             }
@@ -254,7 +242,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             {
                 if (!string.IsNullOrWhiteSpace(tempManifestDir) && Directory.Exists(tempManifestDir))
                 {
-                   Directory.Delete(tempManifestDir, true);
+                    Directory.Delete(tempManifestDir, true);
                 }
             }
         }
@@ -269,14 +257,14 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                 var manifestPackageUrls = _workloadManifestUpdater.GetManifestPackageUrls(includePreview);
                 packageUrls = packageUrls.Concat(manifestPackageUrls);
 
-                tempPath = new DirectoryPath(Path.Combine(_tempDirPath, "dotnet-manifest-extraction"));
+                tempPath = new DirectoryPath(Path.Combine(TempDirectoryPath, "dotnet-manifest-extraction"));
                 await UseTempManifestsToResolvePacksAsync(tempPath.Value, includePreview);
 
                 if (_workloadInstaller.GetInstallationUnit().Equals(InstallationUnit.Packs))
                 {
                     var installer = _workloadInstaller.GetPackInstaller();
                     var packsToUpdate = GetUpdatablePacks(installer)
-                        .Select(packInfo => _nugetPackageDownloader.GetPackageUrl(new PackageId(packInfo.ResolvedPackageId), new NuGetVersion(packInfo.Version), _packageSourceLocation).GetAwaiter().GetResult());
+                        .Select(packInfo => PackageDownloader.GetPackageUrl(new PackageId(packInfo.ResolvedPackageId), new NuGetVersion(packInfo.Version), _packageSourceLocation).GetAwaiter().GetResult());
                     packageUrls = packageUrls.Concat(packsToUpdate);
                     return packageUrls;
                 }
@@ -321,7 +309,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                 var workloads = _workloadInstaller.GetWorkloadInstallationRecordRepository().GetInstalledWorkloads(currentFeatureBand);
                 if (workloads == null || !workloads.Any())
                 {
-                    _reporter.WriteLine(LocalizableStrings.NoWorkloadsToUpdate);
+                    Reporter.WriteLine(LocalizableStrings.NoWorkloadsToUpdate);
                 }
 
                 return workloads;

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
@@ -17,8 +17,6 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option<string> VersionOption = WorkloadInstallCommandParser.VersionOption;
 
-        public static readonly Option<VerbosityOptions> VerbosityOption = WorkloadInstallCommandParser.VerbosityOption;
-
         public static readonly Option<bool> IncludePreviewsOption = WorkloadInstallCommandParser.IncludePreviewOption;
 
         public static readonly Option<string> DownloadToCacheOption = WorkloadInstallCommandParser.DownloadToCacheOption;
@@ -64,7 +62,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(FromPreviousSdkOption);
             command.AddOption(AdManifestOnlyOption);
             command.AddWorkloadCommandNuGetRestoreActionConfigOptions();
-            command.AddOption(VerbosityOption);
+            command.AddOption(CommonOptions.VerbosityOption);
             command.AddOption(PrintRollbackOption);
             command.AddOption(FromRollbackFileOption);
 

--- a/src/Tests/dotnet.Tests/WindowsInstallerTests.cs
+++ b/src/Tests/dotnet.Tests/WindowsInstallerTests.cs
@@ -11,6 +11,7 @@ using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Installer.Windows;
 using Microsoft.DotNet.Installer.Windows.Security;
+using Microsoft.DotNet.Workloads.Workload;
 using Microsoft.NET.TestFramework;
 using Xunit;
 

--- a/src/Tests/dotnet.Tests/WindowsInstallerTests.cs
+++ b/src/Tests/dotnet.Tests/WindowsInstallerTests.cs
@@ -140,6 +140,8 @@ namespace Microsoft.DotNet.Tests
         [WindowsOnlyTheory]
         [InlineData("tampered.msi", false, "The digital signature of the object did not verify.")]
         [InlineData("dual_signed.dll", true, "")]
+        [InlineData("dotnet_realsigned.exe", true, "")]
+        [InlineData("dotnet_fakesigned.exe", false, "A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.")]
         public void AuthentiCodeSignaturesCanBeVerified(string file, bool shouldBeSigned, string expectedError)
         {
             bool isSigned = AuthentiCode.IsSigned(Path.Combine(s_testDataPath, file));
@@ -150,6 +152,14 @@ namespace Microsoft.DotNet.Tests
             {
                 Assert.Equal(expectedError, new Win32Exception(Marshal.GetLastWin32Error()).Message);
             }
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("dotnet_realsigned.exe")]
+        [InlineData("dotnet_fakesigned.exe")]
+        public void IsSignedByTrustedOrganizationOnlyVerifiesTheSubjectOrganization(string file)
+        {
+            Assert.True(AuthentiCode.IsSignedByTrustedOrganization(Path.Combine(s_testDataPath, file), AuthentiCode.TrustedOrganizations));
         }
 
         [WindowsOnlyFact]


### PR DESCRIPTION
Fixes #25377 

The simple fix is to just pass `VerifySignatures` whenever a workload command instantiates `NuGetPackageDownloader`. That still leaves the risk of adding a new command and not passing it through in the future. Instead, all of that code was moved to the `WorkloadCommandBase` so that commands don't duplicate this.

In doing so I uncovered a number of other inconsistencies around the package download folders that vary significantly between commands and because the downloader depends on these values, it also needed to be refactored.