### PR TITLE
Update the default to Release for Pack/Pub in command building

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-pack/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-pack/LocalizableStrings.resx
@@ -148,7 +148,7 @@
     <value>The project to pack, defaults to the project file in the current directory. Can be a path to any project file</value>
   </data>
   <data name="ConfigurationOptionDescription" xml:space="preserve">
-    <value>The configuration to use for building the package. The default for most projects is 'Debug'.</value>
+    <value>The configuration to use for building the package.</value>
   </data>
   <data name="CmdNoLogo" xml:space="preserve">
     <value>Do not display the startup banner or the copyright message.</value>

--- a/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -56,6 +56,8 @@ namespace Microsoft.DotNet.Cli
         {
             var command = new DocumentedCommand("pack", DocsLink, LocalizableStrings.AppFullName);
 
+            ConfigurationOption.SetDefaultValue("Release");
+
             command.AddArgument(SlnOrProjectArgument);
             command.AddOption(OutputOption);
             command.AddOption(NoBuildOption);

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.cs.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">Konfigurace použitá k sestavení balíčku. Výchozí možností pro většinu projektů je Debug.</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">Konfigurace použitá k sestavení balíčku. Výchozí možností pro většinu projektů je Debug.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.de.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">Die für die Paketerstellung zu verwendende Konfiguration. Standard für die meisten Projekte ist "Debug".</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">Die für die Paketerstellung zu verwendende Konfiguration. Standard für die meisten Projekte ist "Debug".</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.es.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">La configuración que se usará para compilar el paquete. El valor predeterminado para la mayoría de los proyectos es "Debug".</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">La configuración que se usará para compilar el paquete. El valor predeterminado para la mayoría de los proyectos es "Debug".</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.fr.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">Configuration à utiliser pour la génération du package. La valeur par défaut pour la plupart des projets est 'Debug'.</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">Configuration à utiliser pour la génération du package. La valeur par défaut pour la plupart des projets est 'Debug'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.it.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">Configurazione da usare per compilare il pacchetto. L'impostazione predefinita per la maggior parte dei progetti è 'Debug'.</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">Configurazione da usare per compilare il pacchetto. L'impostazione predefinita per la maggior parte dei progetti è 'Debug'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ja.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">パッケージのビルドに使用する構成。ほとんどのプロジェクトで既定は 'Debug' です。</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">パッケージのビルドに使用する構成。ほとんどのプロジェクトで既定は 'Debug' です。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ko.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">패키지 빌드에 사용할 구성입니다. 대부분의 프로젝트에서 기본값은 'Debug'입니다.</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">패키지 빌드에 사용할 구성입니다. 대부분의 프로젝트에서 기본값은 'Debug'입니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pl.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">Konfiguracja do użycia na potrzeby kompilacji pakietu. W przypadku większości projektów ustawienie domyślne to „Debugowanie”.</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">Konfiguracja do użycia na potrzeby kompilacji pakietu. W przypadku większości projektów ustawienie domyślne to „Debugowanie”.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pt-BR.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">A configuração a ser usada para compilar o pacote. O padrão para a maioria dos projetos é 'Debug'.</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">A configuração a ser usada para compilar o pacote. O padrão para a maioria dos projetos é 'Debug'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ru.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">Конфигурация, используемая для сборки пакета. По умолчанию для большинства проектов используется "Debug".</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">Конфигурация, используемая для сборки пакета. По умолчанию для большинства проектов используется "Debug".</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.tr.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">Paketi derlemek için kullanılacak yapılandırma. Çoğu proje için varsayılan, ‘Hata Ayıklama’ seçeneğidir.</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">Paketi derlemek için kullanılacak yapılandırma. Çoğu proje için varsayılan, ‘Hata Ayıklama’ seçeneğidir.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hans.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">用于生成包的配置。大多数项目的默认值是 "Debug"。</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">用于生成包的配置。大多数项目的默认值是 "Debug"。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hant.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default for most projects is 'Debug'.</source>
-        <target state="translated">要用於建置套件的組態。大部分的專案預設為「偵錯」。</target>
+        <source>The configuration to use for building the package.</source>
+        <target state="needs-review-translation">要用於建置套件的組態。大部分的專案預設為「偵錯」。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-publish/LocalizableStrings.resx
@@ -146,7 +146,7 @@
 The default is to publish a framework-dependent application.</value>
   </data>
   <data name="ConfigurationOptionDescription" xml:space="preserve">
-    <value>The configuration to publish for. The default for most projects is 'Debug'.</value>
+    <value>The configuration to publish for.</value>
   </data>
   <data name="CmdNoLogo" xml:space="preserve">
     <value>Do not display the startup banner or the copyright message.</value>

--- a/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -62,6 +62,8 @@ namespace Microsoft.DotNet.Cli
         {
             var command = new DocumentedCommand("publish", DocsLink, LocalizableStrings.AppDescription);
 
+            ConfigurationOption.SetDefaultValue("Release");
+
             command.AddArgument(SlnOrProjectArgument);
             RestoreCommandParser.AddImplicitRestoreOptions(command, includeRuntimeOption: false, includeNoDependenciesOption: true);
             command.AddOption(OuputOption);

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.cs.xlf
@@ -55,8 +55,8 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">Konfigurace pro publikování. Výchozí možností pro většinu projektů je Debug.</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">Konfigurace pro publikování. Výchozí možností pro většinu projektů je Debug.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.de.xlf
@@ -55,8 +55,8 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">Die Konfiguration für die Veröffentlichung. Der Standardwert für die meisten Projekte ist "Debug".</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">Die Konfiguration für die Veröffentlichung. Der Standardwert für die meisten Projekte ist "Debug".</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.es.xlf
@@ -55,8 +55,8 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">La configuración para la que se publica. El valor predeterminado para la mayoría de los proyectos es "Debug".</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">La configuración para la que se publica. El valor predeterminado para la mayoría de los proyectos es "Debug".</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.fr.xlf
@@ -55,8 +55,8 @@ La valeur par défaut est de publier une application dépendante du framework.</
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">Configuration pour laquelle la publication est effectuée. La valeur par défaut pour la plupart des projets est 'Debug'.</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">Configuration pour laquelle la publication est effectuée. La valeur par défaut pour la plupart des projets est 'Debug'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.it.xlf
@@ -55,8 +55,8 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">Configurazione per cui eseguire la pubblicazione. L'impostazione predefinita per la maggior parte dei progetti è 'Debug'.</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">Configurazione per cui eseguire la pubblicazione. L'impostazione predefinita per la maggior parte dei progetti è 'Debug'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ja.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">公開する対象の構成。大部分のプロジェクトで、既定値は 'Debug' です。</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">公開する対象の構成。大部分のプロジェクトで、既定値は 'Debug' です。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ko.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">게시할 구성입니다. 대부분의 프로젝트에서 기본값은 'Debug'입니다.</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">게시할 구성입니다. 대부분의 프로젝트에서 기본값은 'Debug'입니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pl.xlf
@@ -55,8 +55,8 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">Konfiguracja, dla której ma być wykonane publikowanie. W przypadku większości projektów ustawienie domyślne to „Debugowanie”.</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">Konfiguracja, dla której ma być wykonane publikowanie. W przypadku większości projektów ustawienie domyślne to „Debugowanie”.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pt-BR.xlf
@@ -55,8 +55,8 @@ O padrão é publicar uma aplicação dependente de framework.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">A configuração para a qual a publicação ocorrerá. O padrão para a maioria dos projetos é 'Debug'.</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">A configuração para a qual a publicação ocorrerá. O padrão para a maioria dos projetos é 'Debug'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ru.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">Конфигурация для публикации. По умолчанию для большинства проектов используется "Debug".</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">Конфигурация для публикации. По умолчанию для большинства проектов используется "Debug".</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.tr.xlf
@@ -55,8 +55,8 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">Yayımlanacak yapılandırma. Çoğu proje için varsayılan, ‘Hata Ayıklama’ seçeneğidir.</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">Yayımlanacak yapılandırma. Çoğu proje için varsayılan, ‘Hata Ayıklama’ seçeneğidir.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hans.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">要发布的配置。大多数项目的默认值是 "Debug"。</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">要发布的配置。大多数项目的默认值是 "Debug"。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hant.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
-        <target state="translated">要為其進行發佈的組態。大部分的專案預設為「偵錯」。</target>
+        <source>The configuration to publish for.</source>
+        <target state="needs-review-translation">要為其進行發佈的組態。大部分的專案預設為「偵錯」。</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fix for https://github.com/dotnet/sdk/issues/23551#issuecomment-1150204351. Drafting until unit tests are added to assure this works. Note that adding a default through System.Commandline adds [Default: Release] to the description and help text. So we are cutting the unnecessary duplicated sentences