### PR TITLE
Don't reference SCI and SRM 5.0.0 during source-build

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -61,7 +61,7 @@
 
 
   <!-- Packages that are in-box for .NET Core, so we only need to reference them for .NET Framework -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(DotNetBuildFromSource)' != 'true'">
     <!--
         MSBuild depends on a new version of SRM/SCI; HostModel a very old one.
         In order to keep working with MSBuild 17.2, which had binding redirects


### PR DESCRIPTION
Directly referencing System.Collections.Immutable and System.Reflection.Metadata 5.0.0 versions here causes package downgrade warnings in source-build. Since we only build the most recent version of MSBuild in source-build, which references 6.0.X versions of SCI and SRM, we can just condition these references out to avoid build failures.
