### PR TITLE
dotnet/templating#3829 evaluating project context for dotnet new execution

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
@@ -129,8 +129,82 @@
     <value>Failed to add project(s) to the solution: {0}</value>
     <comment>{0} - the reason why operation failed, normally ends with period</comment>
   </data>
+  <data name="CapabilityExpressionEvaluator_Exception_InvalidExpression" xml:space="preserve">
+    <value>Invalid expression, position: {0}.</value>
+  </data>
   <data name="DisableSdkTemplates_OptionDescription" xml:space="preserve">
     <value>If present, prevents templates bundled in the SDK from being presented.</value>
+  </data>
+  <data name="EnableProjectContextEval_OptionDescription" xml:space="preserve">
+    <value>Enables evaluating project context using MSBuild.</value>
+  </data>
+  <data name="MSBuildEvaluationResult_Error_NoProjectFound" xml:space="preserve">
+    <value>No project was found at the path: {0}.</value>
+    <comment>{0} - the file path where project was expected to be found.</comment>
+  </data>
+  <data name="MSBuildEvaluationResult_Error_NotRestored" xml:space="preserve">
+    <value>{0} is not restored.</value>
+    <comment>{0} - the full path to the project.</comment>
+  </data>
+  <data name="MSBuildEvaluator_Error_NoTargetFramework" xml:space="preserve">
+    <value>Project '{0}' is a SDK-style project, but does not specify the framework.</value>
+    <comment>{0} - the full path to the project.</comment>
+  </data>
+  <data name="MultipleProjectsEvaluationResult_Error" xml:space="preserve">
+    <value>Multiple projects found: {0}.</value>
+    <comment>{0} - semi-colon separated list of path to projects found.</comment>
+  </data>
+  <data name="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed" xml:space="preserve">
+    <value>Failed to create constraint '{0}': failed to evaluate the project: {1}</value>
+    <comment>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</comment>
+  </data>
+  <data name="ProjectCapabilityConstraintFactory_Exception_NoEvaluator" xml:space="preserve">
+    <value>Failed to create constraint '{0}': {1} component is not available.</value>
+    <comment>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</comment>
+  </data>
+  <data name="ProjectCapabilityConstraint_DisplayName" xml:space="preserve">
+    <value>Project capabiltities</value>
+  </data>
+  <data name="ProjectCapabilityConstraint_Error_ArgumentShouldBeString" xml:space="preserve">
+    <value>argument should be a string</value>
+    <comment>part of a sentence</comment>
+  </data>
+  <data name="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty" xml:space="preserve">
+    <value>arguments should not contain empty values</value>
+    <comment>part of a sentence</comment>
+  </data>
+  <data name="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration" xml:space="preserve">
+    <value>Invalid constraint configuration</value>
+    <comment>part of a sentence</comment>
+  </data>
+  <data name="ProjectCapabilityConstraint_Error_InvalidJson" xml:space="preserve">
+    <value>invalid JSON</value>
+    <comment>part of a sentence</comment>
+  </data>
+  <data name="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message" xml:space="preserve">
+    <value>Failed to evaluate project context: {0}</value>
+    <comment>{0} - failure reason</comment>
+  </data>
+  <data name="ProjectCapabilityConstraint_Restricted_Message" xml:space="preserve">
+    <value>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</value>
+    <comment>{0} - project capability expression (non-localizable), {1} - path to the project.</comment>
+  </data>
+  <data name="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA" xml:space="preserve">
+    <value>Specify the project to use using {0} option.</value>
+    <comment>{0} - option to use - non localizable</comment>
+  </data>
+  <data name="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA" xml:space="preserve">
+    <value>This template can only be created inside the project.</value>
+  </data>
+  <data name="ProjectCapabilityConstraint_Restricted_NotRestored_CTA" xml:space="preserve">
+    <value>Run 'dotnet restore {0}' to restore the project.</value>
+    <comment>do not translate 'dotnet restore {0}'</comment>
+  </data>
+  <data name="ProjectContextSymbolSource_DisplayName" xml:space="preserve">
+    <value>Project context</value>
+  </data>
+  <data name="ProjectPath_OptionDescription" xml:space="preserve">
+    <value>The project that should be used for context evaluation.</value>
   </data>
   <data name="RestoreCallback_Failed" xml:space="preserve">
     <value>Failed to perform restore: {0}</value>

--- a/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
@@ -193,6 +193,10 @@
     <value>Specify the project to use using {0} option.</value>
     <comment>{0} - option to use - non localizable</comment>
   </data>
+  <data name="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message" xml:space="preserve">
+    <value>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</value>
+    <comment>{0} - path to the project</comment>
+  </data>
   <data name="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA" xml:space="preserve">
     <value>This template can only be created inside the project.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/CapabilityExpressionEvaluator.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/CapabilityExpressionEvaluator.cs
