### PR TITLE
Revert "[main] Update dependencies from dotnet/templating"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.6.22321.3">
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.6.22321.2">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
+      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.6.22321.3">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.6.22321.2">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
+      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.6.22321.3">
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.6.22321.2">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
+      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.6.22321.3">
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.6.22321.2">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
+      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.6.22321.3">
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.6.22321.2">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
+      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.6.22321.3">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.6.22321.2">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
+      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.6.22320.7">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -117,11 +117,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateEngineCliPackageVersion>
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateEngineAbstractionsPackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->


### PR DESCRIPTION
Reverts dotnet/sdk#26137
This version of templating packages requires adaptation in dotnet/sdk
https://github.com/dotnet/sdk/pull/26074 should have been detected it if merged prior.

I will adapt dotnet CLI tomorrow.