### PR TITLE
Reference older MSBuild for .NET Framework tasks

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -98,6 +98,11 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
     <MicrosoftBuildPackageVersion>17.3.0-preview-22306-01</MicrosoftBuildPackageVersion>
+    <!-- .NET Framework-targeted tasks will need to run in an MSBuild that is older than the very latest,
+          so target one that matches the version in minimumMSBuildVersion.
+
+          This avoids the need to juggle references to packages that have been updated in newer MSBuild. -->
+    <MicrosoftBuildPackageVersion Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETFramework' ">$([System.IO.File]::ReadAllText('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion').Trim())</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>17.3.0-preview-22306-01</MicrosoftBuildLocalizationPackageVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -65,17 +65,9 @@
         MSBuild depends on a new version of SRM/SCI; HostModel a very old one.
         In order to keep working with MSBuild 17.2, which had binding redirects
         for SCI 0-5.0.0.0 but not 6, this task must compile against 5, even
-        though that's not transitively correct. Nothing uses updated API
-        surface so it all works ok.
-
-        To accomplish this, explicitly reference the current version of the
-        packages, but exclude assets so it doesn't get passed to the compiler.
-        Also download an old version and (later in the target ReferenceOlderSCIandSRM)
-        pass them to the compiler. -->
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" IncludeAssets="none" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" IncludeAssets="none" />
-    <PackageDownload Include="System.Collections.Immutable" Version="[5.0.0]" GeneratePathProperty="true" />
-    <PackageDownload Include="System.Reflection.Metadata" Version="[5.0.0]" GeneratePathProperty="true" />
+        though that's not the very latest. -->
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
   </ItemGroup>
 
   <!-- These are loaded from the CLI's copy on .NET Core, we don't need to duplicate them on disk -->
@@ -113,15 +105,6 @@
     <None Include="..\Common\Resources\xlf\**\*" LinkBase="Resources\xlf" />
     <UpToDateCheckInput Include="@(None)" />
   </ItemGroup>
-
-  <Target Name="ReferenceOlderSCIandSRM" AfterTargets="ResolveAssemblyReferences" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <ItemGroup>
-      <ReferencePath Include="$(NuGetPackageRoot)system.collections.immutable\5.0.0\lib\net461\System.Collections.Immutable.dll" />
-      <ReferencePath Include="$(NuGetPackageRoot)system.reflection.metadata\5.0.0\lib\net461\System.Reflection.Metadata.dll" />
-      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)system.collections.immutable\5.0.0\lib\net461\System.Collections.Immutable.dll" />
-      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)system.reflection.metadata\5.0.0\lib\net461\System.Reflection.Metadata.dll" />
-    </ItemGroup>
-  </Target>
 
   <Target Name="PrepareAdditionalFilesToLayout" BeforeTargets="AssignTargetPaths">
     <PropertyGroup>


### PR DESCRIPTION
Updates of MSBuild's transitive references have caused insertion breaks twice now, in #25507 and #25897. Both happened because, in older-but-still-supported Visual Studio environments, MSBuild's binding redirects mismatched what the task's compilation environment provided, causing some types to be resolved from an older version of an assembly and some types to be resolved from a newer, creating mismatches at runtime.

I initially "fixed" this by manually downgrading some of the transitive references at SDK compilation time in 66826cc. But that is confusing, labor-intensive, and hard to maintain.

This is a different solution: explicitly target the version of MSBuild that the tasks are expected to run on. MSBuild's compatibility guarantees are such that tasks compiled for an older MSBuild should always work, so this should be safe, and it more accurately reflects the intent of the SDK tasks: they should work on older MSBuild (and thus Visual Studio).