### PR TITLE
BinaryFormatter obsolete as error in net7

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
@@ -38,4 +38,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup Condition="'$(SupportsHotReload)' != 'false' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">
     <ProjectCapability Include="SupportsHotReload" />
   </ItemGroup>
+
+  <!--
+    BinaryFormatter infrastructure is obsolete as error in 7.0+.
+    When https://github.com/Microsoft/visualfsharp/issues/3207 is fixed,
+    remove the block below and move it into the shared .targets file.
+  -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0'))">
+    <WarningsAsErrors Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != 'true'">$(WarningsAsErrors);SYSLIB0011</WarningsAsErrors>
+  </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -126,6 +126,15 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!--
+    BinaryFormatter infrastructure is obsolete as error in 7.0+.
+    When https://github.com/Microsoft/visualfsharp/issues/3207 is fixed,
+    remove the block below and move it into the shared .targets file.
+  -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0'))">
+    <WarningsAsErrors Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != 'true'">$(WarningsAsErrors);SYSLIB0011</WarningsAsErrors>
+  </PropertyGroup>
+
+  <!--
     NOTE: We must hook directly to CoreCompile for compatibility with two phase XAML
           build. We also must not pull in a dependency on ResolveAssemblyReferences
           as the generated temporary project for xaml compilation has a hard-coded list

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseBinaryFormatter.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseBinaryFormatter.cs
@@ -71,7 +71,7 @@ namespace BinaryFormatterTests
 
             testProject.SourceFiles.Add("TestClass.cs", SourceWithoutPragmaSuppressions);
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
             var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
 
             buildCommand
@@ -100,7 +100,7 @@ namespace BinaryFormatterTests
 
             testProject.SourceFiles.Add("TestClass.cs", SourceWithPragmaSuppressions);
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
             var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
 
             buildCommand
@@ -125,7 +125,7 @@ namespace BinaryFormatterTests
 
             testProject.SourceFiles.Add("TestClass.cs", SourceWithoutPragmaSuppressions);
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
             var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
 
             buildCommand
@@ -149,7 +149,7 @@ namespace BinaryFormatterTests
 
             testProject.SourceFiles.Add("TestClass.cs", SourceWithoutPragmaSuppressions);
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
             var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
 
             buildCommand
@@ -174,7 +174,7 @@ namespace BinaryFormatterTests
             testProject.SourceFiles.Add("TestClass.cs", SourceWithoutPragmaSuppressions);
             testProject.AdditionalProperties["EnableUnsafeBinaryFormatterSerialization"] = "true";
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
             var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
 
             buildCommand

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseBinaryFormatter.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseBinaryFormatter.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToUseBinaryFormatter : SdkTest
+    {
+        public GivenThatWeWantToUseBinaryFormatter(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private const string SourceWithPragmaSuppressions = @"
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+#pragma warning disable SYSLIB0011
+
+namespace BinaryFormatterTests
+{
+    public class TestClass
+    {
+        public static void Main(string[] args)
+        {
+            var formatter = new BinaryFormatter();
+            var stream = new MemoryStream();
+            var deserializedObj = formatter.Deserialize(stream);
+        }
+    }
+}";
+
+        private const string SourceWithoutPragmaSuppressions = @"
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace BinaryFormatterTests
+{
+    public class TestClass
+    {
+        public static void Main(string[] args)
+        {
+            var formatter = new BinaryFormatter();
+            var stream = new MemoryStream();
+            var deserializedObj = formatter.Deserialize(stream);
+        }
+    }
+}";
+
+        [Theory]
+        [InlineData("netcoreapp3.1")]
+        [InlineData("netstandard2.0")]
+        [InlineData("net472")]
+        public void It_does_not_warn_when_targeting_downlevel_frameworks(string targetFramework)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "BinaryFormatterTests",
+                TargetFrameworks = targetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles.Add("TestClass.cs", SourceWithoutPragmaSuppressions);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("SYSLIB0011");
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.1")]
+        [InlineData("netstandard2.0")]
+        [InlineData("net472")]
+        [InlineData("net5.0")]
+        [InlineData("net6.0")]
+        [InlineData("net7.0")]
+        public void It_does_not_warn_on_any_framework_when_using_pragma_suppressions(string targetFramework)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "BinaryFormatterTests",
+                TargetFrameworks = targetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles.Add("TestClass.cs", SourceWithPragmaSuppressions);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("SYSLIB0011");
+        }
+
+        [Theory]
+        [InlineData("net5.0")]
+        [InlineData("net6.0")]
+        public void It_warns_when_targeting_certain_frameworks_and_not_using_pragma_suppressions(string targetFramework)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "BinaryFormatterTests",
+                TargetFrameworks = targetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles.Add("TestClass.cs", SourceWithoutPragmaSuppressions);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("SYSLIB0011");
+        }
+
+        [Theory]
+        [InlineData("net7.0")]
+        public void It_errors_when_targeting_certain_frameworks_and_not_using_pragma_suppressions(string targetFramework)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "BinaryFormatterTests",
+                TargetFrameworks = targetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles.Add("TestClass.cs", SourceWithoutPragmaSuppressions);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("SYSLIB0011");
+        }
+
+        [Theory]
+        [InlineData("net7.0")]
+        public void It_allows_downgrading_errors_to_warnings_via_project_config(string targetFramework)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "BinaryFormatterTests",
+                TargetFrameworks = targetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles.Add("TestClass.cs", SourceWithoutPragmaSuppressions);
+            testProject.AdditionalProperties["EnableUnsafeBinaryFormatterSerialization"] = "true";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var buildCommand = new BuildCommand(testAsset, "BinaryFormatterTests");
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("SYSLIB0011");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseBinaryFormatter.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseBinaryFormatter.cs
@@ -108,7 +108,9 @@ namespace BinaryFormatterTests
                 .Should()
                 .Pass()
                 .And
-                .NotHaveStdOutContaining("SYSLIB0011");
+                .NotHaveStdOutContaining("warning SYSLIB0011")
+                .And
+                .NotHaveStdOutContaining("error SYSLIB0011");
         }
 
         [Theory]
@@ -133,7 +135,9 @@ namespace BinaryFormatterTests
                 .Should()
                 .Pass()
                 .And
-                .HaveStdOutContaining("SYSLIB0011");
+                .HaveStdOutContaining("warning SYSLIB0011")
+                .And
+                .NotHaveStdOutContaining("error SYSLIB0011");
         }
 
         [Theory]
@@ -157,7 +161,9 @@ namespace BinaryFormatterTests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdOutContaining("SYSLIB0011");
+                .NotHaveStdOutContaining("warning SYSLIB0011")
+                .And
+                .HaveStdOutContaining("error SYSLIB0011");
         }
 
         [Theory]
@@ -182,7 +188,9 @@ namespace BinaryFormatterTests
                 .Should()
                 .Pass()
                 .And
-                .HaveStdOutContaining("SYSLIB0011");
+                .HaveStdOutContaining("warning SYSLIB0011")
+                .And
+                .NotHaveStdOutContaining("error SYSLIB0011");
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/72132.

Per discussions with sdk team, still trying to figure out if we can add tests for this. Could help give us higher confidence in the change. I've performed a bunch of smoke testing offline and didn't see any unintended behaviors.