### PR TITLE
[Blazor] Update the base path to use IntermediateOutputPath

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -273,8 +273,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="ResolveStaticWebAssetsConfiguration">
     <PropertyGroup>
-      <_StaticWebAssetsManifestBase>$(BaseIntermediateOutputPath)$(Configuration)\</_StaticWebAssetsManifestBase>
-      <_StaticWebAssetsManifestBase Condition="'$(AppendTargetFrameworkToOutputPath)' != 'false'">$(_StaticWebAssetsManifestBase)$(TargetFramework.ToLowerInvariant())\</_StaticWebAssetsManifestBase>
+      <_StaticWebAssetsManifestBase>$(IntermediateOutputPath)</_StaticWebAssetsManifestBase>
       <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">_content/$(PackageId)</StaticWebAssetBasePath>
       <StaticWebAssetProjectMode Condition="'$(StaticWebAssetProjectMode)' == ''">Default</StaticWebAssetProjectMode>
       <StaticWebAssetBuildManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.build.json</StaticWebAssetBuildManifestPath>


### PR DESCRIPTION
We can rely on IntermediateOutputPath here since we moved computing these values to a target.

Fixes https://github.com/dotnet/sdk/issues/26762