### PR TITLE
[release/6.0.4xx] Don't retarget testhost 

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -409,8 +409,9 @@
     </PropertyGroup>
     <ItemGroup>
       <!-- Exclude F# from retargeting: https://github.com/dotnet/toolset/issues/2866 -->
+      <!-- Exclude testhost from retargeting: https://github.com/dotnet/sdk/issues/24769 -->
       <ToolRuntimeConfigPath Include="$(OutputPath)/**/*.runtimeconfig.json"
-                             Exclude="$(OutputPath)/**/fsc.runtimeconfig.json;$(OutputPath)/**/fsi.runtimeconfig.json"/>
+                             Exclude="$(OutputPath)/**/fsc.runtimeconfig.json;$(OutputPath)/**/fsi.runtimeconfig.json;$(OutputPath)/**/testhost-*.runtimeconfig.json"/>
 
       <MSBuild15Items Include="$(OutputPath)/15.0/**/*" />
     </ItemGroup>


### PR DESCRIPTION
Testhost is shipped together with multiple runtimeconfigs to be used as fallback when user does not provide runtimeconfig of their own, but tfm can be detected from the assembly. Rewriting them makes the tested assembly use the current runtime version, which is wrong.

Fix https://github.com/dotnet/sdk/issues/24769

Cherry picked from https://github.com/dotnet/sdk/pull/24770