### PR TITLE
Add baseline package validation strict mode option

### DIFF
--- a/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
+++ b/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <DefineConstants Condition="'$(ForceValidationProblem)' == 'true'">$(DefineConstants);ForceValidationProblem</DefineConstants>
+    <DefineConstants Condition="'$(ForceStrictModeBaselineValidationProblem)' == 'true'">$(DefineConstants);ForceStrictModeBaselineValidationProblem</DefineConstants>
     <DefineConstants Condition="'$(AddBreakingChange)' == 'true'">$(DefineConstants);AddBreakingChange</DefineConstants>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <EnablePackageValidation>true</EnablePackageValidation>

--- a/src/Assets/TestProjects/PackageValidationTestProject/Program.cs
+++ b/src/Assets/TestProjects/PackageValidationTestProject/Program.cs
@@ -7,17 +7,22 @@ namespace PackageValidationTestProject
 {
     public class Program
     {
-#if ForceValidationProblem
-#if !NET6_0
-  public void SomeAPINotIn6_0()
-  {
-  }
+#if ForceValidationProblem && !NET6_0
+      public void SomeAPINotIn6_0()
+      {
+      }
 #endif
-#endif
+
 #if !AddBreakingChange
-  public void SomeApiNotInLatestVersion()
-  {
-  }
+      public void SomeApiNotInLatestVersion()
+      {
+      }
+#endif
+
+#if ForceStrictModeBaselineValidationProblem
+      public void SomeApiOnlyInLatestVersion()
+      {
+      }
 #endif
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
@@ -50,6 +50,7 @@ namespace Microsoft.DotNet.ApiCompat
             bool runApiCompat,
             bool enableStrictModeForCompatibleTfms,
             bool enableStrictModeForCompatibleFrameworksInPackage,
+            bool enableStrictModeForBaselineValidation,
             string? baselinePackagePath,
             string? runtimeGraph,
             Dictionary<string, string[]>? packageAssemblyReferences,
@@ -85,7 +86,7 @@ namespace Microsoft.DotNet.ApiCompat
             if (!string.IsNullOrEmpty(baselinePackagePath))
             {
                 serviceProvider.GetService<BaselinePackageValidator>().Validate(new PackageValidatorOption(package,
-                    enableStrictMode: false,
+                    enableStrictMode: enableStrictModeForBaselineValidation,
                     enqueueApiCompatWorkItems: runApiCompat,
                     executeApiCompatWorkItems: false,
                     baselinePackage: Package.Create(baselinePackagePath, baselinePackageAssemblyReferences)));

--- a/src/Compatibility/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
@@ -54,6 +54,11 @@ namespace Microsoft.DotNet.ApiCompat.Task
         public bool EnableStrictModeForCompatibleFrameworksInPackage { get; set; }
 
         /// <summary>
+        /// Enables strict mode api comparison checks enqueued by the baseline package validator.
+        /// </summary>
+        public bool EnableStrictModeForBaselineValidation { get; set; }
+
+        /// <summary>
         /// The path to the baseline package that acts as the contract to inspect.
         /// </summary>
         public string? BaselinePackageTargetPath { get; set; }
@@ -123,6 +128,7 @@ namespace Microsoft.DotNet.ApiCompat.Task
                 RunApiCompat,
                 EnableStrictModeForCompatibleTfms,
                 EnableStrictModeForCompatibleFrameworksInPackage,
+                EnableStrictModeForBaselineValidation,
                 BaselinePackageTargetPath,
                 RuntimeGraph,
                 ParsePackageAssemblyReferences(PackageAssemblyReferences),

--- a/src/Compatibility/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -159,6 +159,8 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 "Validates api compatibility in strict mode for contract and implementation assemblies for all compatible target frameworks.");
             Option<bool> enableStrictModeForCompatibleFrameworksInPackageOption = new("--enable-strict-mode-for-compatible-frameworks-in-package",
                 "Validates api compatibility in strict mode for assemblies that are compatible based on their target framework.");
+            Option<bool> enableStrictModeForBaselineValidationOption = new("--enable-strict-mode-for-baseline-validation",
+                "Validates api compatibility in strict mode for package baseline checks.");
             Option<string?> baselinePackageOption = new("--baseline-package",
                 "The path to a baseline package to validate against the current package.")
             {
@@ -187,6 +189,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             packageCommand.AddOption(runApiCompatOption);
             packageCommand.AddOption(enableStrictModeForCompatibleTfmsOption);
             packageCommand.AddOption(enableStrictModeForCompatibleFrameworksInPackageOption);
+            packageCommand.AddOption(enableStrictModeForBaselineValidationOption);
             packageCommand.AddOption(baselinePackageOption);
             packageCommand.AddOption(packageAssemblyReferencesOption);
             packageCommand.AddOption(baselinePackageAssemblyReferencesOption);
@@ -206,6 +209,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 bool runApiCompat = context.ParseResult.GetValueForOption(runApiCompatOption);
                 bool enableStrictModeForCompatibleTfms = context.ParseResult.GetValueForOption(enableStrictModeForCompatibleTfmsOption);
                 bool enableStrictModeForCompatibleFrameworksInPackage = context.ParseResult.GetValueForOption(enableStrictModeForCompatibleFrameworksInPackageOption);
+                bool enableStrictModeForBaselineValidation = context.ParseResult.GetValueForOption(enableStrictModeForBaselineValidationOption);
                 string? baselinePackage = context.ParseResult.GetValueForOption(baselinePackageOption);
                 string? runtimeGraph = context.ParseResult.GetValueForOption(runtimeGraphOption);
                 Dictionary<string, string[]>? packageAssemblyReferences = context.ParseResult.GetValueForOption(packageAssemblyReferencesOption);
@@ -220,6 +224,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                     runApiCompat,
                     enableStrictModeForCompatibleTfms,
                     enableStrictModeForCompatibleFrameworksInPackage,
+                    enableStrictModeForBaselineValidation,
                     baselinePackage,
                     runtimeGraph,
                     packageAssemblyReferences,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -33,6 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       RunApiCompat="$(RunApiCompat)"
       EnableStrictModeForCompatibleTfms="$([MSBuild]::ValueOrDefault('$(EnableStrictModeForCompatibleTfms)', 'true'))"
       EnableStrictModeForCompatibleFrameworksInPackage="$(EnableStrictModeForCompatibleFrameworksInPackage)"
+      EnableStrictModeForBaselineValidation="$(EnableStrictModeForBaselineValidation)"
       GenerateCompatibilitySuppressionFile="$(GenerateCompatibilitySuppressionFile)"
       CompatibilitySuppressionFilePath="$(CompatibilitySuppressionFilePath)"
       BaselinePackageTargetPath="$(_packageValidationBaselinePath)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/25302

Adds a strict mode option for baseline validation to the apicompat
frontends. This mode is intended to be used during servicing, when in a
patch version update, no new public api additions are allowed.

Adds two tests that verify that the switch works when enabled and
disabled.

cc @dougbu 