### PR TITLE
Stop double copying all of the watch and format files.

### DIFF
--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -24,7 +24,8 @@
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/DotnetTools/**/*" RelativeDestination="DotnetTools"
         Exclude="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/DotnetTools/dotnet-watch/**;$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/DotnetTools/dotnet-format/**" />
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/AppHostTemplate/**/*" RelativeDestination="AppHostTemplate"/>
-      <ToolsetToOverlay Include="$(OutputPath)/**/*" />
+      <ToolsetToOverlay Include="$(OutputPath)/**/*"
+        Exclude="$(OutputPath)/DotnetTools/dotnet-watch/**" />
     </ItemGroup>
 
     <Copy SourceFiles="@(OverlaySDK)"
@@ -51,6 +52,21 @@
 
     <Copy SourceFiles="@(ToolsetToOverlay)"
           DestinationFiles="@(ToolsetToOverlay->'$(SdkOutputDirectory)\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <ItemGroup>
+      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**" />
+      <!-- To reduce the size of the SDK, we use the compiler dependencies that are located in the `Rosyln/bincore` location
+      instead of shipping our own copies in the dotnet-watch tool. These assemblies will be resolved by path in the
+      dotnet-watch executable. -->
+      <DotNetWatchOverlay Remove="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\Microsoft.CodeAnalysis.CSharp.dll" />
+      <DotNetWatchOverlay Remove="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\Microsoft.CodeAnalysis.dll" />
+      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Watch.BrowserRefresh\$(Configuration)\netcoreapp3.1\*.dll" TargetDir="middleware" />
+      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\Microsoft.Extensions.DotNetDeltaApplier\$(Configuration)\net6.0\*.dll" TargetDir="hotreload" />
+      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\DotNetWatchTasks\$(Configuration)\netstandard2.0\DotNetWatchTasks.dll" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(DotNetWatchOverlay)"
+          DestinationFiles="$(DotnetWatchOutputDirectory)\%(RecursiveDir)%(DotNetWatchOverlay.TargetDir)\%(Filename)%(Extension)" />
 
     <!-- Run "dotnet new" (which will just display usage and available templates) in order to print first time
          use message so that it doesn't interfere with tests which check the output of commands. -->

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -22,7 +22,7 @@
       <OverlaySdkFilesFromStage0 Include="$(Stage0IncludedWorkloadManifestsFile)" Condition="Exists('$(Stage0IncludedWorkloadManifestsFile)')"/>
       <!-- Ignore dotnet-watch files from the SDK since we're building a newer version of it in this repo. -->
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/DotnetTools/**/*" RelativeDestination="DotnetTools"
-        Exclude="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/DotnetTools/dotnet-watch/**" />
+        Exclude="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/DotnetTools/dotnet-watch/**;$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/DotnetTools/dotnet-format/**" />
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/AppHostTemplate/**/*" RelativeDestination="AppHostTemplate"/>
       <ToolsetToOverlay Include="$(OutputPath)/**/*" />
     </ItemGroup>
@@ -51,22 +51,6 @@
 
     <Copy SourceFiles="@(ToolsetToOverlay)"
           DestinationFiles="@(ToolsetToOverlay->'$(SdkOutputDirectory)\%(RecursiveDir)%(Filename)%(Extension)')" />
-
-     <!-- Copy dotnet-watch files -->
-    <ItemGroup>
-      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**" />
-      <!-- To reduce the size of the SDK, we use the compiler dependencies that are located in the `Rosyln/bincore` location
-      instead of shipping our own copies in the dotnet-watch tool. These assemblies will be resolved by path in the
-      dotnet-watch executable. -->
-      <DotNetWatchOverlay Remove="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\Microsoft.CodeAnalysis.CSharp.dll" />
-      <DotNetWatchOverlay Remove="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\Microsoft.CodeAnalysis.dll" />
-      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Watch.BrowserRefresh\$(Configuration)\netcoreapp3.1\*.dll" TargetDir="middleware" />
-      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\Microsoft.Extensions.DotNetDeltaApplier\$(Configuration)\net6.0\*.dll" TargetDir="hotreload" />
-      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\DotNetWatchTasks\$(Configuration)\netstandard2.0\DotNetWatchTasks.dll" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(DotNetWatchOverlay)"
-          DestinationFiles="$(DotnetWatchOutputDirectory)\%(RecursiveDir)%(DotNetWatchOverlay.TargetDir)\%(Filename)%(Extension)" />
 
     <!-- Run "dotnet new" (which will just display usage and available templates) in order to print first time
          use message so that it doesn't interfere with tests which check the output of commands. -->


### PR DESCRIPTION
I found that Target PublishBuiltInTools was already copying files around so we were doing this weird thing where we would copy to another location and then had code that copied from both the original and old location.

For the below, the top copy come from the PBIT step and you can see in the double write, we're copying from the new and old location into the final location.  This removes those extra copies as I don't think they are needed at all.

DoubleWrite example
Copying file from "C:\repos\sdk\artifacts\bin\DotNetWatchTasks\Debug\netstandard2.0\DotNetWatchTasks.dll" to "C:\repos\sdk\artifacts\bin\redist\Debug\net7.0\DotnetTools\dotnet-watch\7.0.100-dev\tools\net7.0\any\DotNetWatchTasks.dll".

DoubleWrites
    C:\repos\sdk\artifacts\bin\redist\Debug\dotnet\sdk\7.0.100-dev\DotnetTools\dotnet-watch\7.0.100-dev\tools\net7.0\any\DotNetWatchTasks.dll
        C:\repos\sdk\artifacts\bin\redist\Debug\net7.0\DotnetTools\dotnet-watch\7.0.100-dev\tools\net7.0\any\DotNetWatchTasks.dll
        C:\repos\sdk\artifacts\bin\DotNetWatchTasks\Debug\netstandard2.0\DotNetWatchTasks.dll