### PR TITLE
Delete unused resource files in ApiCompatibility

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.cs.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.de.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.es.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.fr.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.it.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.ja.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.ko.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.pl.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.pt-BR.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.ru.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.tr.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.zh-Hans.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Strings.zh-Hant.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
-    <body />
-  </file>
-</xliff>


### PR DESCRIPTION
These files were brought in via cb8c977b9c0e6a32e0e34ed3698ae11dbbf8b4c1 but aren't in use.