### PR TITLE
Add optional logging to MSBuild SDK Resolver

### DIFF
--- a/src/Common/EnvironmentVariableNames.cs
+++ b/src/Common/EnvironmentVariableNames.cs
@@ -22,6 +22,10 @@ namespace Microsoft.DotNet.Cli
         public static readonly string ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS = "DOTNET_CLI_ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS";
         public static readonly string ENABLE_PACK_RELEASE_FOR_SOLUTIONS = "DOTNET_CLI_ENABLE_PACK_RELEASE_FOR_SOLUTIONS";
         public static readonly string DOTNET_ROOT = "DOTNET_ROOT";
+		
+        public static readonly string DOTNET_MSBUILD_SDK_RESOLVER_ENABLE_LOG = "DOTNET_MSBUILD_SDK_RESOLVER_ENABLE_LOG";
+        public static readonly string DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR = "DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR";
+        public static readonly string DOTNET_MSBUILD_SDK_RESOLVER_SDKS_VER = "DOTNET_MSBUILD_SDK_RESOLVER_SDKS_VER";
 
 #if NET7_0_OR_GREATER
         private static readonly Version s_version6_0 = new(6, 0);

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
 
             if (context.IsRunningInVisualStudio)
             {
-                logger.LogMessage("Running in Visual Studio, using static workload resolver");
+                logger.LogMessage($"Running in Visual Studio, using static workload resolver");
                 workloadResolver = _staticWorkloadResolver;
             }
 
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                 dotnetRoot = EnvironmentProvider.GetDotnetExeDirectory(_getEnvironmentVariable, logger.LogMessage);
                 logger.LogMessage($"\tDotnet root: {dotnetRoot}");
 
-                logger.LogMessage("Resolving .NET Core SDK directory");
+                logger.LogMessage($"Resolving .NET Core SDK directory");
                 string globalJsonStartDir = GetGlobalJsonStartDir(context);
                 logger.LogMessage($"\tglobal.json start directory: {globalJsonStartDir}");
                 var resolverResult = _netCoreSdkResolver.ResolveNETCoreSdkDirectory(globalJsonStartDir, context.MSBuildVersion, context.IsRunningInVisualStudio, dotnetRoot);
@@ -238,10 +238,10 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             return factory.IndicateSuccess(msbuildSdkDir, netcoreSdkVersion, propertiesToAdd, itemsToAdd, warnings);
         }
 
-        private static SdkResult Failure(SdkResultFactory factory, Action<string> log, string format, params object[] args)
+        private static SdkResult Failure(SdkResultFactory factory, Action<FormattableString> log, string format, params object[] args)
         {
             string error = string.Format(format, args);
-            log("Failed to resolve SDK: " + error);
+            log($"Failed to resolve SDK: {error}");
             return factory.IndicateFailure(new[] { error });
         }
 
@@ -321,7 +321,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                 }
             }
 
