### PR TITLE
[release/7.0.1xx-preview5] Integrate new user-jwts tool into SDK

### DIFF
--- a/documentation/general/aspnetcore-tools.md
+++ b/documentation/general/aspnetcore-tools.md
@@ -5,6 +5,7 @@ The .NET Core CLI includes some commands that are specific to ASP.NET Core proje
 
  - dotnet dev-certs
  - dotnet user-secrets
+ - dotnet user-jwts
  - dotnet sql-cache
 
 For more information on these tools, see <https://github.com/aspnet/DotNetTools>.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -196,6 +196,10 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>5ff6e316a8e34bb06b986ec13ec7aae3f61e886b</Sha>
     </Dependency>
+    <Dependency Name="dotnet-user-jwts" Version="7.0.0-preview.5.22274.1">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>5ff6e316a8e34bb06b986ec13ec7aae3f61e886b</Sha>
+    </Dependency>
     <Dependency Name="dotnet-user-secrets" Version="7.0.0-preview.5.22274.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>5ff6e316a8e34bb06b986ec13ec7aae3f61e886b</Sha>

--- a/src/Cli/dotnet/CommandFactory/CommandFactoryUsingResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandFactoryUsingResolver.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.CommandFactory
 {
     public static class CommandFactoryUsingResolver
     {
-        private static string[] _knownCommandsAvailableAsDotNetTool = new[] { "dotnet-dev-certs", "dotnet-sql-cache", "dotnet-user-secrets", "dotnet-watch" };
+        private static string[] _knownCommandsAvailableAsDotNetTool = new[] { "dotnet-dev-certs", "dotnet-sql-cache", "dotnet-user-secrets", "dotnet-watch", "dotnet-user-jwts" };
 
         public static Command CreateDotNet(
             string commandName,

--- a/src/Cli/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -60,8 +60,8 @@ sdk-options:
 {LocalizableStrings.AdditionalTools}
   dev-certs         {LocalizableStrings.DevCertsDefinition}
   fsi               {LocalizableStrings.FsiDefinition}
-  user-secrets      {LocalizableStrings.UserSecretsDefinition}
   user-jwts         {LocalizableStrings.UserJwtsDefinition}
+  user-secrets      {LocalizableStrings.UserSecretsDefinition}
   watch             {LocalizableStrings.WatchDefinition}
 
 {LocalizableStrings.RunDotnetCommandHelpForMore}";

--- a/src/Cli/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -61,6 +61,7 @@ sdk-options:
   dev-certs         {LocalizableStrings.DevCertsDefinition}
   fsi               {LocalizableStrings.FsiDefinition}
   user-secrets      {LocalizableStrings.UserSecretsDefinition}
+  user-jwts         {LocalizableStrings.UserJwtsDefinition}
   watch             {LocalizableStrings.WatchDefinition}
 
 {LocalizableStrings.RunDotnetCommandHelpForMore}";

--- a/src/Cli/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -285,6 +285,9 @@
   <data name="UserSecretsDefinition" xml:space="preserve">
     <value>Manage development user secrets.</value>
   </data>
+  <data name="UserJwtsDefinition" xml:space="preserve">
+    <value>Manage JSON Web Tokens in development.</value>
+  </data>
   <data name="WatchDefinition" xml:space="preserve">
     <value>Start a file watcher that runs a command when files change.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Možnosti hostitele (předané před příkazem)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">Zobrazí verzi sady .NET SDK, včetně vlivů na jakýkoli soubor global.json.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Hostoptionen (werden vor dem Befehl übergeben)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">Hiermit wird die .NET SDK-Version angezeigt, einschließlich der Auswirkungen einer beliebigen "global.json".</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Opciones de host (pasadas antes que el comando)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">Muestra la versión del SDK de .NET, incluidos los efectos de cualquier archivo global.json.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Options de l'hôte (passées avant la commande)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">Afficher la version du kit SDK .NET ainsi que les effets de global.json</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Opzioni host (passate prima del comando)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">Visualizza la versione di .NET SDK, inclusi gli effetti di qualsiasi file global.json</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">ホストのオプション (コマンドの前に渡されます)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">.NET SDK のバージョンを、global.json のすべての効果を含めて表示します</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">호스트 옵션(명령 전에 전달됨)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">global.json의 효과를 포함하여 .NET SDK의 버전을 표시합니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Opcje hosta (przekazywane przed poleceniem)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">Wyświetl wersję zestawu .NET SDK, uwzględniając efekty pliku global.json</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Opções de host (passadas antes do comando)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">Exibir a versão do SDK do .NET, incluindo os efeitos de qualquer global.json</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Параметры узла (передаваемые перед командой)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">Отображение версии пакета SDK для .NET, включая влияние всех файлов global.json.</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Konak seçenekleri (komuttan önce geçirilir)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">Tüm global.json etkileri dahil olmak üzere .NET SDK sürümünü görüntüleyin</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">主机选项(在命令之前传递)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">显示 .NET SDK 的版本，包括任何 global.json 的影响</target>

--- a/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">裝載選項 (在命令之前傳遞)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserJwtsDefinition">
+        <source>Manage JSON Web Tokens in development.</source>
+        <target state="new">Manage JSON Web Tokens in development.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionDescription">
         <source>Display the version of the .NET SDK, including the effects of any global.json</source>
         <target state="translated">顯示 .NET SDK 的版本，包括任何 global.json 的影響</target>

--- a/src/Tests/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/src/Tests/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -68,6 +68,7 @@ SDK commands:
 Additional commands from bundled tools:
   dev-certs         Create and manage development certificates.
   fsi               Start F# Interactive / execute F# scripts.
+  user-jwts         Manage JSON Web Tokens in development.
   user-secrets      Manage development user secrets.
   watch             Start a file watcher that runs a command when files change.
 


### PR DESCRIPTION
This PR reacts to the introduction of the `dotnet user-jwts` CLI tool in the ASP.NET Core repo via https://github.com/dotnet/aspnetcore/pull/41956.

This change depends on the changeset above flowing into the preview5 branch.