### PR TITLE
Include requested .NET SDK version when known

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -151,7 +151,16 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                     {
                         warnings = new List<string>();
                     }
-                    warnings.Add(Strings.GlobalJsonResolutionFailed);
+
+                    if (!string.IsNullOrWhiteSpace(resolverResult.RequestedVersion))
+                    {
+                        warnings.Add(string.Format(Strings.GlobalJsonResolutionFailedSpecificVersion, resolverResult.RequestedVersion));
+                    }
+                    else
+                    {
+                        warnings.Add(Strings.GlobalJsonResolutionFailed);
+                    }
+
                     if (propertiesToAdd == null)
                     {
                         propertiesToAdd = new Dictionary<string, string>();

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Strings.resx
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Strings.resx
@@ -135,4 +135,7 @@
   <data name="GlobalJsonResolutionFailed" xml:space="preserve">
     <value>Unable to locate the .NET SDK as specified by global.json, please check that the specified version is installed.</value>
   </data>
+  <data name="GlobalJsonResolutionFailedSpecificVersion" xml:space="preserve">
+    <value>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</value>
+  </data>
 </root>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.cs.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nepovedlo se najít sadu .NET SDK uvedenou v souboru global.json. Zkontrolujte prosím, že je nainstalovaná zadaná verze.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">{0} nejde najít. Zajistěte, aby byla nainstalovaná dostatečně vysoká verze sady .NET SDK, nebo zvyšte verzi zadanou v souboru global.json.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.de.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Das in "global.json" angegebene .NET SDK wurde nicht gefunden. Überprüfen Sie, ob die angegebene Version installiert ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">{0} wurde nicht gefunden. Stellen Sie sicher, dass eine aktuelle Version des .NET SDK installiert ist, und/oder erhöhen Sie die in "global.json" angegebene Version.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.es.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">No se encuentra el SDK de .NET tal y como se especifica en global.json; compruebe que la versión especificada esté instalada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">No se encuentra {0}. Compruebe que hay un SDK de .NET suficientemente reciente instalado o aumente la versión especificada en global.json.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.fr.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Impossible de localiser le kit .NET SDK spécifié par global.json. Vérifiez que la version indiquée est installée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">{0} introuvable. Vérifiez qu'un SDK .NET suffisamment récent est installé et/ou augmentez la version spécifiée dans global.json.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.it.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Non è possibile trovare la versione di .NET SDK specificata in global.json. Verificare che sia installata la versione specificata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">{0} non è stato trovato. Verificare che sia installata una versione abbastanza recente di .NET SDK e/o aumentare la versione specificata in global.json.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.ja.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">global.json で指定されている .NET SDK が見つかりません。指定されたバージョンがインストールされていることをご確認ください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">{0} が見つかりません。十分新しい .NET SDK がインストールされていることを確認するか、global.json で指定するバージョンを上げてください (どちらも実行する必要がある場合もあります)。</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.ko.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">global.json에 지정된 대로 .NET SDK를 찾을 수 없습니다. 지정한 버전이 설치되어 있는지 확인하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">{0}을(를) 찾을 수 없습니다. 최신 .NET SDK가 설치되어 있는지 확인하거나 global.json에 지정된 버전을 높이세요.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.pl.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nie można zlokalizować zestawu .NET SDK, który został określony przez plik global.json. Upewnij się, że określona wersja jest zainstalowana.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">Nie można odnaleźć elementu {0}. Sprawdź, czy zainstalowano wystarczająco aktualną wersję zestawu .NET SDK i/lub zwiększ wersję określoną w pliku global.json.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.pt-BR.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Não é possível localizar o .NET SDK como especificado pelo global.json. Verifique se a versão especificada está instalada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">{0} não encontrado. Verifique se um SDK do .NET suficientemente recente está instalado e/ou aumente a versão especificada em global.json.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.ru.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Не удалось найти пакет SDK для .NET, указанный в файле global.json. Убедитесь, что указанная версия установлена.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">{0} не найден. Убедитесь, что установлена достаточно свежая версия пакета SDK для .NET, и (или) увеличьте версию, указанную в файле global.json.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.tr.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">global.json tarafından belirtilen .NET SDK bulunamıyor, lütfen belirtilen sürümün yüklü olduğundan emin olun.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">{0} bulunamadı. Yeterince yeni bir .NET SDK'nın yüklü olduğundan emin olun ve/veya global.json içinde belirtilen sürümü artırın.</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.zh-Hans.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">无法找到 global.json 指定的 .NET SDK，请检查是否安装了指定的版本。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">找不到 {0}。请检查是否安装了足够新的 .NET SDK 并/或调高在 global.json 中指定的版本。</target>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.zh-Hant.xlf
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/xlf/Strings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">找不到 global.js 所指定的 .NET SDK，請檢查是否已安裝指定的版本。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalJsonResolutionFailedSpecificVersion">
+        <source>Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</source>
+        <target state="new">Unable to locate the .NET SDK version '{0}' as specified by global.json, please check that the specified version is installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MSBuildSDKDirectoryNotFound">
         <source>{0} not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.</source>
         <target state="translated">找不到 {0}。請檢查安裝的 .NET SDK 是否夠新，以及 (或) 在 global.json 中指定較新的版本。</target>

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -85,6 +85,7 @@ namespace Microsoft.DotNet.NativeWrapper
         {
             resolved_sdk_dir = 0,
             global_json_path = 1,
+            requested_version = 2,
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/SdkResolutionResult.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/SdkResolutionResult.cs
@@ -18,6 +18,11 @@ namespace Microsoft.DotNet.NativeWrapper
         public string GlobalJsonPath;
 
         /// <summary>
+        /// The .NET SDK version specified in <strong>global.json</strong>.
+        /// </summary>
+        public string RequestedVersion;
+
+        /// <summary>
         /// True if a global.json was found but there was no compatible SDK, so it was ignored. 
         /// </summary>
         public bool FailedToResolveSDKSpecifiedInGlobalJson;
@@ -31,6 +36,9 @@ namespace Microsoft.DotNet.NativeWrapper
                     break;
                 case Interop.hostfxr_resolve_sdk2_result_key_t.global_json_path:
                     GlobalJsonPath = value;
+                    break;
+                case Interop.hostfxr_resolve_sdk2_result_key_t.requested_version:
+                    RequestedVersion = value;
                     break;
             }
         }

