### PR TITLE
Fix Description for Pre-Release Reinstallation Updates

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-tool/update/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/LocalizableStrings.resx
@@ -182,7 +182,10 @@ from the tool name you use when calling the tool. You can find the tool names
 and the corresponding package Ids for installed tools using the command
 'dotnet tool list'.</value>
   </data>
-  <data name="UpdateSucceededVersionNoChange" xml:space="preserve">
+  <data name="UpdateSucceededPreVersionNoChange" xml:space="preserve">
+    <value>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</value>
+  </data>
+  <data name="UpdateSucceededStableVersionNoChange" xml:space="preserve">
     <value>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</value>
   </data>
   <data name="UpdateToolFailed" xml:space="preserve">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
@@ -260,7 +260,6 @@ namespace Microsoft.DotNet.Tools.Tool.Update
             }
             else
             {
-                
                 _reporter.WriteLine(
                     string.Format(
                         (

--- a/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
@@ -260,9 +260,13 @@ namespace Microsoft.DotNet.Tools.Tool.Update
             }
             else
             {
+                
                 _reporter.WriteLine(
                     string.Format(
-                        LocalizableStrings.UpdateSucceededVersionNoChange,
+                        (
+                        newInstalledPackage.Version.IsPrerelease ? 
+                        LocalizableStrings.UpdateSucceededPreVersionNoChange : LocalizableStrings.UpdateSucceededStableVersionNoChange
+                        ),
                         newInstalledPackage.Id, newInstalledPackage.Version).Green());
             }
         }

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.cs.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Nástroj {0} byl úspěšně aktualizován z verze {1} na verzi {2} (soubor manifestu {3}).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">Požadovaná verze {0} je nižší než stávající verze {1}.</target>
@@ -130,11 +140,6 @@ Nástroje se aktualizují pomocí svého ID balíčku, které se může lišit
 od názvu nástroje, který používáte při volání nástroje. Názvy nástrojů 
 a odpovídající ID balíčků nainstalovaných nástrojů najdete pomocí
 příkazu 'dotnet tool list'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">Nástroj {0} byl přeinstalován nejnovější stabilní verzí (verze {1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.de.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Das Tool "{0}" wurde erfolgreich von Version {1} auf Version {2} aktualisiert (Manifestdatei "{3}").</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">Die angeforderte Version {0} ist niedriger als die vorhandene Version {1}.</target>
@@ -130,11 +140,6 @@ Tools werden unter Verwendung der zugehörigen Paket-ID aktualisiert. Diese unte
 vom Toolnamen, den Sie zum Aufrufen des Tools verwenden. Sie können die Toolnamen 
 und die zugehörigen Paket-IDs für installierte Tools über den Befehl
 "dotnet tool list" abrufen.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">Das Tool "{0}" wurde in der neuesten stabilen Version neu installiert (Version {1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.es.xlf
@@ -52,6 +52,16 @@
         <target state="translated">La herramienta "{0}" se actualizó correctamente de la versión "{1}" a la versión "{2}" (archivo de manifiesto {3}).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">La versión solicitada {0} es inferior a la versión existente {1}.</target>
@@ -130,11 +140,6 @@ Para actualizar las herramientas se usa su identificador de paquete, que puede s
 del nombre de herramienta que se usa al llamarla. Para buscar los nombres de herramientas 
 y los identificadores de paquete correspondientes de las herramientas instaladas, use el comando
 "dotnet tool list".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">La herramienta "{0}" se reinstaló con la versión estable más reciente (versión "{1}").</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.fr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">L'outil '{0}' a été correctement mis à jour de la version '{1}' à la version '{2}' (fichier manifeste {3}).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">La version demandée {0} est inférieure à la version existante {1}.</target>
@@ -130,11 +140,6 @@ Les outils sont mis à jour via leur ID de package, lequel peut être différent
 du nom d'outil que vous utilisez quand vous appelez ce dernier. Pour trouver les noms d'outils 
 et les ID de package correspondants aux outils installés, utilisez la commande
 'dotnet tool list'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">L'outil '{0}' a été réinstallé avec la dernière version stable (version '{1}').</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.it.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Lo strumento '{0}' è stato aggiornato dalla versione '{1}' alla versione '{2}' (file manifesto {3}).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">La versione richiesta {0} è inferiore a quella esistente {1}.</target>
@@ -130,11 +140,6 @@ Per aggiornare gli strumenti, si usa il relativo ID pacchetto che potrebbe
 essere diverso dal nome dello strumento usato quando si chiama lo strumento.
 Per trovare i nomi degli strumenti e gli ID pacchetto corrispondente 
 per gli strumenti installati, usare il comando 'dotnet tool list'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">Lo strumento '{0}' è stato reinstallato con l'ultima versione stabile (versione '{1}').</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ja.xlf
@@ -52,6 +52,16 @@
         <target state="translated">ツール '{0}' がバージョン '{1}' からバージョン '{2}' (マニフェストファイル {3}) に正常に更新されました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">要求されたバージョン {0} は、既存のバージョン {1} を下回っています。</target>
@@ -130,11 +140,6 @@ and the corresponding package Ids for installed tools using the command
 ツールを呼び出すときに使用するツール名。ツール名が見つかります
 と、コマンドを使用してインストールされたツールの対応するパッケージ Id
 ' dotnet tool list '。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">ツール '{0}' が安定した最新バージョン (バージョン '{1}') で再インストールされました。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ko.xlf
@@ -52,6 +52,16 @@
         <target state="translated">'{0}' 도구가 '{1}' 버전에서 '{2}' 버전(매니페스트 파일 {3})으로 업데이트되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">요청된 버전 {0}이(가) 기존 버전 {1}보다 낮습니다.</target>
@@ -130,11 +140,6 @@ and the corresponding package Ids for installed tools using the command
 도구가 업데이트되었습니다. 'dotnet tool list' 명령을 사용하여 설치된 도구의 
 도구 이름 및 해당 패키지 ID를
 확인할 수 있습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">'{0}' 도구가 안정적인 최신 버전('{1}' 버전)으로 다시 설치되었습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pl.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Narzędzie „{0}” zostało pomyślnie zaktualizowane z wersji „{1}” do wersji „{2}” (plik manifestu {3}).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">Żądana wersja {0} jest niższa niż istniejąca wersja {1}.</target>
@@ -130,11 +140,6 @@ Narzędzia są aktualizowane przy użyciu ich identyfikatora pakietu, który mo�
 niż nazwa narzędzia używana podczas wywoływania narzędzia. Nazwy narzędzi 
 i odpowiednie identyfikatory pakietów zainstalowanych narzędzi można znaleźć przy użyciu polecenia
 „dotnet tool list”.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">Narzędzie „{0}” zostało ponownie zainstalowane przy użyciu najnowszej stabilnej wersji (wersja „{1}”).</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -52,6 +52,16 @@
         <target state="translated">A ferramenta '{0}' foi atualizada com êxito da versão '{1}' para a versão '{2}' (arquivo de manifesto {3}).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">A versão solicitada {0} é inferior à versão existente {1}.</target>
@@ -130,11 +140,6 @@ As ferramentas são atualizadas usando a ID do pacote, o que pode ser diferente
 do nome da ferramenta que você usa ao chamar a ferramenta. Você pode encontrar os nomes das ferramentas 
 e as Ids de pacote correspondentes para as ferramentas instaladas usando o comando
 'lista de ferramentas do dotnet'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">A ferramenta '{0}' foi reinstalada com a versão estável mais recente (versão '{1}').</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ru.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Средство "{0}" обновлено с версии "{1}" до версии "{2}" (файл манифеста {3}).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">Запрошенная версия {0} ниже существующей версии {1}.</target>
@@ -130,11 +140,6 @@ and the corresponding package Ids for installed tools using the command
 от имени средства, используемого при его вызове. Имена средств 
 и соответствующие идентификаторы пакетов для установленных средств можно найти с помощью команды
 "dotnet tool list".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">Инструмент "{0}" был переустановлен с последней стабильной версией (версией "{1}").</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.tr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">'{0}' aracı, '{1}' sürümünden '{2}' (bildirim dosyası {3}) sürümüne başarıyla güncelleştirildi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">İstenen sürümü ({0}) mevcut sürümünden ({1}) düşük.</target>
@@ -130,11 +140,6 @@ Araçlar, aracı çağırırken kullandığınız araç adından farklı olabile
 paket kimlikleri kullanılarak güncelleştirilir. Yüklü araçların araç adlarını ve 
 karşılık gelen paket kimliklerini bulmak için 
 'dotnet tool list' komutunu kullanabilirsiniz.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">'{0}' aracı, en son kararlı sürüm (sürüm '{1}') ile yeniden yüklendi.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -52,6 +52,16 @@
         <target state="translated">工具“{0}”已成功从版本“{1}”更新到版本“{2}”(清单文件 {3})。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">请求的版本 {0} 低于现有版本 {1}。</target>
@@ -130,11 +140,6 @@ and the corresponding package Ids for installed tools using the command
 与调用工具时使用的工具名称不同。可使用 "dotnet tool list" 命令查找
 已安装工具的工具名称和
 对应的包 ID。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">工具“{0}”已重新安装最新稳定版本(版本“{1}”)。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -52,6 +52,16 @@
         <target state="translated">已成功將工具 '{0}' 從 '{1}' 版更新為 '{2}' 版 (資訊清單檔 {3})。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateSucceededPreVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest prerelease version (version '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateSucceededStableVersionNoChange">
+        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
+        <target state="new">Tool '{0}' was reinstalled with the latest stable version (version '{1}').</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UpdateToLowerVersion">
         <source>The requested version {0} is lower than existing version {1}.</source>
         <target state="translated">要求的版本 {0} 低於現有版本 {1}。</target>
@@ -130,11 +140,6 @@ and the corresponding package Ids for installed tools using the command
 而該識別碼可能與您在呼叫工具時的工具名稱不同。您可以使用命令
 'dotnet tool list' 來針對已安裝工具尋找工具名稱
 和對應的套件識別碼。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpdateSucceededVersionNoChange">
-        <source>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</source>
-        <target state="translated">已使用最新穩定版本 ('{1}' 版) 來重新安裝工具 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateToolFailed">

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         private const string LowerPackageVersion = "1.0.4";
         private const string HigherPackageVersion = "1.0.5";
         private const string HigherPreviewPackageVersion = "1.0.5-preview3";
+        private const string HighestPreviewPackageVersion = "1.0.6-preview3";
         private readonly string _shimsDirectory;
         private readonly string _toolsDirectory;
 
@@ -69,6 +70,12 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                         {
                             PackageId = _packageId.ToString(),
                             Version = HigherPreviewPackageVersion,
+                            ToolCommandName = "SimulatorCommand"
+                        },
+                        new MockFeedPackage
+                        {
+                            PackageId = _packageId.ToString(),
+                            Version = HighestPreviewPackageVersion,
                             ToolCommandName = "SimulatorCommand"
                         }
                     }
@@ -221,10 +228,25 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             var command = CreateUpdateCommand($"-g {_packageId}");
 
             command.Execute();
+            
+            _reporter.Lines.First().Should().Contain(string.Format(
+                LocalizableStrings.UpdateSucceededStableVersionNoChange,
+                _packageId, HigherPackageVersion));
+        }
+
+        [Fact]
+        public void GivenAnExistedSameVersionInstallationWhenCallWithPrereleaseItUsesAPrereleaseSuccessMessage()
+        {
+            CreateInstallCommand($"-g {_packageId} --version {HighestPreviewPackageVersion}").Execute();
+            _reporter.Lines.Clear();
+
+            var command = CreateUpdateCommand($"-g {_packageId} --version {HighestPreviewPackageVersion}");
+
+            command.Execute();
 
             _reporter.Lines.First().Should().Contain(string.Format(
-                LocalizableStrings.UpdateSucceededVersionNoChange,
-                _packageId, HigherPackageVersion));
+                LocalizableStrings.UpdateSucceededPreVersionNoChange,
+                _packageId, HighestPreviewPackageVersion));
         }
 
         [Fact]

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                             PackageId = _packageId.ToString(),
                             Version = HigherPreviewPackageVersion,
                             ToolCommandName = "SimulatorCommand"
