### PR TITLE
Revert to token-per-line response file handling

### DIFF
--- a/src/Cli/dotnet/CommonLocalizableStrings.resx
+++ b/src/Cli/dotnet/CommonLocalizableStrings.resx
@@ -699,4 +699,7 @@ The default is 'true' if a runtime identifier is specified.</value>
   <data name="SelfContainAndNoSelfContainedConflict" xml:space="preserve">
     <value>The '--self-contained' and '--no-self-contained' options cannot be used together.</value>
   </data>
+  <data name="ResponseFileNotFound" xml:space="preserve">
+    <value>Response file '{0}' does not exist.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -17,7 +17,8 @@ namespace Microsoft.DotNet.Cli
     internal static class CommonOptions
     {
         public static Option<string[]> PropertiesOption =
-            new ForwardedOption<string[]>(new string[] { "-property", "/p", "-p" })
+            // these are all of the forms that the property switch can be understood by in MSBuild
+            new ForwardedOption<string[]>(new string[] { "--property", "-property", "/property", "/p", "-p", "--p" })
             {
                 IsHidden = true
             }.ForwardAsProperty()

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli
     internal static class CommonOptions
     {
         public static Option<string[]> PropertiesOption =
-            new ForwardedOption<string[]>(new string[] { "-property", "/p" })
+            new ForwardedOption<string[]>(new string[] { "-property", "/p", "-p" })
             {
                 IsHidden = true
             }.ForwardAsProperty()

--- a/src/Cli/dotnet/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/OptionForwardingExtensions.cs
@@ -19,7 +19,11 @@ namespace Microsoft.DotNet.Cli
         public static ForwardedOption<T> ForwardAsSingle<T>(this ForwardedOption<T> option, Func<T, string> format) => option.SetForwardingFunction(format);
 
         public static ForwardedOption<string[]> ForwardAsProperty(this ForwardedOption<string[]> option) => option
-            .SetForwardingFunction((optionVals) => optionVals.SelectMany(optionVal => new string[] { $"{option.Aliases.FirstOrDefault()}:{optionVal.Replace("roperty:", string.Empty)}" }));
+            .SetForwardingFunction((optionVals) =>
+                optionVals
+                    .Select(optionVal => optionVal.Replace(";", "%3B")) // must escape semicolon-delimited property values when forwarding them to MSBuild
+                    .SelectMany(optionVal => new string[] { $"{option.Aliases.FirstOrDefault()}:{optionVal.Replace("roperty:", string.Empty)}" })
+                );
 
         public static Option<T> ForwardAsMany<T>(this ForwardedOption<T> option, Func<T, IEnumerable<string>> format) => option.SetForwardingFunction(format);
 

--- a/src/Cli/dotnet/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/OptionForwardingExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli
             .SetForwardingFunction((optionVals) =>
                 optionVals
                     .Select(optionVal => optionVal.Replace(";", "%3B")) // must escape semicolon-delimited property values when forwarding them to MSBuild
-                    .SelectMany(optionVal => new string[] { $"{option.Aliases.FirstOrDefault()}:{optionVal.Replace("roperty:", string.Empty)}" })
+                    .Select(optionVal => $"{option.Aliases.FirstOrDefault()}:{optionVal}")
                 );
 
         public static Option<T> ForwardAsMany<T>(this ForwardedOption<T> option, Func<T, IEnumerable<string>> format) => option.SetForwardingFunction(format);

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -120,9 +120,8 @@ namespace Microsoft.DotNet.Cli
                 errorMessage = null;
                 return true;
             } else {
-                // don't report an error here, since MSBuild doesn't in the case of nonexistent response files
                 replacementTokens = null;
-                errorMessage = null;
+                errorMessage = string.Format(CommonLocalizableStrings.ResponseFileNotFound, tokenToReplace);
                 return false;
             }
         }

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Cli
         public static bool TokenPerLine(string tokenToReplace, out IReadOnlyList<string> replacementTokens, out string errorMessage) {
             var filePath = Path.GetFullPath(tokenToReplace);
             if (File.Exists(filePath)) {
-                replacementTokens = File.ReadAllLines(filePath).Where(line => !line.StartsWith("#")).ToArray();
+                replacementTokens = File.ReadAllLines(filePath).Where(line => !line.StartsWith("#")).Select(line => $"\"{line}\"").ToArray();
                 errorMessage = null;
                 return true;
             } else {

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Cli
                             } else if (hashPos == 0) {
                                 return "";
                             } else {
-                                return line.Substring(hashPos).Trim();
+                                return line.Substring(0, hashPos).Trim();
                             }
                         })
                         // Remove empty lines

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -116,7 +116,23 @@ namespace Microsoft.DotNet.Cli
         public static bool TokenPerLine(string tokenToReplace, out IReadOnlyList<string> replacementTokens, out string errorMessage) {
             var filePath = Path.GetFullPath(tokenToReplace);
             if (File.Exists(filePath)) {
-                replacementTokens = File.ReadAllLines(filePath).Where(line => !line.StartsWith("#")).Select(line => $"\"{line}\"").ToArray();
+                var lines = File.ReadAllLines(filePath);
+                var trimmedLines =
+                    lines
+                        // Remove content in the lines that contain #, starting from the point of the #
+                        .Select(line => {
+                            var hashPos = line.IndexOf('#');
+                            if (hashPos == -1) {
+                                return line;
+                            } else if (hashPos == 0) {
+                                return "";
+                            } else {
+                                return line.Substring(hashPos).Trim();
+                            }
+                        })
+                        // Remove empty lines
+                        .Where(line => line.Length > 0);
+                replacementTokens = trimmedLines.ToArray();
                 errorMessage = null;
                 return true;
             } else {

--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Tools
         private static bool HasArgumentToExcludeFromRestore(IEnumerable<string> arguments)
             => arguments.Any(a => IsExcludedFromRestore(a));
 
-        private static readonly string[] propertyPrefixes = new string[]{ "-", "/" };
+        private static readonly string[] propertyPrefixes = new string[]{ "-", "/", "--" };
 
         private static bool IsExcludedFromRestore(string argument)
             => propertyPrefixes.Any(prefix => argument.StartsWith($"{prefix}property:TargetFramework=", StringComparison.Ordinal)) ||

--- a/src/Cli/dotnet/commands/dotnet-complete/ParseCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-complete/ParseCommand.cs
@@ -11,26 +11,29 @@ namespace Microsoft.DotNet.Cli
         {
             result.HandleDebugSwitch();
 
-            Console.WriteLine(result.Diagram());
+            var tokens = result.Tokens.Skip(1).Select(t => t.Value).ToArray();
+            var reparsed = Microsoft.DotNet.Cli.Parser.Instance.Parse(tokens);
+            Console.WriteLine(reparsed.Diagram());
 
-            if (result.UnparsedTokens.Any())
+
+            if (reparsed.UnparsedTokens.Any())
             {
                 Console.WriteLine("Unparsed Tokens: ");
-                Console.WriteLine(string.Join(" ", result.UnparsedTokens));
+                Console.WriteLine(string.Join(" ", reparsed.UnparsedTokens));
             }
 
-            var optionValuesToBeForwarded = result.OptionValuesToBeForwarded(ParseCommandParser.GetCommand());
+            var optionValuesToBeForwarded = reparsed.OptionValuesToBeForwarded(ParseCommandParser.GetCommand());
             if (optionValuesToBeForwarded.Any())
             {
                 Console.WriteLine("Option values to be forwarded: ");
                 Console.WriteLine(string.Join(" ", optionValuesToBeForwarded));
             }
-            if (result.Errors.Any())
+            if (reparsed.Errors.Any())
             {
                 Console.WriteLine();
                 Console.WriteLine("ERRORS");
                 Console.WriteLine();
-                foreach (var error in result.Errors)
+                foreach (var error in reparsed.Errors)
                 {
                     Console.WriteLine(error?.Message);
                 }

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -57,6 +57,8 @@ namespace Microsoft.DotNet.Tools.MSBuild
             }
         }
 
+        public IEnumerable<string> MSBuildArguments { get { return _forwardingAppWithoutLogging.GetAllArguments(); } }
+
         public void EnvironmentVariable(string name, string value)
         {
             _forwardingAppWithoutLogging.EnvironmentVariable(name, value);

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Balíček</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">Možnosti --self-contained a --no-self-contained nelze použít společně.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Paket</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">Die Optionen „--self-contained“ und „--no-self-contained“ können nicht gemeinsam verwendet werden.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Paquete</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">Las opciones '--self-contained' y '--no-self-contained' no se pueden usar juntas.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Package</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">Les options « --autonome » et « --non-autonome » ne peuvent pas être utilisées ensemble.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Pacchetto</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">Non è possibile usare contemporaneamente le opzioni '--self-contained' e ‘--no-self-contained'.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">パッケージ</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">'--self-contained' と '--no-self-contained' オプションは同時に使用できません。</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">패키지</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">'--self-contained' 및 '--no-self-contained' 옵션은 함께 사용할 수 없습니다.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Pakiet</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">Opcji „--self-contained” i „--no-self-contained” nie można używać razem.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Pacote</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">As opções '--auto--contidas ' e '--não-independentes ' não podem ser usadas juntas.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Пакет</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">Параметры "--self-contained" и "--no-self-contained" нельзя использовать вместе.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Paket</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">'--self-contained' ve '--no-self-contained' seçenekleri birlikte kullanılamaz.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -165,6 +165,11 @@ EOF
         <target state="translated">打包</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">“--自包含”和“--非自包含”选项不能一起使用。</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -165,6 +165,11 @@ export PATH="$PATH:{0}"
         <target state="translated">套件</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseFileNotFound">
+        <source>Response file '{0}' does not exist.</source>
+        <target state="new">Response file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">
         <source>The '--self-contained' and '--no-self-contained' options cannot be used together.</source>
         <target state="translated">不能同時使用 '--self-contained' 和 '--no-self-contained' 選項。</target>

--- a/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
@@ -25,22 +25,28 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
         [Theory]
         [InlineData(new string[] { "-property:prop1=true", "-p:prop2=false" }, true)]
         [InlineData(new string[] { "-property:prop1=true", "-p:prop2=false" }, false)]
+        [InlineData(new string[] { "-p:teamcity_buildConfName=\"Build, Test and Publish\"" }, false)]
+        [InlineData(new string[] { "-p:teamcity_buildConfName=\"Build, Test and Publish\"" }, true)]
         [InlineData(new string[] { "-detailedSummary" }, true)]
         [InlineData(new string[] { "-clp:NoSummary" }, true)]
         [InlineData(new string[] { "-orc" }, true)]
         [InlineData(new string[] { "-orc" }, false)]
         public void MSBuildArgumentsAreForwardedCorrectly(string[] arguments, bool buildCommand)
         {
-            RestoringCommand command = buildCommand ? 
-                BuildCommand.FromArgs(arguments) : 
+            RestoringCommand command = buildCommand ?
+                BuildCommand.FromArgs(arguments) :
                 PublishCommand.FromArgs(arguments);
             var expectedArguments = arguments.Select(a => a.Replace("-property:", "--property:").Replace("-p:", "--property:"));
-            command.GetArgumentsToMSBuild().Split(' ')
-                .Should()
-                .Contain(expectedArguments);
+            var argString = command.GetArgumentsToMSBuild();
+
+            foreach (var expectedArg in expectedArguments)
+            {
+                argString.Should().Contain(expectedArg);
+            }
         }
 
         [Theory]
+        [InlineData(new string[] { "-p:teamcity_buildConfName=\"Build, Test and Publish\"" }, new string[] { "--property:teamcity_buildConfName=\"Build, Test and Publish\"" })]
         [InlineData(new string[] { "-p:prop1=true", "-p:prop2=false" }, new string[] { "--property:prop1=true", "--property:prop2=false" })]
         [InlineData(new string[] { "-p:prop1=\".;/opt/usr\"" }, new string[] { "--property:prop1=\".%3B/opt/usr\"" })]
         public void Can_pass_msbuild_properties_safely(string[] tokens, string[] forwardedTokens) {

--- a/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.Build;
 using Microsoft.DotNet.Tools.Publish;
+using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
@@ -31,9 +31,10 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
             RestoringCommand command = buildCommand ? 
                 BuildCommand.FromArgs(arguments) : 
                 PublishCommand.FromArgs(arguments);
+            var expectedArguments = arguments.Select(a => a.Replace("-p:", "-property:"));
             command.GetArgumentsToMSBuild().Split(' ')
                 .Should()
-                .Contain(arguments);
+                .Contain(expectedArguments);
         }
     }
 }

--- a/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.Build;
 using Microsoft.DotNet.Tools.Publish;
+using System.CommandLine;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -32,10 +34,20 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
             RestoringCommand command = buildCommand ? 
                 BuildCommand.FromArgs(arguments) : 
                 PublishCommand.FromArgs(arguments);
-            var expectedArguments = arguments.Select(a => a.Replace("-p:", "-property:"));
+            var expectedArguments = arguments.Select(a => a.Replace("-property:", "--property:").Replace("-p:", "--property:"));
             command.GetArgumentsToMSBuild().Split(' ')
                 .Should()
                 .Contain(expectedArguments);
+        }
+
+        [Theory]
+        [InlineData(new string[] { "-p:prop1=true", "-p:prop2=false" }, new string[] { "--property:prop1=true", "--property:prop2=false" })]
+        [InlineData(new string[] { "-p:prop1=\".;/opt/usr\"" }, new string[] { "--property:prop1=\".%3B/opt/usr\"" })]
+        public void Can_pass_msbuild_properties_safely(string[] tokens, string[] forwardedTokens) {
+            var forwardingFunction = (CommonOptions.PropertiesOption as ForwardedOption<string[]>).GetForwardingFunction();
+            var result = CommonOptions.PropertiesOption.Parse(tokens);
+            var parsedTokens = forwardingFunction(result);
+            parsedTokens.Should().BeEquivalentTo(forwardedTokens);
         }
     }
 }

