### PR TITLE
Fix unit test

### DIFF
--- a/src/Tests/trustedroots.Tests/GivenCodeSigningCtlFile.cs
+++ b/src/Tests/trustedroots.Tests/GivenCodeSigningCtlFile.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Tests
             _certificates.ImportFromPemFile(_filePath);
         }
 
-        [Fact(Skip="https://github.com/dotnet/sdk/issues/26115")]
+        [Fact]
         public void File_contains_certificates_very_commonly_used_in_NuGet_org_package_signatures()
         {
             // CN=DigiCert Assured ID Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Tests
 
         private void VerifyCertificateExists(string thumbprint)
         {
-            _certificates.Find(X509FindType.FindByThumbprint, thumbprint, validOnly: true)
+            _certificates.Find(X509FindType.FindByThumbprint, thumbprint, validOnly: false)
                 .Count
                 .Should()
                 .Be(1, $"a certificate with thumbprint '{thumbprint}' should be in '{_filePath}'");


### PR DESCRIPTION
Resolve https://github.com/dotnet/sdk/issues/26115.

The test fails on Ubuntu because `validOnly` was `true` and one certificate isn't trusted on Ubuntu 18.04.

The test shouldn't care if a certificate is trusted by the system, only that the PEM file contains specific certificates.

CC @marcpopMSFT, @joeloff 