### PR TITLE
[QB Mode] Fix Workload Restore Crashes

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Restore
             foreach (string file in slnFiles)
             {
                 var solutionFile = SolutionFile.Parse(file);
-                var projects = solutionFile.ProjectsInOrder;
+                var projects = solutionFile.ProjectsInOrder.Where(p => p.ProjectType != SolutionProjectType.SolutionFolder);
                 foreach (var p in projects)
                 {
                     projectFiles.Add(p.AbsolutePath);

--- a/src/Tests/dotnet-workload-restore.Tests/DiscoverAllProjectsTests.cs
+++ b/src/Tests/dotnet-workload-restore.Tests/DiscoverAllProjectsTests.cs
@@ -69,5 +69,25 @@ namespace Microsoft.DotNet.Cli.Workload.Restore.Tests
             result.Should().Contain(f => Path.GetFileName(f) == "First.csproj");
             result.Should().Contain(f => Path.GetFileName(f) == "Second.csproj");
         }
+
+        [Fact]
+        public void WhenCallWithSlnContainingSolutionFolderItExcludesFolderProjectsFromSolution()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndSolutionFolders")
+                .WithSource()
+                .Path;
+
+            var result =
+                WorkloadRestoreCommand.DiscoverAllProjects("",
+                    new[]
+                    {
+                        Path.Combine(projectDirectory, "App.sln"),
+                    });
+
+            // 'src' solution folder is filtered out
+            result.Should().Contain(f => Path.GetFileName(f) == "App.csproj", "from checking the sln file");
+            result.Count.Should().Be(1);
+        }
     }
 }


### PR DESCRIPTION
A community member was very kind to provide a fix for a crash a lot of users have been experiencing. https://github.com/dotnet/sdk/pull/25919 That's already been merged in, but it was merged into main. Enough people are reporting this issue to us that I think it'd be better to fix it sooner than whenever we push main to release again. 

## Description
See the following discussion thread.
Fixes (https://github.com/dotnet/sdk/issues/26273#issuecomment-1171731164)

## Customer Impact

Workload restore becomes functional for customers who have solution folders in their directory.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The change is quite minor in scope. 

## Verification

- [x] Manual (required)
- [X] Automated

We have already tested in this main. 

## Packaging changes reviewed?

I don't know what this means.

- [ ] Yes
- [ ] No
- [X] N/A
