### PR TITLE
implemented in-proc callbacks for dotnet operations

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.6.22321.2">
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-preview.6.22321.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
+      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.6.22321.2">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-preview.6.22321.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
+      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.6.22321.2">
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="7.0.100-preview.6.22321.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
+      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.6.22321.2">
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="7.0.100-preview.6.22321.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
+      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.6.22321.2">
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="7.0.100-preview.6.22321.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
+      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.6.22321.2">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-preview.6.22321.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>302ab2bf2db02656f7b8af27b6a21a9a9106e851</Sha>
+      <Sha>e189aa38d7c9bee04be453b716d7f3be386c63fe</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.6.22320.7">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -117,11 +117,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateEngineCliPackageVersion>
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateEngineAbstractionsPackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.6.22321.2</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>7.0.100-preview.6.22321.3</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->

--- a/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
@@ -117,6 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AddPackageReferenceCallback_Failed" xml:space="preserve">
+    <value>Failed to add package reference: {0}</value>
+    <comment>{0} - the reason why operation failed, normally ends with period</comment>
+  </data>
+  <data name="AddProjectReferenceCallback_Failed" xml:space="preserve">
+    <value>Failed to add project reference: {0}</value>
+    <comment>{0} - the reason why operation failed, normally ends with period</comment>
+  </data>
+  <data name="AddProjectsToSolutionCallback_Failed" xml:space="preserve">
+    <value>Failed to add project(s) to the solution: {0}</value>
+    <comment>{0} - the reason why operation failed, normally ends with period</comment>
+  </data>
+  <data name="DisableSdkTemplates_OptionDescription" xml:space="preserve">
+    <value>If present, prevents templates bundled in the SDK from being presented.</value>
+  </data>
+  <data name="RestoreCallback_Failed" xml:space="preserve">
+    <value>Failed to perform restore: {0}</value>
+    <comment>{0} - the reason why operation failed, normally ends with period</comment>
+  </data>
   <data name="SdkInfoProvider_Message_InstallSdk" xml:space="preserve">
     <value>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</value>
     <comment>{0} is the list of supported versions.</comment>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AddPackageReferenceCallback_Failed">
+        <source>Failed to add package reference: {0}</source>
+        <target state="new">Failed to add package reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectReferenceCallback_Failed">
+        <source>Failed to add project reference: {0}</source>
+        <target state="new">Failed to add project reference: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="AddProjectsToSolutionCallback_Failed">
+        <source>Failed to add project(s) to the solution: {0}</source>
+        <target state="new">Failed to add project(s) to the solution: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
+      <trans-unit id="DisableSdkTemplates_OptionDescription">
+        <source>If present, prevents templates bundled in the SDK from being presented.</source>
+        <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoreCallback_Failed">
+        <source>Failed to perform restore: {0}</source>
+        <target state="new">Failed to perform restore: {0}</target>
+        <note>{0} - the reason why operation failed, normally ends with period</note>
+      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="new">Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</target>

--- a/src/Tests/dotnet-new.Tests/NewCommandTests.cs
+++ b/src/Tests/dotnet-new.Tests/NewCommandTests.cs
@@ -94,8 +94,8 @@ namespace Microsoft.DotNet.New.Tests
                 .Execute("new", "TestAssets.AddReference", "--debug:custom-hive", tempSettingsDir.Path);
 
             cmd.Should().Pass()
-                .And.HaveStdOutContaining("Adding a project reference.")
-                .And.HaveStdOutContaining("Successfully added");
+                .And.HaveStdOutContaining("Adding a project reference")
+                .And.HaveStdOutContaining("Successfully added a reference to the project file.");
         }
 
         [Fact]
@@ -109,9 +109,8 @@ namespace Microsoft.DotNet.New.Tests
 
             cmd = new DotnetCommand(Log).Execute("new", "TestAssets.AddReference", "-o", tempDir.Path, "--debug:custom-hive", tempSettingsDir.Path);
             cmd.Should().Pass()
-                .And.HaveStdOutContaining("Adding a package reference.")
-                .And.HaveStdOutContaining("Successfully added")
-                .And.HaveStdOutContaining("reference: Newtonsoft.Json");
+                .And.HaveStdOutContaining("Adding a package reference Newtonsoft.Json (version: 13.0.1) to project file")
+                .And.HaveStdOutContaining("Successfully added a reference to the project file.");
         }
 
         [Fact]
@@ -125,8 +124,7 @@ namespace Microsoft.DotNet.New.Tests
 
             cmd = new DotnetCommand(Log).Execute("new", "TestAssets.AddProjectToSolution", "-o", tempDir.Path, "--debug:custom-hive", tempSettingsDir.Path);
             cmd.Should().Pass()
-                .And.HaveStdOutContaining("Adding project reference(s) to solution file")
-                .And.HaveStdOutContaining("Successfully added");
+                .And.HaveStdOutContaining("Successfully added project(s) to a solution file.");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/templating/issues/4518

dotnet/templating part is here: https://github.com/dotnet/templating/pull/4797

`dotnet new` was starting new processes for other `dotnet` operations
This is not good a) performance-wise b) security-wise

Implemented callbacks instead (like was already available for `dotnet restore`).
This code might be simplified once `Microsoft.TemplateEngine.Cli` is moved to `dotnet-sdk`.

Note: due to heavy dependencies of command handler on `ParseResult` had to do the re-parsing in the callbacks.