### PR TITLE
Use Taskkill to kill any hanging dotnet processes left by debuggers

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,4 @@
 @echo off
+taskkill /IM "dotnet.exe" /F /T > nul 2> nul
 powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "& """%~dp0eng\common\build.ps1""" -build -restore %*"
 exit /b %ErrorLevel%


### PR DESCRIPTION
Perhaps a petty change, but I want to add this to `build.cmd` as I've observed myself running this taskkill command about 5 times a day before I run `build.cmd` to kill any remaining dotnet processes holding onto the `hostfxr.dll` and `etc.dll`'s. Didn't add it to the powershell script or .sh to be agnostic to other types of systems, not sure if they encounter that issue. Thoughts? 