### PR TITLE
[Static web assets] Fix pack when no assets exist

### DIFF
--- a/src/Assets/TestPackages/PackageLibraryNoStaticAssets/PackageLibraryNoStaticAssets.csproj
+++ b/src/Assets/TestPackages/PackageLibraryNoStaticAssets/PackageLibraryNoStaticAssets.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Copyright>© Microsoft</Copyright>
+    <Product>Razor Test</Product>
+    <Company>Microsoft</Company>
+    <Description>PackageLibraryNoStaticAssets Description</Description>
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- We don't want to run build server when not running as tests. -->
+    <UseRazorBuildServer>false</UseRazorBuildServer>
+  </PropertyGroup>
+</Project>

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.Pack.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.Pack.targets
@@ -195,18 +195,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="IncludeStaticWebAssetsPackItems" 
+  <Target Name="IncludeStaticWebAssetsPackItems"
     DependsOnTargets="$(IncludeStaticWebAssetsPackItemsDependsOn)">
     
     <!-- LoadStaticWebAssetsBuildManifest takes care of removing all the static web assets from existing item groups
          if they were present already. That ensures no static web asset is mistakenly included as content even if it is
          not an asset that needs to be included on the package. -->
     
-    <StaticWebAssetsReadPackManifest ManifestPath="$(StaticWebAssetPackManifestPath)">
+    <StaticWebAssetsReadPackManifest Condition="Exists('$(StaticWebAssetPackManifestPath)')" ManifestPath="$(StaticWebAssetPackManifestPath)">
       <Output TaskParameter="Files" ItemName="_StaticWebAssetsFilesToPack" />
     </StaticWebAssetsReadPackManifest>
 
-    <ItemGroup>
+    <ItemGroup Condition="Exists('$(StaticWebAssetPackManifestPath)')">
       <Content Include="@(_StaticWebAssetsFilesToPack)" 
         Pack="true" 
         CopyToOutputDirectory="Never"

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.Pack.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.Pack.targets
@@ -206,7 +206,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="Files" ItemName="_StaticWebAssetsFilesToPack" />
     </StaticWebAssetsReadPackManifest>
 
-    <ItemGroup Condition="Exists('$(StaticWebAssetPackManifestPath)')">
+    <ItemGroup>
       <Content Include="@(_StaticWebAssetsFilesToPack)" 
         Pack="true" 
         CopyToOutputDirectory="Never"

--- a/src/RazorSdk/Tasks/StaticWebAssets/StaticWebAssetsGeneratePackManifest.cs
+++ b/src/RazorSdk/Tasks/StaticWebAssets/StaticWebAssetsGeneratePackManifest.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             if (Assets.Length == 0)
             {
                 // Do nothing if there are no assets to pack.
+                Log.LogMessage(MessageImportance.Low, "Skipping manifest creation because there are no static web assets to pack.");
                 return true;
             }
 

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
@@ -926,6 +926,34 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         [Fact]
+        public void Pack_NoAssets_DoesNothing()
+        {
+            var testAsset = "PackageLibraryNoStaticAssets";
+            var projectDirectory = CreateAspNetSdkTestAsset(testAsset, subdirectory: "TestPackages");
+
+            var pack = new MSBuildCommand(Log, "Pack", projectDirectory.Path);
+            pack.WithWorkingDirectory(projectDirectory.Path);
+            var result = pack.Execute("/bl");
+
+            result.Should().Pass();
+
+            var outputPath = pack.GetOutputDirectory(DefaultTfm, "Debug").ToString();
+
+            new FileInfo(Path.Combine(outputPath, "PackageLibraryNoStaticAssets.dll")).Should().Exist();
+
+            result.Should().NuPkgDoesNotContain(
+                Path.Combine(projectDirectory.Path, "bin", "Debug", "PackageLibraryNoStaticAssets.1.0.0.nupkg"),
+                filePaths: new[]
+                {
+                    Path.Combine("staticwebassets"),
+                    Path.Combine("build", "Microsoft.AspNetCore.StaticWebAssets.props"),
+                    Path.Combine("build", "PackageLibraryNoStaticAssets.props"),
+                    Path.Combine("buildMultiTargeting", "PackageLibraryNoStaticAssets.props"),
+                    Path.Combine("buildTransitive", "PackageLibraryNoStaticAssets.props")
+                });
+        }
+
+        [Fact]
         public void Pack_Incremental_IncludesStaticWebAssets()
         {
             var testAsset = "PackageLibraryDirectDependency";


### PR DESCRIPTION
Add a condition to check that the manifest was generated before attempting to add assets to pack. 
Include a test to validate the fix.
Include a log message to make troubleshooting easier.