### PR TITLE
Fix workload updates failing due to packages not found.

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             if (resource == null)
             {
                 throw new NuGetPackageNotFoundException(
-                    string.Format(LocalizableStrings.FailedToLoadNuGetSource, source.Source));
+                    string.Format(LocalizableStrings.IsNotFoundInNuGetFeeds, packageId, source.Source));
             }
 
             string nupkgPath = downloadFolder == null || !downloadFolder.HasValue
@@ -413,8 +413,8 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
             if (!foundPackagesBySource.Any())
             {
-                throw new NuGetPackageInstallerException(string.Format(LocalizableStrings.FailedToLoadNuGetSource,
-                    string.Join(" ", packageSources.Select(s => s.Source))));
+                throw new NuGetPackageNotFoundException(
+                    string.Format(LocalizableStrings.IsNotFoundInNuGetFeeds, packageIdentifier, packageSources.Select(s => s.Source)));
             }
 
             IEnumerable<(PackageSource source, IPackageSearchMetadata package)> accumulativeSearchResults =
@@ -423,7 +423,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
             if (!accumulativeSearchResults.Any())
             {
-                throw new NuGetPackageInstallerException(
+                throw new NuGetPackageNotFoundException(
                     string.Format(
                         LocalizableStrings.IsNotFoundInNuGetFeeds,
                         packageIdentifier,
@@ -524,7 +524,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                     string.Join(";", sources.Select(s => s.Source))));
             }
 
-            throw new NuGetPackageInstallerException(string.Format(LocalizableStrings.IsNotFoundInNuGetFeeds,
+            throw new NuGetPackageNotFoundException(string.Format(LocalizableStrings.IsNotFoundInNuGetFeeds,
                 $"{packageIdentifier}::{packageVersion}", string.Join(";", sources.Select(s => s.Source))));
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                 var manifests = _workloadResolver.GetInstalledManifests().ToDictionary(m => m.Id, m => m.Version + "/" + m.ManifestFeatureBand, StringComparer.OrdinalIgnoreCase);
 
                 Reporter.WriteLine("==workloadRollbackDefinitionJsonOutputStart==");
-                Reporter.WriteLine(JsonSerializer.Serialize(manifests));
+                Reporter.WriteLine(JsonSerializer.Serialize(manifests, new JsonSerializerOptions() { WriteIndented = true }));
                 Reporter.WriteLine("==workloadRollbackDefinitionJsonOutputEnd==");
             }
             else

--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
         [Fact]
         public async Task GivenNoFeedInstallFailsWithException() =>
-            await Assert.ThrowsAsync<NuGetPackageInstallerException>(() =>
+            await Assert.ThrowsAsync<NuGetPackageNotFoundException>(() =>
                 _installer.DownloadPackageAsync(TestPackageId, new NuGetVersion(TestPackageVersion)));
 
         [Fact]
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             DirectoryPath nonExistFeed =
                 new DirectoryPath(Path.GetTempPath()).WithSubDirectories(Path.GetRandomFileName());
 
-            await Assert.ThrowsAsync<NuGetPackageInstallerException>(() =>
+            await Assert.ThrowsAsync<NuGetPackageNotFoundException>(() =>
                 _installer.DownloadPackageAsync(
                     TestPackageId,
                     new NuGetVersion(TestPackageVersion),
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             // should not throw FatalProtocolException
             // when there is at least one valid source, it should pass.
             // but it is hard to set up that in unit test
-            await Assert.ThrowsAsync<NuGetPackageInstallerException>(() =>
+            await Assert.ThrowsAsync<NuGetPackageNotFoundException>(() =>
                 installer.DownloadPackageAsync(
                     TestPackageId,
                     new NuGetVersion(TestPackageVersion),
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             WriteNugetConfigFileToPointToTheFeed(fileSystem, validNugetConfigPath);
 
             // "source" option will override everything like nuget.config just like "dotner restore --source ..."
-            await Assert.ThrowsAsync<NuGetPackageInstallerException>(() =>
+            await Assert.ThrowsAsync<NuGetPackageNotFoundException>(() =>
                 _installer.DownloadPackageAsync(
                     TestPackageId,
                     new NuGetVersion(TestPackageVersion),


### PR DESCRIPTION
- Fixes #25678
- Use indentation in output when printing rollback file.