### PR TITLE
add post actions tests for dotnet new

### DIFF
--- a/src/Tests/dotnet.Tests/TestTemplates/AddPackageReference/.template.config/template.json
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddPackageReference/.template.config/template.json
@@ -1,0 +1,29 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.AddReference",
+    "generatorVersions": "[1.0.0.0-*)",
+    "groupIdentity": "TestAssets.AddReference",
+    "precedence": "100",
+    "identity": "TestAssets.AddReference",
+    "shortName": "TestAssets.AddReference",
+    "sourceName": "Basic",
+    "postActions": [
+        {
+            "Description": "Adding Reference to Newtonsoft.Json NuGet package",
+            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+            "ContinueOnError": "false",
+            "ManualInstructions": [
+                {
+                    "Text": "Manually add the reference to  Newtonsoft.Json to your project file"
+                }
+            ],
+            "args": {
+                "referenceType": "package",
+                "reference": "Newtonsoft.Json",
+                "version": "13.0.1",
+                "projectFileExtensions": ".csproj"
+            }
+        }
+    ]
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/AddPackageReference/Basic.csproj
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddPackageReference/Basic.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/dotnet.Tests/TestTemplates/AddPackageReference/Program.cs
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddPackageReference/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Basic
+{
+    class MyClass
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+            string result = JsonConvert.SerializeObject(new { a = "test" });
+        }
+    }
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/.template.config/template.json
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/.template.config/template.json
@@ -1,0 +1,37 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.AddReference",
+    "groupIdentity": "TestAssets.AddReference",
+    "precedence": "100",
+    "identity": "TestAssets.AddReference",
+    "shortName": "TestAssets.AddReference",
+    "primaryOutputs": [
+        {
+            "path": "Project1/Project1.csproj"
+        },
+        {
+            "path": "Project2/Project2.csproj"
+        }
+    ],
+    "postActions": [
+        {
+            "Description": "Adding Reference to Newtonsoft.Json NuGet package",
+            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+            "ContinueOnError": "false",
+            "ManualInstructions": [
+                {
+                    "Text": "Manually add the reference to Project2 in Project1"
+                }
+            ],
+            "args": {
+                "targetFiles": [
+                    "./Project1/Project1.csproj"
+                ],
+                "referenceType": "project",
+                "reference": "./Project2/Project2.csproj",
+                "projectFileExtensions": ".csproj"
+            }
+        }
+    ]
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/Project1/Program.cs
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/Project1/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Project1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+            MyClass.SayHello();
+        }
+    }
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/Project1/Project1.csproj
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/Project1/Project1.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/Project2/MyClass.cs
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/Project2/MyClass.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Project2
+{
+    public class MyClass
+    {
+        public static void SayHello()
+        {
+            Console.WriteLine("Hello World from MyClass");
+        }
+    }
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/Project2/Project2.csproj
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddProjectReference/Project2/Project2.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/dotnet.Tests/TestTemplates/AddProjectToSolution/.template.config/template.json
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddProjectToSolution/.template.config/template.json
@@ -1,0 +1,26 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.AddProjectToSolution",
+    "groupIdentity": "TestAssets.AddProjectToSolution",
+    "precedence": "100",
+    "identity": "TestAssets.AddProjectToSolution",
+    "shortName": "TestAssets.AddProjectToSolution",
+    "sourceName": "Basic",
+    "primaryOutputs": [
+        {
+            "path": "Basic.csproj"
+        }
+    ],
+    "postActions": [
+        {
+            "description": "Add projects to solution",
+            "manualInstructions": [ { "text": "Add generated project to solution manually." } ],
+            "args": {
+                "solutionFolder": "src"
+            },
+            "actionId": "D396686C-DE0E-4DE6-906D-291CD29FC5DE",
+            "continueOnError": true
+        }
+    ]
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/AddProjectToSolution/Basic.csproj
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddProjectToSolution/Basic.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/Tests/dotnet.Tests/TestTemplates/AddProjectToSolution/Program.cs
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddProjectToSolution/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Basic
+{
+    class MyClass
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/AddProjectToSolution/Solution1.sln
+++ b/src/Tests/dotnet.Tests/TestTemplates/AddProjectToSolution/Solution1.sln
@@ -1,0 +1,14 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Tests/dotnet.Tests/dotnet.Tests.csproj
+++ b/src/Tests/dotnet.Tests/dotnet.Tests.csproj
@@ -167,6 +167,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="TestTemplates\**\*" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Content Include="TestTemplates\**\*" Exclude="TestTemplates\**\bin\**;TestTemplates\**\obj\**" CopyToOutputDirectory="Always" />
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 


### PR DESCRIPTION
Added tests that tests post action.
This is preparational work for https://github.com/dotnet/templating/issues/4518

These tests are expected to fail once `dotnet new` require callbacks for these operations.