### PR TITLE
Remove dependency on Assembly.GetCallingAssembly

### DIFF
--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorLegacyIntegrationTest50.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorLegacyIntegrationTest50.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
     public class BlazorLegacyIntegrationTest50 : AspNetSdkBaselineTest
     {
-        public BlazorLegacyIntegrationTest50(ITestOutputHelper log) : base(log)
+        public BlazorLegacyIntegrationTest50(ITestOutputHelper log) : base(log, typeof(BlazorLegacyIntegrationTest50).Assembly)
         {
         }
 

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIncrementalismTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIncrementalismTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
     public class WasmBuildIncrementalismTest : AspNetSdkTest
     {
-        public WasmBuildIncrementalismTest(ITestOutputHelper log) : base(log) { }
+        public WasmBuildIncrementalismTest(ITestOutputHelper log) : base(log, typeof(WasmBuildIncrementalismTest).Assembly) { }
 
         [Fact]
         public void Build_IsIncremental()

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildLazyLoadTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildLazyLoadTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
     public class WasmBuildLazyLoadTest : AspNetSdkTest
     {
-        public WasmBuildLazyLoadTest(ITestOutputHelper log) : base(log) {}
+        public WasmBuildLazyLoadTest(ITestOutputHelper log) : base(log, typeof(WasmBuildLazyLoadTest).Assembly) {}
 
         [Fact]
         public void Build_LazyLoadExplicitAssembly_Debug_Works()

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmCompressionTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmCompressionTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
     public class WasmCompressionTests : AspNetSdkTest
     {
-        public WasmCompressionTests(ITestOutputHelper log) : base(log) {}
+        public WasmCompressionTests(ITestOutputHelper log) : base(log, typeof(WasmCompressionTests).Assembly) {}
 
         [Fact]
         public void Publish_UpdatesFilesWhenSourcesChange()

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTestBase.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTestBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
     public abstract class WasmPublishIntegrationTestBase : AspNetSdkTest
     {
-        public WasmPublishIntegrationTestBase(ITestOutputHelper log) : base(log) { }
+        public WasmPublishIntegrationTestBase(ITestOutputHelper log) : base(log, typeof(WasmPublishIntegrationTestBase).Assembly) { }
 
         protected static void VerifyBootManifestHashes(TestAsset testAsset, string blazorPublishDirectory)
         {

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPwaManifestTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPwaManifestTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
     public class WasmPwaManifestTests : AspNetSdkTest
     {
-        public WasmPwaManifestTests(ITestOutputHelper log) : base(log) {}
+        public WasmPwaManifestTests(ITestOutputHelper log) : base(log, typeof(WasmPwaManifestTests).Assembly) {}
 
         [Fact]
         public void Build_ServiceWorkerAssetsManifest_Works()

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ApplicationPartDiscoveryIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ApplicationPartDiscoveryIntegrationTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 {
     public class ApplicationPartDiscoveryIntegrationTest : AspNetSdkTest
     {
-        public ApplicationPartDiscoveryIntegrationTest(ITestOutputHelper log) : base(log) {}
+        public ApplicationPartDiscoveryIntegrationTest(ITestOutputHelper log) : base(log, typeof(ApplicationPartDiscoveryIntegrationTest).Assembly) {}
 
         [CoreMSBuildOnlyFact]
         public void Build_ProjectWithDependencyThatReferencesMvc_AddsAttribute_WhenBuildingUsingDotnetMsbuild()

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
@@ -39,15 +39,15 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         // path. Returning null avoids any transformation
         protected Func<StaticWebAsset, string, StaticWebAsset, string> PathTemplatizer { get; set; } = (asset, originalValue, related) => null;
 
-        public AspNetSdkBaselineTest(ITestOutputHelper log) : base(log)
+        public AspNetSdkBaselineTest(ITestOutputHelper log, Assembly testAssembly) : base(log, typeof(AspNetSdkBaselineTest).Assembly)
         {
-            TestAssembly = Assembly.GetCallingAssembly();
+            TestAssembly = testAssembly;
             var testAssemblyMetadata = TestAssembly.GetCustomAttributes<AssemblyMetadataAttribute>();
             RuntimeVersion = testAssemblyMetadata.SingleOrDefault(a => a.Key == "NetCoreAppRuntimePackageVersion").Value;
             DefaultPackageVersion = testAssemblyMetadata.SingleOrDefault(a => a.Key == "DefaultTestBaselinePackageVersion").Value;
         }
 
-        public AspNetSdkBaselineTest(ITestOutputHelper log, bool generateBaselines) : this(log)
+        public AspNetSdkBaselineTest(ITestOutputHelper log, bool generateBaselines) : this(log, typeof(AspNetSdkBaselineTest).Assembly)
         {
             _generateBaselines = generateBaselines;
         }

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIncrementalismTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIncrementalismTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 {
     public class BuildIncrementalismTest : AspNetSdkTest
     {
-        public BuildIncrementalismTest(ITestOutputHelper log) : base(log) {}
+        public BuildIncrementalismTest(ITestOutputHelper log) : base(log, typeof(BuildIncrementalismTest).Assembly) {}
 
 
         [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/28780")]

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntegrationTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 {
     public class BuildIntegrationTest : AspNetSdkTest
     {
-        public BuildIntegrationTest(ITestOutputHelper log) : base(log) {}
+        public BuildIntegrationTest(ITestOutputHelper log) : base(log, typeof(BuildIntegrationTest).Assembly) {}
 
         [CoreMSBuildOnlyFact]
         public void Build_SimpleMvc_UsingDotnetMSBuildAndWithoutBuildServer_CanBuildSuccessfully()

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntrospectionTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntrospectionTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 {
     public class BuildIntrospectionTest : AspNetSdkTest
     {
-        public BuildIntrospectionTest(ITestOutputHelper log) : base(log) {}
+        public BuildIntrospectionTest(ITestOutputHelper log) : base(log, typeof(BuildIntrospectionTest).Assembly) {}
 
         [Fact]
         public void RazorSdk_AddsCshtmlFilesToUpToDateCheckInput()

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponents31IntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponents31IntegrationTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 {
     public class BuildWithComponents31IntegrationTest : AspNetSdkTest
     {
-        public BuildWithComponents31IntegrationTest(ITestOutputHelper log) : base(log) {}
+        public BuildWithComponents31IntegrationTest(ITestOutputHelper log) : base(log, typeof(BuildWithComponents31IntegrationTest).Assembly) {}
 
         [CoreMSBuildOnlyFact]
         public void Build_Components_WithDotNetCoreMSBuild_Works()

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponentsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponentsIntegrationTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 {
     public class BuildWithComponentsIntegrationTest : AspNetSdkTest
     {
-        public BuildWithComponentsIntegrationTest(ITestOutputHelper log) : base(log) {}
+        public BuildWithComponentsIntegrationTest(ITestOutputHelper log) : base(log, typeof(BuildWithComponentsIntegrationTest).Assembly) {}
 
         [CoreMSBuildOnlyFact]
         public void Build_Components_WithDotNetCoreMSBuild_Works() => Build_ComponentsWorks();

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/DesignTimeBuildIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/DesignTimeBuildIntegrationTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 {
     public class DesignTimeBuildIntegrationTest : AspNetSdkTest
     {
-        public DesignTimeBuildIntegrationTest(ITestOutputHelper log) : base(log) {}
+        public DesignTimeBuildIntegrationTest(ITestOutputHelper log) : base(log, typeof(DesignTimeBuildIntegrationTest).Assembly) {}
 
         [Fact]
         public void DesignTimeBuild_DoesNotRunRazorTargets()

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTest21NetFx.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTest21NetFx.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         private const string TestProjectName ="SimpleMvc21NetFx";
         private const string TargetFramework = "net462";
         public const string OutputFileName = TestProjectName + ".exe";
-        public MvcBuildIntegrationTest21NetFx(ITestOutputHelper log) : base(log) { }
+        public MvcBuildIntegrationTest21NetFx(ITestOutputHelper log) : base(log, typeof(MvcBuildIntegrationTest21NetFx).Assembly) { }
 
         [Fact]
         public virtual void Building_Project()

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTestLegacy.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTestLegacy.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         // Remove Razor prefix from assembly name
         public virtual string OutputFileName => $"{TestProjectName}.dll";
 
-        public MvcBuildIntegrationTestLegacy(ITestOutputHelper log) : base(log) { }
+        public MvcBuildIntegrationTestLegacy(ITestOutputHelper log) : base(log, typeof(MvcBuildIntegrationTestLegacy).Assembly) { }
 
         [CoreMSBuildOnlyFact]
         public virtual void Building_Project()

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/PackIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/PackIntegrationTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
     public class PackIntegrationTest : AspNetSdkTest
     {
 
-        public PackIntegrationTest(ITestOutputHelper log) : base(log) {}
+        public PackIntegrationTest(ITestOutputHelper log) : base(log, typeof(PackIntegrationTest).Assembly) {}
 
         [Fact]
         public void Pack_NoBuild_Works_IncludesAssembly()

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/PublishIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/PublishIntegrationTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 {
     public class PublishIntegrationTest : AspNetSdkTest
     {
-        public PublishIntegrationTest(ITestOutputHelper log) : base(log) {}
+        public PublishIntegrationTest(ITestOutputHelper log) : base(log, typeof(PublishIntegrationTest).Assembly) {}
 
         [Fact]
         public void Publish_RazorCompileOnPublish_IsDefault()

--- a/src/Tests/Microsoft.NET.TestFramework/AspNetSdkTest.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/AspNetSdkTest.cs
@@ -18,10 +18,9 @@ namespace Microsoft.NET.TestFramework
     {
         public readonly string DefaultTfm;
 
-        protected AspNetSdkTest(ITestOutputHelper log) : base(log)
+        protected AspNetSdkTest(ITestOutputHelper log, Assembly testAssembly) : base(log)
         {
-            var assembly = Assembly.GetCallingAssembly();
-            var testAssemblyMetadata = assembly.GetCustomAttributes<AssemblyMetadataAttribute>();
+            var testAssemblyMetadata = testAssembly.GetCustomAttributes<AssemblyMetadataAttribute>();
             DefaultTfm = testAssemblyMetadata.SingleOrDefault(a => a.Key == "AspNetTestTfm").Value;
         }
 


### PR DESCRIPTION
This PR was used to prep expected changes based on a new breaking change caused by the expected behavior of the JIT inlining a target method due to the new support for IL-Emit'd invokers where IL is used to do the invoke and not native\interpreted logic. This caused `Assembly.GetCallingAssembly()` to not return the expected assembly, which caused SDK integration tests to fail.

In general, using `GetCallingAssembly()` is not recommended in general since it doesn't work on all platforms\environments and it is fragile essentially requiring `NoInlining` attribute.

However, there is now a work-around in place in https://github.com/dotnet/runtime/pull/69575 to avoid that breaking change plus plans to remove that work-around in favor of a better approach to using `calli` that does not re-introduce the breaking change.

Closing the PR since it is no longer required, although this PR still has merit as mentioned above due to using the fragile `GetCallingAssembly()`; i.e. if the tests were invoked without reflection they would fail today.