### PR TITLE
use $HOME in zsh tool path instead of ~

### DIFF
--- a/src/Cli/Microsoft.DotNet.Configurer/BashPathUnderHomeDirectory.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/BashPathUnderHomeDirectory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Configurer
 
         public string PathWithTilde => $"~/{_pathRelativeToHome}";
 
-        public string PathWithDollar => $"$HOME/{_pathRelativeToHome}";
+        public string PathWithHome => $"$HOME/{_pathRelativeToHome}";
 
         public string Path => $"{_fullHomeDirectoryPath}/{_pathRelativeToHome}";
     }

--- a/src/Cli/dotnet/ShellShim/LinuxEnvironmentPath.cs
+++ b/src/Cli/dotnet/ShellShim/LinuxEnvironmentPath.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.ShellShim
                 return;
             }
 
-            var script = $"export PATH=\"$PATH:{_packageExecutablePath.PathWithDollar}\"";
+            var script = $"export PATH=\"$PATH:{_packageExecutablePath.PathWithHome}\"";
             _fileSystem.WriteAllText(DotnetCliToolsProfilePath, script);
         }
 

--- a/src/Cli/dotnet/ShellShim/OsxBashEnvironmentPath.cs
+++ b/src/Cli/dotnet/ShellShim/OsxBashEnvironmentPath.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.ShellShim
                 return;
             }
 
-            _fileSystem.WriteAllText(DotnetCliToolsPathsDPath, _packageExecutablePath.PathWithTilde);
+            _fileSystem.WriteAllText(DotnetCliToolsPathsDPath, _packageExecutablePath.PathWithHome);
         }
 
         private bool PackageExecutablePathExists()

--- a/src/Cli/dotnet/ShellShim/OsxZshEnvironmentPathInstruction.cs
+++ b/src/Cli/dotnet/ShellShim/OsxZshEnvironmentPathInstruction.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.ShellShim
 
             return value
                 .Split(':')
-                .Any(p => p == _packageExecutablePath.Path);
+                .Any(p => p == _packageExecutablePath.Path || p == _packageExecutablePath.PathWithHome);
         }
 
         public void PrintAddPathInstructionIfPathDoesNotExist()

--- a/src/Tests/Microsoft.DotNet.ShellShim.Tests/LinuxEnvironmentPathTests.cs
+++ b/src/Tests/Microsoft.DotNet.ShellShim.Tests/LinuxEnvironmentPathTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
                 .File
                 .ReadAllText(LinuxEnvironmentPath.DotnetCliToolsProfilePath)
                 .Should()
-                .Be($"export PATH=\"$PATH:{toolsPath.PathWithDollar}\"");
+                .Be($"export PATH=\"$PATH:{toolsPath.PathWithHome}\"");
         }
     }
 }

--- a/src/Tests/Microsoft.DotNet.ShellShim.Tests/OsxEnvironmentPathTests.cs
+++ b/src/Tests/Microsoft.DotNet.ShellShim.Tests/OsxEnvironmentPathTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
                 .File
                 .ReadAllText(OsxBashEnvironmentPath.DotnetCliToolsPathsDPath)
                 .Should()
-                .Be(toolsPath.PathWithTilde);
+                .Be(toolsPath.PathWithHome);
         }
     }
 }

--- a/src/Tests/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/src/Tests/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.Tests
 
             File.Exists(profiled).Should().BeTrue();
             File.ReadAllText(profiled).Should().Be(
-                $"export PATH=\"$PATH:{CliFolderPathCalculator.ToolsShimPathInUnix.PathWithDollar}\"");
+                $"export PATH=\"$PATH:{CliFolderPathCalculator.ToolsShimPathInUnix.PathWithHome}\"");
         }
 
         [MacOsOnlyFact]
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.Tests
             command.Execute("internal-reportinstallsuccess", "test").Should().Pass();
 
             File.Exists(pathsd).Should().BeTrue();
-            File.ReadAllText(pathsd).Should().Be(CliFolderPathCalculator.ToolsShimPathInUnix.PathWithTilde);
+            File.ReadAllText(pathsd).Should().Be(CliFolderPathCalculator.ToolsShimPathInUnix.PathWithHome);
         }
 
         private string GetDotnetVersion()


### PR DESCRIPTION
Fixes #22214 by using $HOME in the generated `/etc/path.d` shim for ZSH.  I need to add more testing, and I'd like to make sure that existing bad PATHs are detected - if the file exists and has bad content we should feel free to overwrite it to correct the mistake.

Some of the issues I'll link here suggest that path_helper doesn't expand variables, so testing for that will be required as well.