-            public void LogMessage(string message)
+            public void LogMessage(FormattableString message)
             {
                 if (_stream != null)
                 {

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver;
+using Microsoft.DotNet.Cli;
 
 #nullable disable
 
@@ -48,7 +49,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             _getEnvironmentVariable = getEnvironmentVariable;
             _netCoreSdkResolver = new NETCoreSdkResolver(getEnvironmentVariable, vsSettings);
 
-            if (_getEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_ENABLE_LOG") is string val &&
+            if (_getEnvironmentVariable(EnvironmentVariableNames.DOTNET_MSBUILD_SDK_RESOLVER_ENABLE_LOG) is string val &&
                 (string.Equals(val, "true", StringComparison.OrdinalIgnoreCase) ||
                  string.Equals(val, "1", StringComparison.Ordinal)))
             {
@@ -139,8 +140,8 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                 // These are overrides that are used to force the resolved SDK tasks and targets to come from a given
                 // base directory and report a given version to msbuild (which may be null if unknown. One key use case
                 // for this is to test SDK tasks and targets without deploying them inside the .NET Core SDK.
-                var msbuildSdksDirFromEnv = _getEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR");
-                var netcoreSdkVersionFromEnv = _getEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_SDKS_VER");
+                var msbuildSdksDirFromEnv = _getEnvironmentVariable(EnvironmentVariableNames.DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR);
+                var netcoreSdkVersionFromEnv = _getEnvironmentVariable(EnvironmentVariableNames.DOTNET_MSBUILD_SDK_RESOLVER_SDKS_VER);
                 if (!string.IsNullOrEmpty(msbuildSdksDirFromEnv))
                 {
                     logger?.LogMessage($"MSBuild SDKs dir overridden via DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR to {msbuildSdksDirFromEnv}");

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -48,7 +48,8 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             _getEnvironmentVariable = getEnvironmentVariable;
             _netCoreSdkResolver = new NETCoreSdkResolver(getEnvironmentVariable, vsSettings);
 
-            if (!string.IsNullOrEmpty(_getEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_ENABLE_LOG")))
+            if (_getEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_ENABLE_LOG") is String val &&
+                string.Equals(val, "true", StringComparison.OrdinalIgnoreCase))
             {
                 _shouldLog = true;
             }
@@ -106,7 +107,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
 
             if (msbuildSdksDir == null)
             {
-                dotnetRoot = EnvironmentProvider.GetDotnetExeDirectory(_getEnvironmentVariable);
+                dotnetRoot = EnvironmentProvider.GetDotnetExeDirectory(_getEnvironmentVariable, logger.LogMessage);
                 logger.LogMessage($"\tDotnet root: {dotnetRoot}");
 
                 logger.LogMessage("Resolving .NET Core SDK directory");

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -35,6 +35,8 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
 
         private static CachingWorkloadResolver _staticWorkloadResolver = new CachingWorkloadResolver();
 
+        private bool _shouldLog = false;
+
         public DotNetMSBuildSdkResolver() 
             : this(Environment.GetEnvironmentVariable, VSSettings.Ambient)
         {
@@ -45,6 +47,11 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
         {
             _getEnvironmentVariable = getEnvironmentVariable;
             _netCoreSdkResolver = new NETCoreSdkResolver(getEnvironmentVariable, vsSettings);
+
+            if (!string.IsNullOrEmpty(_getEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_ENABLE_LOG")))
+            {
+                _shouldLog = true;
+            }
         }
 
         private sealed class CachedState
@@ -66,17 +73,29 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             List<string> warnings = null;
             CachingWorkloadResolver workloadResolver = null;
 
+            using var logger = new ResolverLogger(sdkReference, _shouldLog);
+
+            logger.LogMessage($"Attempting to resolve MSBuild SDK {sdkReference.Name}");
+
             if (context.State is CachedState priorResult)
             {
+                logger.LogMessage($"Using previously cached state");
+                
+
                 dotnetRoot = priorResult.DotnetRoot;
                 msbuildSdksDir = priorResult.MSBuildSdksDir;
                 netcoreSdkVersion = priorResult.NETCoreSdkVersion;
                 propertiesToAdd = priorResult.PropertiesToAdd;
                 workloadResolver = priorResult.WorkloadResolver;
+
+                logger.LogMessage($"\tDotnet root: {dotnetRoot}");
+                logger.LogMessage($"\tMSBuild SDKs Dir: {msbuildSdksDir}");
+                logger.LogMessage($"\t.NET Core SDK Version: {netcoreSdkVersion}");
             }
 
             if (context.IsRunningInVisualStudio)
             {
+                logger.LogMessage("Running in Visual Studio, using static workload resolver");
                 workloadResolver = _staticWorkloadResolver;
             }
 
@@ -88,15 +107,25 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             if (msbuildSdksDir == null)
             {
                 dotnetRoot = EnvironmentProvider.GetDotnetExeDirectory(_getEnvironmentVariable);
+                logger.LogMessage($"\tDotnet root: {dotnetRoot}");
+
+                logger.LogMessage("Resolving .NET Core SDK directory");
                 string globalJsonStartDir = GetGlobalJsonStartDir(context);
+                logger.LogMessage($"\tglobal.json start directory: {globalJsonStartDir}");
                 var resolverResult = _netCoreSdkResolver.ResolveNETCoreSdkDirectory(globalJsonStartDir, context.MSBuildVersion, context.IsRunningInVisualStudio, dotnetRoot);
 
                 if (resolverResult.ResolvedSdkDirectory == null)
                 {
+                    logger.LogMessage($"Failed to resolve .NET SDK.  Global.json path: {resolverResult.GlobalJsonPath}");
                     return Failure(
                         factory,
+                        logger.LogMessage,
                         Strings.UnableToLocateNETCoreSdk);
                 }
+
+                logger.LogMessage($"\tResolved SDK directory: {resolverResult.ResolvedSdkDirectory}");
+                logger.LogMessage($"\tglobal.json path: {resolverResult.GlobalJsonPath}");
+                logger.LogMessage($"\tFailed to resolve SDK from global.json: {resolverResult.FailedToResolveSDKSpecifiedInGlobalJson}");
 
                 msbuildSdksDir = Path.Combine(resolverResult.ResolvedSdkDirectory, "Sdks");
                 netcoreSdkVersion = new DirectoryInfo(resolverResult.ResolvedSdkDirectory).Name;
@@ -108,10 +137,12 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                 var netcoreSdkVersionFromEnv = _getEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_SDKS_VER");
                 if (!string.IsNullOrEmpty(msbuildSdksDirFromEnv))
                 {
+                    logger.LogMessage($"MSBuild SDKs dir overridden via DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR to {msbuildSdksDirFromEnv}");
                     msbuildSdksDir = msbuildSdksDirFromEnv;
                 }
                 if (!string.IsNullOrEmpty(netcoreSdkVersionFromEnv))
                 {
+                    logger.LogMessage($".NET Core SDK version overridden via DOTNET_MSBUILD_SDK_RESOLVER_SDKS_VER to {netcoreSdkVersionFromEnv}");
                     netcoreSdkVersion = netcoreSdkVersionFromEnv;
                 }
 
@@ -119,6 +150,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                 {
                     return Failure(
                         factory,
+                        logger.LogMessage,
                         Strings.NETCoreSDKSmallerThanMinimumRequestedVersion,
                         netcoreSdkVersion,
                         sdkReference.MinimumVersion);
@@ -129,6 +161,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                 {
                     return Failure(
                         factory,
+                        logger.LogMessage,
                         Strings.MSBuildSmallerThanMinimumVersion,
                         netcoreSdkVersion,
                         minimumMSBuildVersion,
@@ -140,6 +173,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                 {
                     return Failure(
                         factory,
+                        logger.LogMessage,
                         Strings.NETCoreSDKSmallerThanMinimumVersionRequiredByVisualStudio,
                         netcoreSdkVersion,
                         minimumVSDefinedSDKVersion);
@@ -147,6 +181,8 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
 
                 if (resolverResult.FailedToResolveSDKSpecifiedInGlobalJson)
                 {
+                    logger.LogMessage($"Could not resolve SDK specified in '{resolverResult.GlobalJsonPath}'. Ignoring global.json for this resolution.");
+
                     if (warnings == null)
                     {
                         warnings = new List<string>();
@@ -193,6 +229,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             {
                 return Failure(
                     factory,
+                    logger.LogMessage,
                     Strings.MSBuildSDKDirectoryNotFound,
                     msbuildSdkDir);
             }
@@ -200,9 +237,11 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             return factory.IndicateSuccess(msbuildSdkDir, netcoreSdkVersion, propertiesToAdd, itemsToAdd, warnings);
         }
 
-        private static SdkResult Failure(SdkResultFactory factory, string format, params object[] args)
+        private static SdkResult Failure(SdkResultFactory factory, Action<string> log, string format, params object[] args)
         {
-            return factory.IndicateFailure(new[] { string.Format(format, args) });
+            string error = string.Format(format, args);
+            log("Failed to resolve SDK: " + error);
+            return factory.IndicateFailure(new[] { error });
         }
 
         /// <summary>
@@ -267,5 +306,32 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
         }
 
 
+        class ResolverLogger : IDisposable
+        {
+            private readonly StreamWriter _stream;
+
+            public ResolverLogger(SdkReference sdkReference, bool enabled)
+            {
+                if (enabled)
+                {
+                    var path = Path.Combine(Path.GetTempPath(), $"Microsoft.DotNet.MSBuildSdkResolver_{DateTime.Now:yyyyMMdd_HHmmss}_{sdkReference.Name}_{Guid.NewGuid()}.log");
+                    Directory.CreateDirectory(Path.GetDirectoryName(path));
+                    _stream = File.CreateText(path);
+                }
+            }
+
+            public void LogMessage(string message)
+            {
+                if (_stream != null)
+                {
+                    _stream.WriteLine(message);
+                }
+            }
+
+            public void Dispose()
+            {
+                _stream?.Dispose();
+            }
+        }
     }
 }

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -56,11 +56,12 @@ namespace Microsoft.DotNet.NativeWrapper
             return commandPath;
         }
 
-        public string GetDotnetExeDirectory()
+        public string GetDotnetExeDirectory(Action<string> log = null)
         {
             string environmentOverride = _getEnvironmentVariable(Constants.DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR);
             if (!string.IsNullOrEmpty(environmentOverride))
             {
+                log?.Invoke($"GetDotnetExeDirectory: {Constants.DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR} set to {environmentOverride}");
                 return environmentOverride;
             }
 
@@ -75,6 +76,9 @@ namespace Microsoft.DotNet.NativeWrapper
 
             if (string.IsNullOrWhiteSpace(dotnetExe))
             {
+                log?.Invoke($"GetDotnetExeDirectory: dotnet command path not found.  Using current process");
+                log?.Invoke($"GetDotnetExeDirectory: Path variable: {_getEnvironmentVariable(Constants.PATH)}");
+
 #if NET6_0_OR_GREATER
                 dotnetExe = Environment.ProcessPath;
 #else
@@ -82,17 +86,21 @@ namespace Microsoft.DotNet.NativeWrapper
 #endif
             }
 
-            return Path.GetDirectoryName(dotnetExe);
+            var dotnetDirectory = Path.GetDirectoryName(dotnetExe);
+
+            log?.Invoke($"GetDotnetExeDirectory: Returning {dotnetDirectory}");
+
+            return dotnetDirectory;
         }
 
-        public static string GetDotnetExeDirectory(Func<string, string> getEnvironmentVariable = null)
+        public static string GetDotnetExeDirectory(Func<string, string> getEnvironmentVariable = null, Action<string> log = null)
         {
             if (getEnvironmentVariable == null)
             {
                 getEnvironmentVariable = Environment.GetEnvironmentVariable;
             }
             var environmentProvider = new EnvironmentProvider(getEnvironmentVariable);
-            return environmentProvider.GetDotnetExeDirectory();
+            return environmentProvider.GetDotnetExeDirectory(log);
         }
     }
 }

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.NativeWrapper
             return commandPath;
         }
 
-        public string GetDotnetExeDirectory(Action<string> log = null)
+        public string GetDotnetExeDirectory(Action<FormattableString> log = null)
         {
             string environmentOverride = _getEnvironmentVariable(Constants.DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR);
             if (!string.IsNullOrEmpty(environmentOverride))
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.NativeWrapper
             return dotnetDirectory;
         }
 
-        public static string GetDotnetExeDirectory(Func<string, string> getEnvironmentVariable = null, Action<string> log = null)
+        public static string GetDotnetExeDirectory(Func<string, string> getEnvironmentVariable = null, Action<FormattableString> log = null)
         {
             if (getEnvironmentVariable == null)
             {

--- a/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -729,9 +729,12 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 set => ProjectFilePath = Path.Combine(value.FullName, "test.csproj");
             }
 
+            public override SdkLogger Logger { get; protected set; }
+
             public MockContext()
             {
                 MSBuildVersion = new Version(15, 3, 0);
+                Logger = new MockLogger();
             }
         }
 
@@ -795,6 +798,14 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             public override IDictionary<string, SdkResultItem> ItemsToAdd { get; protected set; }
             public IEnumerable<string> Errors { get; }
             public IEnumerable<string> Warnings { get; }
+        }
+
+        private sealed class MockLogger : SdkLogger
+        {
+            public override void LogMessage(string message, MessageImportance messageImportance = MessageImportance.Low)
+            {
+
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, when the .NET SDK MSBuild SDK resolver fails, it can be pretty hard to figure out why.  This PR adds the option for better error logging which can help figure out what's wrong.

To enable this, set the `DOTNET_MSBUILD_SDK_RESOLVER_ENABLE_LOG` environment variable to `true`.  If set, then the .NET SDK MSBuild SDK resolver will write logs when resolving SDKs.  If the resolver fails to resolve the SDK, the log will be logged to MSBuild (and can be seen in the binlog) and included in the failure message.

The log will look something like this:

```
Attempting to resolve MSBuild SDK Microsoft.NET.Sdk
	Dotnet root: C:\Program Files\dotnet
Resolving .NET Core SDK directory
	global.json start directory: C:\git\repro\ConsoleTest
Failed to resolve .NET SDK.  Global.json path: C:\git\repro\ConsoleTest\global.json
Failed to resolve SDK: Unable to locate the .NET SDK. Check that it is installed and that the version specified in global.json (if any) matches the installed version.
```

We're not enabling this by default yet because of the possible perf / memory impact on MSBuild evaluation.