--- a/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
                 BuildCommand.FromArgs(arguments) :
                 PublishCommand.FromArgs(arguments);
             var expectedArguments = arguments.Select(a => a.Replace("-property:", "--property:").Replace("-p:", "--property:"));
-            var argString = command.GetArgumentsToMSBuild();
+            var argString = command.MSBuildArguments;
 
             foreach (var expectedArg in expectedArguments)
             {

--- a/src/Tests/dotnet.Tests/ParserTests/ResponseFileTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ResponseFileTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Parsing;
+using FluentAssertions;
+using Microsoft.DotNet.Cli;
+using Xunit;
+using Xunit.Abstractions;
+using Parser = Microsoft.DotNet.Cli.Parser;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    public class ResponseFileTests
+    {
+        [Fact]
+        public void Can_safely_expand_response_file_lines() {
+            var tempFilePath = Path.GetTempFileName();
+            var lines = new[] {
+                "build",
+                "a b",
+                "/p=\".;c:/program files/\""
+            };
+            File.WriteAllLines(tempFilePath, lines);
+
+            var quoted = lines.Select(l => $"\"{l}\"");
+            var parser = Parser.Instance;
+            var parseResult = parser.Parse(new []{ "dotnet", $"@{tempFilePath}" });
+            var tokens = parseResult.Tokens.Select(t => t.Value);
+            tokens.Should().HaveCount(lines.Length + 1); // dotnet token too
+            tokens.Should().StartWith("dotnet");
+            tokens.Skip(1).Should().BeEquivalentTo(quoted);
+        }
+    }
+}
+     

