### PR TITLE
Version Microsoft.DotNet.Compatibility same as SDK

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.Compatibility/Microsoft.DotNet.Compatibility.csproj
+++ b/src/Compatibility/Microsoft.DotNet.Compatibility/Microsoft.DotNet.Compatibility.csproj
@@ -5,7 +5,6 @@
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <!-- This package doesnot contain any lib or ref assemblies because its a tooling package.-->
     <NoWarn>$(NoWarn);NU5128</NoWarn>


### PR DESCRIPTION
We discussed offline that it makes sense to version this component alongside the SDK. We just recently noticed that during servicing, this package causes conflicts as the same version already exists on NuGet. Versioning it alongside the SDK will fix this during servicing and makes the component more consistent with the rest of the shipping assets.