### PR TITLE
fix(cli): handle sln folders in workload restore command

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Restore
             foreach (string file in slnFiles)
             {
                 var solutionFile = SolutionFile.Parse(file);
-                var projects = solutionFile.ProjectsInOrder;
+                var projects = solutionFile.ProjectsInOrder.Where(p => p.ProjectType != SolutionProjectType.SolutionFolder);
                 foreach (var p in projects)
                 {
                     projectFiles.Add(p.AbsolutePath);

--- a/src/Tests/dotnet-workload-restore.Tests/DiscoverAllProjectsTests.cs
+++ b/src/Tests/dotnet-workload-restore.Tests/DiscoverAllProjectsTests.cs
@@ -69,5 +69,25 @@ namespace Microsoft.DotNet.Cli.Workload.Restore.Tests
             result.Should().Contain(f => Path.GetFileName(f) == "First.csproj");
             result.Should().Contain(f => Path.GetFileName(f) == "Second.csproj");
         }
+
+        [Fact]
+        public void WhenCallWithSlnContainingSolutionFolderItExcludesFolderProjectsFromSolution()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndSolutionFolders")
+                .WithSource()
+                .Path;
+
+            var result =
+                WorkloadRestoreCommand.DiscoverAllProjects("",
+                    new[]
+                    {
+                        Path.Combine(projectDirectory, "App.sln"),
+                    });
+
+            // 'src' solution folder is filtered out
+            result.Should().Contain(f => Path.GetFileName(f) == "App.csproj", "from checking the sln file");
+            result.Count.Should().Be(1);
+        }
     }
 }


### PR DESCRIPTION
Fixes #25592 

Was in the process of reporting the issue when I realized others have encountered this as well. It seems to me that the best solution to this is to simply exclude SolutionFolders when trying to identify workloads to be restored; solution folders won't add any workloads, and any standard project targets that reside within a sln folder will still be discovered