--- a/src/Tests/dotnet.Tests/ParserTests/ResponseFileTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ResponseFileTests.cs
@@ -48,5 +48,28 @@ namespace Microsoft.DotNet.Tests.ParserTests
             Log.WriteLine($"Token string is {tokenString}");
             tokens.Skip(1).Should().BeEquivalentTo(tokenized);
         }
+
+        [Fact]
+        public void Can_skip_empty_and_commented_lines() {
+             var tempFileDir = _testAssetsManager.CreateTestDirectory().Path;
+            var tempFilePath = Path.Combine(tempFileDir, "skips.rsp");
+            var lines = new[] {
+                "build",
+                "",
+                "run# but skip this",
+                "# and this"
+            };
+            File.WriteAllLines(tempFilePath, lines);
+
+            var parser = Parser.Instance;
+            var parseResult = parser.Parse(new []{ "dotnet", $"@{tempFilePath}" });
+            var tokens = parseResult.Tokens.Select(t => t.Value);
+            var tokenized = new [] {
+                "build",
+                "run"
+            };
+
+            tokens.Skip(1).Should().BeEquivalentTo(tokenized);
+        }
     }
 }

--- a/src/Tests/dotnet.Tests/ParserTests/ResponseFileTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ResponseFileTests.cs
@@ -1,37 +1,52 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.CommandLine.Parsing;
 using FluentAssertions;
 using Microsoft.DotNet.Cli;
