### PR TITLE
Support for msbuild/build event

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -63,8 +63,6 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         public ProcessStartInfo GetProcessStartInfo()
         {
-            EnvironmentVariable(TelemetrySessionIdEnvironmentVariableName, Telemetry.CurrentSessionId);
-
             return _forwardingAppWithoutLogging.GetProcessStartInfo();
         }
 
@@ -84,6 +82,10 @@ namespace Microsoft.DotNet.Tools.MSBuild
             Console.CancelKeyPress += (sender, e) => { e.Cancel = true; };
 
             int exitCode;
+
+            // Config needed for telemetry logger
+            EnvironmentVariable(TelemetrySessionIdEnvironmentVariableName, Telemetry.CurrentSessionId);
+
             if (_forwardingAppWithoutLogging.ExecuteMSBuildOutOfProc)
             {
                 ProcessStartInfo startInfo = GetProcessStartInfo();

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -63,6 +63,8 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         public ProcessStartInfo GetProcessStartInfo()
         {
+            EnvironmentVariable(TelemetrySessionIdEnvironmentVariableName, Telemetry.CurrentSessionId);
+
             return _forwardingAppWithoutLogging.GetProcessStartInfo();
         }
 
@@ -82,10 +84,6 @@ namespace Microsoft.DotNet.Tools.MSBuild
             Console.CancelKeyPress += (sender, e) => { e.Cancel = true; };
 
             int exitCode;
-
-            // Config needed for telemetry logger
-            EnvironmentVariable(TelemetrySessionIdEnvironmentVariableName, Telemetry.CurrentSessionId);
-
             if (_forwardingAppWithoutLogging.ExecuteMSBuildOutOfProc)
             {
                 ProcessStartInfo startInfo = GetProcessStartInfo();

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -63,9 +63,14 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         public ProcessStartInfo GetProcessStartInfo()
         {
-            EnvironmentVariable(TelemetrySessionIdEnvironmentVariableName, Telemetry.CurrentSessionId);
+            InitializeRequiredEnvironmentVariables();
 
             return _forwardingAppWithoutLogging.GetProcessStartInfo();
+        }
+
+        private void InitializeRequiredEnvironmentVariables()
+        {
+            EnvironmentVariable(TelemetrySessionIdEnvironmentVariableName, Telemetry.CurrentSessionId);
         }
 
         /// <summary>
@@ -94,6 +99,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             }
             else
             {
+                InitializeRequiredEnvironmentVariables();
                 string[] arguments = _forwardingAppWithoutLogging.GetAllArguments();
                 if (PerformanceLogEventSource.Log.IsEnabled())
                 {

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -8,7 +8,9 @@ using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Configurer;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.MSBuild
 {
@@ -17,8 +19,10 @@ namespace Microsoft.DotNet.Tools.MSBuild
         private readonly IFirstTimeUseNoticeSentinel _sentinel =
             new FirstTimeUseNoticeSentinel();
         private readonly ITelemetry _telemetry;
-        private const string NewEventName = "msbuild";
+
         internal const string TargetFrameworkTelemetryEventName = "targetframeworkeval";
+        internal const string BuildTelemetryEventName = "build";
+
         internal const string SdkTaskBaseCatchExceptionTelemetryEventName = "taskBaseCatchException";
         internal const string PublishPropertiesTelemetryEventName = "PublishProperties";
         internal const string ReadyToRunTelemetryEventName = "ReadyToRun";
@@ -107,15 +111,47 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
                 telemetry.TrackEvent(newEventName, maskedProperties, measurements: null);
             }
+            else if (args.EventName == BuildTelemetryEventName)
+            {
+                var newEventName = $"msbuild/{BuildTelemetryEventName}";
+                Dictionary<string, string> properties = new Dictionary<string, string>(args.Properties);
+                Dictionary<string, double> measurements = new Dictionary<string, double>();
 
-            var passthroughEvents = new string[] {
-                    SdkTaskBaseCatchExceptionTelemetryEventName,
+                string[] toBeHashed = new[] { "ProjectPath" };
+                foreach (var propertyToBeHashed in toBeHashed)
+                {
+                    if (properties.TryGetValue(propertyToBeHashed, out string value))
+                    {
+                        properties[propertyToBeHashed] = Sha256Hasher.HashWithNormalizedCasing(value);
+                    }
+                }
+
+                string[] toBeMeasured = new[] { "BuildDurationInMilliseconds", "InnerBuildDurationInMilliseconds" };
+                foreach (var propertyToBeMeasured in toBeMeasured)
+                {
+                    if (properties.TryGetValue(propertyToBeMeasured, out string value))
+                    {
+                        properties.Remove(propertyToBeMeasured);
+                        if (double.TryParse(value, CultureInfo.InvariantCulture, out double realValue))
+                        {
+                            measurements[propertyToBeMeasured] = realValue;
+                        }
+                    }
+                }
+
+                telemetry.TrackEvent(newEventName, properties, measurements);
+            }
+            else
+            {
+                var passthroughEvents = new string[] {
+                    SdkTaskBaseCatchExceptionTelemetryEventName, 
                     PublishPropertiesTelemetryEventName,
                     ReadyToRunTelemetryEventName };
 
-            if (passthroughEvents.Contains(args.EventName))
-            {
-                telemetry.TrackEvent(args.EventName, args.Properties, measurements: null);
+                if (passthroughEvents.Contains(args.EventName))
+                {
+                    telemetry.TrackEvent(args.EventName, args.Properties, measurements: null);
+                }
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 Dictionary<string, string> properties = new Dictionary<string, string>(args.Properties);
                 Dictionary<string, double> measurements = new Dictionary<string, double>();
 
-                string[] toBeHashed = new[] { "ProjectPath" };
+                string[] toBeHashed = new[] { "ProjectPath", "BuildTarget" };
                 foreach (var propertyToBeHashed in toBeHashed)
                 {
                     if (properties.TryGetValue(propertyToBeHashed, out string value))


### PR DESCRIPTION
Support for telemetry emitted by https://github.com/dotnet/msbuild/pull/7778

This telemetry is supposed to be sent with every build, including base measurements and properties usable to understand usage of MSBuild.

This PR also fixes bug causing not sending telemetry from msbuild - introduced during changes of SDK calling msbuild.dll inproc.

NOTE: Although it is related to MSBuild server it could be merged into SDK before MSBuild server is released.