### PR TITLE
Explain the Purpose of Dogfood in The Dev Guide

### DIFF
--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -65,7 +65,14 @@ Run the following command from the root of the repository to run all the .NET Co
 
 The `dotnet` executable in the artifacts directory can be run directly.
 
-However, it's easier to configure a test environment to run the built `dotnet`.
+However, it's easier to configure a test environment to run the built `dotnet`. This test environment is managed by dogfood. 
+The dogfood script starts a new Powershell with the environment configured to redirect SDK resolution to your build.
+
+From that shell your SDK will be available in:
+
+- any Visual Studio instance launched (via `& devenv.exe`)
+- `dotnet build`
+- `msbuild`
 
 ### Windows
 


### PR DESCRIPTION
I was initially confused because I did not read the main page when trying to initially build the SDK. This provides context for new developers as to why they are running dogfood and would've saved a lot of time for @joeloff (asking him about my initial confusions) and me if it were initially included.