### PR TITLE
Update Roslyn version to 4.3.0-2.22302.14

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -84,30 +84,30 @@
       <Sha>07c1c0c6117427ebb9f5ab93d501513491db9e8a</Sha>
       <SourceBuildTarball RepoName="format" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.3.0-3.22305.2">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.3.0-2.22302.14">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>74ac6e8cb2d38cb5954a30ac0b59a7e02ebc8b4a</Sha>
+      <Sha>0c2fb6c0e941a32b519da371bc4b253d6cfad375</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis" Version="4.3.0-3.22305.2">
+    <Dependency Name="Microsoft.CodeAnalysis" Version="4.3.0-2.22302.14">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>74ac6e8cb2d38cb5954a30ac0b59a7e02ebc8b4a</Sha>
+      <Sha>0c2fb6c0e941a32b519da371bc4b253d6cfad375</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.3.0-3.22305.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.3.0-2.22302.14">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>74ac6e8cb2d38cb5954a30ac0b59a7e02ebc8b4a</Sha>
+      <Sha>0c2fb6c0e941a32b519da371bc4b253d6cfad375</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.3.0-3.22305.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.3.0-2.22302.14">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>74ac6e8cb2d38cb5954a30ac0b59a7e02ebc8b4a</Sha>
+      <Sha>0c2fb6c0e941a32b519da371bc4b253d6cfad375</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0-3.22305.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0-2.22302.14">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>74ac6e8cb2d38cb5954a30ac0b59a7e02ebc8b4a</Sha>
+      <Sha>0c2fb6c0e941a32b519da371bc4b253d6cfad375</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.3.0-3.22305.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.3.0-2.22302.14">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>74ac6e8cb2d38cb5954a30ac0b59a7e02ebc8b4a</Sha>
+      <Sha>0c2fb6c0e941a32b519da371bc4b253d6cfad375</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="7.0.0-preview.5.22303.8">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -128,12 +128,12 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.3.0-3.22305.2</MicrosoftNetCompilersToolsetPackageVersion>
-    <MicrosoftCodeAnalysisPackageVersion>4.3.0-3.22305.2</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.3.0-3.22305.2</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.3.0-3.22305.2</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.3.0-3.22305.2</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.3.0-3.22305.2</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.3.0-2.22302.14</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftCodeAnalysisPackageVersion>4.3.0-2.22302.14</MicrosoftCodeAnalysisPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.3.0-2.22302.14</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.3.0-2.22302.14</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.3.0-2.22302.14</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.3.0-2.22302.14</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Due to a darc configuration issue, Roslyn published validation builds to the VS 17.3 channel. This moves Roslyn to an official build from release/dev17.3 instead of a validation build of main.