### PR TITLE
Fix typo in HostWriter.CreateAppHost

### DIFF
--- a/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
+++ b/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
@@ -51,17 +51,17 @@ namespace Microsoft.DotNet.ShellShim
                                          appHostDestinationFilePath: appHostDestinationFilePath,
                                          appBinaryFilePath: appBinaryFilePath,
                                          windowsGraphicalUserInterface: (windowsGraphicalUserInterfaceBit == WindowsGUISubsystem),
-                                         assemblyToCopyResorcesFrom: entryPointFullPath);
+                                         assemblyToCopyResourcesFrom: entryPointFullPath);
             }
             else
             {
-                // by passing null to assemblyToCopyResorcesFrom, it will skip copying resources,
+                // by passing null to assemblyToCopyResourcesFrom, it will skip copying resources,
                 // which is only supported on Windows
                 HostWriter.CreateAppHost(appHostSourceFilePath: appHostSourcePath,
                                          appHostDestinationFilePath: appHostDestinationFilePath,
                                          appBinaryFilePath: appBinaryFilePath,
                                          windowsGraphicalUserInterface: false,
-                                         assemblyToCopyResorcesFrom: null,
+                                         assemblyToCopyResourcesFrom: null,
                                          enableMacOSCodeSign: OperatingSystem.IsMacOS());
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
@@ -77,7 +77,7 @@ namespace Microsoft.NET.Build.Tasks
                                                 appHostDestinationFilePath: AppHostDestinationPath,
                                                 appBinaryFilePath: AppBinaryName,
                                                 windowsGraphicalUserInterface: isGUI,
-                                                assemblyToCopyResorcesFrom: resourcesAssembly,
+                                                assemblyToCopyResourcesFrom: resourcesAssembly,
                                                 enableMacOSCodeSign: EnableMacOSCodeSign);
                         return;
                     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
@@ -120,11 +120,11 @@ namespace Microsoft.NET.Build.Tasks
                                                  appHostDestinationFilePath: appHostDestinationFilePath,
                                                  appBinaryFilePath: appBinaryFilePath,
                                                  windowsGraphicalUserInterface: windowsGraphicalUserInterface,
-                                                 assemblyToCopyResorcesFrom: IntermediateAssembly);
+                                                 assemblyToCopyResourcesFrom: IntermediateAssembly);
                     }
                     else
                     {
-                        // by passing null to assemblyToCopyResorcesFrom, it will skip copying resources,
+                        // by passing null to assemblyToCopyResourcesFrom, it will skip copying resources,
                         // which is only supported on Windows
                         if (windowsGraphicalUserInterface)
                         {
@@ -135,7 +135,7 @@ namespace Microsoft.NET.Build.Tasks
                                                  appHostDestinationFilePath: appHostDestinationFilePath,
                                                  appBinaryFilePath: appBinaryFilePath,
                                                  windowsGraphicalUserInterface: false,
-                                                 assemblyToCopyResorcesFrom: null);
+                                                 assemblyToCopyResourcesFrom: null);
                     }
                 }
                 catch (AppNameTooLongException ex)


### PR DESCRIPTION
Runtime PR, https://github.com/dotnet/runtime/pull/72709, fixed a typo that is impacting runtime dependency update to SDK. Hopefully, this is not a breaking change for the SDK.

Thanks to @sbomer for spotting this.