-                        },
+                        }
                     }
                 }
             };

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         private const string LowerPackageVersion = "1.0.4";
         private const string HigherPackageVersion = "1.0.5";
         private const string HigherPreviewPackageVersion = "1.0.5-preview3";
-        private const string HighestPreviewPackageVersion = "1.0.6-preview3";
         private readonly string _shimsDirectory;
         private readonly string _toolsDirectory;
 
@@ -72,12 +71,6 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                             Version = HigherPreviewPackageVersion,
                             ToolCommandName = "SimulatorCommand"
                         },
-                        new MockFeedPackage
-                        {
-                            PackageId = _packageId.ToString(),
-                            Version = HighestPreviewPackageVersion,
-                            ToolCommandName = "SimulatorCommand"
-                        }
                     }
                 }
             };
@@ -237,16 +230,16 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         [Fact]
         public void GivenAnExistedSameVersionInstallationWhenCallWithPrereleaseItUsesAPrereleaseSuccessMessage()
         {
-            CreateInstallCommand($"-g {_packageId} --version {HighestPreviewPackageVersion}").Execute();
+            CreateInstallCommand($"-g {_packageId} --version {HigherPreviewPackageVersion}").Execute();
             _reporter.Lines.Clear();
 
-            var command = CreateUpdateCommand($"-g {_packageId} --version {HighestPreviewPackageVersion}");
+            var command = CreateUpdateCommand($"-g {_packageId} --version {HigherPreviewPackageVersion}");
 
             command.Execute();
 
             _reporter.Lines.First().Should().Contain(string.Format(
                 LocalizableStrings.UpdateSucceededPreVersionNoChange,
-                _packageId, HighestPreviewPackageVersion));
+                _packageId, HigherPreviewPackageVersion));
         }
 
         [Fact]


### PR DESCRIPTION
References https://github.com/dotnet/sdk/issues/25486#event-6754430549 and adds a regression test and new string to include stable or prerelease accurately. Note that I didn't use a flagged token because translators need to be able to change the structure of the sentence, so I created two separate strings. 