### PR TITLE
Enable nullable for the mapper types and code clean-up

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/ElementContainer.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/ElementContainer.cs
@@ -9,17 +9,17 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// Class to wrap an Element of T with it's <see cref="MetadataInformation"/>.
     /// </summary>
     /// <typeparam name="T">The type of the Element that is holded</typeparam>
-    public class ElementContainer<T> where T : ISymbol
+    public readonly struct ElementContainer<T> where T : ISymbol
     {
         /// <summary>
         /// The element that the container is holding.
         /// </summary>
-        public T Element { get; private set; }
+        public T Element { get; }
 
         /// <summary>
         /// The metadata associated to the element.
         /// </summary>
-        public MetadataInformation MetadataInformation { get; private set; }
+        public MetadataInformation MetadataInformation { get; }
 
         /// <summary>
         /// Instantiates a new object with the <paramref name="element"/> and <paramref name="metadataInformation"/> used.

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/AssemblySetMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/AssemblySetMapper.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
-using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiCompatibility.Abstractions
 {
@@ -13,7 +11,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// </summary>
     public class AssemblySetMapper : ElementMapper<IEnumerable<IAssemblySymbol>>
     {
-        private Dictionary<IAssemblySymbol, AssemblyMapper> _assemblies;
+        private Dictionary<IAssemblySymbol, AssemblyMapper>? _assemblies;
 
         /// <summary>
         /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
@@ -33,20 +31,14 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                 _assemblies = new Dictionary<IAssemblySymbol, AssemblyMapper>(Settings.EqualityComparer);
                 AddOrCreateMappers(Left, ElementSide.Left);
 
-                if (Right.Length == 1)
+                for (int i = 0; i < Right.Length; i++)
                 {
-                    AddOrCreateMappers(Right[0], ElementSide.Right);
-                }
-                else
-                {
-                    for (int i = 0; i < Right.Length; i++)
-                    {
-                        AddOrCreateMappers(Right[i], ElementSide.Right, i);
-                    }
+                    AddOrCreateMappers(Right[i], ElementSide.Right, i);
                 }
 
-                void AddOrCreateMappers(IEnumerable<IAssemblySymbol> symbols, ElementSide side, int setIndex = 0)
+                void AddOrCreateMappers(IEnumerable<IAssemblySymbol>? symbols, ElementSide side, int setIndex = 0)
                 {
+                    // Silently return if the element hasn't been added yet.
                     if (symbols == null)
                     {
                         return;
@@ -54,7 +46,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
 
                     foreach (IAssemblySymbol assembly in symbols)
                     {
-                        if (!_assemblies.TryGetValue(assembly, out AssemblyMapper mapper))
+                        if (!_assemblies.TryGetValue(assembly, out AssemblyMapper? mapper))
                         {
                             mapper = new AssemblyMapper(Settings, Right.Length);
                             _assemblies.Add(assembly, mapper);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ElementMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ElementMapper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
@@ -13,23 +11,22 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// </summary>
     public class ElementMapper<T>
     {
-        private IReadOnlyList<IEnumerable<CompatDifference>> _differences;
-        protected IList<CompatDifference>[] _assemblyLoadErrors;
+        private IReadOnlyList<IEnumerable<CompatDifference>>? _differences;
 
         /// <summary>
         /// Property representing the Left hand side of the mapping.
         /// </summary>
-        public T Left { get; private set; }
+        public T? Left { get; private set; }
 
         /// <summary>
         /// Property representing the Right hand side element(s) of the mapping.
         /// </summary>
-        public T[] Right { get; private set; }
+        public T?[] Right { get; private set; }
 
         /// <summary>
         /// The <see cref="ComparingSettings"/> used to diff <see cref="Left"/> and <see cref="Right"/>.
         /// </summary>
-        public ComparingSettings Settings { get; internal set; }
+        public ComparingSettings Settings { get; }
 
         /// <summary>
         /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
@@ -38,22 +35,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
         public ElementMapper(ComparingSettings settings, int rightSetSize)
         {
-            if (rightSetSize <= 0)
+            if (rightSetSize < 1)
                 throw new ArgumentOutOfRangeException(nameof(rightSetSize), Resources.ShouldBeGreaterThanZero);
 
-            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            Settings = settings;
             Right = new T[rightSetSize];
-            _assemblyLoadErrors = new IList<CompatDifference>[rightSetSize];
-            for (int i = 0; i < rightSetSize; i++)
-                _assemblyLoadErrors[i] = new List<CompatDifference>();
         }
-
-        /// <summary>
-        /// Adds an element to the given <paramref name="side"/> using the index 0 for <see cref="ElementSide.Right"/>.
-        /// </summary>
-        /// <param name="element">The element to add.</param>
-        /// <param name="side">Value representing the side of the mapping. </param>
-        public virtual void AddElement(T element, ElementSide side) => AddElement(element, side, 0);
 
         /// <summary>
         /// Adds an element to the mapping given the <paramref name="side"/> and the <paramref name="setIndex"/>.
@@ -61,7 +48,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// <param name="element">The element to add to the mapping.</param>
         /// <param name="side">Value representing the side of the mapping.</param>
         /// <param name="setIndex">Value representing the index the element is added. Only used when adding to <see cref="ElementSide.Right"/>.</param>
-        public virtual void AddElement(T element, ElementSide side, int setIndex)
+        public virtual void AddElement(T element, ElementSide side, int setIndex = 0)
         {
             if (side == ElementSide.Left)
             {
@@ -77,6 +64,22 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         }
 
         /// <summary>
+        /// Returns the element from the specified <see cref="ElementSide"/> and index.
+        /// </summary>
+        /// <param name="side">Value representing the side of the mapping.</param>
+        /// <param name="setIndex">Value representing the index the element is retrieved. Only used when adding to <see cref="ElementSide.Right"/>.</param>
+        /// <returns></returns>
+        public T? GetElement(ElementSide side, int setIndex)
+        {
+            if (side == ElementSide.Left)
+            {
+                return Left;
+            }
+
+            return Right[setIndex];
+        }
+
+        /// <summary>
         /// Runs the rules found by the rule driver on the element mapper and returns a list of differences.
         /// </summary>
         /// <returns>A list containing the list of differences for each possible combination of
@@ -85,22 +88,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         public IReadOnlyList<IEnumerable<CompatDifference>> GetDifferences()
         {
             return _differences ??= Settings.RuleRunnerFactory.GetRuleRunner().Run(this);
-        }
-
-        /// <summary>
-        /// Gets the assembly load errors that happened when trying to follow type forwards.
-        /// </summary>
-        /// <returns>A list containing the assembly load errors that ocurred when following type forwards.</returns>
-        public IList<CompatDifference>[] GetAssemblyLoadErrors() => _assemblyLoadErrors;
-
-        internal T GetElement(ElementSide side, int setIndex)
-        {
-            if (side == ElementSide.Left)
-            {
-                return Left;
-            }
-
-            return Right[setIndex];
         }
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/MemberMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/MemberMapper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiCompatibility.Abstractions
@@ -13,6 +11,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     public class MemberMapper : ElementMapper<ISymbol>
     {
         /// <summary>
+        /// The containg type of this member.
+        /// </summary>
+        internal TypeMapper ContainingType { get; }
+
+        /// <summary>
         /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
         /// </summary>
         /// <param name="settings">The settings used to diff the elements in the mapper.</param>
@@ -22,8 +25,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         {
             ContainingType = containingType;
         }
-
-        internal TypeMapper ContainingType { get; }
 
         // If we got to this point it means that ContainingType.Left is not null.
         // Because of that we can only check ContainingType.Right.

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/NamespaceMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/NamespaceMapper.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
-using Microsoft.CodeAnalysis;
-using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiCompatibility.Abstractions
 {
@@ -16,7 +13,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// </summary>
     public class NamespaceMapper : ElementMapper<INamespaceSymbol>
     {
-        private Dictionary<ITypeSymbol, TypeMapper> _types;
+        private readonly Dictionary<ITypeSymbol, TypeMapper> _types;
         private bool _expandedTree = false;
         private readonly bool _typeforwardsOnly;
 
@@ -29,6 +26,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         public NamespaceMapper(ComparingSettings settings, int rightSetSize = 1, bool typeforwardsOnly = false)
             : base(settings, rightSetSize)
         {
+            _types = new Dictionary<ITypeSymbol, TypeMapper>(Settings.EqualityComparer);
             _typeforwardsOnly = typeforwardsOnly;
         }
 
@@ -40,8 +38,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         {
             if (!_expandedTree)
             {
-                EnsureTypesInitialized();
-
                 // if the typeforwardsOnly flag is specified it means this namespace is already
                 // populated with the resolved typeforwards by the assembly mapper and that we 
                 // didn't find this namespace in the initial assembly. So we avoid getting the types
@@ -50,17 +46,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                 if (!_typeforwardsOnly)
                 {
                     AddOrCreateMappers(Left, ElementSide.Left);
-
-                    if (Right.Length == 1)
+                    for (int i = 0; i < Right.Length; i++)
                     {
-                        AddOrCreateMappers(Right[0], ElementSide.Right);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < Right.Length; i++)
-                        {
-                            AddOrCreateMappers(Right[i], ElementSide.Right, i);
-                        }
+                        AddOrCreateMappers(Right[i], ElementSide.Right, i);
                     }
                 }
 
@@ -76,19 +64,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// <param name="forwardedTypes">List containing the <see cref="INamedTypeSymbol"/> that represents the forwarded types.</param>
         /// <param name="side">Side to add the forwarded types into, 0 (Left) or 1 (Right).</param>
         /// <param name="setIndex">Value representing the index on the set of elements corresponding to the compared side.</param>
-        public void AddForwardedTypes(IEnumerable<INamedTypeSymbol> forwardedTypes, ElementSide side, int setIndex)
+        public void AddForwardedTypes(IEnumerable<INamedTypeSymbol>? forwardedTypes, ElementSide side, int setIndex)
         {
-            EnsureTypesInitialized();
             AddOrCreateMappers(forwardedTypes, side, setIndex);
         }
 
-        private void EnsureTypesInitialized()
-        {
-            if (_types == null)
-                _types = new Dictionary<ITypeSymbol, TypeMapper>(Settings.EqualityComparer);
-        }
-
-        private void AddOrCreateMappers(INamespaceSymbol symbol, ElementSide side, int setIndex = 0)
+        private void AddOrCreateMappers(INamespaceSymbol? symbol, ElementSide side, int setIndex = 0)
         {
             if (symbol == null)
             {
@@ -98,8 +79,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
             AddOrCreateMappers(symbol.GetTypeMembers(), side, setIndex);
         }
 
-        private void AddOrCreateMappers(IEnumerable<ITypeSymbol> types, ElementSide side, int setIndex)
+        private void AddOrCreateMappers(IEnumerable<ITypeSymbol>? types, ElementSide side, int setIndex)
         {
+            // Silently return if the element hasn't been added yet.
             if (types == null)
                 return;
 
@@ -107,7 +89,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
             {
                 if (Settings.Filter.Include(type))
                 {
-                    if (!_types.TryGetValue(type, out TypeMapper mapper))
+                    if (!_types.TryGetValue(type, out TypeMapper? mapper))
                     {
                         mapper = new TypeMapper(Settings, null, Right.Length);
                         _types.Add(type, mapper);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/TypeMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/TypeMapper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         private Dictionary<ISymbol, MemberMapper>? _members;
 
         /// <summary>
-        /// The containg type of this type. Null if the type isn't nested.
+        /// The containing type of this type. Null if the type isn't nested.
         /// </summary>
         internal TypeMapper? ContainingType { get; }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/TypeMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/TypeMapper.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
-using Microsoft.CodeAnalysis;
-using Microsoft.DotNet.ApiCompatibility.Extensions;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiCompatibility.Extensions;
 
 namespace Microsoft.DotNet.ApiCompatibility.Abstractions
 {
@@ -18,31 +15,35 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// </summary>
     public class TypeMapper : ElementMapper<ITypeSymbol>
     {
-        private readonly TypeMapper _containingType;
-        private Dictionary<ITypeSymbol, TypeMapper> _nestedTypes;
-        private Dictionary<ISymbol, MemberMapper> _members;
+        private Dictionary<ITypeSymbol, TypeMapper>? _nestedTypes;
+        private Dictionary<ISymbol, MemberMapper>? _members;
+
+        /// <summary>
+        /// The containg type of this type. Null if the type isn't nested.
+        /// </summary>
+        internal TypeMapper? ContainingType { get; }
 
         /// <summary>
         /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
         /// </summary>
         /// <param name="settings">The settings used to diff the elements in the mapper.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
-        public TypeMapper(ComparingSettings settings, TypeMapper containingType = null, int rightSetSize = 1)
+        public TypeMapper(ComparingSettings settings, TypeMapper? containingType = null, int rightSetSize = 1)
             : base(settings, rightSetSize)
         {
-            _containingType = containingType;
+            ContainingType = containingType;
         }
 
         internal bool ShouldDiffElement(int rightIndex)
         {
-            if (IsNested)
+            if (ContainingType != null)
             {
-                Debug.Assert(_containingType.ShouldDiffMembers);
+                Debug.Assert(ContainingType.ShouldDiffMembers);
 
                 // This should only be called at a point where containingType.ShouldDiffMembers is true
                 // So that means that containingType.Left is not null and we don't need to check.
                 // If containingType.Right only contains one element, we can assume it is not null.
-                return _containingType.Right.Length == 1 || _containingType.Right[rightIndex] != null;
+                return ContainingType.Right.Length == 1 || ContainingType.Right[rightIndex] != null;
             }
 
             return true;
@@ -74,11 +75,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         }
 
         /// <summary>
-        /// Indicates whether a type is nested or not.
-        /// </summary>
-        public bool IsNested => _containingType != null;
-
-        /// <summary>
         /// Gets the nested types within the mapped types.
         /// </summary>
         /// <returns>The list of <see cref="TypeMapper"/> representing the nested types.</returns>
@@ -89,21 +85,14 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                 _nestedTypes = new Dictionary<ITypeSymbol, TypeMapper>(Settings.EqualityComparer);
 
                 AddOrCreateMappers(Left, ElementSide.Left);
-
-                if (Right.Length == 1)
+                for (int i = 0; i < Right.Length; i++)
                 {
-                    AddOrCreateMappers(Right[0], ElementSide.Right);
-                }
-                else
-                {
-                    for (int i = 0; i < Right.Length; i++)
-                    {
-                        AddOrCreateMappers(Right[i], ElementSide.Right, i);
-                    }
+                    AddOrCreateMappers(Right[i], ElementSide.Right, i);
                 }
 
-                void AddOrCreateMappers(ITypeSymbol symbol, ElementSide side, int setIndex = 0)
+                void AddOrCreateMappers(ITypeSymbol? symbol, ElementSide side, int setIndex = 0)
                 {
+                    // Silently return if the element hasn't been added yet.
                     if (symbol == null)
                     {
                         return;
@@ -113,7 +102,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                     {
                         if (Settings.Filter.Include(nestedType))
                         {
-                            if (!_nestedTypes.TryGetValue(nestedType, out TypeMapper mapper))
+                            if (!_nestedTypes.TryGetValue(nestedType, out TypeMapper? mapper))
                             {
                                 mapper = new TypeMapper(Settings, this, Right.Length);
                                 _nestedTypes.Add(nestedType, mapper);
@@ -138,21 +127,14 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                 _members = new Dictionary<ISymbol, MemberMapper>(Settings.EqualityComparer);
 
                 AddOrCreateMappers(Left, ElementSide.Left);
-
-                if (Right.Length == 1)
+                for (int i = 0; i < Right.Length; i++)
                 {
-                    AddOrCreateMappers(Right[0], ElementSide.Right);
-                }
-                else
-                {
-                    for (int i = 0; i < Right.Length; i++)
-                    {
-                        AddOrCreateMappers(Right[i], ElementSide.Right, i);
-                    }
+                    AddOrCreateMappers(Right[i], ElementSide.Right, i);
                 }
 
-                void AddOrCreateMappers(ITypeSymbol symbol, ElementSide side, int setIndex = 0)
+                void AddOrCreateMappers(ITypeSymbol? symbol, ElementSide side, int setIndex = 0)
                 {
+                    // Silently return if the element hasn't been added yet.
                     if (symbol == null)
                     {
                         return;
@@ -166,7 +148,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                         // we would compare __value vs null and emit some warnings.
                         if (Settings.Filter.Include(member) && member is not ITypeSymbol && !IsSpecialEnumField(member))
                         {
-                            if (!_members.TryGetValue(member, out MemberMapper mapper))
+                            if (!_members.TryGetValue(member, out MemberMapper? mapper))
                             {
                                 mapper = new MemberMapper(Settings, this, Right.Length);
                                 _members.Add(member, mapper);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.ApiCompatibility.Abstractions;
 using System;
 using System.Collections.Generic;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
 
 namespace Microsoft.DotNet.ApiCompatibility
 {
@@ -13,6 +13,12 @@ namespace Microsoft.DotNet.ApiCompatibility
     public class DifferenceVisitor : MapperVisitor
     {
         private readonly HashSet<CompatDifference>[] _diagnostics;
+
+        /// <summary>
+        /// A list of <see cref="DiagnosticBag{CompatDifference}"/>.
+        /// One per element compared in the right hand side.
+        /// </summary>
+        public IReadOnlyList<IReadOnlyCollection<CompatDifference>> DiagnosticCollections => _diagnostics;
 
         /// <summary>
         /// Instantiates the visitor with the desired settings.
@@ -26,7 +32,6 @@ namespace Microsoft.DotNet.ApiCompatibility
             }
 
             _diagnostics = new HashSet<CompatDifference>[rightCount];
-
             for (int i = 0; i < rightCount; i++)
             {
                 _diagnostics[i] = new HashSet<CompatDifference>();
@@ -43,7 +48,7 @@ namespace Microsoft.DotNet.ApiCompatibility
             base.Visit(assembly);
             // After visiting the assembly, the assembly mapper will contain any assembly load errors that happened
             // when trying to resolve typeforwarded types. If there were any, we add them to the diagnostic bag next.
-            AddAssemblyLoadErrors(assembly);
+            AddToDiagnosticCollections(assembly.AssemblyLoadErrors);
         }
 
         /// <summary>
@@ -69,24 +74,10 @@ namespace Microsoft.DotNet.ApiCompatibility
             AddDifferences(member);
         }
 
-        /// <summary>
-        /// A list of <see cref="DiagnosticBag{CompatDifference}"/>.
-        /// One per element compared in the right hand side.
-        /// </summary>
-        public IEnumerable<IEnumerable<CompatDifference>> DiagnosticCollections => _diagnostics;
-
         private void AddDifferences<T>(ElementMapper<T> mapper)
         {
             IReadOnlyList<IEnumerable<CompatDifference>> differences = mapper.GetDifferences();
-
             AddToDiagnosticCollections(differences);
-        }
-
-        private void AddAssemblyLoadErrors<T>(ElementMapper<T> mapper)
-        {
-            IReadOnlyList<IEnumerable<CompatDifference>> assemblyLoadErrors = mapper.GetAssemblyLoadErrors();
-
-            AddToDiagnosticCollections(assemblyLoadErrors);
         }
 
         private void AddToDiagnosticCollections(IReadOnlyList<IEnumerable<CompatDifference>> diagnosticsToAdd)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -4,6 +4,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
@@ -50,14 +51,20 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 else if (mapper is MemberMapper mm)
                 {
                     if (mm.ShouldDiffElement(rightIndex))
+                    {
+                        // ContainingType Left and Right cannot be null, as otherwise, the above condition would be false.
+                        Debug.Assert(mm.ContainingType.Left != null);
+                        Debug.Assert(mm.ContainingType.Right[rightIndex] != null);
+
                         _context.RunOnMemberSymbolActions(
                             mm.Left,
                             mm.Right[rightIndex],
-                            mm.ContainingType.Left,
-                            mm.ContainingType.Right[rightIndex],
+                            mm.ContainingType.Left!,
+                            mm.ContainingType.Right[rightIndex]!,
                             leftName,
                             rightName,
                             differences);
+                    }
                 }
 
                 result[rightIndex] = differences;

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -52,18 +52,15 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 {
                     if (mm.ShouldDiffElement(rightIndex))
                     {
-                        ITypeSymbol? leftContainingType = mm.ContainingType.Left;
-                        ITypeSymbol? rightContainingType = mm.ContainingType.Right[rightIndex];
-                    
                         // ContainingType Left and Right cannot be null, as otherwise, the above condition would be false.
-                        Debug.Assert(leftContainingType != null);
-                        Debug.Assert(rightContainingType != null);
+                        Debug.Assert(mm.ContainingType.Left != null);
+                        Debug.Assert(mm.ContainingType.Right[rightIndex] != null);
 
                         _context.RunOnMemberSymbolActions(
                             mm.Left,
                             mm.Right[rightIndex],
-                            leftContainingType,
-                            rightContainingType,
+                            mm.ContainingType.Left!,
+                            mm.ContainingType.Right[rightIndex]!,
                             leftName,
                             rightName,
                             differences);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -52,15 +52,18 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 {
                     if (mm.ShouldDiffElement(rightIndex))
                     {
+                        ITypeSymbol? leftContainingType = mm.ContainingType.Left;
+                        ITypeSymbol? rightContainingType = mm.ContainingType.Right[rightIndex];
+                    
                         // ContainingType Left and Right cannot be null, as otherwise, the above condition would be false.
-                        Debug.Assert(mm.ContainingType.Left != null);
-                        Debug.Assert(mm.ContainingType.Right[rightIndex] != null);
+                        Debug.Assert(leftContainingType != null);
+                        Debug.Assert(rightContainingType != null);
 
                         _context.RunOnMemberSymbolActions(
                             mm.Left,
                             mm.Right[rightIndex],
-                            mm.ContainingType.Left!,
-                            mm.ContainingType.Right[rightIndex]!,
+                            leftContainingType,
+                            rightContainingType,
                             leftName,
                             rightName,
                             differences);


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/25760

I left out the mapper types in my previous changes as I haven't yet looked into them more closely. I just spent several hours drawing a call stack and trying to understand the mapping infrastructure and I fell much more enlightened now 😁.