### PR TITLE
[Razor] Fix static webassets pack when there are no assets in cross-targeting builds

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.Pack.CrossTargeting.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.Pack.CrossTargeting.targets
@@ -90,7 +90,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Clean up static web assets from existing item groups -->
 
     <ReadStaticWebAssetsManifestFile
-      Condition="'$(StaticWebAssetBuildManifestPath)' != ''"
+      Condition="'$(StaticWebAssetBuildManifestPath)' != '' and Exists('$(StaticWebAssetBuildManifestPath)')"
       ManifestPath="$(StaticWebAssetBuildManifestPath)">
       <Output TaskParameter="Assets" ItemName="_CachedBuildStaticWebAssets" />
     </ReadStaticWebAssetsManifestFile>
@@ -103,7 +103,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Add assets as content items to be packed -->
     
     <StaticWebAssetsReadPackManifest
-      Condition="'$(StaticWebAssetPackManifestPath)' != ''"
+      Condition="'$(StaticWebAssetPackManifestPath)' != '' and Exists('$(StaticWebAssetPackManifestPath)')"
       ManifestPath="$(StaticWebAssetPackManifestPath)"
     >
       <Output TaskParameter="Files" ItemName="_StaticWebAssetsFilesToPack" />


### PR DESCRIPTION
We fixed the single target case https://github.com/dotnet/sdk/commit/6c50892ff1b0cc237f98f946fd26ea7bdd7f012c but we missed fixing the multitargeting one.