### PR TITLE
Add -lp alias for --launch-profile on dotnet run

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli
             new ForwardedOption<IEnumerable<string>>(new string[] { "--property", "-p" }, LocalizableStrings.PropertyOptionDescription)
                 .SetForwardingFunction((values, parseResult) => parseResult.GetRunCommandPropertyValues().Select(value => $"-p:{value}"));
 
-        public static readonly Option<string> LaunchProfileOption = new Option<string>("--launch-profile", LocalizableStrings.CommandOptionLaunchProfileDescription);
+        public static readonly Option<string> LaunchProfileOption = new Option<string>(new string[] { "--launch-profile", "-lp" }, LocalizableStrings.CommandOptionLaunchProfileDescription);
 
         public static readonly Option<bool> NoLaunchProfileOption = new Option<bool>("--no-launch-profile", LocalizableStrings.CommandOptionNoLaunchProfileDescription);
 


### PR DESCRIPTION
As part of [[EPIC] Revisiting HTTPS defaults in ASP.NET Core](https://github.com/dotnet/aspnetcore/issues/41990)

ASP.NET Core projects are being updated to have multiple launch profiles by default. As such, we'd like it to be easier to select a launch profile when running the project using `dotnet run`.

We propose supporting `-lp` as an option alias for `--launch-profile`, e.g.:

```
$ dotnet run -lp https
```

#25770