### PR TITLE
older msbuild plus breaking update

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -66,13 +66,13 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>70ae3df4a6f3c92fb6b315afc405edd10ff38579</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22309-01">
+    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22315-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>142158cb52aae16f8fdf6efb5b8723a67b51da00</Sha>
+      <Sha>8474025ddfdc07e1eba823fad3198eecdb7a51c6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22309-01">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22315-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>142158cb52aae16f8fdf6efb5b8723a67b51da00</Sha>
+      <Sha>8474025ddfdc07e1eba823fad3198eecdb7a51c6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.4-beta.22305.1">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -66,13 +66,13 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>70ae3df4a6f3c92fb6b315afc405edd10ff38579</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22307-01">
+    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22309-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>bfd80ab1692721767c3fa8c0d4bcd35254489086</Sha>
+      <Sha>142158cb52aae16f8fdf6efb5b8723a67b51da00</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22307-01">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22309-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>bfd80ab1692721767c3fa8c0d4bcd35254489086</Sha>
+      <Sha>142158cb52aae16f8fdf6efb5b8723a67b51da00</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.4-beta.22305.1">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -66,13 +66,13 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>70ae3df4a6f3c92fb6b315afc405edd10ff38579</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22315-01">
+    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22315-02">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>8474025ddfdc07e1eba823fad3198eecdb7a51c6</Sha>
+      <Sha>cd75d014831860da851c61853521fb0b0d9ba63e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22315-01">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22315-02">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>8474025ddfdc07e1eba823fad3198eecdb7a51c6</Sha>
+      <Sha>cd75d014831860da851c61853521fb0b0d9ba63e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.4-beta.22305.1">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -66,13 +66,13 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>70ae3df4a6f3c92fb6b315afc405edd10ff38579</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22315-02">
+    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22315-03">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>cd75d014831860da851c61853521fb0b0d9ba63e</Sha>
+      <Sha>c2ec5c98a76a5496a36025b3f5e790cca6ea3b2f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22315-02">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22315-03">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>cd75d014831860da851c61853521fb0b0d9ba63e</Sha>
+      <Sha>c2ec5c98a76a5496a36025b3f5e790cca6ea3b2f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.4-beta.22305.1">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -66,13 +66,13 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>70ae3df4a6f3c92fb6b315afc405edd10ff38579</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22315-03">
+    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22315-04">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>c2ec5c98a76a5496a36025b3f5e790cca6ea3b2f</Sha>
+      <Sha>3db83fdeb160404917b6bd3f4dd9e62338539a48</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22315-03">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22315-04">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>c2ec5c98a76a5496a36025b3f5e790cca6ea3b2f</Sha>
+      <Sha>3db83fdeb160404917b6bd3f4dd9e62338539a48</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.4-beta.22305.1">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -66,13 +66,13 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>70ae3df4a6f3c92fb6b315afc405edd10ff38579</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22306-01">
+    <Dependency Name="Microsoft.Build" Version="17.3.0-preview-22307-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>1c045cf58dcb0d2f0474364550eeab37877257a1</Sha>
+      <Sha>bfd80ab1692721767c3fa8c0d4bcd35254489086</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22306-01">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.3.0-preview-22307-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>1c045cf58dcb0d2f0474364550eeab37877257a1</Sha>
+      <Sha>bfd80ab1692721767c3fa8c0d4bcd35254489086</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.4-beta.22305.1">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,10 +97,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.3.0-preview-22309-01</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.3.0-preview-22315-01</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22309-01</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22315-01</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,10 +97,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.3.0-preview-22315-02</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.3.0-preview-22315-03</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22315-02</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22315-03</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,10 +97,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.3.0-preview-22307-01</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.3.0-preview-22309-01</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22307-01</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22309-01</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,10 +97,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.3.0-preview-22306-01</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.3.0-preview-22307-01</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22306-01</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22307-01</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,10 +97,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.3.0-preview-22315-01</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.3.0-preview-22315-02</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22315-01</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22315-02</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -98,6 +98,11 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
     <MicrosoftBuildPackageVersion>17.3.0-preview-22315-04</MicrosoftBuildPackageVersion>
+    <!-- .NET Framework-targeted tasks will need to run in an MSBuild that is older than the very latest,
+          so target one that matches the version in src\Layout\redist\minimumMSBuildVersion.
+
+          This avoids the need to juggle references to packages that have been updated in newer MSBuild. -->
+    <MicrosoftBuildPackageVersion Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETFramework' ">17.0.0</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22315-04</MicrosoftBuildLocalizationPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,10 +97,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.3.0-preview-22315-03</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.3.0-preview-22315-04</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22315-03</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22315-04</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -61,21 +61,8 @@
 
   <!-- Packages that are in-box for .NET Core, so we only need to reference them for .NET Framework -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <!--
-        MSBuild depends on a new version of SRM/SCI; HostModel a very old one.
-        In order to keep working with MSBuild 17.2, which had binding redirects
-        for SCI 0-5.0.0.0 but not 6, this task must compile against 5, even
-        though that's not transitively correct. Nothing uses updated API
-        surface so it all works ok.
-
-        To accomplish this, explicitly reference the current version of the
-        packages, but exclude assets so it doesn't get passed to the compiler.
-        Also download an old version and (later in the target ReferenceOlderSCIandSRM)
-        pass them to the compiler. -->
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" IncludeAssets="none" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" IncludeAssets="none" />
-    <PackageDownload Include="System.Collections.Immutable" Version="[5.0.0]" GeneratePathProperty="true" />
-    <PackageDownload Include="System.Reflection.Metadata" Version="[5.0.0]" GeneratePathProperty="true" />
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    
   </ItemGroup>
 
   <!-- These are loaded from the CLI's copy on .NET Core, we don't need to duplicate them on disk -->
@@ -113,15 +100,6 @@
     <None Include="..\Common\Resources\xlf\**\*" LinkBase="Resources\xlf" />
     <UpToDateCheckInput Include="@(None)" />
   </ItemGroup>
-
-  <Target Name="ReferenceOlderSCIandSRM" AfterTargets="ResolveAssemblyReferences" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <ItemGroup>
-      <ReferencePath Include="$(NuGetPackageRoot)system.collections.immutable\5.0.0\lib\net461\System.Collections.Immutable.dll" />
-      <ReferencePath Include="$(NuGetPackageRoot)system.reflection.metadata\5.0.0\lib\net461\System.Reflection.Metadata.dll" />
-      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)system.collections.immutable\5.0.0\lib\net461\System.Collections.Immutable.dll" />
-      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)system.reflection.metadata\5.0.0\lib\net461\System.Reflection.Metadata.dll" />
-    </ItemGroup>
-  </Target>
 
   <Target Name="PrepareAdditionalFilesToLayout" BeforeTargets="AssignTargetPaths">
     <PropertyGroup>


### PR DESCRIPTION
- Update dependencies from https://github.com/dotnet/msbuild build 20220607.1
- Update dependencies from https://github.com/dotnet/msbuild build 20220609.1
- Update dependencies from https://github.com/dotnet/msbuild build 20220615.1
- Update dependencies from https://github.com/dotnet/msbuild build 20220615.2
- Update dependencies from https://github.com/dotnet/msbuild build 20220615.3
- Update dependencies from https://github.com/dotnet/msbuild build 20220615.4
- .NET Framework tasks reference older MSBuild
- Revert "Preserve compat with older MSBuild-on-Framework"
