### PR TITLE
[25961]  - dotnet watch first key press fix

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
@@ -43,10 +43,13 @@ namespace Microsoft.Extensions.Tools.Internal
             {
                 while (true)
                 {
-                    var key = Console.ReadKey(intercept: true);
-                    for (var i = 0; i < _keyPressedListeners.Count; i++)
+                    if (Console.KeyAvailable)
                     {
-                        _keyPressedListeners[i](key);
+                        var key = Console.ReadKey(intercept: true);
+                        for (var i = 0; i < _keyPressedListeners.Count; i++)
+                        {
+                            _keyPressedListeners[i](key);
+                        }
                     }
                 }
             }, TaskCreationOptions.LongRunning);


### PR DESCRIPTION
Fixes #25961
Now dotnet-watch can't restart by Ctrl+R if watched process "take" `Console`, but I don't think that it is a problem.