-using Xunit;
-using Xunit.Abstractions;
+using Microsoft.NET.TestFramework;
 using Parser = Microsoft.DotNet.Cli.Parser;
+using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Tests.ParserTests
 {
-    public class ResponseFileTests
+    public class ResponseFileTests : SdkTest
     {
+        public ResponseFileTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void Can_safely_expand_response_file_lines() {
-            var tempFilePath = Path.GetTempFileName();
+            var tempFileDir = _testAssetsManager.CreateTestDirectory().Path;
+            var tempFilePath = Path.Combine(tempFileDir, "params.rsp");
             var lines = new[] {
                 "build",
                 "a b",
-                "/p=\".;c:/program files/\""
+                "-p:VSTestTestAdapterPath=\".;/opt/buildagent/plugins/dotnet/tools/vstest15\""
             };
             File.WriteAllLines(tempFilePath, lines);
 
-            var quoted = lines.Select(l => $"\"{l}\"");
             var parser = Parser.Instance;
             var parseResult = parser.Parse(new []{ "dotnet", $"@{tempFilePath}" });
+
             var tokens = parseResult.Tokens.Select(t => t.Value);
-            tokens.Should().HaveCount(lines.Length + 1); // dotnet token too
-            tokens.Should().StartWith("dotnet");
-            tokens.Skip(1).Should().BeEquivalentTo(quoted);
+            var tokenString = string.Join(", ", tokens);
+            var bc = Microsoft.DotNet.Tools.Build.BuildCommand.FromParseResult(parseResult);
+            var tokenized = new [] {
+                "build",
+                "a b",
+                "-p",
+                "VSTestTestAdapterPath=\".;/opt/buildagent/plugins/dotnet/tools/vstest15\""
+            };
+
+            Log.WriteLine($"MSbuild Args are {string.Join(" ", bc.MSBuildArguments)}");
+            Log.WriteLine($"Parse Diagram is {parseResult.Diagram()}");
+            Log.WriteLine($"Token string is {tokenString}");
+            tokens.Skip(1).Should().BeEquivalentTo(tokenized);
         }
     }
 }
