### PR TITLE
[dotnet-watch] Fixes an infinite loop of reloads when the process fails to start

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -129,7 +129,12 @@ namespace Microsoft.DotNet.Watcher
 
                         if (finishedTask != fileSetTask || fileSetTask.Result is not FileItem[] fileItems)
                         {
-                            // The app exited.
+                            if (processTask.IsFaulted && finishedTask == processTask && !cancellationToken.IsCancellationRequested)
+                            {
+                                // Only show this error message if the process exited non-zero due to a normal process exit.
+                                // Don't show this if dotnet-watch killed the inner process due to file change or CTRL+C by the user
+                                _reporter.Error($"Application failed to start: {processTask.Exception.InnerException.Message}");
+                            }
                             break;
                         }
                         else
@@ -181,7 +186,7 @@ namespace Microsoft.DotNet.Watcher
 
                     await Task.WhenAll(processTask, fileSetTask);
 
-                    if (processTask.Result != 0 && finishedTask == processTask && !cancellationToken.IsCancellationRequested)
+                    if (!processTask.IsFaulted && processTask.Result != 0 && finishedTask == processTask && !cancellationToken.IsCancellationRequested)
                     {
                         // Only show this error message if the process exited non-zero due to a normal process exit.
                         // Don't show this if dotnet-watch killed the inner process due to file change or CTRL+C by the user


### PR DESCRIPTION
When for some reason the app fails to launch dotnet watch would continue to build and try to start the app indefinitely.

## Description

The issue was that we would try to access the `.Result` of a faulted task and that would cause the exception in the task to be raised.

Instead, we check to see if the task has faulted and print the exception error message to the console.

Fixes https://github.com/dotnet/aspnetcore/issues/39073

## Customer Impact

Customers are confused because the only thing that `dotnet-watch` reports by default is that it is building the app, and starting it repeatedly and no error is shown unless they use the `--verbose` flag.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The change is very localized and doesn't impact a happy path scenario, it only makes the error visible when you run into this situation.

## Verification

- [X] Manual (required)
- [ ] Automated

Tested with some of the suggested repro projects provided by customers.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A