### PR TITLE
Ensure the Razor generator doesn't generate when it's suppressed

### DIFF
--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
@@ -2263,7 +2263,7 @@ namespace AspNetCoreGeneratedDocument
         }
 
         [Fact]
-        public async Task SourceGenerator_DoesNotUpdateSources_WhenSourceGeneratorIsSuppressed()
+        public async Task SourceGenerator_DoesNotOutput_WhenSourceGeneratorIsSuppressed()
         {
             // Regression test for https://github.com/dotnet/aspnetcore/issues/36227
             var project = CreateTestProject(new()
@@ -2332,9 +2332,10 @@ namespace MyApp.Pages
             suppressedOptions.TestGlobalOptions["build_property.SuppressRazorSourceGenerator"] = "true";
             driver = driver.WithUpdatedAnalyzerConfigOptions(suppressedOptions);
 
-            // results should be the same (even though we changed text)
-            result = RunGenerator(compilation!, ref driver)
-                    .VerifyOutputsMatch(result);
+            // we should no longer be outputting anything
+            var suppressedResult = RunGenerator(compilation!, ref driver);
+            Assert.Empty(suppressedResult.GeneratedSources);
+            Assert.Empty(suppressedResult.Diagnostics);
 
             // now unsuppress and re-run
             driver = driver.WithUpdatedAnalyzerConfigOptions(optionsProvider);


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/24928 made a change to the Razor generator to ensure that even if the generator is suppressed, it's still going to run and cache its outputs so later runs aren't a from-scratch run on a performance-critical path. However, a bug meant that if the generator was suppressed, it'd still run the first time it's invoked, and will still output files even though it was supposed to be suppressed.

The approach taken here is to suppress the addition of the files, but at the very end of the chain only -- the generation and walking in the middle of the incremental chain is left untouched, so that still has the existing caching behavior.

This fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1545938 but we're still considering https://github.com/dotnet/roslyn/pull/61675 as a tactical fix instead.