-     

--- a/src/Tests/dotnet.Tests/ParserTests/RestoreParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/RestoreParserTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
             var result = Parser.Instance.Parse(@"dotnet restore .\some.csproj --packages c:\.nuget\packages /p:SkipInvalidConfigurations=true");
 
             result.GetValueForArgument<IEnumerable<string>>(RestoreCommandParser.SlnOrProjectArgument).Should().BeEquivalentTo(@".\some.csproj");
-            result.OptionValuesToBeForwarded(RestoreCommandParser.GetCommand()).Should().Contain(@"-property:SkipInvalidConfigurations=true");
+            result.OptionValuesToBeForwarded(RestoreCommandParser.GetCommand()).Should().Contain(@"--property:SkipInvalidConfigurations=true");
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
         {
             var result = Parser.Instance.Parse(@"dotnet restore --packages c:\.nuget\packages /p:SkipInvalidConfigurations=true");
 
-            result.OptionValuesToBeForwarded(RestoreCommandParser.GetCommand()).Should().Contain(@"-property:SkipInvalidConfigurations=true");
+            result.OptionValuesToBeForwarded(RestoreCommandParser.GetCommand()).Should().Contain(@"--property:SkipInvalidConfigurations=true");
         }
 
         [Fact]

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [Theory]
         [InlineData(new string[] { }, "")]
         [InlineData(new string[] { "-o", "foo" }, "-property:OutputPath=<cwd>foo")]
