### PR TITLE
Add support for specifying launch profile to `dotnet watch run`

### DIFF
--- a/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.Watcher
     internal class CommandLineOptions
     {
         public string Project { get; set; }
+        public string LaunchProfile { get; set; }
         public bool Quiet { get; set; }
         public bool Verbose { get; set; }
         public bool List { get; set; }

--- a/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public BrowserRefreshServer? BrowserRefreshServer { get; set; }
 
-        public LaunchSettingsProfile DefaultLaunchSettingsProfile { get; init; } = default!;
+        public LaunchSettingsProfile LaunchSettingsProfile { get; init; } = default!;
 
         public ProjectGraph? ProjectGraph { get; set; }
     }

--- a/src/BuiltInTools/dotnet-watch/Filters/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/LaunchBrowserFilter.cs
@@ -151,13 +151,13 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return false;
             }
 
-            if (context.DefaultLaunchSettingsProfile is not { LaunchBrowser: true })
+            if (context.LaunchSettingsProfile is not { LaunchBrowser: true })
             {
                 reporter.Verbose("launchSettings does not allow launching browsers.");
                 return false;
             }
 
-            launchUrl = context.DefaultLaunchSettingsProfile.LaunchUrl;
+            launchUrl = context.LaunchSettingsProfile.LaunchUrl;
             return true;
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -300,9 +300,9 @@ namespace Microsoft.DotNet.Watcher
                 processSpec.WorkingDirectory = project.RunWorkingDirectory;
             }
 
-            if (!string.IsNullOrEmpty(context.DefaultLaunchSettingsProfile.ApplicationUrl))
+            if (!string.IsNullOrEmpty(context.LaunchSettingsProfile.ApplicationUrl))
             {
-                processSpec.EnvironmentVariables["ASPNETCORE_URLS"] = context.DefaultLaunchSettingsProfile.ApplicationUrl;
+                processSpec.EnvironmentVariables["ASPNETCORE_URLS"] = context.LaunchSettingsProfile.ApplicationUrl;
             }
 
             var rootVariableName = Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)";
@@ -311,7 +311,7 @@ namespace Microsoft.DotNet.Watcher
                 processSpec.EnvironmentVariables[rootVariableName] = Path.GetDirectoryName(DotnetMuxer.MuxerPath);
             }
 
-            if (context.DefaultLaunchSettingsProfile.EnvironmentVariables is IDictionary<string, string> envVariables)
+            if (context.LaunchSettingsProfile.EnvironmentVariables is IDictionary<string, string> envVariables)
             {
                 foreach (var entry in envVariables)
                 {

--- a/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             }
 
             // Load the specified launch profile
-            var namedProfile = launchSettings?.Profiles?.FirstOrDefault(f => string.Equals(f.Key , launchProfileName, StringComparison.OrdinalIgnoreCase)).Value;
+            var namedProfile = launchSettings?.Profiles?.FirstOrDefault(f => string.Equals(f.Key , launchProfileName, StringComparison.Ordinal)).Value;
 
             if (namedProfile is null)
             {

--- a/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
@@ -18,8 +18,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public string? CommandName { get; set; }
 
-        // TODO: Add support for commandLineArgs defined in the launch profile
-
         public bool LaunchBrowser { get; set; }
 
         public string? LaunchUrl { get; set; }
@@ -54,15 +52,26 @@ namespace Microsoft.DotNet.Watcher.Tools
             }
 
             // Load the specified launch profile
-            var namedProfile = launchSettings?.Profiles?.FirstOrDefault(f => string.Equals(f.Key , launchProfileName, StringComparison.Ordinal)).Value;
+            var namedProfile = launchSettings?.Profiles?.FirstOrDefault(kvp =>
+                string.Equals(kvp.Key, launchProfileName, StringComparison.Ordinal)).Value;
 
             if (namedProfile is null)
             {
                 reporter.Warn($"Unable to find launch profile with name '{launchProfileName}'. Falling back to default profile.");
 
+                // Check if a case-insensitive match exists
+                var caseInsensitiveNamedProfile = launchSettings?.Profiles?.FirstOrDefault(kvp =>
+                    string.Equals(kvp.Key, launchProfileName, StringComparison.OrdinalIgnoreCase)).Key;
+
+                if (caseInsensitiveNamedProfile is not null)
+                {
+                    reporter.Warn($"Note: Launch profile names are case-sensitive. Did you mean '{caseInsensitiveNamedProfile}'?");
+                }
+
                 return ReadDefaultLaunchProfile(launchSettings, reporter);
             }
 
+            reporter.Verbose($"Found named launch profile '{launchProfileName}'.");
             return namedProfile;
         }
 

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -136,20 +136,17 @@ Examples:
                 }
             });
 
