### PR TITLE
Avoid parallel workload MSI extraction

### DIFF
--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using NuGet.Versioning;
 using Command = System.CommandLine.Command;
+using Product = Microsoft.DotNet.Cli.Utils.Product;
 using Strings = Microsoft.DotNet.Workloads.Workload.Install.LocalizableStrings;
 
 namespace Microsoft.DotNet.Workloads.Workload
@@ -70,7 +71,7 @@ namespace Microsoft.DotNet.Workloads.Workload
             _sdkVersion = WorkloadOptionsExtensions.GetValidatedSdkVersion(parseResult.GetValueForOption(InstallingWorkloadCommandParser.VersionOption), version, _dotnetPath, _userProfileDir, _checkIfManifestExist);
             _sdkFeatureBand = new SdkFeatureBand(_sdkVersion);
 
-            _installedFeatureBand = installedFeatureBand == null ? new SdkFeatureBand(DotnetFiles.VersionFileObject.BuildNumber) : new SdkFeatureBand(installedFeatureBand);
+            _installedFeatureBand = installedFeatureBand == null ? new SdkFeatureBand(Product.Version) : new SdkFeatureBand(installedFeatureBand);
 
             _fromRollbackDefinition = parseResult.GetValueForOption(InstallingWorkloadCommandParser.FromRollbackFileOption);
             var configOption = parseResult.GetValueForOption(InstallingWorkloadCommandParser.ConfigOption);
@@ -78,7 +79,7 @@ namespace Microsoft.DotNet.Workloads.Workload
             _packageSourceLocation = string.IsNullOrEmpty(configOption) && (sourceOption == null || !sourceOption.Any()) ? null :
                 new PackageSourceLocation(string.IsNullOrEmpty(configOption) ? null : new FilePath(configOption), sourceFeedOverrides: sourceOption);
                        
-            var sdkWorkloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(_dotnetPath, _installedFeatureBand.ToString(), userProfileDir);
+            var sdkWorkloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(_dotnetPath, _sdkVersion.ToString(), userProfileDir);
             _workloadResolver = workloadResolver ?? WorkloadResolver.Create(sdkWorkloadManifestProvider, _dotnetPath, _sdkVersion.ToString(), _userProfileDir);
 
             _workloadInstallerFromConstructor = workloadInstaller;

--- a/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
@@ -392,6 +392,17 @@ namespace Microsoft.DotNet.Installer.Windows
         }
 
         /// <summary>
+        /// Creates the log filename to use when performing an admin install on an MSI.
+        /// </summary>
+        /// <param name="msiPath">The full path to the MSI</param>
+        /// <returns>The full path of the log file</returns>
+        protected string GetMsiLogNameForAdminInstall(string msiPath)
+        {
+            return Path.Combine(Path.GetDirectoryName(Log.LogPath),
+                Path.GetFileNameWithoutExtension(Log.LogPath) + $"_{Path.GetFileNameWithoutExtension(msiPath)}_AdminInstall.log");
+        }
+
+        /// <summary>
         /// Creates the log filename to use when executing an MSI. The name is based on the primary log, workload pack record and <see cref="InstallAction"/>.
         /// </summary>
         /// <param name="record">The workload record to use when generating the log name.</param>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -487,8 +487,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             return new PackageId($"{manifestId}.Manifest-{featureBand}.Msi.{RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()}");
         }
 
