### PR TITLE
Switch NuGet assets for tests as tools to be under the test execution…

### DIFF
--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -169,9 +169,9 @@ namespace Microsoft.NET.TestFramework
             }
             else if (runAsTool)
             {
-                testContext.NuGetFallbackFolder = Path.Combine(testContext.TestAssetsDirectory, ".nuget", "NuGetFallbackFolder");
-                testContext.NuGetExePath = Path.Combine(testContext.TestAssetsDirectory, ".nuget", $"nuget{Constants.ExeSuffix}");
-                testContext.NuGetCachePath = Path.Combine(testContext.TestAssetsDirectory, ".nuget", "packages");
+                testContext.NuGetFallbackFolder = Path.Combine(testContext.TestExecutionDirectory, ".nuget", "NuGetFallbackFolder");
+                testContext.NuGetExePath = Path.Combine(testContext.TestExecutionDirectory, ".nuget", $"nuget{Constants.ExeSuffix}");
+                testContext.NuGetCachePath = Path.Combine(testContext.TestExecutionDirectory, ".nuget", "packages");
 
                 var testPackages = Path.Combine(testContext.TestExecutionDirectory, "Testpackages");
                 if (Directory.Exists(testPackages))


### PR DESCRIPTION
… directory.


This will help avoid long path issues.