### PR TITLE
Remove unnecessary fields on FirstPartyNuGetPackageSigningVerifier

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/FirstPartyNuGetPackageSigningVerifier.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/FirstPartyNuGetPackageSigningVerifier.cs
@@ -5,12 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.EnvironmentAbstractions;
-using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Signing;
 using HashAlgorithmName = System.Security.Cryptography.HashAlgorithmName;
@@ -32,13 +29,8 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
         private const string FirstPartyCertificateSubject =
             "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
 
-        private DirectoryPath _tempDirectory;
-        private ILogger _logger;
-
-        public FirstPartyNuGetPackageSigningVerifier(DirectoryPath? tempDirectory = null, ILogger logger = null)
+        public FirstPartyNuGetPackageSigningVerifier()
         {
-            _tempDirectory = tempDirectory ?? new DirectoryPath(Path.GetTempPath());
-            _logger = logger ?? new NullLogger();
         }
 
         public bool Verify(FilePath nupkgToVerify, out string commandOutput)

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -59,8 +59,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             _reporter = reporter ?? Reporter.Output;
             _verboseLogger = verboseLogger ?? new NuGetConsoleLogger();
             _firstPartyNuGetPackageSigningVerifier = firstPartyNuGetPackageSigningVerifier ??
-                                                     new FirstPartyNuGetPackageSigningVerifier(
-                                                         tempDirectory: packageInstallDir, logger: _verboseLogger);
+                                                     new FirstPartyNuGetPackageSigningVerifier();
             _filePermissionSetter = filePermissionSetter ?? new FilePermissionSetter();
             _restoreActionConfig = restoreActionConfig ?? new RestoreActionConfig();
             _retryTimer = timer;

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Workloads.Workload
 
             PackageDownloader = nugetPackageDownloader ?? new NuGetPackageDownloader(TempPackagesDirectory,
                 filePermissionSetter: null,
-                new FirstPartyNuGetPackageSigningVerifier(TempPackagesDirectory, nugetLogger),
+                new FirstPartyNuGetPackageSigningVerifier(),
                 nugetLogger,
                 restoreActionConfig: RestoreActionConfiguration,
                 verifySignatures: VerifySignatures);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             _restoreActionConfig = restoreActionConfig;
             _nugetPackageDownloader = nugetPackageDownloader ??
                                       new NuGetPackageDownloader(_tempPackagesDir, filePermissionSetter: null,
-                                          new FirstPartyNuGetPackageSigningVerifier(_tempPackagesDir), logger,
+                                          new FirstPartyNuGetPackageSigningVerifier(), logger,
                                           restoreActionConfig: _restoreActionConfig);
             bool userLocal = WorkloadFileBasedInstall.IsUserLocal(_dotnetDir, sdkFeatureBand.ToString());
             _workloadMetadataDir = Path.Combine(userLocal ? _userProfileDir : _dotnetDir, "metadata", "workloads");

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -949,7 +949,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 DirectoryPath tempPackagesDir = new(string.IsNullOrWhiteSpace(tempDirPath) ? Path.GetTempPath() : tempDirPath);
 
                 nugetPackageDownloader = new NuGetPackageDownloader(tempPackagesDir,
-                    filePermissionSetter: null, new FirstPartyNuGetPackageSigningVerifier(tempPackagesDir),
+                    filePermissionSetter: null, new FirstPartyNuGetPackageSigningVerifier(),
                     new NullLogger(), restoreActionConfig: restoreActionConfig);
             }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             var tempPackagesDir = new DirectoryPath(Path.Combine(Path.GetTempPath(), "dotnet-sdk-advertising-temp"));
             var nugetPackageDownloader = new NuGetPackageDownloader(tempPackagesDir,
                                           filePermissionSetter: null,
-                                          new FirstPartyNuGetPackageSigningVerifier(tempPackagesDir, new NullLogger()),
+                                          new FirstPartyNuGetPackageSigningVerifier(),
                                           new NullLogger(),
                                           reporter,
                                           verifySignatures: SignCheck.IsDotNetSigned());


### PR DESCRIPTION
These fields are not being used, so they might as well be removed and simplify the code. Unnecessary objects are being created.