### PR TITLE
Change BrotliCompress response files to quote file paths

### DIFF
--- a/src/BlazorWasmSdk/Tasks/BrotliCompress.cs
+++ b/src/BlazorWasmSdk/Tasks/BrotliCompress.cs
@@ -111,10 +111,10 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                 }
 
                 builder.AppendLine("-s");
-                builder.AppendLine(inputFullPath);
+                builder.AppendLine(Quote(inputFullPath));
 
                 builder.AppendLine("-o");
-                builder.AppendLine(outputFullPath);
+                builder.AppendLine(Quote(outputFullPath));
             }
 
             return builder.ToString();

--- a/src/BlazorWasmSdk/Tasks/BrotliCompress.cs
+++ b/src/BlazorWasmSdk/Tasks/BrotliCompress.cs
@@ -67,8 +67,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
 
         protected override string GenerateCommandLineCommands() => Quote(ToolAssembly);
 
-        protected override string GenerateResponseFileCommands()
-        {
+        public string GenerateResponseFileCommandsCore() {
             var builder = new StringBuilder();
 
 
@@ -119,6 +118,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
 
             return builder.ToString();
         }
+        protected override string GenerateResponseFileCommands() => GenerateResponseFileCommandsCore();
 
         internal static string CalculateTargetPath(string relativePath, string extension)
         {

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BrotliCompressTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BrotliCompressTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using FluentAssertions;
+using Moq;
+using Xunit;
+using System.Linq;
+
+namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
+{
+    public class BrotliCompressTest
+    {
+        [Fact]
+        public void GeneratesResponseFileWithQuotes()
+        {
+            // Arrange/Act
+            var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            var dummyFile = new TaskItem("Sample Path With Spaces.txt");
+            dummyFile.SetMetadata("RelativePath", "Sample Path With Spaces.txt");
+
+            var engine = new Mock<IBuildEngine>();
+            
+            var compressTask = new BrotliCompress
+            {
+                BuildEngine = engine.Object,
+                // don't actually run the tool, just collect the output
+                UseCommandProcessor = false,
+                OutputDirectory = "out man",
+                FilesToCompress = new [] { dummyFile }
+            };
+
+            var args = compressTask.GenerateResponseFileCommandsCore();
+
+            var lines = args.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            lines.Length.Should().Be(5); // dotnet brotli, -s, arg, -o, arg
+            // the only one we _know_ should be quoted is line 3 and 5, the input file path and output file path
+            var inputFilePath = lines[2];
+            inputFilePath.Should().StartWith("\"").And.EndWith("\"");
+            var outputFilePath = lines[4];
+            outputFilePath.Should().StartWith("\"").And.EndWith("\"");
+        }
+    }
+}


### PR DESCRIPTION


## Description

Fixes a regression in the parsing/handling of response files (raised in #26061) by ensuring that file paths are quoted in response files generated by the brotli compression tool task. This ensures that the response files can be read by System.CommandLine, which updated and brought along this change in handling.

Given that this utility is the only report of this problem, we decided this was an acceptable fix for the issue. If it proves to be more widespread we can reimplement the old tokenization inside of Parser.cs. 

If/when the other razor CLI tools migrate to System.CommandLine we'll need to do the same quoting of file paths.

## Customer Impact

Users using the brotli compression feature cannot compile their applications if the application is in a path containing spaces. The user must rename containing folders to work around this at the moment.

## Regression

Yes. Introduced in 6.0.302.

## Testing

New tests verifying the contents of the generated response files were added for the Brotli Compression task.

## Risk

The risk of taking this is low - it only impacts response file generation for the Brotli compression command, which is also authored in the SDK and not distributed anywhere else.
