### PR TITLE
add tests to cover the resolution of AnalysisLevel known-strings

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -17,19 +17,19 @@ namespace Microsoft.NET.Build.Tests
     public class GivenThatWeWantToFloatWarningLevels : SdkTest
     {
         private const string targetFrameworkNet6 = "net6.0";
-        private const string targetFrameworkNet7 = "net7.0";
         private const string targetFrameworkNetFramework472 = "net472";
 
         public GivenThatWeWantToFloatWarningLevels(ITestOutputHelper log) : base(log)
         {
         }
 
-        [InlineData(targetFrameworkNet6, 6)]
-        [InlineData(targetFrameworkNet7, 7)]
-        [InlineData(targetFrameworkNetFramework472, 4)]
+        [InlineData(targetFrameworkNet6, "6")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.CurrentTargetFrameworkVersion)]
+        [InlineData(targetFrameworkNetFramework472, "4")]
         [RequiresMSBuildVersionTheory("16.8")]
-        public void It_defaults_WarningLevel_To_The_Current_TFM_When_Net(string tfm, int warningLevel)
+        public void It_defaults_WarningLevel_To_The_Current_TFM_When_Net(string tfm, string warningLevel)
         {
+            int parsedWarningLevel = int.Parse(warningLevel);
             var testProject = new TestProject
             {
                 Name = "HelloWorld",
@@ -66,7 +66,7 @@ namespace Microsoft.NET.Build.Tests
             var buildResult = buildCommand.Execute();
             var computedWarningLevel = buildCommand.GetValues()[0];
             buildResult.StdErr.Should().Be(string.Empty);
-            computedWarningLevel.Should().Be(warningLevel.ToString());
+            computedWarningLevel.Should().Be(parsedWarningLevel.ToString());
         }
 
         [InlineData(1, 1)]
@@ -77,7 +77,7 @@ namespace Microsoft.NET.Build.Tests
             var testProject = new TestProject
             {
                 Name = "HelloWorld",
-                TargetFrameworks = "net7.0",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
                 SourceFiles =
                 {
@@ -103,7 +103,7 @@ namespace Microsoft.NET.Build.Tests
             var buildCommand = new GetValuesCommand(
                 Log,
                 Path.Combine(testAsset.TestRoot, testProject.Name),
-                "net7.0", "WarningLevel")
+                ToolsetInfo.CurrentTargetFramework, "WarningLevel")
             {
                 DependsOnTargets = "Build"
             };
@@ -114,7 +114,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [InlineData(targetFrameworkNet6, "6.0")]
-        [InlineData(targetFrameworkNet7, "7.0")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.CurrentTargetFrameworkVersion)]
         [InlineData(targetFrameworkNetFramework472, null)]
         [RequiresMSBuildVersionTheory("16.8")]
         public void It_defaults_AnalysisLevel_To_The_Current_TFM_When_NotLatestTFM(string tfm, string analysisLevel)
@@ -166,7 +166,7 @@ namespace Microsoft.NET.Build.Tests
             buildResult.StdErr.Should().Be(string.Empty);
         }
 