-            var listOption = new Option<bool>(
-                "--list",
-                "Lists all discovered files without starting the watcher");
-
-            var shortProjectOption = new Option<string>("-p", "The project to watch") { IsHidden = true };
+            var listOption = new Option<bool>("--list", "Lists all discovered files without starting the watcher.");
+            var shortProjectOption = new Option<string>("-p", "The project to watch.") { IsHidden = true };
             var longProjectOption = new Option<string>("--project","The project to watch");
-            var noHotReloadOption = new Option<bool>(
-                new[] { "--no-hot-reload" },
-                "Suppress hot reload for supported apps.");
+            var launchProfileOption = new Option<string>(new[] { "-lp", "--launch-profile" }, "The launch profile to start the project with. " +
+                "This option is only supported when running 'dotnet watch' or 'dotnet watch run'.");
+            var noHotReloadOption = new Option<bool>("--no-hot-reload", "Suppress hot reload for supported apps.");
             var nonInteractiveOption = new Option<bool>(
-                new[] { "--non-interactive" },
-                "Runs dotnet-watch in non-interative mode. This option is only supported when running with Hot Reload enabled. " +
+                "--non-interactive",
+                "Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled. " +
                 "Use this option to prevent console input from being captured.");
-            var forwardedArguments = new Argument<string[]>("forwardedArgs", "Arguments to pass to the child dotnet process");
+            var forwardedArguments = new Argument<string[]>("forwardedArgs", "Arguments to pass to the child dotnet process.");
 
             var root = new RootCommand(Description)
             {
@@ -159,11 +156,12 @@ Examples:
                  nonInteractiveOption,
                  longProjectOption,
                  shortProjectOption,
+                 launchProfileOption,
                  listOption,
                  forwardedArguments
             };
 
-            var binder = new CommandLineOptionsBinder(longProjectOption, shortProjectOption, quiet, listOption, noHotReloadOption, nonInteractiveOption, verbose, forwardedArguments, reporter);
+            var binder = new CommandLineOptionsBinder(longProjectOption, shortProjectOption, launchProfileOption, quiet, listOption, noHotReloadOption, nonInteractiveOption, verbose, forwardedArguments, reporter);
             root.SetHandler((CommandLineOptions options) => handler(options), binder);
             return root;
         }
@@ -271,14 +269,14 @@ Examples:
                 _reporter.Output("Polling file watcher is enabled");
             }
 
-            var defaultProfile = LaunchSettingsProfile.ReadDefaultProfile(processInfo.WorkingDirectory, _reporter) ?? new();
+            var launchProfile = LaunchSettingsProfile.ReadLaunchProfile(processInfo.WorkingDirectory, options.LaunchProfile, _reporter) ?? new();
 
             var context = new DotNetWatchContext
             {
                 ProcessSpec = processInfo,
                 Reporter = _reporter,
                 SuppressMSBuildIncrementalism = watchOptions.SuppressMSBuildIncrementalism,
-                DefaultLaunchSettingsProfile = defaultProfile,
+                LaunchSettingsProfile = launchProfile,
             };
 
             context.ProjectGraph = TryReadProject(projectFile);