+        private static object _msiAdminInstallLock = new();
+
         public async Task ExtractManifestAsync(string nupkgPath, string targetPath)
         {
+            Log?.LogMessage($"ExtractManifestAsync: Extracting '{nupkgPath}' to '{targetPath}'");
+
             string extractionPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             if (Directory.Exists(extractionPath))
             {
@@ -499,7 +503,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             {
                 Directory.CreateDirectory(extractionPath);
 
-                Log?.LogMessage($"Extracting '{nupkgPath}' to '{extractionPath}'");
+                Log?.LogMessage($"ExtractManifestAsync: Temporary extraction path: '{extractionPath}'");
                 await _nugetPackageDownloader.ExtractPackageAsync(nupkgPath, new DirectoryPath(extractionPath));
                 if (Directory.Exists(targetPath))
                 {
@@ -509,7 +513,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 string extractedManifestPath = Path.Combine(extractionPath, "data", "extractedManifest");
                 if (Directory.Exists(extractedManifestPath))
                 {
-                    Log?.LogMessage($"Copying manifest from '{extractionPath}' to '{targetPath}'");
+                    Log?.LogMessage($"ExtractManifestAsync: Copying manifest from '{extractionPath}' to '{targetPath}'");
                     Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
                     FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(extractedManifestPath, targetPath));
                 }
@@ -523,12 +527,21 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     string msiExtractionPath = Path.Combine(extractionPath, "msi");
 
 
-                    _ = WindowsInstaller.SetInternalUI(InstallUILevel.None);
-                    var result = WindowsInstaller.InstallProduct(msiPath, $"TARGETDIR={msiExtractionPath} ACTION=ADMIN");
-
-                    if (result != Error.SUCCESS)
+                    lock (_msiAdminInstallLock)
                     {
-                        throw new GracefulException(String.Format(LocalizableStrings.FailedToExtractMsi, msiPath));
+                        string adminInstallLog = Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{DateTime.Now:yyyyMMdd_HHmmss}_AdminInstall_{Path.GetFileNameWithoutExtension(msiPath)}.log");
+
+                        Log?.LogMessage($"ExtractManifestAsync: Running admin install for '{msiExtractionPath}'.  Log file: '{adminInstallLog}'");
+
+                        ConfigureInstall(adminInstallLog);
+
+                        var result = WindowsInstaller.InstallProduct(msiPath, $"TARGETDIR={msiExtractionPath} ACTION=ADMIN");
+
+                        if (result != Error.SUCCESS)
+                        {
+                            Log?.LogMessage($"ExtractManifestAsync: Admin install failed: {result}");
+                            throw new GracefulException(String.Format(LocalizableStrings.FailedToExtractMsi, msiPath));
+                        }
                     }
 
                     var manifestsFolder = Path.Combine(msiExtractionPath, "dotnet", "sdk-manifests");

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -529,7 +529,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
                     lock (_msiAdminInstallLock)
                     {
-                        string adminInstallLog = Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{DateTime.Now:yyyyMMdd_HHmmss}_AdminInstall_{Path.GetFileNameWithoutExtension(msiPath)}.log");
+                        string adminInstallLog = GetMsiLogNameForAdminInstall(msiPath);
 
                         Log?.LogMessage($"ExtractManifestAsync: Running admin install for '{msiExtractionPath}'.  Log file: '{adminInstallLog}'");
 


### PR DESCRIPTION
## Description

Fix issues updating advertising manifests where manifest packages haven't been updated to include `extractedManifest` folder.  The admin install extractions were running in parallel, which isn't supported by the MSI APIs.  Also add better logging.

Also fix issue where IncludedWorkloadManifests.txt wasn't being found if SDK version wasn't the exact feature band.

## Customer Impact

When attempting to update to the latest workloads using the dotnet CLI for an MSI-based installation, most updates will fail.  It appears that at most one manifest will be updated each time `dotnet workload update` is run.  Workarounds are to keep running the update command until it completes without displaying any manifest update errors, or to use a [rollback file](https://github.com/dotnet/sdk/blob/main/documentation/general/workloads/workload-rollback.md) to specify the versions of the manifests to install.

Separately, the issue with IncludedWorkloadManifests.txt had no effect on 6.0.400, but would prevent workload fallback from working in 6.0.401.  This would currently break all workloads as none of them have switched from 6.0.300 to 6.0.400 branding.

## Regression

Yes

## Risk

Low.  The fix is to avoid running the MSI operations concurrently, and to switch back to previous logic for how the SDK version was passed to the workload resolver.

## Testing

Manual testing of impacted scenarios.