### PR TITLE
Fix StatInterop to include new signature

### DIFF
--- a/src/Cli/dotnet/StatInterop.cs
+++ b/src/Cli/dotnet/StatInterop.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.Cli
             internal long BirthTime;
             internal long BirthTimeNsec;
             internal long Dev;
+            internal long RDev;
             internal long Ino;
             internal uint UserFlags;
         }


### PR DESCRIPTION
The LStat native method was updated to include a new field, but the SDK copy wasn't updated. Adding the new field to fix interop issues and crashes.

Fix https://github.com/dotnet/runtime/issues/72308

I verified this fixes the issue manually. I'm not sure how to test this in CI. @dsplaisted - any thoughts?