### PR TITLE
Forward FSI help to the actual binary

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -279,7 +279,8 @@ namespace Microsoft.DotNet.Cli
                 {
                     new DotnetFormatForwardingApp(helpArgs).Execute();
                 }
-                else if (command.Name.Equals(FsiCommandParser.GetCommand().Name)){
+                else if (command.Name.Equals(FsiCommandParser.GetCommand().Name))
+                {
                     new FsiForwardingApp(helpArgs).Execute();
                 }
                 else

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -279,6 +279,9 @@ namespace Microsoft.DotNet.Cli
                 {
                     new DotnetFormatForwardingApp(helpArgs).Execute();
                 }
+                else if (command.Name.Equals(FsiCommandParser.GetCommand().Name)){
+                    new FsiForwardingApp(helpArgs).Execute();
+                }
                 else
                 {
                     if (command.Name.Equals(ListProjectToProjectReferencesCommandParser.GetCommand().Name))

--- a/src/Cli/dotnet/commands/dotnet-fsi/FsiForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-fsi/FsiForwardingApp.cs
@@ -22,6 +22,10 @@ namespace Microsoft.DotNet.Cli
         {
         }
 
+        public FsiForwardingApp(string[] arguments) : base(GetFsiAppPath(), arguments)
+        {
+        }
+
         private static bool exists(string path)
         {
             try


### PR DESCRIPTION
Closes https://github.com/dotnet/fsharp/issues/13520

Unlike other forwarded commands, the `dotnet fsi` command didn't forward help to the forwarded application. As a result, help was what the SDK command had defined, which is very little. This plumbs the help command the same way we've done for other such commands.