### PR TITLE
Trim response file lines to prevent forwarding along whitespace-only tokens

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -128,6 +128,8 @@ namespace Microsoft.DotNet.Cli
                                 return line.Substring(0, hashPos).Trim();
                             }
                         })
+                        // trim leading/trailing whitespace to not pass along dead spaces
+                        .Select(x => x.Trim())
                         // Remove empty lines
                         .Where(line => line.Length > 0);
                 replacementTokens = trimmedLines.ToArray();


### PR DESCRIPTION
After talking with @jonathanpeppers, we discovered that Xamarin-Android creates response files that have leading spaces on the lines. Previous response file handling understood this and did a `String.Trim()` call on the lines post-comment-stripping, which I lost when I implemented this handling using the new System.CommandLine mechanism for token replacement.

This re-introduces the trimming that should have never left!