--- a/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -289,7 +289,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.PropertiesToAdd.ContainsKey("SdkResolverGlobalJsonPath");
             result.PropertiesToAdd["SdkResolverHonoredGlobalJson"].Should().Be("false");
             result.Version.Should().Be(disallowPreviews ? "98.98.98" : "99.99.99-preview");
-            result.Warnings.Should().BeEquivalentTo(new[] { "Unable to locate the .NET SDK as specified by global.json, please check that the specified version is installed." });
+            result.Warnings.Should().BeEquivalentTo(new[] { "Unable to locate the .NET SDK version '1.2.3' as specified by global.json, please check that the specified version is installed." });
             result.Errors.Should().BeNullOrEmpty();
         }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithGlobalJson.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithGlobalJson.cs
@@ -45,7 +45,9 @@ namespace Microsoft.NET.Build.Tests
                 var result = buildCommand.Execute($"/p:BuildingInsideVisualStudio={runningInVS}", $"/bl:binlog{runningInVS}.binlog")
                     .Should()
                     .Fail();
-                var warningString = "warning : Unable to locate the .NET SDK as specified by global.json, please check that the specified version is installed.";
+                var warningString = runningInVS
+                    ? "warning : Unable to locate the .NET SDK version '9.9.999' as specified by global.json, please check that the specified version is installed."
+                    : "warning : Unable to locate the .NET SDK as specified by global.json, please check that the specified version is installed.";
                 var errorString = "Unable to locate the .NET SDK. Check that it is installed, your PATH is configured for the correct architecture, and that the version specified in global.json (if any) matches the installed version.";
                 if (runningInVS)
                 {


### PR DESCRIPTION
Please let me know if/where tests should be for this. Relies on https://github.com/dotnet/runtime/pull/68355 to enable the new error message path.

Related to #24480