### PR TITLE
Fix error log message string.Format exception for failed ZipDeploy

### DIFF
--- a/src/WebSdk/Publish/Tasks/Properties/Resources.Designer.cs
+++ b/src/WebSdk/Publish/Tasks/Properties/Resources.Designer.cs
@@ -1942,11 +1942,20 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at &apos;{2}&apos;..
+        ///   Looks up a localized string similar to The attempt to publish the ZIP file through &apos;{0}&apos; failed with HTTP status code &apos;{1}&apos;..
         /// </summary>
         public static string ZIPDEPLOY_FailedDeploy {
             get {
                 return ResourceManager.GetString("ZIPDEPLOY_FailedDeploy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The attempt to publish the ZIP file through &apos;{0}&apos; failed with HTTP status code &apos;{1}&apos;. See the logs at &apos;{2}&apos;..
+        /// </summary>
+        public static string ZIPDEPLOY_FailedDeployWithLogs {
+            get {
+                return ResourceManager.GetString("ZIPDEPLOY_FailedDeployWithLogs", resourceCulture);
             }
         }
         

--- a/src/WebSdk/Publish/Tasks/Properties/Resources.resx
+++ b/src/WebSdk/Publish/Tasks/Properties/Resources.resx
@@ -1164,8 +1164,8 @@ For more information on this deploy script visit:	https://go.microsoft.com/fwlin
     <value>Publishing {0} to {1}...</value>
     <comment>{0} - Path of zip to publish, {1} - URL to deploy zip</comment>
   </data>
-  <data name="ZIPDEPLOY_FailedDeploy" xml:space="preserve">
-    <value>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</value>
+  <data name="ZIPDEPLOY_FailedDeployWithLogs" xml:space="preserve">
+    <value>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</value>
     <comment>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</comment>
   </data>
   <data name="ZIPDEPLOY_FailedToRetrieveCred" xml:space="preserve">
@@ -1198,5 +1198,9 @@ For more information on this deploy script visit:	https://go.microsoft.com/fwlin
   </data>
   <data name="ZIPDEPLOY_Uploaded" xml:space="preserve">
     <value>Uploaded the Zip file to the target.</value>
+  </data>
+  <data name="ZIPDEPLOY_FailedDeploy" xml:space="preserve">
+    <value>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</value>
+    <comment>{0} - URL to deploy zip, {1} - HTTP response code</comment>
   </data>
 </root>

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.cs.xlf
@@ -1164,8 +1164,13 @@ Podrobné informace o chybě:</target>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.de.xlf
@@ -1164,8 +1164,13 @@ Fehlerdetails:</target>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.es.xlf
@@ -1164,8 +1164,13 @@ Detalles del error:</target>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.fr.xlf
@@ -1164,8 +1164,13 @@ Détails de l'erreur :</target>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.it.xlf
@@ -1164,8 +1164,13 @@ Dettagli errore:</target>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.ja.xlf
@@ -1164,8 +1164,13 @@ Error details:</source>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.ko.xlf
@@ -1161,8 +1161,13 @@ Error details:</source>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.pl.xlf
@@ -1164,8 +1164,13 @@ Szczegóły błędu:</target>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -1164,8 +1164,13 @@ Detalhes do erro:</target>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.ru.xlf
@@ -1164,8 +1164,13 @@ Error details:</source>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.tr.xlf
@@ -1164,8 +1164,13 @@ Hata ayrıntıları:</target>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -1164,8 +1164,13 @@ Error details:</source>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/WebSdk/Publish/Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -1164,8 +1164,13 @@ Error details:</source>
         <note />
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedDeploy">
-        <source>The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</source>
-        <target state="new">The attempt to publish the ZIP file through {0} failed with HTTP status code {1}. See the logs at '{2}'.</target>
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'.</target>
+        <note>{0} - URL to deploy zip, {1} - HTTP response code</note>
+      </trans-unit>
+      <trans-unit id="ZIPDEPLOY_FailedDeployWithLogs">
+        <source>The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</source>
+        <target state="new">The attempt to publish the ZIP file through '{0}' failed with HTTP status code '{1}'. See the logs at '{2}'.</target>
         <note>{0} - URL to deploy zip, {1} - HTTP response code, {2} - Logs URL</note>
       </trans-unit>
       <trans-unit id="ZIPDEPLOY_FailedToRetrieveCred">

--- a/src/WebSdk/Publish/Tasks/Tasks/ZipDeploy/ZipDeploy.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/ZipDeploy/ZipDeploy.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -124,7 +123,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.ZipDeploy
                     }
                     else if (deploymentResponse is null || deploymentResponse?.Status == DeployStatus.Failed || deploymentResponse?.Status == DeployStatus.Unknown)
                     {
-                        Log.LogError(string.Format(Resources.ZIPDEPLOY_Failed,
+                        Log.LogError(string.Format(Resources.ZIPDEPLOY_FailedDeployWithLogs,
                             zipDeployPublishUrl,
                             deploymentResponse?.Status ?? DeployStatus.Unknown,
                             deploymentResponse?.GetLogUrlWithId()));


### PR DESCRIPTION
Fix  [[WebToolsE2E] Publishing an ASP.NET Core 7.0 project to Windows ~ Zip Deploy is failed with error: "The "ZipDeploy" task failed unexpectedly.System.AggregateException......"](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1555390)

**RCA:** the error was caused by incorrect resource string used when initial push request failed. We passed 2 parameters, but the message expected 3.

**FIX:** define new resource string with the correct number of parameters.