### PR TITLE
Fix package installer tests

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -30,5 +30,5 @@ dotnet new --debug:ephemeral-hive
 REM avoid potetial cocurrency issues when nuget is creating nuget.config
 dotnet nuget list source
 REM We downloaded a special zip of files to the .nuget folder so add that as a source
-dotnet nuget add source %DOTNET_ROOT%\.nuget
-dir /B %DOTNET_ROOT%\.nuget
+dotnet new nugetconfig
+dotnet nuget add source %DOTNET_ROOT%\.nuget --configfile nuget.config

--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -29,4 +29,6 @@ REM call dotnet new so the first run message doesn't interfere with the first te
 dotnet new --debug:ephemeral-hive
 REM avoid potetial cocurrency issues when nuget is creating nuget.config
 dotnet nuget list source
+REM We downloaded a special zip of files to the .nuget folder so add that as a source
+dotnet nuget add source %DOTNET_ROOT%\.nuget
 dir /B %DOTNET_ROOT%\.nuget

--- a/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -130,9 +130,6 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
             string msbuildAdditionalSdkResolverFolder = netFramework ? "-e DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\\r" : IsPosixShell ? "" : "-msbuildAdditionalSdkResolverFolder %HELIX_CORRELATION_PAYLOAD%\\r";
 
-            // We want to add a nuget cache for predownloaded runtime packages but this appears to break the packageinstall tests. For now only enable on windows
-            string localNugetCache = IsPosixShell || assemblyName.Contains("Microsoft.DotNet.PackageInstall.Tests") ? "" : "dotnet nuget add source %DOTNET_ROOT%\\.nuget & ";
-
             var scheduler = new AssemblyScheduler(methodLimit: 32);
             var assemblyPartitionInfos = scheduler.Schedule(targetPath, netFramework: netFramework);
 
@@ -145,8 +142,6 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                     var testFilter = String.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
                     command = $"{driver} test {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .\\ --logger trx {testFilter}";
                 }
-
-                command = localNugetCache + command;
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");
 


### PR DESCRIPTION
Revert my prior change that removed the package installer tests from configuring the nuget cache.
The actual issue is that helix machines are reused without a full reimage. This means that the caches from prior runs are still configured in nuget but the folders may not exist anymore (causing these tests to fail).

This is an alternative solution of adding a nuget.config file to the folder that dotnet is being run from. Alternatively, we may need it at the root of the test folder itself but from viewing output, there is already one there that runs a clear and likely isn't being picked up.