@@ -1,0 +1,294 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Microsoft.TemplateEngine.MSBuildEvaluation
+{
+    /// <remarks>
+    /// As implemented in: https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.vsprojectcapabilityexpressionmatcher?
+    /// </remarks>
+    internal class CapabilityExpressionEvaluator
+    {
+        /// <summary>
+        /// The set of terms that are present.
+        /// </summary>
+        private readonly IReadOnlyList<string> _presentTerms;
+
+        /// <summary>
+        /// The tokenizer that reads the expression.
+        /// </summary>
+        private readonly Tokenizer _tokenizer;
+
+        /// <summary>
+        /// The set of disallowed characters in terms.
+        /// </summary>
+        /// <remarks>
+        /// We restrict many symbols, especially mathematical symbols, because we may eventually want to 
+        /// support arithmetic expressions.
+        /// </remarks>
+        internal static readonly char[] DisallowedCharacters = "\"'`:;,+-*/\\!~|&%$@^()={}[]<>? \t\b\n\r".ToCharArray();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CapabilityExpressionEvaluator"/> class.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <param name="presentTerms">The present terms.</param>
+        private CapabilityExpressionEvaluator(string expression, IReadOnlyList<string> presentTerms)
+        {
+            _tokenizer = new Tokenizer(expression);
+            _presentTerms = presentTerms ?? throw new ArgumentNullException(nameof(presentTerms));
+        }
+
+        /// <summary>
+        /// Evaluates the given expression against the given set of true terms. Missing terms are assumed to be false.
+        /// </summary>
+        /// <param name="expression">
+        /// The expression, such as "(VisualC | CSharp) + (MSTest | NUnit)".  
+        /// The '|' is the OR operator.
+        /// The '&' and '+' characters are both AND operators.
+        /// The '!' character is the NOT operator.
+        /// Parentheses force evaluation precedence order.
+        /// A null or empty expression is evaluated as true.
+        /// </param>
+        /// <param name="presentTerms">The terms that are currently defined.</param>
+        /// <returns>The result of evaluating the Boolean expression.</returns>
+        public static bool Evaluate(string expression, IReadOnlyList<string> presentTerms)
+        {
+            if (string.IsNullOrWhiteSpace(expression))
+            {
+                // An empty expression evaluates to true.
+                return true;
+            }
+
+            var eval = new CapabilityExpressionEvaluator(expression, presentTerms);
+            return eval.Top();
+        }
+
+        /// <summary>
+        /// Checks whether a given character is an allowed member of a term.
+        /// </summary>
+        /// <param name="ch">The character to test.</param>
+        /// <returns>true if the character would be an allowed member of a term; false otherwise.</returns>
+        private static bool IsSymbolCharacter(char ch)
+        {
+            return !DisallowedCharacters.Contains(ch);
+        }
+
+        /// <summary>
+        /// Processes | operators.
+        /// </summary>
+        /// <returns>The result of evaluating the current sub-expression.</returns>
+        private bool OrTerm()
+        {
+            bool lhs = AndTerm();
+            while (_tokenizer.Peek() == "|")
+            {
+                _tokenizer.Next();
+                bool rhs = AndTerm();
+                lhs = lhs || rhs;
+            }
+
+            return lhs;
+        }
+
+        /// <summary>
+        /// Processes &amp; operators.
+        /// </summary>
+        /// <returns>The result of evaluating the current sub-expression.</returns>
+        private bool AndTerm()
+        {
+            bool lhs = Term();
+            while (_tokenizer.Peek() == "&")
+            {
+                _tokenizer.Next();
+                bool rhs = Term();
+                lhs = lhs && rhs;
+            }
+
+            return lhs;
+        }
+
+        /// <summary>
+        /// Processes terms.
+        /// </summary>
+        /// <returns>The result of evaluating the current sub-expression.</returns>
+        private bool Term()
+        {
+            int notCount = 0;
+            while (_tokenizer.Peek() == "!")
+            {
+                _tokenizer.Next();
+                notCount++;
+            }
+
+            if (_tokenizer.Peek() == "(")
+            {
+                _tokenizer.Next();
+                bool r = OrTerm();
+                if (_tokenizer.Peek() != ")")
+                {
+                    throw _tokenizer.CreateInvalidExpressionException();
+                }
+                _tokenizer.Next();
+                return (notCount % 2 == 0) ? r : !r;
+            }
+            else if (_tokenizer.Peek() != null && IsSymbolCharacter(_tokenizer.Peek()![0]))
+            {
+                string? ident = _tokenizer.Next();
+                bool isPresent = _presentTerms.Contains(ident, StringComparer.OrdinalIgnoreCase);
+                return (notCount % 2 == 0) ? isPresent : !isPresent;
+            }
+            else
+            {
+                throw _tokenizer.CreateInvalidExpressionException();
+            }
+        }
+
+        /// <summary>
+        /// Processes the entire expression.
+        /// </summary>
+        /// <returns>The result of evaluating the expression.</returns>
+        private bool Top()
+        {
+            bool r = OrTerm();
+            if (_tokenizer.Peek() != null)
+            {
+                throw _tokenizer.CreateInvalidExpressionException(_tokenizer.Input.Length);
+            }
+
+            return r;
+        }
+
+        /// <summary>
+        /// The expression tokenizer.
+        /// </summary>
+        /// <devremarks>
+        /// This is a struct rather than a class to avoid allocating memory unnecessarily.
+        /// </devremarks>
+        private class Tokenizer
+        {
+            /// <summary>
+            /// The most recently previewed token.
+            /// </summary>
+            private string? _peeked;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Tokenizer"/> class.
+            /// </summary>
+            /// <param name="input">The expression to parse.</param>
+            internal Tokenizer(string input)
+            {
+                if (string.IsNullOrEmpty(input))
+                {
+                    throw new ArgumentException($"'{nameof(input)}' cannot be null or empty.", nameof(input));
+                }
+                Input = input;
+            }
+
+            /// <summary>
+            /// Gets the entire expression being tokenized.
+            /// </summary>
+            internal string Input { get; }
+
+            /// <summary>
+            /// Gets the position of the next token.
+            /// </summary>
+            internal int Position { get; private set; }
+
+            /// <summary>
+            /// Gets the next token in the expression.
+            /// </summary>
+            internal string? Next()
+            {
+                // If the last call to Next() was within a Peek() method call,
+                // we need to return the same value again this time so that
+                // the Peek() doesn't impact the token stream.
+                if (_peeked != null)
+                {
+                    string token = _peeked;
+                    _peeked = null;
+                    return token;
+                }
+
+                // Skip whitespace.
+                while (Position < Input.Length && char.IsWhiteSpace(Input[Position]))
+                {
+                    Position++;
+                }
+
+                if (Position == Input.Length)
+                {
+                    return null;
+                }
+
+                switch (Input[Position])
+                {
+                    case char sym when IsSymbolCharacter(sym):
+                        int begin = Position;
+                        while (Position < Input.Length && IsSymbolCharacter(Input[Position]))
+                        {
+                            Position++;
+                        }
+                        int end = Position;
+                        return Input.Substring(begin, end - begin);
+                    // we prefer & but also accept + so that XML manifest files don't have to write the &amp; escape sequence.
+                    case '&':
+                    case '+':
+                        Position++;
+                        return "&";  // always return '&' to simplify the parser logic by consolidating on only one of the two possible operators.
+                    case '|':
+                        Position++;
+                        return "|";
+                    case '(':
+                        Position++;
+                        return "(";
+                    case ')':
+                        Position++;
+                        return ")";
+                    case '!':
+                        Position++;
+                        return "!";
+                    default: throw CreateInvalidExpressionException(Position);
+                }
+            }
+
+            /// <summary>
+            /// Peeks at the next token in the stream without skipping it on
+            /// the next invocation of <see cref="Next"/>.
+            /// </summary>
+            internal string? Peek()
+            {
+                return _peeked = Next();
+            }
+
+            /// <summary>
+            /// Create an exception indicating that the expression is invalid and reporting the current position.
+            /// </summary>
+            /// <param name="position">The position in the expression where the error was detected.</param>
+            /// <returns>An exception for diagnosing the invalid expression.</returns>
+            internal Exception CreateInvalidExpressionException()
+            {
+                return CreateInvalidExpressionException(Position);
+            }
+
+            /// <summary>
+            /// Create an exception indicating that the expression is invalid and reporting the given position.
+            /// </summary>
+            /// <param name="position">The position in the expression where the error was detected.</param>
+            /// <returns>An exception for diagnosing the invalid expression.</returns>
+            internal Exception CreateInvalidExpressionException(int position)
+            {
+                return new ArgumentException(
+                    $"Invalid expression, position: {position}.",
+                    "expression");
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/CapabilityExpressionEvaluator.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/CapabilityExpressionEvaluator.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 
 namespace Microsoft.TemplateEngine.MSBuildEvaluation
 {
@@ -286,7 +287,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
             internal Exception CreateInvalidExpressionException(int position)
             {
                 return new ArgumentException(
-                    $"Invalid expression, position: {position}.",
+                    string.Format(LocalizableStrings.CapabilityExpressionEvaluator_Exception_InvalidExpression, position),
                     "expression");
             }
         }

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluationResult.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluationResult.cs
@@ -5,6 +5,7 @@
 
 using System.IO;
 using Microsoft.Build.Evaluation;
+using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 
 namespace Microsoft.TemplateEngine.MSBuildEvaluation
 {
@@ -52,7 +53,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
         {
             return new MSBuildEvaluationResult(EvalStatus.NoProjectFound)
             {
-                ErrorMessage = $"No project was found at the path: {path}."
+                ErrorMessage = string.Format(LocalizableStrings.MSBuildEvaluationResult_Error_NoProjectFound, path)
             };
         }
 
@@ -60,7 +61,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
         {
             return new MSBuildEvaluationResult(EvalStatus.NoRestore, path)
             {
-                ErrorMessage = $"{path} is not restored. Run 'dotnet restore {Path.GetFullPath(path)}' to restore that project."
+                ErrorMessage = string.Format(LocalizableStrings.MSBuildEvaluationResult_Error_NotRestored, path)
             };
         }
 

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluationResult.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluationResult.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.IO;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.TemplateEngine.MSBuildEvaluation
+{
+    /// <summary>
+    /// Represents MSBuild evaluation result. 
+    /// For success results, <see cref="SDKStyleEvaluationResult"/>, <see cref="NonSDKStyleEvaluationResult"/>, <see cref="MultiTargetEvaluationResult"/> are used depending on the evaluated project.
+    /// </summary>
+    internal class MSBuildEvaluationResult
+    {
+        protected MSBuildEvaluationResult(EvalStatus status)
+        {
+            Status = status;
+        }
+
+        protected MSBuildEvaluationResult(EvalStatus status, string projectPath)
+        {
+            Status = status;
+            ProjectPath = projectPath;
+
+            string extension = Path.GetExtension(projectPath);
+            Language = extension.ToLowerInvariant() switch
+            {
+                "csproj" => DotNetLanguage.CSharp,
+                "fsproj" => DotNetLanguage.FSharp,
+                "vbproj" => DotNetLanguage.VB,
+                _ => DotNetLanguage.NotEvaluated
+            };
+        }
+
+        internal enum EvalStatus { NotEvaluated, NoProjectFound, MultipleProjectFound, NoRestore, Succeeded, Failed }
+
+        internal enum DotNetLanguage { NotEvaluated, CSharp, VB, FSharp }
+
+        internal EvalStatus Status { get; }
+
+        internal DotNetLanguage Language { get; private set; }
+
+        internal string? ProjectPath { get; }
+
+        public Project? EvaluatedProject { get; protected set; }
+
+        public string? ErrorMessage { get; protected set; }
+
+        internal static MSBuildEvaluationResult CreateNoProjectFound(string path)
+        {
+            return new MSBuildEvaluationResult(EvalStatus.NoProjectFound)
+            {
+                ErrorMessage = $"No project was found at the path: {path}."
+            };
+        }
+
+        internal static MSBuildEvaluationResult CreateNoRestore (string path)
+        {
+            return new MSBuildEvaluationResult(EvalStatus.NoRestore, path)
+            {
+                ErrorMessage = $"{path} is not restored. Run 'dotnet restore {Path.GetFullPath(path)}' to restore that project."
+            };
+        }
+
+        internal static MSBuildEvaluationResult CreateFailure(string path, string errorMessage)
+        {
+            return new MSBuildEvaluationResult(EvalStatus.Failed, path)
+            {
+                ErrorMessage = errorMessage,
+            };
+        }
+    }
+
+}

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluator.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluator.cs
@@ -11,7 +11,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
-using NuGet.Configuration;
+using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 
 namespace Microsoft.TemplateEngine.MSBuildEvaluation
 {
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
         internal MSBuildEvaluator(string? outputDirectory = null, string? projectPath = null)
         {
             _outputDirectory = outputDirectory ?? Directory.GetCurrentDirectory();
-            _projectFullPath = projectPath;
+            _projectFullPath = projectPath != null ? Path.GetFullPath(projectPath) : null;
         }
 
         public Guid Id => Guid.Parse("{6C2CB5CA-06C3-460A-8ADB-5F21E113AB24}");
@@ -106,7 +106,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                     _logger?.LogDebug("Multiple projects found.");
                     return MultipleProjectsEvaluationResult.Create(foundFiles);
                 }
-                projectPath = foundFiles.Single();
+                projectPath = Path.GetFullPath(foundFiles.Single());
             }
             else
             {
@@ -154,7 +154,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 if (targetFrameworks == null)
                 {
                     _logger?.LogDebug("Project is SDK style, but does not specify the framework.");
-                    return MSBuildEvaluationResult.CreateFailure(projectPath, $"Project '{projectPath}' is a SDK-style project, but does not specify the framework.");
+                    return MSBuildEvaluationResult.CreateFailure(projectPath, string.Format(LocalizableStrings.MSBuildEvaluator_Error_NoTargetFramework, projectPath));
                 }
 
                 //For multi-target project, we need to do additional evaluation for each target framework.

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluator.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluator.cs
@@ -8,14 +8,21 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Evaluation;
+using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
+using NuGet.Configuration;
 
 namespace Microsoft.TemplateEngine.MSBuildEvaluation
 {
     internal class MSBuildEvaluator : IIdentifiedComponent
     {
         private readonly ProjectCollection _projectCollection = new ProjectCollection();
+        private readonly object _lockObj = new object();
+
+        private IEngineEnvironmentSettings? _settings;
+        private ILogger? _logger;
+        private MSBuildEvaluationResult? _cachedEvaluationResult;
         private string _outputDirectory;
         internal MSBuildEvaluator()
         {
@@ -29,55 +36,104 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
 
         public Guid Id => Guid.Parse("{6C2CB5CA-06C3-460A-8ADB-5F21E113AB24}");
 
+        /// <summary>
+        /// Evaluates the project at current location.
+        /// Current location is specified by `--output` or is current working directory.
+        /// The location is set once when component is created.
+        /// If location changes, recreate the component.
+        /// </summary>
+        /// <param name="engineEnvironmentSettings"></param>
+        /// <returns>MSBuild project evaluation result.</returns>
         internal MSBuildEvaluationResult EvaluateProject(IEngineEnvironmentSettings engineEnvironmentSettings)
         {
+            lock (_lockObj)
+            {
+                //we cache result of evaluation if instance of environment settings used is the same.
+                //reason: the component is only used in dotnet CLI, which execution is short lived.
+                //we don't care about changes done to project during command execution.
+                if (_settings == null || _settings != engineEnvironmentSettings || _cachedEvaluationResult == null)
+                {
+                    _settings = engineEnvironmentSettings;
+                    _logger = _settings.Host.LoggerFactory.CreateLogger(nameof(MSBuildEvaluator));
+                    _cachedEvaluationResult = EvaluateProjectInternal(_settings);
+                }
+                return _cachedEvaluationResult;
+            }
+        }
+
+        /// <summary>
+        /// Forces cache reset.
+        /// </summary>
+        internal void ResetCache()
+        {
+            lock (_lockObj)
+            {
+                _settings = null;
+                _cachedEvaluationResult = null;
+            }
+        }
+
+        private MSBuildEvaluationResult EvaluateProjectInternal(IEngineEnvironmentSettings engineEnvironmentSettings)
+        {
+            _logger?.LogDebug("Output directory is: {0}.", string.Join("; ", _outputDirectory));
             IReadOnlyList<string> foundFiles = Array.Empty<string>();
             try
             {
                 foundFiles = FileFindHelpers.FindFilesAtOrAbovePath(engineEnvironmentSettings.Host.FileSystem, _outputDirectory, "*.*proj");
+                _logger?.LogDebug("Found project files: {0}.", string.Join("; ", foundFiles));
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 //do nothing
                 //in case of exception, no project found result is used.
+                _logger?.LogDebug("Exception occurred when searching for the project file: {0}", e.Message);
             }
 
             if (foundFiles.Count == 0)
             {
+                _logger?.LogDebug("No project found.");
                 return MSBuildEvaluationResult.CreateNoProjectFound(_outputDirectory);
             }
             if (foundFiles.Count > 1)
             {
+                _logger?.LogDebug("Multiple projects found.");
                 return MultipleProjectsEvaluationResult.Create(foundFiles);
             }
 
             string projectPath = foundFiles.Single();
             try
             {
+                _logger?.LogDebug("Evaluating project: {0}", projectPath);
                 Project evaluatedProject = RunEvaluate(projectPath);
 
                 //if project is using Microsoft.NET.Sdk, then it is SDK-style project.
                 bool IsSdkStyleProject = evaluatedProject.GetProperty("UsingMicrosoftNETSDK")?.EvaluatedValue == "true";
+                _logger?.LogDebug("SDK-style project: {0}", IsSdkStyleProject);
 
                 IReadOnlyList<string>? targetFrameworks = evaluatedProject.GetProperty("TargetFrameworks")?.EvaluatedValue?.Split(";");
+                _logger?.LogDebug("Target frameworks: {0}", string.Join("; ", targetFrameworks ?? Array.Empty<string>()));
                 string? targetFramework = evaluatedProject.GetProperty("TargetFramework")?.EvaluatedValue;
+                _logger?.LogDebug("Target framework: {0}", targetFramework ?? "<null>");
 
                 if (!IsSdkStyleProject || string.IsNullOrWhiteSpace(targetFramework) && targetFrameworks == null)
                 {
                     //For non SDK style project, we cannot evaluate more info. Also there is no indication, whether the project
                     //was restored or not, so it is not checked.
+                    _logger?.LogDebug("Project is non-SDK style, cannot evaluate restore status, succeeding.");
                     return NonSDKStyleEvaluationResult.CreateSuccess(projectPath, evaluatedProject);
                 }
 
                 //For SDK-style project, if the project was restored "RestoreSuccess" property will be set to true.
                 if (!evaluatedProject.GetProperty("RestoreSuccess")?.EvaluatedValue.Equals("true", StringComparison.OrdinalIgnoreCase) ?? true)
                 {
+                    _logger?.LogDebug("Project is not restored, exiting.");
                     return MSBuildEvaluationResult.CreateNoRestore(projectPath);
                 }
 
                 //If target framework is set, no further evaluation is needed.
                 if (!string.IsNullOrWhiteSpace(targetFramework))
                 {
+                    _logger?.LogDebug("Project is SDK style, single TFM:{0}, evaluation succeeded.", targetFramework);
                     return SDKStyleEvaluationResult.CreateSuccess(projectPath, targetFramework, evaluatedProject);
                 }
 
@@ -85,20 +141,24 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 //If there are no target frameworks, it is not expected.
                 if (targetFrameworks == null)
                 {
-                    throw new Exception($"Project '{projectPath}' is a SDK-style project, but does not specify the framework.");
+                    _logger?.LogDebug("Project is SDK style, but does not specify the framework.");
+                    return MSBuildEvaluationResult.CreateFailure(projectPath, $"Project '{projectPath}' is a SDK-style project, but does not specify the framework.");
                 }
 
                 //For multi-target project, we need to do additional evaluation for each target framework.
                 Dictionary<string, Project?> evaluatedTfmBasedProjects = new Dictionary<string, Project?>();
                 foreach (string tfm in targetFrameworks)
                 {
+                    _logger?.LogDebug("Evaluating project for target framework: {0}", tfm);
                     evaluatedTfmBasedProjects[tfm] = RunEvaluate(projectPath, tfm);
                 }
+                _logger?.LogDebug("Project is SDK style, multi-target, evaluation succeeded.");
                 return MultiTargetEvaluationResult.CreateSuccess(projectPath, evaluatedProject, evaluatedTfmBasedProjects);
 
             }
             catch (Exception e)
             {
+                _logger?.LogDebug("Unexpected error: {0}", e);
                 return MSBuildEvaluationResult.CreateFailure(projectPath, e.Message);
             }
         }

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluator.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluator.cs
@@ -1,0 +1,171 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Evaluation;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Utils;
+
+namespace Microsoft.TemplateEngine.MSBuildEvaluation
+{
+    internal class MSBuildEvaluator : IIdentifiedComponent
+    {
+        private readonly ProjectCollection _projectCollection = new ProjectCollection();
+        private string _outputDirectory;
+        internal MSBuildEvaluator()
+        {
+            _outputDirectory = Directory.GetCurrentDirectory();
+        }
+
+        internal MSBuildEvaluator(string outputDirectory)
+        {
+            _outputDirectory = outputDirectory;
+        }
+
+        public Guid Id => Guid.Parse("{6C2CB5CA-06C3-460A-8ADB-5F21E113AB24}");
+
+        internal MSBuildEvaluationResult EvaluateProject(IEngineEnvironmentSettings engineEnvironmentSettings)
+        {
+            IReadOnlyList<string> foundFiles = Array.Empty<string>();
+            try
+            {
+                foundFiles = FileFindHelpers.FindFilesAtOrAbovePath(engineEnvironmentSettings.Host.FileSystem, _outputDirectory, "*.*proj");
+            }
+            catch (Exception)
+            {
+                //do nothing
+                //in case of exception, no project found result is used.
+            }
+
+            if (foundFiles.Count == 0)
+            {
+                return MSBuildEvaluationResult.CreateNoProjectFound(_outputDirectory);
+            }
+            if (foundFiles.Count > 1)
+            {
+                return MultipleProjectsEvaluationResult.Create(foundFiles);
+            }
+
+            string projectPath = foundFiles.Single();
+            try
+            {
+                Project evaluatedProject = RunEvaluate(projectPath);
+
+                //if project is using Microsoft.NET.Sdk, then it is SDK-style project.
+                bool IsSdkStyleProject = evaluatedProject.GetProperty("UsingMicrosoftNETSDK")?.EvaluatedValue == "true";
+
+                IReadOnlyList<string>? targetFrameworks = evaluatedProject.GetProperty("TargetFrameworks")?.EvaluatedValue?.Split(";");
+                string? targetFramework = evaluatedProject.GetProperty("TargetFramework")?.EvaluatedValue;
+
+                if (!IsSdkStyleProject || string.IsNullOrWhiteSpace(targetFramework) && targetFrameworks == null)
+                {
+                    //For non SDK style project, we cannot evaluate more info. Also there is no indication, whether the project
+                    //was restored or not, so it is not checked.
+                    return NonSDKStyleEvaluationResult.CreateSuccess(projectPath, evaluatedProject);
+                }
+
+                //For SDK-style project, if the project was restored "RestoreSuccess" property will be set to true.
+                if (!evaluatedProject.GetProperty("RestoreSuccess")?.EvaluatedValue.Equals("true", StringComparison.OrdinalIgnoreCase) ?? true)
+                {
+                    return MSBuildEvaluationResult.CreateNoRestore(projectPath);
+                }
+
+                //If target framework is set, no further evaluation is needed.
+                if (!string.IsNullOrWhiteSpace(targetFramework))
+                {
+                    return SDKStyleEvaluationResult.CreateSuccess(projectPath, targetFramework, evaluatedProject);
+                }
+
+                //If target framework is not set, then presumably it is multi-target project.
+                //If there are no target frameworks, it is not expected.
+                if (targetFrameworks == null)
+                {
+                    throw new Exception($"Project '{projectPath}' is a SDK-style project, but does not specify the framework.");
+                }
+
+                //For multi-target project, we need to do additional evaluation for each target framework.
+                Dictionary<string, Project?> evaluatedTfmBasedProjects = new Dictionary<string, Project?>();
+                foreach (string tfm in targetFrameworks)
+                {
+                    evaluatedTfmBasedProjects[tfm] = RunEvaluate(projectPath, tfm);
+                }
+                return MultiTargetEvaluationResult.CreateSuccess(projectPath, evaluatedProject, evaluatedTfmBasedProjects);
+
+            }
+            catch (Exception e)
+            {
+                return MSBuildEvaluationResult.CreateFailure(projectPath, e.Message);
+            }
+        }
+
+        private Project RunEvaluate(string projectToLoad, string? tfm = null)
+        {
+            if (!File.Exists(projectToLoad))
+            {
+                throw new FileNotFoundException(message: null, projectToLoad);
+            }
+
+            Project? project = GetLoadedProject(projectToLoad, tfm);
+            if (project != null)
+            {
+                return project;
+            }
+            var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(tfm))
+            {
+                globalProperties["TargetFramework"] = tfm;
+            }
+
+            //We do only best effort here, also the evaluation should be fast vs complete; therefore ignoring imports errors.
+            //The result of evaluation is used for the following:
+            // - determining if the template can be run in the following context(constraints) based on Project Capabilities
+            // - determining properties values that will be used in template content
+            //The cost of the error is not substantial:
+            //- worst case scenario the user can create a template, which should not be allowed to and it fails to compile / build-- > likely user will remove it or fix it manually then
+            //- or the template content will be corrupted and consequent build fails --> the user may fix the issues manually if needed
+            //- or the user will not see that template that is expected --> but they can always override it with --force
+            //Therefore, we should not fail on missing imports or invalid imports, if this is the case rather restore/build should fail.
+            return new Project(
+                    projectToLoad,
+                    globalProperties,
+                    toolsVersion: null,
+                    subToolsetVersion: null,
+                    _projectCollection,
+                    ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports);
+        }
+
+        private Project? GetLoadedProject(string projectToLoad, string? tfm)
+        {
+            Project? project;
+            ICollection<Project> loadedProjects = _projectCollection.GetLoadedProjects(projectToLoad);
+            if (string.IsNullOrEmpty(tfm))
+            {
+                project = loadedProjects.FirstOrDefault(project => !project.GlobalProperties.ContainsKey("TargetFramework"));
+            }
+            else
+            {
+                project = loadedProjects.FirstOrDefault(project =>
+                    project.GlobalProperties.TryGetValue("TargetFramework", out string? targetFramework)
+                    && targetFramework.Equals(tfm, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (project != null)
+            {
+                return project;
+            }
+            if (loadedProjects.Any())
+            {
+                foreach (Project loaded in loadedProjects)
+                {
+                    _projectCollection.UnloadProject(loaded);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MultiTargetEvaluationResult.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MultiTargetEvaluationResult.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections.Generic;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.TemplateEngine.MSBuildEvaluation
+{
+    /// <summary>
+    /// Represents the result of evaluation for multi-target project.
+    /// </summary>
+    internal class MultiTargetEvaluationResult : MSBuildEvaluationResult
+    {
+        private MultiTargetEvaluationResult(string projectPath) : base(EvalStatus.Succeeded, projectPath) { }
+
+        internal IReadOnlyDictionary<string, Project?> EvaluatedProjects { get; private set; } = new Dictionary<string, Project?>();
+
+        internal IEnumerable<string> TargetFrameworks => EvaluatedProjects.Keys;
+
+        internal static MultiTargetEvaluationResult CreateSuccess(string path, Project project, IReadOnlyDictionary<string, Project?> frameworkBasedResults)
+        {
+            return new MultiTargetEvaluationResult(path)
+            {
+                EvaluatedProject = project,
+                EvaluatedProjects = frameworkBasedResults,
+            };
+        }
+    }
+
+}

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MultipleProjectsEvaluationResult.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MultipleProjectsEvaluationResult.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 
 namespace Microsoft.TemplateEngine.MSBuildEvaluation
 {
@@ -19,7 +20,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
             return new MultipleProjectsEvaluationResult()
             {
                 ProjectPaths = projectPaths,
-                ErrorMessage = $"Multiple projects found: {string.Join(";", projectPaths)}."
+                ErrorMessage = string.Format(LocalizableStrings.MultipleProjectsEvaluationResult_Error, string.Join("; ", projectPaths))
             };
         }
     }

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MultipleProjectsEvaluationResult.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MultipleProjectsEvaluationResult.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.TemplateEngine.MSBuildEvaluation
+{
+    internal class MultipleProjectsEvaluationResult : MSBuildEvaluationResult
+    {
+        private MultipleProjectsEvaluationResult() : base(EvalStatus.MultipleProjectFound) { }
+
+        internal IReadOnlyList<string> ProjectPaths { get; private set; } = Array.Empty<string>();
+
+        internal static MultipleProjectsEvaluationResult Create(IReadOnlyList<string> projectPaths)
+        {
+            return new MultipleProjectsEvaluationResult()
+            {
+                ProjectPaths = projectPaths,
+                ErrorMessage = $"Multiple projects found: {string.Join(";", projectPaths)}."
+            };
+        }
+    }
+
+}

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/NonSDKStyleEvaluationResult.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/NonSDKStyleEvaluationResult.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.TemplateEngine.MSBuildEvaluation
+{
+    /// <summary>
+    /// Represents the result of evaluation for mon-SDK style project.
+    /// </summary>
+    internal class NonSDKStyleEvaluationResult : MSBuildEvaluationResult
+    {
+        private NonSDKStyleEvaluationResult(string projectPath) : base(EvalStatus.Succeeded, projectPath) { }
+
+        internal string? TargetFrameworkVersion => EvaluatedProject?.GetProperty("TargetFrameworkVersion").EvaluatedValue;
+
+        internal string? PlatformTarget => EvaluatedProject?.GetProperty("PlatformTarget").EvaluatedValue;
+
+        internal static NonSDKStyleEvaluationResult CreateSuccess(string path, Project project)
+        {
+            return new NonSDKStyleEvaluationResult(path)
+            {
+                EvaluatedProject = project,
+            };
+        }
+    }
+
+}

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
@@ -135,6 +135,11 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                     _logger.LogDebug("Failed to evaluate project context: {0}", _evaluationResult.ErrorMessage);
                     return TemplateConstraintResult.CreateRestricted(this, string.Format(LocalizableStrings.ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message, _evaluationResult.ErrorMessage));
                 }
+                if (_evaluationResult is NonSDKStyleEvaluationResult)
+                {
+                    _logger.LogDebug("The project {0} is not an SDK style project, and is not supported for evaluation.", _evaluationResult.ProjectPath);
+                    return TemplateConstraintResult.CreateRestricted(this, string.Format(LocalizableStrings.ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message, _evaluationResult.ProjectPath));
+                }
 
                 try
                 {

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
@@ -1,0 +1,153 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Constraints;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.MSBuildEvaluation
+{
+    internal class ProjectCapabilityConstraintFactory : ITemplateConstraintFactory
+    {
+        public string Type => "project-capability";
+
+        public Guid Id => Guid.Parse("{85F3EFFB-315F-4F2F-AA0A-99EABE3B6FB3}");
+
+        public Task<ITemplateConstraint> CreateTemplateConstraintAsync(IEngineEnvironmentSettings environmentSettings, CancellationToken cancellationToken)
+        {
+            MSBuildEvaluator evaluator = environmentSettings.Components.OfType<MSBuildEvaluator>().First();
+
+            MSBuildEvaluationResult evaluationResult = evaluator.EvaluateProject(environmentSettings);
+            return Task.FromResult((ITemplateConstraint)new ProjectCapabilityConstraint(environmentSettings, this, evaluationResult));
+
+        }
+
+        internal class ProjectCapabilityConstraint : ITemplateConstraint
+        {
+            private readonly IEngineEnvironmentSettings _environmentSettings;
+            private readonly ITemplateConstraintFactory _factory;
+            private readonly MSBuildEvaluationResult _evaluationResult;
+            private readonly IReadOnlyList<string> _projectCapabilities;
+
+            internal ProjectCapabilityConstraint(IEngineEnvironmentSettings environmentSettings, ITemplateConstraintFactory factory, MSBuildEvaluationResult evaluationResult)
+            {
+                _environmentSettings = environmentSettings;
+                _factory = factory;
+                _evaluationResult = evaluationResult;
+                _projectCapabilities = GetProjectCapabilities(evaluationResult);
+            }
+
+            public string Type => _factory.Type;
+
+            public string DisplayName => "Project capabiltities";
+
+            public TemplateConstraintResult Evaluate(string? args)
+            {
+                JToken? token;
+                try
+                {
+                    token = JToken.Parse(args!);
+                }
+                catch (Exception e)
+                {
+                    throw new Exception("Invalid constraint configuration.", e);
+                }
+
+                IEnumerable<string> configuredCapabilties;
+
+                if (token.Type == JTokenType.String)
+                {
+                    string? configuredCapability = token.Value<string>();
+                    if (string.IsNullOrWhiteSpace(configuredCapability))
+                    {
+                        throw new Exception("Invalid constraint configuration: arguments should not contain empty values.");
+                    }
+                    configuredCapabilties = new[] { configuredCapability };
+                }
+                else
+                {
+                    if (token is not JArray array)
+                    {
+                        throw new Exception("Invalid constraint configuration: arguments should be either a JSON array or a string.");
+                    }
+
+                    configuredCapabilties = array.Values<string>().Select(value =>
+                    {
+                        if (string.IsNullOrWhiteSpace(value))
+                        {
+                            throw new Exception("Invalid constraint configuration: arguments should not contain empty values.");
+                        }
+                        return value;
+                    });
+                }
+
+                if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NoProjectFound)
+                {
+                    return TemplateConstraintResult.CreateRestricted(this, "No project found.", "This template can only be created inside the project.");
+                }
+                if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.MultipleProjectFound)
+                {
+                    return TemplateConstraintResult.CreateRestricted(this, $"Multiple project(s) found: {string.Join (", ", _evaluationResult.ProjectPath)}", "Specify the project to use.");
+                }
+                if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NoRestore)
+                {
+                    return TemplateConstraintResult.CreateRestricted(this, $"The project is not restored.", $"Run 'dotnet restore {_evaluationResult.ProjectPath}' to restore the project.");
+                }
+                if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.Failed || _evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NotEvaluated || _evaluationResult.EvaluatedProject == null)
+                {
+                    return TemplateConstraintResult.CreateRestricted(this, $"Failed to evaluate project context: {_evaluationResult.ErrorMessage}");
+                }
+
+                foreach (string capability in configuredCapabilties)
+                {
+                    if (!_projectCapabilities.Contains(capability, StringComparer.OrdinalIgnoreCase))
+                    {
+                        return TemplateConstraintResult.CreateRestricted(this, $"The item needs '{capability}' project capability, and current project ({_evaluationResult.ProjectPath}) does not define it.");
+                    }
+                }
+                return TemplateConstraintResult.CreateAllowed(this);
+            }
+
+            private IReadOnlyList<string> GetProjectCapabilities(MSBuildEvaluationResult result)
+            {
+                HashSet<string> capabilities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                AddProjectCapabilities(capabilities, result.EvaluatedProject);
+
+                //in case of multi-target project, consider project capabilities for all target frameworks
+                if (result is MultiTargetEvaluationResult multiTargetResult)
+                {
+                    foreach (Project? tfmBasedEvaluation in multiTargetResult.EvaluatedProjects.Values)
+                    {
+                        AddProjectCapabilities(capabilities, tfmBasedEvaluation);
+                    }
+                }
+                return capabilities.ToArray();
+
+                void AddProjectCapabilities (HashSet<string> collection, Project? evaluatedProject)
+                {
+                    if (evaluatedProject == null)
+                    {
+                        return;
+                    }
+                    foreach (ProjectItem capability in evaluatedProject.GetItems("ProjectCapability"))
+                    {
+                        if (!string.IsNullOrWhiteSpace(capability.EvaluatedInclude))
+                        {
+                            collection.Add(capability.EvaluatedInclude);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
@@ -11,9 +11,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
+using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Constraints;
 using Newtonsoft.Json.Linq;
+using NuGet.Configuration;
 
 namespace Microsoft.TemplateEngine.MSBuildEvaluation
 {
@@ -25,10 +27,24 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
 
         public Task<ITemplateConstraint> CreateTemplateConstraintAsync(IEngineEnvironmentSettings environmentSettings, CancellationToken cancellationToken)
         {
-            MSBuildEvaluator evaluator = environmentSettings.Components.OfType<MSBuildEvaluator>().First();
+            MSBuildEvaluator? evaluator = environmentSettings.Components.OfType<MSBuildEvaluator>().FirstOrDefault();
 
-            MSBuildEvaluationResult evaluationResult = evaluator.EvaluateProject(environmentSettings);
-            return Task.FromResult((ITemplateConstraint)new ProjectCapabilityConstraint(environmentSettings, this, evaluationResult));
+            if (evaluator == null)
+            {
+                environmentSettings.Host.Logger.LogDebug("{0}: '{1}' component is not available.", nameof(ProjectCapabilityConstraintFactory), nameof(MSBuildEvaluator));
+                throw new Exception($"Failed to create constraint '{Type}': {nameof(MSBuildEvaluator)} component is not available.");
+            }
+
+            try
+            {
+                MSBuildEvaluationResult evaluationResult = evaluator.EvaluateProject(environmentSettings);
+                return Task.FromResult((ITemplateConstraint)new ProjectCapabilityConstraint(environmentSettings, this, evaluationResult));
+            }
+            catch (Exception e)
+            {
+                environmentSettings.Host.Logger.LogDebug("{0}: Failed to evaluate the project: {1}.", nameof(ProjectCapabilityConstraintFactory), e.Message);
+                throw new Exception($"Failed to create constraint '{Type}': failed to evaluate the project: {e.Message}", e);
+            }
 
         }
 
@@ -38,10 +54,12 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
             private readonly ITemplateConstraintFactory _factory;
             private readonly MSBuildEvaluationResult _evaluationResult;
             private readonly IReadOnlyList<string> _projectCapabilities;
+            private readonly ILogger _logger;
 
             internal ProjectCapabilityConstraint(IEngineEnvironmentSettings environmentSettings, ITemplateConstraintFactory factory, MSBuildEvaluationResult evaluationResult)
             {
                 _environmentSettings = environmentSettings;
+                _logger = _environmentSettings.Host.LoggerFactory.CreateLogger(nameof(MSBuildEvaluator));
                 _factory = factory;
                 _evaluationResult = evaluationResult;
                 _projectCapabilities = GetProjectCapabilities(evaluationResult);
@@ -53,6 +71,12 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
 
             public TemplateConstraintResult Evaluate(string? args)
             {
+                if (string.IsNullOrWhiteSpace(args))
+                {
+                    throw new ArgumentException($"{nameof(args)} cannot be null or whitespace.", nameof(args));
+                }
+
+                _logger.LogDebug("Configuration: '{0}'", args);
                 JToken? token;
                 try
                 {
@@ -60,6 +84,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 }
                 catch (Exception e)
                 {
+                    _logger.LogDebug("Failed to parse configuration: '{0}', reason: {1}", args, e.Message);
                     throw new Exception("Invalid constraint configuration.", e);
                 }
 
@@ -70,42 +95,53 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                     string? configuredCapability = token.Value<string>();
                     if (string.IsNullOrWhiteSpace(configuredCapability))
                     {
+                        _logger.LogDebug("Invalid configuration: '{0}', reason: arguments should not contain empty values.", args);
                         throw new Exception("Invalid constraint configuration: arguments should not contain empty values.");
                     }
                     configuredCapabiltiesExpression = configuredCapability;
                 }
                 else
                 {
+                    _logger.LogDebug("Invalid configuration: '{0}', reason: arguments be a string.", args);
                     throw new Exception("Invalid constraint configuration: arguments should be a string.");
                 }
 
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NoProjectFound)
                 {
+                    _logger.LogDebug("No project found. This template can only be created inside the project.");
                     return TemplateConstraintResult.CreateRestricted(this, "No project found.", "This template can only be created inside the project.");
                 }
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.MultipleProjectFound)
                 {
-                    return TemplateConstraintResult.CreateRestricted(this, $"Multiple project(s) found: {string.Join (", ", _evaluationResult.ProjectPath)}", "Specify the project to use.");
+                    string foundProjects = string.Join("; ", (_evaluationResult as MultipleProjectsEvaluationResult)?.ProjectPaths ?? (IReadOnlyList<string?>)new[] { _evaluationResult.ProjectPath });
+                    _logger.LogDebug("Multiple projects found: {0}, specify the project to use.", foundProjects);
+                    return TemplateConstraintResult.CreateRestricted(this, $"Multiple projects found: {foundProjects}", "Specify the project to use.");
                 }
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NoRestore)
                 {
+                    _logger.LogDebug("The project is not restored. Run 'dotnet restore {0}' to restore the project.", _evaluationResult.ProjectPath);
                     return TemplateConstraintResult.CreateRestricted(this, $"The project is not restored.", $"Run 'dotnet restore {_evaluationResult.ProjectPath}' to restore the project.");
                 }
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.Failed || _evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NotEvaluated || _evaluationResult.EvaluatedProject == null)
                 {
+                    _logger.LogDebug("Failed to evaluate project context: {0}", _evaluationResult.ErrorMessage);
                     return TemplateConstraintResult.CreateRestricted(this, $"Failed to evaluate project context: {_evaluationResult.ErrorMessage}");
                 }
 
                 try
                 {
+                    _logger.LogDebug("Evaluating '{0}' on '{1}' set.", configuredCapabiltiesExpression, string.Join(", ", _projectCapabilities));
                     if (!CapabilityExpressionEvaluator.Evaluate(configuredCapabiltiesExpression, _projectCapabilities))
                     {
+                        _logger.LogDebug("Expression evaluated to 'false'.");
                         return TemplateConstraintResult.CreateRestricted(this, $"The item needs '{configuredCapabiltiesExpression}', and current project ({_evaluationResult.ProjectPath}) does not satisfy it.");
                     }
+                    _logger.LogDebug("Expression evaluated to 'true'.");
                     return TemplateConstraintResult.CreateAllowed(this);
                 }
                 catch (ArgumentException ae)
                 {
+                    _logger.LogDebug("Invalid expression '{0}'.", configuredCapabiltiesExpression);
                     throw new Exception("Invalid constraint configuration: invalid expression.", ae);
                 }
             }

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
@@ -5,9 +5,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
@@ -16,7 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Constraints;
 using Newtonsoft.Json.Linq;
-using NuGet.Configuration;
+using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 
 namespace Microsoft.TemplateEngine.MSBuildEvaluation
 {
@@ -33,7 +31,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
             if (evaluator == null)
             {
                 environmentSettings.Host.Logger.LogDebug("{0}: '{1}' component is not available.", nameof(ProjectCapabilityConstraintFactory), nameof(MSBuildEvaluator));
-                throw new Exception($"Failed to create constraint '{Type}': {nameof(MSBuildEvaluator)} component is not available.");
+                throw new Exception(string.Format(LocalizableStrings.ProjectCapabilityConstraintFactory_Exception_NoEvaluator, Type, nameof(MSBuildEvaluator)));
             }
 
             try
@@ -44,7 +42,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
             catch (Exception e)
             {
                 environmentSettings.Host.Logger.LogDebug("{0}: Failed to evaluate the project: {1}.", nameof(ProjectCapabilityConstraintFactory), e.Message);
-                throw new Exception($"Failed to create constraint '{Type}': failed to evaluate the project: {e.Message}", e);
+                throw new Exception(string.Format(LocalizableStrings.ProjectCapabilityConstraintFactory_Exception_EvaluationFailed, Type, e.Message), e);
             }
 
         }
@@ -68,7 +66,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
 
             public string Type => _factory.Type;
 
-            public string DisplayName => "Project capabiltities";
+            public string DisplayName => LocalizableStrings.ProjectCapabilityConstraint_DisplayName;
 
             public TemplateConstraintResult Evaluate(string? args)
             {
@@ -86,7 +84,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 catch (Exception e)
                 {
                     _logger.LogDebug("Failed to parse configuration: '{0}', reason: {1}", args, e.Message);
-                    throw new Exception("Invalid constraint configuration.", e);
+                    throw new Exception($"{LocalizableStrings.ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration}:{LocalizableStrings.ProjectCapabilityConstraint_Error_InvalidJson}.", e);
                 }
 
                 string configuredCapabiltiesExpression;
@@ -97,36 +95,45 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                     if (string.IsNullOrWhiteSpace(configuredCapability))
                     {
                         _logger.LogDebug("Invalid configuration: '{0}', reason: arguments should not contain empty values.", args);
-                        throw new Exception("Invalid constraint configuration: arguments should not contain empty values.");
+                        throw new Exception($"{LocalizableStrings.ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration}: {LocalizableStrings.ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty}.");
                     }
                     configuredCapabiltiesExpression = configuredCapability;
                 }
                 else
                 {
-                    _logger.LogDebug("Invalid configuration: '{0}', reason: arguments be a string.", args);
-                    throw new Exception("Invalid constraint configuration: arguments should be a string.");
+                    _logger.LogDebug("Invalid configuration: '{0}', reason: argument should be a string.", args);
+                    throw new Exception($"{LocalizableStrings.ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration}: {LocalizableStrings.ProjectCapabilityConstraint_Error_ArgumentShouldBeString}.");
                 }
 
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NoProjectFound)
                 {
                     _logger.LogDebug("No project found. This template can only be created inside the project.");
-                    return TemplateConstraintResult.CreateRestricted(this, "No project found.", "This template can only be created inside the project.");
+                    return TemplateConstraintResult.CreateRestricted(
+                        this, 
+                        _evaluationResult.ErrorMessage ?? LocalizableStrings.MSBuildEvaluationResult_Error_NoProjectFound, 
+                        LocalizableStrings.ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA);
                 }
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.MultipleProjectFound)
                 {
                     string foundProjects = string.Join("; ", (_evaluationResult as MultipleProjectsEvaluationResult)?.ProjectPaths ?? (IReadOnlyList<string?>)new[] { _evaluationResult.ProjectPath });
                     _logger.LogDebug("Multiple projects found: {0}, specify the project to use.", foundProjects);
-                    return TemplateConstraintResult.CreateRestricted(this, $"Multiple projects found: {foundProjects}.", $"Specify the project to use using {NewCommandParser.ProjectPathOption.Aliases.First()} option.");
+                    return TemplateConstraintResult.CreateRestricted(
+                        this,
+                        _evaluationResult.ErrorMessage ?? string.Format(LocalizableStrings.MultipleProjectsEvaluationResult_Error, foundProjects),
+                        string.Format(LocalizableStrings.ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA, NewCommandParser.ProjectPathOption.Aliases.First()));
                 }
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NoRestore)
                 {
                     _logger.LogDebug("The project is not restored. Run 'dotnet restore {0}' to restore the project.", _evaluationResult.ProjectPath);
-                    return TemplateConstraintResult.CreateRestricted(this, $"The project is not restored.", $"Run 'dotnet restore {_evaluationResult.ProjectPath}' to restore the project.");
+                    return TemplateConstraintResult.CreateRestricted(
+                        this,
+                        _evaluationResult.ErrorMessage ?? string.Format(LocalizableStrings.MSBuildEvaluationResult_Error_NotRestored, _evaluationResult.ProjectPath),
+                        string.Format(LocalizableStrings.ProjectCapabilityConstraint_Restricted_NotRestored_CTA, _evaluationResult.ProjectPath));
                 }
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.Failed || _evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NotEvaluated || _evaluationResult.EvaluatedProject == null)
                 {
                     _logger.LogDebug("Failed to evaluate project context: {0}", _evaluationResult.ErrorMessage);
-                    return TemplateConstraintResult.CreateRestricted(this, $"Failed to evaluate project context: {_evaluationResult.ErrorMessage}");
+                    return TemplateConstraintResult.CreateRestricted(this, string.Format(LocalizableStrings.ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message, _evaluationResult.ErrorMessage));
                 }
 
                 try
@@ -135,7 +142,9 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                     if (!CapabilityExpressionEvaluator.Evaluate(configuredCapabiltiesExpression, _projectCapabilities))
                     {
                         _logger.LogDebug("Expression evaluated to 'false'.");
-                        return TemplateConstraintResult.CreateRestricted(this, $"The item needs '{configuredCapabiltiesExpression}', and current project ({_evaluationResult.ProjectPath}) does not satisfy it.");
+                        return TemplateConstraintResult.CreateRestricted(
+                            this,
+                            string.Format(LocalizableStrings.ProjectCapabilityConstraint_Restricted_Message, configuredCapabiltiesExpression, _evaluationResult.ProjectPath));
                     }
                     _logger.LogDebug("Expression evaluated to 'true'.");
                     return TemplateConstraintResult.CreateAllowed(this);
@@ -143,7 +152,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 catch (ArgumentException ae)
                 {
                     _logger.LogDebug("Invalid expression '{0}'.", configuredCapabiltiesExpression);
-                    throw new Exception("Invalid constraint configuration: invalid expression.", ae);
+                    throw new Exception($"{LocalizableStrings.ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration}:{ae.Message}.", ae);
                 }
             }
 

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
+using Microsoft.DotNet.Cli;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Constraints;
@@ -115,7 +116,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 {
                     string foundProjects = string.Join("; ", (_evaluationResult as MultipleProjectsEvaluationResult)?.ProjectPaths ?? (IReadOnlyList<string?>)new[] { _evaluationResult.ProjectPath });
                     _logger.LogDebug("Multiple projects found: {0}, specify the project to use.", foundProjects);
-                    return TemplateConstraintResult.CreateRestricted(this, $"Multiple projects found: {foundProjects}", "Specify the project to use.");
+                    return TemplateConstraintResult.CreateRestricted(this, $"Multiple projects found: {foundProjects}.", $"Specify the project to use using {NewCommandParser.ProjectPathOption.Aliases.First()} option.");
                 }
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NoRestore)
                 {

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectContextSymbolSource.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectContextSymbolSource.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Components;
+using NuGet.Configuration;
+
+namespace Microsoft.TemplateEngine.MSBuildEvaluation
+{
+
+    /// <summary>
+    /// Allows to bind symbols to MSBuild properties.
+    /// </summary>
+    internal class ProjectContextSymbolSource : IBindSymbolSource
+    {
+        private readonly object LockObj = new object();
+
+        private IEngineEnvironmentSettings? _settings;
+        private MSBuildEvaluationResult? _cachedEvaluationResult;
+
+        public string DisplayName => "Project context";
+
+        public string? SourcePrefix => "msbuild";
+
+        public int Priority => 200;
+
+        public Guid Id => Guid.Parse("{9A839474-CE00-4430-A352-98967542B56B}");
+
+        public bool RequiresPrefixMatch => true;
+
+        public Task<string?> GetBoundValueAsync(IEngineEnvironmentSettings settings, string bindname, CancellationToken cancellationToken)
+        {
+            MSBuildEvaluationResult evaluationResult = GetEvaluationResult(settings);
+            if (evaluationResult.EvaluatedProject == null)
+            {
+                return Task.FromResult((string?)null);
+            }
+
+            string? propertyValue = evaluationResult.EvaluatedProject.GetProperty(bindname)?.EvaluatedValue;
+
+            //we check only for null as property may exist with empty value
+            if (propertyValue == null && evaluationResult is MultiTargetEvaluationResult multiTargetResult)
+            {
+                foreach (Project? tfmBasedProject in multiTargetResult.EvaluatedProjects.Values)
+                {
+                    propertyValue = evaluationResult.EvaluatedProject.GetProperty(bindname)?.EvaluatedValue;
+                    if (propertyValue != null)
+                    {
+                        Task.FromResult(propertyValue);
+                    }
+                }
+            }
+            return Task.FromResult(propertyValue);
+        }
+
+        internal void ResetCache()
+        {
+            lock (LockObj)
+            {
+                _settings = null;
+                _cachedEvaluationResult = null;
+            }
+        }
+
+        private MSBuildEvaluationResult GetEvaluationResult(IEngineEnvironmentSettings settings)
+        {
+            lock (LockObj)
+            {
+                if (_settings == null || _settings != settings || _cachedEvaluationResult == null)
+                {
+                    _settings = settings;
+                    _cachedEvaluationResult = _settings.Components.OfType<MSBuildEvaluator>().Single().EvaluateProject(_settings);
+                }
+                return _cachedEvaluationResult;
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectContextSymbolSource.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectContextSymbolSource.cs
@@ -11,6 +11,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Components;
+using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 
 namespace Microsoft.TemplateEngine.MSBuildEvaluation
 {
@@ -20,7 +21,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
     /// </summary>
     internal class ProjectContextSymbolSource : IBindSymbolSource
     {
-        public string DisplayName => "Project context";
+        public string DisplayName => LocalizableStrings.ProjectContextSymbolSource_DisplayName;
 
         public string? SourcePrefix => "msbuild";
 

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectContextSymbolSource.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectContextSymbolSource.cs
@@ -49,6 +49,11 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                     settings.Host.Logger.LogDebug("{0}: evaluation did not succeed, status: {1}, exiting.", nameof(ProjectContextSymbolSource), evaluationResult.Status);
                     return Task.FromResult((string?)null);
                 }
+                if (evaluationResult is NonSDKStyleEvaluationResult)
+                {
+                    settings.Host.Logger.LogDebug("The project {0} is not an SDK style project, and is not supported for evaluation.", evaluationResult.ProjectPath);
+                    return Task.FromResult((string?)null);
+                }
 
                 string? propertyValue = evaluationResult.EvaluatedProject.GetProperty(bindname)?.EvaluatedValue;
                 //we check only for null as property may exist with empty value

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/SDKStyleEvaluationResult.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/SDKStyleEvaluationResult.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.TemplateEngine.MSBuildEvaluation
+{
+    /// <summary>
+    /// Represents the result of evaluation for single-target SDK style project.
+    /// </summary>
+    internal class SDKStyleEvaluationResult : MSBuildEvaluationResult
+    {
+        private SDKStyleEvaluationResult(string projectPath, string targetFramework) : base(EvalStatus.Succeeded, projectPath)
+        {
+            TargetFramework = targetFramework;
+        }
+
+        internal string TargetFramework { get; }
+
+        internal static SDKStyleEvaluationResult CreateSuccess(string path, string targetFramework, Project project)
+        {
+            return new SDKStyleEvaluationResult(path, targetFramework)
+            {
+                EvaluatedProject = project,
+            };
+        }
+    }
+
+}

--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
@@ -25,6 +27,7 @@ using Microsoft.DotNet.Tools.Common;
 using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 using Microsoft.TemplateEngine.MSBuildEvaluation;
 using Microsoft.TemplateEngine.Abstractions.Constraints;
+using System.IO;
 
 namespace Microsoft.DotNet.Cli
 {
@@ -37,6 +40,8 @@ namespace Microsoft.DotNet.Cli
         private static readonly Option<bool> _disableSdkTemplates = new Option<bool>("--debug:disable-sdk-templates", () => false, LocalizableStrings.DisableSdkTemplates_OptionDescription).Hide();
 
         private static readonly Option<bool> _enableProjectContextEvaluation = new Option<bool>("--debug:enable-project-context", () => false, "Enables evaluating project context using MSBuild.").Hide();
+
+        internal static Option<FileInfo> ProjectPathOption { get; } = new Option<FileInfo>("--project", "The project the item template should be added to.").ExistingOnly().Hide();
 
         internal static readonly System.CommandLine.Command Command = GetCommand();
 
@@ -76,11 +81,12 @@ namespace Microsoft.DotNet.Cli
             };
 
             var getEngineHost = (ParseResult parseResult) => {
-                var disableSdkTemplates = parseResult.GetValueForOption(_disableSdkTemplates);
-                var enableProjectContext = parseResult.GetValueForOption(_enableProjectContextEvaluation);
+                bool disableSdkTemplates = parseResult.GetValueForOption(_disableSdkTemplates);
+                bool enableProjectContext = parseResult.GetValueForOption(_enableProjectContextEvaluation);
+                FileInfo? projectPath = parseResult.GetValueForOption(ProjectPathOption);
 
                 //TODO: read and pass output directory
-                return CreateHost(disableSdkTemplates, enableProjectContext);
+                return CreateHost(disableSdkTemplates, enableProjectContext, projectPath);
             };
 
             var command = Microsoft.TemplateEngine.Cli.NewCommandFactory.Create(CommandName, getEngineHost, getLogger, callbacks);
@@ -88,10 +94,11 @@ namespace Microsoft.DotNet.Cli
             // adding this option lets us look for its bound value during binding in a typed way
             command.AddGlobalOption(_disableSdkTemplates);
             command.AddGlobalOption(_enableProjectContextEvaluation);
+            command.AddGlobalOption(ProjectPathOption);
             return command;
         }
 
-        private static ITemplateEngineHost CreateHost(bool disableSdkTemplates, bool enableProjectContext)
+        private static ITemplateEngineHost CreateHost(bool disableSdkTemplates, bool enableProjectContext, FileInfo? projectPath)
         {
             var builtIns = new List<(Type InterfaceType, IIdentifiedComponent Instance)>();
             builtIns.AddRange(Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Components.AllComponents);
@@ -107,12 +114,12 @@ namespace Microsoft.DotNet.Cli
             {
                 builtIns.Add((typeof(IBindSymbolSource), new ProjectContextSymbolSource()));
                 builtIns.Add((typeof(ITemplateConstraintFactory), new ProjectCapabilityConstraintFactory()));
-                builtIns.Add((typeof(MSBuildEvaluator), new MSBuildEvaluator()));
+                builtIns.Add((typeof(MSBuildEvaluator), new MSBuildEvaluator(outputDirectory: null, projectPath: projectPath?.FullName)));
             }
             builtIns.Add((typeof(IWorkloadsInfoProvider), new WorkloadsInfoProvider(new WorkloadInfoHelper())));
             builtIns.Add((typeof(ISdkInfoProvider), new SdkInfoProvider()));
 
-            string preferredLangEnvVar = Environment.GetEnvironmentVariable("DOTNET_NEW_PREFERRED_LANG");
+            string? preferredLangEnvVar = Environment.GetEnvironmentVariable("DOTNET_NEW_PREFERRED_LANG");
             string preferredLang = string.IsNullOrWhiteSpace(preferredLangEnvVar)? "C#" : preferredLangEnvVar;
 
             var preferences = new Dictionary<string, string>
@@ -140,7 +147,7 @@ namespace Microsoft.DotNet.Cli
             }
         }
 
-        private static bool AddPackageReference(string projectPath, string packageName, string version)
+        private static bool AddPackageReference(string projectPath, string packageName, string? version)
         {
             try
             {
@@ -177,7 +184,7 @@ namespace Microsoft.DotNet.Cli
             }
         }
 
-        private static bool AddProjectsToSolution(string solutionPath, IReadOnlyList<string> projectsToAdd, string solutionFolder)
+        private static bool AddProjectsToSolution(string solutionPath, IReadOnlyList<string> projectsToAdd, string? solutionFolder)
         {
             try
             {

--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
@@ -39,9 +39,9 @@ namespace Microsoft.DotNet.Cli
 
         private static readonly Option<bool> _disableSdkTemplates = new Option<bool>("--debug:disable-sdk-templates", () => false, LocalizableStrings.DisableSdkTemplates_OptionDescription).Hide();
 
-        private static readonly Option<bool> _enableProjectContextEvaluation = new Option<bool>("--debug:enable-project-context", () => false, "Enables evaluating project context using MSBuild.").Hide();
+        private static readonly Option<bool> _enableProjectContextEvaluation = new Option<bool>("--debug:enable-project-context", () => false, LocalizableStrings.EnableProjectContextEval_OptionDescription).Hide();
 
-        internal static Option<FileInfo> ProjectPathOption { get; } = new Option<FileInfo>("--project", "The project the item template should be added to.").ExistingOnly().Hide();
+        internal static Option<FileInfo> ProjectPathOption { get; } = new Option<FileInfo>("--project", LocalizableStrings.ProjectPath_OptionDescription).ExistingOnly().Hide();
 
         internal static readonly System.CommandLine.Command Command = GetCommand();
 

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
@@ -107,6 +107,11 @@
         <target state="new">This template can only be created inside the project.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NonSDKStyle_Message">
+        <source>The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</source>
+        <target state="new">The project {0} is not an SDK style project, and is not supported for evaluation. It is only possible to use this template with SDK-style projects.</target>
+        <note>{0} - path to the project</note>
+      </trans-unit>
       <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
         <source>Run 'dotnet restore {0}' to restore the project.</source>
         <target state="new">Run 'dotnet restore {0}' to restore the project.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
@@ -17,9 +17,109 @@
         <target state="new">Failed to add project(s) to the solution: {0}</target>
         <note>{0} - the reason why operation failed, normally ends with period</note>
       </trans-unit>
+      <trans-unit id="CapabilityExpressionEvaluator_Exception_InvalidExpression">
+        <source>Invalid expression, position: {0}.</source>
+        <target state="new">Invalid expression, position: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="new">If present, prevents templates bundled in the SDK from being presented.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnableProjectContextEval_OptionDescription">
+        <source>Enables evaluating project context using MSBuild.</source>
+        <target state="new">Enables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">
+        <source>No project was found at the path: {0}.</source>
+        <target state="new">No project was found at the path: {0}.</target>
+        <note>{0} - the file path where project was expected to be found.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluationResult_Error_NotRestored">
+        <source>{0} is not restored.</source>
+        <target state="new">{0} is not restored.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildEvaluator_Error_NoTargetFramework">
+        <source>Project '{0}' is a SDK-style project, but does not specify the framework.</source>
+        <target state="new">Project '{0}' is a SDK-style project, but does not specify the framework.</target>
+        <note>{0} - the full path to the project.</note>
+      </trans-unit>
+      <trans-unit id="MultipleProjectsEvaluationResult_Error">
+        <source>Multiple projects found: {0}.</source>
+        <target state="new">Multiple projects found: {0}.</target>
+        <note>{0} - semi-colon separated list of path to projects found.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_EvaluationFailed">
+        <source>Failed to create constraint '{0}': failed to evaluate the project: {1}</source>
+        <target state="new">Failed to create constraint '{0}': failed to evaluate the project: {1}</target>
+        <note>{0} - type of constraint (non-localizable), {1} - localized reason why evaluation failed, ends with period.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraintFactory_Exception_NoEvaluator">
+        <source>Failed to create constraint '{0}': {1} component is not available.</source>
+        <target state="new">Failed to create constraint '{0}': {1} component is not available.</target>
+        <note>{0} - type of constraint (non-localizable), {1} - name of required component (non-localizable).</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_DisplayName">
+        <source>Project capabiltities</source>
+        <target state="new">Project capabiltities</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldBeString">
+        <source>argument should be a string</source>
+        <target state="new">argument should be a string</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_ArgumentShouldNotBeEmpty">
+        <source>arguments should not contain empty values</source>
+        <target state="new">arguments should not contain empty values</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidConstraintConfiguration">
+        <source>Invalid constraint configuration</source>
+        <target state="new">Invalid constraint configuration</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Error_InvalidJson">
+        <source>invalid JSON</source>
+        <target state="new">invalid JSON</target>
+        <note>part of a sentence</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_EvaluationFailed_Message">
+        <source>Failed to evaluate project context: {0}</source>
+        <target state="new">Failed to evaluate project context: {0}</target>
+        <note>{0} - failure reason</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_Message">
+        <source>The template needs project capability '{0}', and current project ({1}) does not satisfy it.</source>
+        <target state="new">The template needs project capability '{0}', and current project ({1}) does not satisfy it.</target>
+        <note>{0} - project capability expression (non-localizable), {1} - path to the project.</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA">
+        <source>Specify the project to use using {0} option.</source>
+        <target state="new">Specify the project to use using {0} option.</target>
+        <note>{0} - option to use - non localizable</note>
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NoProjectFound_CTA">
+        <source>This template can only be created inside the project.</source>
+        <target state="new">This template can only be created inside the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCapabilityConstraint_Restricted_NotRestored_CTA">
+        <source>Run 'dotnet restore {0}' to restore the project.</source>
+        <target state="new">Run 'dotnet restore {0}' to restore the project.</target>
+        <note>do not translate 'dotnet restore {0}'</note>
+      </trans-unit>
+      <trans-unit id="ProjectContextSymbolSource_DisplayName">
+        <source>Project context</source>
+        <target state="new">Project context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectPath_OptionDescription">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestoreCallback_Failed">

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="commands\dotnet-new\**" />
-    <Compile Include="commands\dotnet-new\*.cs" />
+    <Compile Include="commands\dotnet-new\**\*.cs" />
     <Compile Include="..\..\Resolvers\Microsoft.DotNet.MSBuildSdkResolver\FXVersion.cs" />
     <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Common\WorkloadFileBasedInstall.cs" LinkBase="Common" />

--- a/src/Tests/dotnet-new.Tests/CapabilityExpressionEvaluationTests.cs
+++ b/src/Tests/dotnet-new.Tests/CapabilityExpressionEvaluationTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.Assertions;
+using System.IO;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.MSBuildEvaluation;
+using System;
+
+namespace Microsoft.DotNet.New.Tests
+{
+    public class CapabilityExpressionEvaluationTests 
+    {
+        [Theory]
+        [InlineData("Capability", "", false)]
+        [InlineData("Cap1", "cap1", true)]
+        [InlineData("Cap1 | Cap2", "Cap3", false)]
+        [InlineData("Cap1 | Cap2", "Cap1", true)]
+        [InlineData("Cap1 & Cap2", "Cap3", false)]
+        [InlineData("Cap1 & Cap2", "Cap1", false)]
+        [InlineData("Cap1 & Cap2", "Cap1|Cap2", true)]
+        [InlineData("Cap1 + Cap2", "Cap3", false)]
+        [InlineData("Cap1 + Cap2", "Cap1", false)]
+        [InlineData("Cap1 + Cap2", "Cap1|Cap2", true)]
+        [InlineData("!Cap3", "Cap3", false)]
+        [InlineData("!Cap3", "Cap1", true)]
+        [InlineData("(Cap1 | Cap2) + (Cap3 | Cap4)", "Cap3", false)]
+        [InlineData("(Cap1 | Cap2) + (Cap3 | Cap4)", "Cap3|Cap1", true)]
+        [InlineData("(Cap1 | Cap2) | (Cap3 | Cap4)", "Cap3", true)]
+        [InlineData("Cap1 | Cap2 + Cap3 | Cap4", "Cap3", false)]
+        [InlineData("Cap1 | Cap2 + Cap3 | Cap4", "Cap3|Cap1", true)]
+        [InlineData("Cap1 | Cap2 & Cap3 | Cap4", "Cap3", false)]
+        [InlineData("Cap1 | Cap2 & Cap3 | Cap4", "Cap3|Cap1", true)]
+        public void EvaluateCapaibilityExpression(string expression, string availableCapabilities, bool expectedResult)
+        {
+            IReadOnlyList<string> projectCapabilites = availableCapabilities.Split("|");
+            Assert.Equal(expectedResult, CapabilityExpressionEvaluator.Evaluate(expression, projectCapabilites));
+
+        }
+
+        [Theory]
+        [InlineData("Cap1 |", "Cap3")]
+        [InlineData("(Cap1 | Cap2", "Cap1")]
+        [InlineData("(Cap1 | Cap2) + ((Cap3 | Cap4)", "Cap3")]
+        public void EvaluateCapaibilityExpression_ThrowsOnInvalidExpression(string expression, string availableCapabilities)
+        {
+            IReadOnlyList<string> projectCapabilites = availableCapabilities.Split("|");
+            Assert.Throws<ArgumentException>(() => CapabilityExpressionEvaluator.Evaluate(expression, projectCapabilites));
+
+        }
+
+    }
+}

--- a/src/Tests/dotnet-new.Tests/MSBuildEvaluationTests.cs
+++ b/src/Tests/dotnet-new.Tests/MSBuildEvaluationTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.Assertions;
+using System.IO;
+
+namespace Microsoft.DotNet.New.Tests
+{
+    public class MSBuildEvaluationTests : SdkTest
+    {
+        public MSBuildEvaluationTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void Class_BasicTest()
+        {
+            TestDirectory tempDir = _testAssetsManager.CreateTestDirectory();
+            TestDirectory tempSettingsDir = _testAssetsManager.CreateTestDirectory();
+
+            string templateLocation = GetTestTemplatePath("Item/ClassTemplate");
+            var cmd = new DotnetCommand(Log).Execute("new", "install", templateLocation, "--debug:custom-hive", tempSettingsDir.Path);
+            cmd.Should().Pass();
+
+            cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(tempDir.Path)
+                .Execute("new", "console", "--debug:custom-hive", tempSettingsDir.Path, "--name", "MyConsole");
+            cmd.Should().Pass();
+
+            string projectPath = Path.Combine(tempDir.Path, "MyConsole");
+
+            cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectPath)
+                .Execute("new", "TestAssets.ClassTemplate", "--debug:custom-hive", tempSettingsDir.Path, "--debug:enable-project-context", "--name", "MyTestClass");
+            cmd.Should().Pass();
+
+            string testFilePath = Path.Combine(projectPath, "MyTestClass.cs");
+
+            Assert.True(File.Exists(testFilePath));
+            Assert.Contains("namespace MyConsole", File.ReadAllText(testFilePath));
+
+            cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectPath)
+                .Execute("build");
+
+            cmd.Should().Pass();
+        }
+
+        [Fact]
+        public void TestClass_BasicTest()
+        {
+            TestDirectory tempDir = _testAssetsManager.CreateTestDirectory();
+            TestDirectory tempSettingsDir = _testAssetsManager.CreateTestDirectory();
+
+            string templateLocation = GetTestTemplatePath("Item/TestClassTemplate");
+            var cmd = new DotnetCommand(Log).Execute("new", "install", templateLocation, "--debug:custom-hive", tempSettingsDir.Path);
+            cmd.Should().Pass();
+
+            cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(tempDir.Path)
+                .Execute("new", "xunit", "--debug:custom-hive", tempSettingsDir.Path, "--name", "MyTestProject");
+            cmd.Should().Pass();
+
+
+            string projectPath = Path.Combine(tempDir.Path, "MyTestProject");
+
+            cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectPath)
+                .Execute("new", "TestAssets.TestClassTemplate", "--debug:custom-hive", tempSettingsDir.Path, "--debug:enable-project-context", "--name", "MyTestClass");
+            cmd.Should().Pass();
+
+            string testFilePath = Path.Combine(projectPath, "MyTestClass.cs");
+
+            Assert.True(File.Exists(testFilePath));
+            Assert.Contains("namespace MyTestProject", File.ReadAllText(testFilePath));
+
+            cmd = new DotnetCommand(Log)
+                 .WithWorkingDirectory(projectPath)
+                 .Execute("build");
+
+            cmd.Should().Pass();
+        }
+
+        [Fact]
+        public void ListFiltersOutRestrictedTemplates()
+        {
+            TestDirectory tempDir = _testAssetsManager.CreateTestDirectory();
+            TestDirectory tempSettingsDir = _testAssetsManager.CreateTestDirectory();
+
+            string templateLocation = GetTestTemplatePath("Item/TestClassTemplate");
+            var cmd = new DotnetCommand(Log).Execute("new", "install", templateLocation, "--debug:custom-hive", tempSettingsDir.Path);
+            cmd.Should().Pass();
+            templateLocation = GetTestTemplatePath("Item/ClassTemplate");
+            cmd = new DotnetCommand(Log).Execute("new", "install", templateLocation, "--debug:custom-hive", tempSettingsDir.Path);
+            cmd.Should().Pass();
+
+            cmd = new DotnetCommand(Log).Execute("new", "list", "--debug:enable-project-context", "--debug:custom-hive", tempSettingsDir.Path);
+            cmd.Should().Pass();
+            cmd.StdOut.Should().NotContain("TestAssets.ClassTemplate").And.NotContain("TestAssets.TestClassTemplate");
+
+            cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(tempDir.Path)
+                .Execute("new", "console", "--debug:custom-hive", tempSettingsDir.Path, "--name", "MyConsole");
+            cmd.Should().Pass();
+
+            string projectPath = Path.Combine(tempDir.Path, "MyConsole");
+
+            cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectPath)
+                .Execute("new", "list", "--debug:enable-project-context", "--debug:custom-hive", tempSettingsDir.Path);
+            cmd.Should().Pass();
+            cmd.StdOut.Should().Contain("TestAssets.ClassTemplate").And.NotContain("TestAssets.TestClassTemplate");
+        }
+
+
+
+        private static string GetTestTemplatePath(string templateName)
+        {
+            string templateFolder = Path.Combine(Path.GetDirectoryName(typeof(NewCommandTests).Assembly.Location) ?? string.Empty, "TestTemplates", templateName);
+            Assert.True(Directory.Exists(templateFolder));
+            return Path.GetFullPath(templateFolder);
+        }
+    }
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/ConsoleFullFramework/ConsoleFullFramework.csproj
+++ b/src/Tests/dotnet.Tests/TestTemplates/ConsoleFullFramework/ConsoleFullFramework.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A949AF0A-C72E-404B-BA6C-CB7B7E22817C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ConsoleFullFramework</RootNamespace>
+    <AssemblyName>ConsoleFullFramework</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Tests/dotnet.Tests/TestTemplates/ConsoleFullFramework/Program.cs
+++ b/src/Tests/dotnet.Tests/TestTemplates/ConsoleFullFramework/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConsoleFullFramework
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/Item/ClassTemplate/.template.config/template.json
+++ b/src/Tests/dotnet.Tests/TestTemplates/Item/ClassTemplate/.template.config/template.json
@@ -1,0 +1,24 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "ClassTemplate",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.ClassTemplate",
+  "precedence": "100",
+  "identity": "TestAssets.ClassTemplate",
+  "shortName": "TestAssets.ClassTemplate",
+  "sourceName": "Class1",
+  "symbols": {
+    "DefaultNamespace": {
+      "type": "bind",
+      "binding": "msbuild:RootNamespace",
+      "replaces": "%NAMESPACE%"
+    }
+  },
+  "constraints": {
+    "csharp-only": {
+      "type": "project-capability",
+      "args": "CSharp"
+    }
+  }
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/Item/ClassTemplate/Class1.cs
+++ b/src/Tests/dotnet.Tests/TestTemplates/Item/ClassTemplate/Class1.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace %NAMESPACE%
+{
+    public class Class1
+    {
+
+    }
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/Item/TestClassTemplate/.template.config/template.json
+++ b/src/Tests/dotnet.Tests/TestTemplates/Item/TestClassTemplate/.template.config/template.json
@@ -1,0 +1,24 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TestClassTemplate",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TestClassTemplate",
+  "precedence": "100",
+  "identity": "TestAssets.TestClassTemplate",
+  "shortName": "TestAssets.TestClassTemplate",
+  "sourceName": "UnitTest1",
+  "symbols": {
+    "DefaultNamespace": {
+      "type": "bind",
+      "binding": "msbuild:RootNamespace",
+      "replaces": "%NAMESPACE%"
+    }
+  },
+  "constraints": {
+    "csharp-only": {
+      "type": "project-capability",
+      "args": [ "CSharp", "TestContainer" ] 
+    }
+  }
+}

--- a/src/Tests/dotnet.Tests/TestTemplates/Item/TestClassTemplate/.template.config/template.json
+++ b/src/Tests/dotnet.Tests/TestTemplates/Item/TestClassTemplate/.template.config/template.json
@@ -18,7 +18,7 @@
   "constraints": {
     "csharp-only": {
       "type": "project-capability",
-      "args": [ "CSharp", "TestContainer" ] 
+      "args": "CSharp + TestContainer"
     }
   }
 }

--- a/src/Tests/dotnet.Tests/TestTemplates/Item/TestClassTemplate/UnitTest1.cs
+++ b/src/Tests/dotnet.Tests/TestTemplates/Item/TestClassTemplate/UnitTest1.cs
@@ -1,0 +1,13 @@
+﻿using Xunit;
+
+namespace %NAMESPACE%
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/dotnet/templating/issues/3829

Primarily for item templates, `dotnet new` needs to know details of the project the item is added to, in particular project capabilities and MSBuild properties. 

Implemented:
- evaluator for MSBuild project 
- `ITemplateConstraint` based on project capabilities. For now only project capabilities that can be evaluated during MSBuild evaluation are taken into account.
- `IBindSymbolSource` which allows to bind symbols to MSBuild properties.

Pending: 
- [x] clean up localizations.
- [x] force using prefix for `ProjectContextSymbolSource` (needs work in dotnet/templating)