-        [InlineData(new string[] { "-property:Verbosity=diag" }, "-property:Verbosity=diag")]
+        [InlineData(new string[] { "-property:Verbosity=diag" }, "--property:Verbosity=diag")]
         [InlineData(new string[] { "--output", "foo" }, "-property:OutputPath=<cwd>foo")]
         [InlineData(new string[] { "-o", "foo1 foo2" }, "\"-property:OutputPath=<cwd>foo1 foo2\"")]
         [InlineData(new string[] { "--no-incremental" }, "-target:Rebuild")]
@@ -56,8 +56,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
         [Theory]
         [InlineData(new string[] { "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm")]
-        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore", "-property:TargetFramework=tfm")]
-        [InlineData(new string[] { "/p:TargetFramework=tfm" }, "-target:Restore", "-property:TargetFramework=tfm")]
+        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore", "--property:TargetFramework=tfm")]
+        [InlineData(new string[] { "/p:TargetFramework=tfm" }, "-target:Restore", "--property:TargetFramework=tfm")]
         [InlineData(new string[] { "-t:Run", "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm -t:Run")]
         [InlineData(new string[] { "/t:Run", "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm /t:Run")]
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
         [Theory]
         [InlineData(new string[] { "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm")]
-        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore", "-p:TargetFramework=tfm")]
+        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore", "-property:TargetFramework=tfm")]
         [InlineData(new string[] { "/p:TargetFramework=tfm" }, "-target:Restore", "-property:TargetFramework=tfm")]
         [InlineData(new string[] { "-t:Run", "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm -t:Run")]
         [InlineData(new string[] { "/t:Run", "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm /t:Run")]

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             command.GetArgumentsToMSBuild()
                .Should()
-               .Be($"{ExpectedPrefix} -restore -target:Publish -property:Prop1=prop1 -property:Prop2=prop2");
+               .Be($"{ExpectedPrefix} -restore -target:Publish --property:Prop1=prop1 --property:Prop2=prop2");
         }
     }
 }


### PR DESCRIPTION
An update to System.CommandLine changed the response file handling support to a different, more cross-platform-consistent logic. However, we cannot take this change because users expect a token-per-line style of processing. As a result, we change the dotnet CLI to use token-per-line handling for response files.

## Description

There are two issues resolved here:
* A change to the defaults in System.CommandLine resulted in response-file parsing breaking across versions. This was resolved by using the S.CL extension points to implement the old, one-token-per-line behavior.
* A user scenario used a version of the MSBuild `--property` option (`/p`) that the .NET SDK didn't have handling for. This was resolved by adding in handling for all unhandled forms of this property.

Fixes https://github.com/dotnet/sdk/issues/26026.

## Customer Impact

Customers that relied on the old response-file behavior typically ran into it in one of two scenarios - the first is related to an internal Brotli compression tool, the workaround here is to publish your application in a directory that contains no spaces. The second involved response files with the `/p` flag - the workaround here is to modify the response file to convert `/p` into one of the recognized forms (`-p`, `--p`, `-property`).

## Regression?

- [X] Yes
- [ ] No

## Risk

- [ ] High
- [X] Medium
- [ ] Low

The change touches response file handling, which can be very broadly used. It does however have testing and reimplements prior behavior.

## Verification

- [X] Manual (required)
- [X] Automated

Manually tested the provided user scenarios, and also added automated testing around the parsing changes.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
