### PR TITLE
Implement new flag for ignoreing apphosts in dotnet run

### DIFF
--- a/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
@@ -24,6 +24,12 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public IDictionary<string, string>? EnvironmentVariables { get; set; }
 
+        ///<summary>
+        /// If set, the project will be executed using the generated AppHost if one is available.
+        /// This means the project will be run like `./myapp.exe &lt;args&gt;` instead of like `dotnet myapp.dll &lt;args&gt;`.
+        ///</summary>
+        public bool UseAppHostIfAvailable {get; set;} = true;
+
         internal static LaunchSettingsProfile? ReadDefaultProfile(string projectDirectory, IReporter reporter)
         {
             var launchSettingsPath = Path.Combine(projectDirectory, "Properties", "launchSettings.json");

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsModel.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsModel.cs
@@ -19,5 +19,11 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
         public string DotNetRunMessages { get; set; }
 
         public Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        ///<summary>
+        /// If set, the project will be executed using the generated AppHost if one is available.
+        /// This means the project will be run like `./myapp.exe &lt;args&gt;` instead of like `dotnet myapp.dll &lt;args&gt;`.
+        ///</summary>
+        public bool UseAppHostIfAvailable {get; set;} = true;
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.Tools.Run
 
             try
             {
-                ICommand targetCommand = GetTargetCommand();
+                ICommand targetCommand = GetTargetCommand(launchSettings.UseAppHostIfAvailable);
                 if (launchSettings != null)
                 {
                     if (!string.IsNullOrEmpty(launchSettings.ApplicationUrl))
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.Tools.Run
             return args;
         }
 
-        private ICommand GetTargetCommand()
+        private ICommand GetTargetCommand(bool useAppHostIfAvailable)
         {
             var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -238,6 +238,13 @@ namespace Microsoft.DotNet.Tools.Run
             if (!string.IsNullOrWhiteSpace(Runtime))
             {
                 globalProperties.Add("RuntimeIdentifier", Runtime);
+            }
+
+            // if the user doesn't want us to use an apphost, then we must force the evaluation to not use one, 
+            // regardless of what the user has set in the project.
+            if(!useAppHostIfAvailable)
+            {
+                globalProperties.Add("UseAppHost", "false");
             }
 
             var project = new ProjectInstance(Project, globalProperties, null);

--- a/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
+++ b/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
@@ -326,7 +326,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             var output = new OutputSink();
             var options = GetWatchOptions();
-            var filesetFactory = new MsBuildFileSetFactory(options, _reporter, projectA, output, waitOnError: false, trace: true);
+            var filesetFactory = new MsBuildFileSetFactory(options, _reporter, projectA, output, waitOnError: false, trace: true, useAppHostIfAvailable: true);
 
             var fileset = await GetFileSet(filesetFactory);
 
@@ -361,7 +361,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         private Task<FileSet> GetFileSet(string projectPath)
         {
             DotNetWatchOptions options = GetWatchOptions();
-            return GetFileSet(new MsBuildFileSetFactory(options, _reporter, projectPath, new OutputSink(), waitOnError: false, trace: false));
+            return GetFileSet(new MsBuildFileSetFactory(options, _reporter, projectPath, new OutputSink(), waitOnError: false, trace: false, useAppHostIfAvailable: true));
         }
 
         private static DotNetWatchOptions GetWatchOptions() => 

--- a/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
+++ b/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
@@ -240,6 +240,52 @@ namespace Microsoft.DotNet.Watcher.Tools
             );
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task FileSetChangesAppHostDetectionBasedOnFlag(bool useAppHost) {
+            (string expectedRunner, string expectedArgs) GetArgsFor(string projectName, bool useAppHost)
+            {
+                if (System.OperatingSystem.IsWindows()) {
+                    if (useAppHost)
+                    {
+                        return ($"{projectName}.exe", "");
+                    } 
+                    else 
+                    {
+                        return ("dotnet.exe", projectName);
+                    }
+                } 
+                else 
+                {
+                    if (useAppHost)
+                    {
+                        return ($"{projectName}", "");
+                    } 
+                    else 
+                    {
+                        return ("dotnet", projectName);
+                    }
+                }
+            }
+            
+            var projectName = $"AppHost-{useAppHost}";
+            var project = _testAssets.CreateTestProject(new TestProject(projectName)
+            {
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework
+            });
+
+
+            var fileset = await GetFileSet(project);
+            var projectInfo = fileset.Project;
+            var command = projectInfo.RunCommand;
+            var args = projectInfo.RunArguments;
+            var (expectedRunner, expectedArgs) = GetArgsFor(projectName, useAppHost);
+            Assert.Equal(command, expectedRunner);
+            Assert.Equal(args, expectedArgs);
+               
+        }
+
         [Fact]
         public async Task ProjectReferences_OneLevel()
         {


### PR DESCRIPTION
This is a draft PR to fix #22544.

It introduces a new flag `UseAppHostIfAvailable` that defaults to `true`. If this flag is ever false, then we evaluate the project with `UseAppHost=false`, which forces the RunCommand and RunArguments properties to invoke the dll directly.

TODO:
* [ ] should we change the default behavior on macos specifically? As it is, we will require users to create and maintain launch profiles.