### PR TITLE
safeguards around verbosity option direct access in the telemetry filter

### DIFF
--- a/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
@@ -128,14 +128,18 @@ namespace Microsoft.DotNet.Cli.Telemetry
             string topLevelCommandName,
             Dictionary<string, double> measurements = null)
         {
-            if (parseResult.IsDotnetBuiltInCommand() && parseResult.HasOption(CommonOptions.VerbosityOption))
+            if (parseResult.IsDotnetBuiltInCommand() && 
+                parseResult.HasOption(CommonOptions.VerbosityOption) && 
+                parseResult.FindResultFor(CommonOptions.VerbosityOption) is OptionResult verbosityResult &&
+                !String.IsNullOrEmpty(verbosityResult.ErrorMessage)
+                )
             {
                 result.Add(new ApplicationInsightsEntryFormat(
                     "sublevelparser/command",
                     new Dictionary<string, string>()
                     {
                         { "verb", topLevelCommandName},
-                        {"verbosity", Enum.GetName(parseResult.GetValueForOption(CommonOptions.VerbosityOption))}
+                        { "verbosity", Enum.GetName(verbosityResult.GetValueForOption(CommonOptions.VerbosityOption))}
                     },
                     measurements));
             }

--- a/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
@@ -128,10 +128,10 @@ namespace Microsoft.DotNet.Cli.Telemetry
             string topLevelCommandName,
             Dictionary<string, double> measurements = null)
         {
-            if (parseResult.IsDotnetBuiltInCommand() && 
-                parseResult.HasOption(CommonOptions.VerbosityOption) && 
+            if (parseResult.IsDotnetBuiltInCommand() &&
+                parseResult.HasOption(CommonOptions.VerbosityOption) &&
                 parseResult.FindResultFor(CommonOptions.VerbosityOption) is OptionResult verbosityResult &&
-                !String.IsNullOrEmpty(verbosityResult.ErrorMessage)
+                !parseResult.Errors.Any(e => e.SymbolResult == verbosityResult)
                 )
             {
                 result.Add(new ApplicationInsightsEntryFormat(


### PR DESCRIPTION
Fixes #26809 by safeguarding access to the verbosity option's values.