-        [InlineData(targetFrameworkNet7, "8.0")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.NextTargetFramework)]
         [RequiresMSBuildVersionTheory("16.8")]
         public void It_defaults_preview_AnalysisLevel_to_the_next_tfm(string currentTFM, string nextTFM)
         {
@@ -220,7 +220,7 @@ namespace Microsoft.NET.Build.Tests
             var testProject = new TestProject
             {
                 Name = "HelloWorld",
-                TargetFrameworks = targetFrameworkNet7,
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
                 SourceFiles =
                 {
@@ -242,12 +242,12 @@ namespace Microsoft.NET.Build.Tests
             testProject.AdditionalProperties.Add("AnalysisLevel", analysisLevel);
 
             var testAsset = _testAssetsManager
-                .CreateTestProject(testProject, identifier: "analysisLevelPreviewConsoleApp"+targetFrameworkNet7+analysisLevel, targetExtension: ".csproj");
+                .CreateTestProject(testProject, identifier: "analysisLevelPreviewConsoleApp"+ToolsetInfo.CurrentTargetFramework+analysisLevel, targetExtension: ".csproj");
 
             var buildCommand = new GetValuesCommand(
                 Log,
                 Path.Combine(testAsset.TestRoot, testProject.Name),
-                targetFrameworkNet7, "EffectiveAnalysisLevel")
+                ToolsetInfo.CurrentTargetFramework, "EffectiveAnalysisLevel")
             {
                 DependsOnTargets = "Build"
             };

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -242,7 +242,7 @@ namespace Microsoft.NET.Build.Tests
             testProject.AdditionalProperties.Add("AnalysisLevel", analysisLevel);
 
             var testAsset = _testAssetsManager
-                .CreateTestProject(testProject, identifier: "analysisLevelPreviewConsoleApp"+targetFrameworkNet7, targetExtension: ".csproj");
+                .CreateTestProject(testProject, identifier: "analysisLevelPreviewConsoleApp"+targetFrameworkNet7+analysisLevel, targetExtension: ".csproj");
 
             var buildCommand = new GetValuesCommand(
                 Log,

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NET.Build.Tests
         [RequiresMSBuildVersionTheory("16.8")]
         public void It_defaults_WarningLevel_To_The_Current_TFM_When_Net(string tfm, string warningLevel)
         {
-            int parsedWarningLevel = int.Parse(warningLevel);
+            int parsedWarningLevel = double.Parse(warningLevel);
             var testProject = new TestProject
             {
                 Name = "HelloWorld",

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NET.Build.Tests
         [RequiresMSBuildVersionTheory("16.8")]
         public void It_defaults_WarningLevel_To_The_Current_TFM_When_Net(string tfm, string warningLevel)
         {
-            int parsedWarningLevel = double.Parse(warningLevel);
+            int parsedWarningLevel = (int)double.Parse(warningLevel);
             var testProject = new TestProject
             {
                 Name = "HelloWorld",

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -166,9 +166,9 @@ namespace Microsoft.NET.Build.Tests
             buildResult.StdErr.Should().Be(string.Empty);
         }
 
-        [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.NextTargetFramework)]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.NextTargetFrameworkVersion)]
         [RequiresMSBuildVersionTheory("16.8")]
-        public void It_defaults_preview_AnalysisLevel_to_the_next_tfm(string currentTFM, string nextTFM)
+        public void It_defaults_preview_AnalysisLevel_to_the_next_tfm(string currentTFM, string nextTFMVersionNumber)
         {
             var testProject = new TestProject
             {
@@ -208,7 +208,7 @@ namespace Microsoft.NET.Build.Tests
 
             buildResult.StdErr.Should().Be(string.Empty);
             var computedEffectiveAnalysisLevel = buildCommand.GetValues()[0];
-            computedEffectiveAnalysisLevel.Should().Be(nextTFM.ToString());
+            computedEffectiveAnalysisLevel.Should().Be(nextTFMVersionNumber.ToString());
         }
 
         [InlineData("preview")]

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -19,6 +19,8 @@ namespace Microsoft.NET.TestFramework
     {
         public const string CurrentTargetFramework = "net7.0";
         public const string CurrentTargetFrameworkVersion = "7.0";
+        public const string NextTargetFramework = "net8.0";
+        public const string NextTargetFrameworkVersion = "8.0";
 
         public string DotNetRoot { get; }
         public string DotNetHostPath { get; }


### PR DESCRIPTION
Fixes #25450 by

* adding a test that covers the promotion of the `preview` term to a target TFM
* adding tests that verify that for all of the known AnalysisLevel terms, we resolve those terms to an actual version number before moving on

Potential enhancements I'd like some feedback on:

* [x] right now I'm hard-coding the 3 known string AnalysisLevel values. Is there an enum of these available somewhere to reference? Guessing not, since this is entirely an MSBuild-level construct. Resolution: just hard-coded them for now.
* [x] the 'preview floats to the next TFM' test currently hard-codes 8.0. I would love to be able to get the TFM we're built for at runtime somehow. anyone know how to do this? maybe a custom AssemblyAttribute? Resolution: Used the ToolSetInfo to ensure that when we bump our concept of 'next' and 'current' TFMs the sentinel test will break, so we will have to update this implementation.
* [ ] currently it's hard to tell the user the valid values of the AnalysisLevel property via MSBuild warnings or errors, because all of this calculation happens as part of property evaluation. Other .targets files do this property evaluation inside of a target to allow for creating NETSDK errors. Is it worth trying to move in that direction? What I'm trying to fix is unknown AnalysisLevels getting passed into a TFM version evaluation because of this condition:
  ```xml
      <EffectiveAnalysisLevel Condition="'$(EffectiveAnalysisLevel)' == '' And
                                       '$(AnalysisLevel)' != ''">$(AnalysisLevel)</EffectiveAnalysisLevel>
    ```
    
    Resolution: too hard and error prone to do - will discuss with SDK/MSBuild team for a later date