### PR TITLE
Invoke PackageValidation only when inputs have changed

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -11,6 +11,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
   <PropertyGroup>
+    <ApiCompatValidatePackageSemaphoreFile>$(IntermediateOutputPath)$(MSBuildThisFileName).semaphore</ApiCompatValidatePackageSemaphoreFile>
     <!-- Add any custom targets that need to run before package validation to the following property. -->
     <RunPackageValidationDependsOn>CollectApiCompatInputs;_GetReferencePathFromInnerProjects;$(RunPackageValidationDependsOn)</RunPackageValidationDependsOn>
   </PropertyGroup>
@@ -18,6 +19,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="RunPackageValidation"
           DependsOnTargets="$(RunPackageValidationDependsOn)"
           AfterTargets="Pack"
+          Inputs="@(NuGetPackInput);$(CompatibilitySuppressionFilePath)"
+          Outputs="$(ApiCompatValidatePackageSemaphoreFile)"
           Condition="'$(EnablePackageValidation)' == 'true' and '$(IsPackable)' == 'true'">
     <PropertyGroup>
       <PackageValidationBaselineName Condition="'$(PackageValidationBaselineName)' == ''">$(PackageId)</PackageValidationBaselineName>
@@ -38,6 +41,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       BaselinePackageTargetPath="$(_packageValidationBaselinePath)"
       RoslynAssembliesPath="$(RoslynAssembliesPath)"
       PackageAssemblyReferences="@(PackageValidationReferencePath)" />
+
+      <Touch Files="$(ApiCompatValidatePackageSemaphoreFile)" AlwaysCreate="true" />
   </Target>
 
   <Target Name="_GetReferencePathForPackageValidation"


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/23517
Contributes to https://github.com/dotnet/sdk/issues/23893

By defining inputs and a semaphore file as the output, PackageValidation doesn't run anymore in an no-op incremental build. In the example of dotnet/runtime, this saves nearly two minutes of unnecessary work.