### PR TITLE
Support suppressions without a diagnostic id

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Logging/Suppression.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Logging/Suppression.cs
@@ -53,8 +53,14 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         /// the property won't be serialized to keep the baseline file minimal. The method's name is important as
         /// XmlSerializer will look for methods called ShouldSerializeX to determine if properties should be serialized.
         /// </summary>
-        /// <returns>Returns true if IsBaselineSuppression should be serialized</returns>
+        /// <returns>Returns true if IsBaselineSuppression should be serialized.</returns>
         public bool ShouldSerializeIsBaselineSuppression() => IsBaselineSuppression;
+
+        /// <summary>
+        /// Same as the above, this method is used to determine if the DiagnosticId property should be serialized.
+        /// </summary>
+        /// <returns>Returns true if DiagnosticId shoudl be serialized.</returns>
+        public bool ShouldSerializeDiagnosticId() => DiagnosticId != string.Empty;
 
         /// <inheritdoc/>
         public bool Equals(Suppression? other)

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -62,7 +62,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         /// <returns><see langword="true"/> if the error is already suppressed. <see langword="false"/> otherwise.</returns>
         public bool IsErrorSuppressed(Suppression error)
         {
-            // An error is suppressed if
             _readerWriterLock.EnterReadLock();
             try
             {

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;


### PR DESCRIPTION
Fixes [what @joperezr identified as a bug in the suppression engine]( https://github.com/dotnet/sdk/pull/25765#discussion_r889313428).

Any component in the Compatibility tooling that creates/logs a
suppression, needs to provide a suppression id, in order for suppressions
to be uniquely identifyable and suppressable (ie via NoWarn). Therefore
the suppression id is non nullable in the Suppression type.

A customer can provide a suppression file that contains a suppression
without a diagnostic id. When that is being deserialized, a Suppression
object with an empty diagnostic id is created. This change updates the
suppression engine to support this new form of global suppression, for
which only a left and right (+ IsBaselineSuppression) is passed in.

Adding tests that verify that this added global suppression type is
respected and correctly roundtrips.