### PR TITLE
CFS tool configuration for templating testfile

### DIFF
--- a/.sscignore
+++ b/.sscignore
@@ -1,0 +1,4 @@
+{
+    "__comment": "CFS0013 intended for src\\Assets\\TestPackages\\dotnet-new\\test_templates\\TemplateWithConditions\\nuget.config",
+    "cfs" : ["CFS0013"]
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithConditions/nuget.config
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithConditions/nuget.config
@@ -2,8 +2,12 @@
 <!-- comment foo -->
 foo
 <!--#endif -->
-<!--#if (B)
-<!-- comment bar -- >
+<!--#if (B) -->
+<!-- comment bar -->
 bar
-#endif -->
+<!--#endif -->
 baz
+<!--#if (false) -->
+<!-- added extra content to make a valid nuget.config file -->
+<config />
+<!--#endif -->


### PR DESCRIPTION
## Problem:
* CFS Scan tool issues due to templating configuration file

## Solution:
* Fix the invalid xml commenting style and missing `config` node in test nuget.config
* Add cfs configuration file