### PR TITLE
[dotnet-watch] Updates the request path to always be host relative

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -8,7 +8,7 @@ async function receiveHotReloadAsync() {
   if (cache) {
     headers = { 'if-none-match' : cache.etag };
   }
-  const response = await fetch('_framework/blazor-hotreload', { headers });
+  const response = await fetch('/_framework/blazor-hotreload', { headers });
   if (response.status === 200) {
     const deltas = await response.json();
     if (deltas) {


### PR DESCRIPTION
Hot reload will fail if the app is hosted in a subdirectory

## Description

The issue is that the script sends a document relative network request when we always host all scripts at the root of the url space.

The change updates the script to make the request to a host relative URL so that it finds it independently of where the application is being hosted.

Fixes https://github.com/dotnet/aspnetcore/issues/40971

## Customer Impact

Hotreload won't work if the app is hosted inside a subfolder.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The change is very localized and doesn't impact the main scenario since in that case, both requests are equivalent.

## Verification

- [X] Manual (required)
- [ ] Automated

Tested by hosting an application in a subdirectory and validating that the script is loaded correctly in that scenario.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A