### PR TITLE
Add --skip-sign-check option to repair, uninstall, and update

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/repair/WorkloadRepairCommandParser.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(SourceOption);
             command.AddOption(CommonOptions.VerbosityOption);
             command.AddWorkloadCommandNuGetRestoreActionConfigOptions();
+            command.AddOption(WorkloadInstallCommandParser.SkipSignCheckOption);
 
             command.SetHandler((parseResult) => new WorkloadRepairCommand(parseResult).Execute());
 

--- a/src/Cli/dotnet/commands/dotnet-workload/uninstall/WorkloadUninstallCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/uninstall/WorkloadUninstallCommandParser.cs
@@ -27,6 +27,7 @@ namespace Microsoft.DotNet.Cli
         {
             Command command = new Command("uninstall", LocalizableStrings.CommandDescription);
             command.AddArgument(WorkloadIdArgument);
+            command.AddOption(WorkloadInstallCommandParser.SkipSignCheckOption);
 
             command.SetHandler((parseResult) => new WorkloadUninstallCommand(parseResult).Execute());
 

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
@@ -65,6 +65,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(CommonOptions.VerbosityOption);
             command.AddOption(PrintRollbackOption);
             command.AddOption(FromRollbackFileOption);
+            command.AddOption(WorkloadInstallCommandParser.SkipSignCheckOption);
 
             command.SetHandler((parseResult) => new WorkloadUpdateCommand(parseResult).Execute());
 


### PR DESCRIPTION
Currently, only the install command supports `--skip-sign-check` option. Other commands can also interact with downloading packages and should be able to turn off the check consistently