### PR TITLE
Remove duplicated PackageReference

### DIFF
--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -62,8 +62,4 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" Condition="'$(UseSystemTextJson)'!='True'"/>
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
**Problem:**

System.Private.Uri package reference was duplicated during the [merging change](https://github.com/dotnet/sdk/commit/e055a10860e927ef2b0bb7900c9071a6b3805eff)
This leads to unnecessary build warnings

**Solution:**

Remove the duplicated reference.