### PR TITLE
[6.0.3xx] Disable Microsoft.DN.Compatibility pkg

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.Compatibility/Microsoft.DotNet.Compatibility.csproj
+++ b/src/Compatibility/Microsoft.DotNet.Compatibility/Microsoft.DotNet.Compatibility.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
-    <IsPackable>true</IsPackable>
+    <!-- Re-enable and update the VersionPrefix in case of a servicing change. -->
+    <IsPackable>false</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <VersionPrefix>1.1.0</VersionPrefix>


### PR DESCRIPTION
The Microsoft.DotNet.Compatibility package gets published during servicing but hardcodes the VersionPrefix. Because of that, during a servicing event with stabilized versions, it fails to be pubished as the package with same version already exists upstream.

Don't publish the package unless there's a servicing need for it instead.