### PR TITLE
Move the nuget cache creation into the work item creation class

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -29,6 +29,4 @@ REM call dotnet new so the first run message doesn't interfere with the first te
 dotnet new --debug:ephemeral-hive
 REM avoid potetial cocurrency issues when nuget is creating nuget.config
 dotnet nuget list source
-REM We downloaded a special zip of files to the .nuget folder so add that as a source
-dotnet nuget add source %DOTNET_ROOT%\.nuget
 dir /B %DOTNET_ROOT%\.nuget

--- a/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             string msbuildAdditionalSdkResolverFolder = netFramework ? "-e DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\\r" : IsPosixShell ? "" : "-msbuildAdditionalSdkResolverFolder %HELIX_CORRELATION_PAYLOAD%\\r";
 
             // We want to add a nuget cache for predownloaded runtime packages but this appears to break the packageinstall tests. For now only enable on windows
-            string localNugetCache = IsPosixShell || assemblyName.Contains("Microsoft.DotNet.PackageInstall.Tests") ? "" : "dotnet nuget add source %DOTNET_ROOT%\\.nuget && ";
+            string localNugetCache = IsPosixShell || assemblyName.Contains("Microsoft.DotNet.PackageInstall.Tests") ? "" : "dotnet nuget add source %DOTNET_ROOT%\\.nuget & ";
 
             var scheduler = new AssemblyScheduler(methodLimit: 32);
             var assemblyPartitionInfos = scheduler.Schedule(targetPath, netFramework: netFramework);

--- a/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -130,6 +130,9 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
             string msbuildAdditionalSdkResolverFolder = netFramework ? "-e DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\\r" : IsPosixShell ? "" : "-msbuildAdditionalSdkResolverFolder %HELIX_CORRELATION_PAYLOAD%\\r";
 
+            // We want to add a nuget cache for predownloaded runtime packages but this appears to break the packageinstall tests. For now only enable on windows
+            string localNugetCache = IsPosixShell || assemblyName.Contains("Microsoft.DotNet.PackageInstall.Tests") ? "" : "dotnet nuget add source %DOTNET_ROOT%\\.nuget && ";
+
             var scheduler = new AssemblyScheduler(methodLimit: 32);
             var assemblyPartitionInfos = scheduler.Schedule(targetPath, netFramework: netFramework);
 
@@ -142,6 +145,8 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                     var testFilter = String.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
                     command = $"{driver} test {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .\\ --logger trx {testFilter}";
                 }
+
+                command = localNugetCache + command;
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");
 


### PR DESCRIPTION
Exclude the nuget cache from the package install tests.