### PR TITLE
Define SystemCollectionsImmutableVersion Versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,6 +29,7 @@
     <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</NETStandardLibraryNETFrameworkVersion>
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
     <NewtonsoftJsonVersion>$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersion>
+    <SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
     <SystemReflectionMetadataVersion>6.0.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>7.0.0-beta.22308.5</MicrosoftDotNetSignToolVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -74,7 +74,7 @@
         Also download an old version and (later in the target ReferenceOlderSCIandSRM)
         pass them to the compiler. -->
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" IncludeAssets="none" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" IncludeAssets="none" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" IncludeAssets="none" />
     <PackageDownload Include="System.Collections.Immutable" Version="[5.0.0]" GeneratePathProperty="true" />
     <PackageDownload Include="System.Reflection.Metadata" Version="[5.0.0]" GeneratePathProperty="true" />
   </ItemGroup>


### PR DESCRIPTION
Remove hard-coded System.Collections.Immutable package version reference in Microsoft.NET.Build.Tasks.csproj and replace with Versions.props property.  This avoids package version downgrade issues in source-build.

This is related to the changes made with https://github.com/dotnet/sdk/commit/13a506b44ac6b0daa8ba2e77eb1342518f7e81a4