@@ -410,7 +408,7 @@ Examples:
                 if (assembly.Name is "Microsoft.CodeAnalysis" or "Microsoft.CodeAnalysis.CSharp")
                 {
                     var loadedAssembly = context.LoadFromAssemblyPath(Path.Combine(roslynPath, assembly.Name + ".dll"));
-                    // Avoid scenarioes where the assembly in rosylnPath is older than what we expect
+                    // Avoid scenarios where the assembly in rosylnPath is older than what we expect
                     if (loadedAssembly.GetName().Version < assembly.Version)
                     {
                         throw new Exception($"Found a version of {assembly.Name} that was lower than the target version of {assembly.Version}");
@@ -424,6 +422,7 @@ Examples:
         {
             private readonly Option<string> _longProjectOption;
             private readonly Option<string> _shortProjectOption;
+            private readonly Option<string> _launchProfileOption;
             private readonly Option<bool> _quietOption;
             private readonly Option<bool> _listOption;
             private readonly Option<bool> _noHotReloadOption;
@@ -436,6 +435,7 @@ Examples:
             internal CommandLineOptionsBinder(
                 Option<string> longProjectOption,
                 Option<string> shortProjectOption,
+                Option<string> launchProfileOption,
                 Option<bool> quietOption,
                 Option<bool> listOption,
                 Option<bool> noHotReloadOption,
@@ -446,6 +446,7 @@ Examples:
             {
                 _longProjectOption = longProjectOption;
                 _shortProjectOption = shortProjectOption;
+                _launchProfileOption = launchProfileOption;
                 _quietOption = quietOption;
                 _listOption = listOption;
                 _noHotReloadOption = noHotReloadOption;
@@ -479,6 +480,7 @@ Examples:
                     NonInteractive = parseResults.GetValueForOption(_nonInteractiveOption),
                     Verbose = parseResults.GetValueForOption(_verboseOption),
                     Project = projectValue,
+                    LaunchProfile = parseResults.GetValueForOption(_launchProfileOption),
                     RemainingArguments = parseResults.GetValueForArgument(_argumentsToForward),
                 };
                 return options;

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -139,7 +139,7 @@ Examples:
             var listOption = new Option<bool>("--list", "Lists all discovered files without starting the watcher.");
             var shortProjectOption = new Option<string>("-p", "The project to watch.") { IsHidden = true };
             var longProjectOption = new Option<string>("--project","The project to watch");
-            var launchProfileOption = new Option<string>(new[] { "-lp", "--launch-profile" }, "The launch profile to start the project with. " +
+            var launchProfileOption = new Option<string>(new[] { "-lp", "--launch-profile" }, "The launch profile to start the project with (case-sensitive). " +
                 "This option is only supported when running 'dotnet watch' or 'dotnet watch run'.");
             var noHotReloadOption = new Option<bool>("--no-hot-reload", "Suppress hot reload for supported apps.");
             var nonInteractiveOption = new Option<bool>(

--- a/src/BuiltInTools/dotnet-watch/README.md
+++ b/src/BuiltInTools/dotnet-watch/README.md
@@ -9,9 +9,15 @@ The command must be executed in the directory that contains the project to be wa
     Usage: dotnet watch [options] [[--] <args>...]
 
     Options:
-      -?|-h|--help  Show help information
-      -q|--quiet    Suppresses all output except warnings and errors
-      -v|--verbose  Show verbose output
+      -q, --quiet                             Suppresses all output except warnings and errors
+      -v, --verbose                           Show verbose output
+      --no-hot-reload                         Suppress hot reload for supported apps.
+      --non-interactive                       Runs dotnet-watch in non-interactive mode. This option is only supported when running with
+                                              Hot Reload enabled. Use this option to prevent console input from being captured.
+      --project <project>                     The project to watch
+      -lp, --launch-profile <launch-profile>  The launch profile to start the project with. This option is only supported when running
+                                              'dotnet watch' or 'dotnet watch run'.
+      --list                                  Lists all discovered files without starting the watcher.
 
 Add `watch` after `dotnet` and before the command arguments that you want to run:
 

--- a/src/Tests/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/src/Tests/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -97,5 +97,33 @@ namespace Microsoft.DotNet.Watcher.Tools
             Assert.NotNull(options);
             Assert.Equal("MyProject.csproj", options.Project);
         }
+
+        [Fact]
+        public async Task LongFormForLaunchProfileArgumentWorks()
+        {
+            var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
+            CommandLineOptions options = null;
+            var rootCommand = Program.CreateRootCommand(c => { options = c; return Task.FromResult(0); }, reporter.Object);
+
+            await rootCommand.InvokeAsync(new[] { "--launch-profile", "CustomLaunchProfile" }, _console);
+
+            reporter.Verify(r => r.Warn(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            Assert.NotNull(options);
+            Assert.Equal("CustomLaunchProfile", options.LaunchProfile);
+        }
+
+        [Fact]
+        public async Task ShortFormForLaunchProfileArgumentWorks()
+        {
+            var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
+            CommandLineOptions options = null;
+            var rootCommand = Program.CreateRootCommand(c => { options = c; return Task.FromResult(0); }, reporter.Object);
+
+            await rootCommand.InvokeAsync(new[] { "-lp", "CustomLaunchProfile" }, _console);
+
+            reporter.Verify(r => r.Warn(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            Assert.NotNull(options);
+            Assert.Equal("CustomLaunchProfile", options.LaunchProfile);
+        }
     }
 }


### PR DESCRIPTION
Fixes dotnet/aspnetcore#41988

As part of [[EPIC] Revisiting HTTPS defaults in ASP.NET Core](https://github.com/dotnet/aspnetcore/issues/41990)

ASP.NET Core projects are being updated to have multiple launch profiles by default. As such, we'd like it to be easier to select a launch profile when running the project using `dotnet watch`/`dotnet watch run`.

Add support for `-lp` as an option alias for `--launch-profile`, e.g.:

```
$ dotnet watch -lp https
```

or

```
$ dotnet watch --launch-profile https
```

Matching issue for `dotnet run`: dotnet/sdk#25770