### PR TITLE
Handle error when status runtime information cannot find version in productCollection.

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sdk/check/BundleOutputWriter.cs
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/BundleOutputWriter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
 using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.NativeWrapper;
@@ -26,18 +27,18 @@ namespace Microsoft.DotNet.Tools.Sdk.Check
             _reporter = reporter;
         }
 
-        protected bool BundleIsMaintenance(INetBundleInfo bundle)
+        protected bool? BundleIsMaintenance(INetBundleInfo bundle)
         {
             return _productCollection
-                .First(product => product.ProductVersion.Equals($"{bundle.Version.Major}.{bundle.Version.Minor}"))
-                .SupportPhase.Equals(SupportPhase.Maintenance);
+                .FirstOrDefault(product => product.ProductVersion.Equals($"{bundle.Version.Major}.{bundle.Version.Minor}"))
+                ?.SupportPhase.Equals(SupportPhase.Maintenance);
         }
 
-        protected bool BundleIsEndOfLife(INetBundleInfo bundle)
+        protected bool? BundleIsEndOfLife(INetBundleInfo bundle)
         {
             return _productCollection
-                .First(product => product.ProductVersion.Equals($"{bundle.Version.Major}.{bundle.Version.Minor}"))
-                .IsOutOfSupport();
+                .FirstOrDefault(product => product.ProductVersion.Equals($"{bundle.Version.Major}.{bundle.Version.Minor}"))
+                ?.IsOutOfSupport();
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/LocalizableStrings.resx
@@ -141,6 +141,9 @@
   <data name="MaintenanceMessage" xml:space="preserve">
     <value>.NET {0} is going out of support soon.</value>
   </data>
+  <data name="VersionCheckFailure" xml:space="preserve">
+    <value>No version found to check if this is up to date. Please check for updates manually.</value>
+  </data>
   <data name="NewFeatureBandMessage" xml:space="preserve">
     <value>Try out the newest .NET SDK features with .NET {0}.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.cs.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Rozhraní .NET {0} se už nepodporuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">Nedají se získat informace o vydaných verzích: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.de.xlf
@@ -52,6 +52,11 @@
         <target state="translated">.NET {0} wird nicht mehr unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">Die Versionsinformationen können nicht abgerufen werden: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.es.xlf
@@ -52,6 +52,11 @@
         <target state="translated">.NET {0} no tiene soporte técnico.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">No se puede obtener información de las versiones: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.fr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">.NET {0} n'est plus pris en charge.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">Impossible d'obtenir les informations sur les versions : {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.it.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Il supporto per .NET {0} non è più disponibile.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">Non è possibile ottenere informazioni sulle versioni: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.ja.xlf
@@ -52,6 +52,11 @@
         <target state="translated">.NET {0} はサポートされていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">リリース情報を取得できません: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.ko.xlf
@@ -52,6 +52,11 @@
         <target state="translated">.NET {0}은(는) 지원되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">릴리스 정보를 가져올 수 없음: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.pl.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Platforma .NET {0} nie jest już wspierana.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">Nie można uzyskać informacji o wersjach: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Não há mais suporte para o .NET {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">Não é possível obter informações sobre versões: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.ru.xlf
@@ -52,6 +52,11 @@
         <target state="translated">.NET {0} не поддерживается.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">Не удалось получить сведения о выпусках: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.tr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">.NET {0} desteği kaldırıldı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">Sürüm bilgileri alınamıyor: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="translated">.NET {0} 结束支持。</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">无法获取发布信息: {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/xlf/LocalizableStrings.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="translated">.NET {0} 已不再支援。</target>
         <note />
       </trans-unit>
+      <trans-unit id="VersionCheckFailure">
+        <source>No version found to check if this is up to date. Please check for updates manually.</source>
+        <target state="new">No version found to check if this is up to date. Please check for updates manually.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReleasesLibraryFailed">
         <source>Unable to get releases information: {0}</source>
         <target state="translated">無法取得發行資訊: {0}</target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/26509.

Changes:
- Change the ``.First()`` calls that operate on ``productCollection`` to ``FirstOrDefault()`` and use nullable annotate the return value to make them nullable.
- Added a new localizable string resource.
