### PR TITLE
Support left and right names for assembly set

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/ElementContainer.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/ElementContainer.cs
@@ -9,17 +9,17 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// Class to wrap an Element of T with it's <see cref="MetadataInformation"/>.
     /// </summary>
     /// <typeparam name="T">The type of the Element that is holded</typeparam>
-    public readonly struct ElementContainer<T> where T : ISymbol
+    public class ElementContainer<T> where T : ISymbol
     {
         /// <summary>
         /// The element that the container is holding.
         /// </summary>
-        public T Element { get; }
+        public readonly T Element;
 
         /// <summary>
         /// The metadata associated to the element.
         /// </summary>
-        public MetadataInformation MetadataInformation { get; }
+        public readonly MetadataInformation MetadataInformation;
 
         /// <summary>
         /// Instantiates a new object with the <paramref name="element"/> and <paramref name="metadataInformation"/> used.

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/AssemblySetMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/AssemblySetMapper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// <summary>
     /// Object that represents a mapping between two lists of <see cref="IAssemblySymbol"/>.
     /// </summary>
-    public class AssemblySetMapper : ElementMapper<IEnumerable<IAssemblySymbol>>
+    public class AssemblySetMapper : ElementMapper<IEnumerable<ElementContainer<IAssemblySymbol>>>
     {
         private Dictionary<IAssemblySymbol, AssemblyMapper>? _assemblies;
 
@@ -36,23 +36,23 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                     AddOrCreateMappers(Right[i], ElementSide.Right, i);
                 }
 
-                void AddOrCreateMappers(IEnumerable<IAssemblySymbol>? symbols, ElementSide side, int setIndex = 0)
+                void AddOrCreateMappers(IEnumerable<ElementContainer<IAssemblySymbol>>? assemblyContainers, ElementSide side, int setIndex = 0)
                 {
                     // Silently return if the element hasn't been added yet.
-                    if (symbols == null)
+                    if (assemblyContainers == null)
                     {
                         return;
                     }
 
-                    foreach (IAssemblySymbol assembly in symbols)
+                    foreach (ElementContainer<IAssemblySymbol> assemblyContainer in assemblyContainers)
                     {
-                        if (!_assemblies.TryGetValue(assembly, out AssemblyMapper? mapper))
+                        if (!_assemblies.TryGetValue(assemblyContainer.Element, out AssemblyMapper? mapper))
                         {
-                            mapper = new AssemblyMapper(Settings, Right.Length);
-                            _assemblies.Add(assembly, mapper);
+                            mapper = new AssemblyMapper(Settings, Right.Length, this);
+                            _assemblies.Add(assemblyContainer.Element, mapper);
                         }
 
-                        mapper.AddElement(assembly, side, setIndex);
+                        mapper.AddElement(assemblyContainer, side, setIndex);
                     }
                 }
             }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/MemberMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/MemberMapper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// <summary>
         /// The containg type of this member.
         /// </summary>
-        internal TypeMapper ContainingType { get; }
+        public TypeMapper ContainingType { get; }
 
         /// <summary>
         /// Instantiates an object with the provided <see cref="ComparingSettings"/>.

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/NamespaceMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/NamespaceMapper.cs
@@ -18,14 +18,20 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         private readonly bool _typeforwardsOnly;
 
         /// <summary>
+        /// The containing assembly of this namespace.
+        /// </summary>
+        public AssemblyMapper ContainingAssembly { get; }
+
+        /// <summary>
         /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
         /// </summary>
         /// <param name="settings">The settings used to diff the elements in the mapper.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
         /// <param name="typeforwardsOnly">Indicates if <see cref="GetTypes"/> should only return typeforwards.</param>
-        public NamespaceMapper(ComparingSettings settings, int rightSetSize = 1, bool typeforwardsOnly = false)
+        public NamespaceMapper(ComparingSettings settings, AssemblyMapper containingAssembly, int rightSetSize = 1, bool typeforwardsOnly = false)
             : base(settings, rightSetSize)
         {
+            ContainingAssembly = containingAssembly;
             _types = new Dictionary<ITypeSymbol, TypeMapper>(Settings.EqualityComparer);
             _typeforwardsOnly = typeforwardsOnly;
         }
@@ -91,7 +97,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                 {
                     if (!_types.TryGetValue(type, out TypeMapper? mapper))
                     {
-                        mapper = new TypeMapper(Settings, null, Right.Length);
+                        mapper = new TypeMapper(Settings, this, null, Right.Length);
                         _types.Add(type, mapper);
                     }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/TypeMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/TypeMapper.cs
@@ -19,6 +19,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         private Dictionary<ISymbol, MemberMapper>? _members;
 
         /// <summary>
+        /// The containg namespace of this type.
+        /// </summary>
+        public NamespaceMapper ContainingNamespace { get; }
+
+        /// <summary>
         /// The containing type of this type. Null if the type isn't nested.
         /// </summary>
         internal TypeMapper? ContainingType { get; }
@@ -28,9 +33,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// </summary>
         /// <param name="settings">The settings used to diff the elements in the mapper.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
-        public TypeMapper(ComparingSettings settings, TypeMapper? containingType = null, int rightSetSize = 1)
+        public TypeMapper(ComparingSettings settings, NamespaceMapper containingNamespace, TypeMapper? containingType = null, int rightSetSize = 1)
             : base(settings, rightSetSize)
         {
+            ContainingNamespace = containingNamespace;
             ContainingType = containingType;
         }
 
@@ -104,7 +110,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                         {
                             if (!_nestedTypes.TryGetValue(nestedType, out TypeMapper? mapper))
                             {
-                                mapper = new TypeMapper(Settings, this, Right.Length);
+                                mapper = new TypeMapper(Settings, ContainingNamespace, this, Right.Length);
                                 _nestedTypes.Add(nestedType, mapper);
                             }
                             mapper.AddElement(nestedType, side, setIndex);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/MetadataInformation.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/MetadataInformation.cs
@@ -62,10 +62,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
             int hashCode = 1447485498;
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(AssemblyName);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(AssemblyId);
-            if (FullPath != null)
-            {
-                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FullPath);
-            }
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FullPath);
             return hashCode;
         }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
@@ -13,6 +12,8 @@ namespace Microsoft.DotNet.ApiCompatibility
     /// </summary>
     public class ApiComparer : IApiComparer
     {
+        private ComparingSettings? _comparingSettings;
+
         /// <inheritdoc />
         public bool IncludeInternalSymbols { get; set; }
 
@@ -23,30 +24,38 @@ namespace Microsoft.DotNet.ApiCompatibility
         public bool WarnOnMissingReferences { get; set; }
 
         /// <inheritdoc />
-        public Func<string?, string[]?, ComparingSettings>? GetComparingSettings { get; set; }
-
-        /// <inheritdoc />
-        public IEnumerable<CompatDifference> GetDifferences(IEnumerable<IAssemblySymbol> left,
-            IEnumerable<IAssemblySymbol> right,
-            string? leftName = null,
-            string? rightName = null)
+        public ComparingSettings ComparingSettings
         {
-            AssemblySetMapper mapper = new(GetComparingSettingsCore(leftName, rightName != null ? new[] { rightName } : null));
-            mapper.AddElement(left, ElementSide.Left);
-            mapper.AddElement(right, ElementSide.Right);
+            get => _comparingSettings ?? new ComparingSettings(includeInternalSymbols: IncludeInternalSymbols,
+                strictMode: StrictMode,
+                warnOnMissingReferences: WarnOnMissingReferences);
+            set => _comparingSettings = value;
+        }
 
-            DifferenceVisitor visitor = new();
-            visitor.Visit(mapper);
-            return visitor.DiagnosticCollections[0];
+        public ApiComparer(bool includeInternalSymbols = false,
+            bool strictMode = false,
+            bool warnOnMissingReferences = false,
+            ComparingSettings? comparingSettings = null)
+        {
+            IncludeInternalSymbols = includeInternalSymbols;
+            StrictMode = strictMode;
+            WarnOnMissingReferences = warnOnMissingReferences;
+            _comparingSettings = comparingSettings;
         }
 
         /// <inheritdoc />
         public IEnumerable<CompatDifference> GetDifferences(IAssemblySymbol left,
-            IAssemblySymbol right,
-            string? leftName = null,
-            string? rightName = null)
+            IAssemblySymbol right)
         {
-            AssemblyMapper mapper = new(GetComparingSettingsCore(leftName, rightName != null ? new[] { rightName } : null));
+            return GetDifferences(new ElementContainer<IAssemblySymbol>(left, new MetadataInformation()),
+                new ElementContainer<IAssemblySymbol>(right, new MetadataInformation()));
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<CompatDifference> GetDifferences(ElementContainer<IAssemblySymbol> left,
+            ElementContainer<IAssemblySymbol> right)
+        {
+            AssemblyMapper mapper = new(ComparingSettings);
             mapper.AddElement(left, ElementSide.Left);
             mapper.AddElement(right, ElementSide.Right);
 
@@ -56,47 +65,61 @@ namespace Microsoft.DotNet.ApiCompatibility
         }
 
         /// <inheritdoc />
+        public IEnumerable<CompatDifference> GetDifferences(IEnumerable<ElementContainer<IAssemblySymbol>> left,
+            IEnumerable<ElementContainer<IAssemblySymbol>> right)
+        {
+            AssemblySetMapper mapper = new(ComparingSettings);
+            mapper.AddElement(left, ElementSide.Left);
+            mapper.AddElement(right, ElementSide.Right);
+
+            DifferenceVisitor visitor = new();
+            visitor.Visit(mapper);
+            return visitor.DiagnosticCollections[0];
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<CompatDifference> GetDifferences(IEnumerable<IAssemblySymbol> left,
+            IEnumerable<IAssemblySymbol> right)
+        {
+            List<ElementContainer<IAssemblySymbol>> transformedLeft = new();
+            foreach (IAssemblySymbol assemblySymbol in left)
+            {
+                transformedLeft.Add(new ElementContainer<IAssemblySymbol>(assemblySymbol, new MetadataInformation()));
+            }
+
+            List<ElementContainer<IAssemblySymbol>> transformedRight = new();
+            foreach (IAssemblySymbol assemblySymbol in right)
+            {
+                transformedRight.Add(new ElementContainer<IAssemblySymbol>(assemblySymbol, new MetadataInformation()));
+            }
+
+            return GetDifferences(transformedLeft, transformedRight);
+        }
+
+        /// <inheritdoc />
         public IEnumerable<(MetadataInformation left, MetadataInformation right, IEnumerable<CompatDifference> differences)> GetDifferences(ElementContainer<IAssemblySymbol> left,
-            IList<ElementContainer<IAssemblySymbol>> right)
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right)
         {
             int rightCount = right.Count;
 
-            // Retrieve the right names
-            string[] rightNames = new string[rightCount];
+            AssemblyMapper mapper = new(ComparingSettings, rightCount);
+            mapper.AddElement(left, ElementSide.Left);
+
             for (int i = 0; i < rightCount; i++)
             {
-                rightNames[i] = right[i].MetadataInformation.DisplayString;
+                mapper.AddElement(right[i], ElementSide.Right, i);
             }
 
-            AssemblyMapper mapper = new(GetComparingSettingsCore(left.MetadataInformation.DisplayString, rightNames), rightSetSize: rightCount);
-            mapper.AddElement(left.Element, ElementSide.Left);
-            for (int i = 0; i < rightCount; i++)
-            {
-                mapper.AddElement(right[i].Element, ElementSide.Right, i);
-            }
-
-            DifferenceVisitor visitor = new(rightCount: rightCount);
+            DifferenceVisitor visitor = new(rightCount);
             visitor.Visit(mapper);
 
-            (MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)[] result = new(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)[rightCount];
+            var result = new(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)[rightCount];
             for (int i = 0; i < visitor.DiagnosticCollections.Count; i++)
             {
                 result[i] = (left.MetadataInformation, right[i].MetadataInformation, visitor.DiagnosticCollections[i]);
             }
             
             return result;
-        }
-
-        private ComparingSettings GetComparingSettingsCore(string? leftName, string[]? rightNames)
-        {
-            if (GetComparingSettings != null)
-                return GetComparingSettings(leftName, rightNames);
-
-            return new ComparingSettings(includeInternalSymbols: IncludeInternalSymbols,
-                strictMode: StrictMode,
-                leftName: leftName,
-                rightNames: rightNames,
-                warnOnMissingReferences: WarnOnMissingReferences);
         }
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ComparingSettings.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ComparingSettings.cs
@@ -44,13 +44,11 @@ namespace Microsoft.DotNet.ApiCompatibility
             IEqualityComparer<ISymbol>? equalityComparer = null,
             bool includeInternalSymbols = false,
             bool strictMode = false,
-            bool warnOnMissingReferences = false,
-            string? leftName = null,
-            string[]? rightNames = null)
+            bool warnOnMissingReferences = false)
         {
             Filter = filter ?? new SymbolAccessibilityBasedFilter(includeInternalSymbols: includeInternalSymbols);
             EqualityComparer = equalityComparer ?? new DefaultSymbolsEqualityComparer();
-            RuleRunnerFactory = ruleRunnerFactory ?? new RuleRunnerFactory(leftName, rightNames, EqualityComparer, includeInternalSymbols, strictMode, warnOnMissingReferences);
+            RuleRunnerFactory = ruleRunnerFactory ?? new RuleRunnerFactory(strictMode, EqualityComparer, includeInternalSymbols, warnOnMissingReferences);
             WarnOnMissingReferences = warnOnMissingReferences;
         }
     }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IApiComparer.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IApiComparer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         bool StrictMode { get; set; }
 
         /// <summary>
-        /// Flag indicating whether the api comparison should warn when references are missing.
+        /// Flag indicating whether the API comparison should warn when references are missing.
         /// </summary>
         bool WarnOnMissingReferences { get; set; }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IApiComparer.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IApiComparer.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
-using System;
-using System.Collections.Generic;
 
 namespace Microsoft.DotNet.ApiCompatibility
 {
@@ -29,35 +26,50 @@ namespace Microsoft.DotNet.ApiCompatibility
         bool StrictMode { get; set; }
 
         /// <summary>
-        /// Flag indicating whether the ApiComparison will warn if there are missing references
+        /// Flag indicating whether the api comparison should warn when references are missing.
         /// </summary>
         bool WarnOnMissingReferences { get; set; }
 
         /// <summary>
-        /// Callback function to get the <see cref="ComparingSettings"/> to be used when creating the settings to get the differences.
-        /// The callback takes a string leftName and string[] rightNames parameters to indicate API Compat via the settings what the 
-        /// name for the left and right the user specified.
-        /// This callback is called at the beginning of every <see cref="GetDifferences"/> overload.
+        /// <see cref="ComparingSettings"/> to be used when creating the mapping to get the differences.
         /// </summary>
-        Func<string?, string[]?, ComparingSettings>? GetComparingSettings { get; set; }
+        ComparingSettings ComparingSettings { get; set; }
 
         /// <summary>
-        /// Get's the differences when comparing Left vs Right based on the settings at the moment this method is called.
-        /// It compares two lists of symbols.
-        /// </summary>
-        /// <param name="left">Left symbols to compare against.</param>
-        /// <param name="right">Right symbols to compare against.</param>
-        /// <returns>List of found differences.</returns>
-        IEnumerable<CompatDifference> GetDifferences(IEnumerable<IAssemblySymbol> left, IEnumerable<IAssemblySymbol> right, string? leftName = null, string? rightName = null);
-
-        /// <summary>
-        /// Get's the differences when comparing Left vs Right based on the settings at the moment this method is called.
+        /// Get's the differences when comparing a left assembly against a right based on the comparison settings.
         /// It compares two symbols.
         /// </summary>
-        /// <param name="left">Left symbol to compare against.</param>
-        /// <param name="right">Right symbol to compare against.</param>
+        /// <param name="left">Left assembly symbol to compare against.</param>
+        /// <param name="right">Right assembly symbol to compare against.</param>
         /// <returns>List of found differences.</returns>
-        IEnumerable<CompatDifference> GetDifferences(IAssemblySymbol left, IAssemblySymbol right, string? leftName = null, string? rightName = null);
+        IEnumerable<CompatDifference> GetDifferences(IAssemblySymbol left, IAssemblySymbol right);
+
+        /// <summary>
+        /// Get's the differences when comparing a left assembly against a right based on the comparison settings.
+        /// It compares two symbols.
+        /// </summary>
+        /// <param name="left">Left assembly symbol including metadata to compare against.</param>
+        /// <param name="right">Right assembly symbol including metadata to compare against.</param>
+        /// <returns>List of found differences.</returns>
+        IEnumerable<CompatDifference> GetDifferences(ElementContainer<IAssemblySymbol> left, ElementContainer<IAssemblySymbol> right);
+
+        /// <summary>
+        /// Get's the differences when comparing a left assembly set against a right set based on the comparison settings.
+        /// It compares two symbol sets.
+        /// </summary>
+        /// <param name="left">Left assembly symbols to compare against.</param>
+        /// <param name="right">Right assembly symbols to compare against.</param>
+        /// <returns>List of found differences.</returns>
+        IEnumerable<CompatDifference> GetDifferences(IEnumerable<IAssemblySymbol> left, IEnumerable<IAssemblySymbol> right);
+
+        /// <summary>
+        /// Get's the differences when comparing a left assembly set against a right set based on the comparison settings.
+        /// It compares two symbol sets.
+        /// </summary>
+        /// <param name="left">Left assembly symbols including metadata to compare against.</param>
+        /// <param name="right">Right assembly symbols including metadata to compare against.</param>
+        /// <returns>List of found differences.</returns>
+        IEnumerable<CompatDifference> GetDifferences(IEnumerable<ElementContainer<IAssemblySymbol>> left, IEnumerable<ElementContainer<IAssemblySymbol>> right);
 
         /// <summary>
         /// Get the differences for all the combinations of <paramref name="left"/> against each <paramref name="right"/>
@@ -67,6 +79,6 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// <returns>Return a list containing the (left, right) tuple and it's list of <see cref="CompatDifference"/>.
         /// The returning list contains one element per (left, right) combination, which is the same length as <paramref name="right"/>.
         /// </returns>
-        IEnumerable<(MetadataInformation left, MetadataInformation right, IEnumerable<CompatDifference> differences)> GetDifferences(ElementContainer<IAssemblySymbol> left, IList<ElementContainer<IAssemblySymbol>> right);
+        IEnumerable<(MetadataInformation left, MetadataInformation right, IEnumerable<CompatDifference> differences)> GetDifferences(ElementContainer<IAssemblySymbol> left, IReadOnlyList<ElementContainer<IAssemblySymbol>> right);
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerFactory.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerFactory.cs
@@ -12,26 +12,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     {
         private readonly Lazy<RuleRunner> _runner;
 
-        public RuleRunnerFactory(string? leftName, string[]? rightNames, IEqualityComparer<ISymbol> equalityComparer, bool includeInternalSymbols, bool strictMode, bool withReferences)
+        public RuleRunnerFactory(bool strictMode, IEqualityComparer<ISymbol> equalityComparer, bool includeInternalSymbols, bool withReferences)
         {
-            if (string.IsNullOrEmpty(leftName))
-                leftName = RuleRunner.DEFAULT_LEFT_NAME;
-
-            rightNames ??= new string[] { RuleRunner.DEFAULT_RIGHT_NAME };
-            if (rightNames.Length == 0)
-            {
-                throw new ArgumentException(Resources.RightNamesAtLeastOne, nameof(rightNames));
-            }
-
-            for (int i = 0; i < rightNames.Length; i++)
-            {
-                if (string.IsNullOrEmpty(rightNames[i]))
-                {
-                    rightNames[i] = RuleRunner.DEFAULT_RIGHT_NAME;
-                }
-            }
-
-            _runner = new Lazy<RuleRunner>(() => new RuleRunner(leftName!, rightNames, strictMode, equalityComparer, includeInternalSymbols, withReferences));
+            _runner = new Lazy<RuleRunner>(() => new RuleRunner(strictMode, equalityComparer, includeInternalSymbols, withReferences));
         }
 
         public virtual IRuleRunner GetRuleRunner()

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddAbstractMemberTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddAbstractMemberTests.cs
@@ -150,7 +150,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
@@ -186,7 +186,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotRemoveBaseTypeOrInterfaceTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotRemoveBaseTypeOrInterfaceTests.cs
@@ -284,7 +284,7 @@ namespace CompatTests
             MetadataInformation leftMetadata = new("left", @"ref\a.dll");
             ElementContainer<IAssemblySymbol> leftContainer = new(left, leftMetadata);
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             ApiComparer differ = new();
             IEnumerable<(MetadataInformation left, MetadataInformation right, IEnumerable<CompatDifference> differences)> result =

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotSealTypeTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotSealTypeTests.cs
@@ -141,7 +141,7 @@ namespace CompatTests
             MetadataInformation leftMetadata = new("left", @"ref\a.dll");
             ElementContainer<IAssemblySymbol> leftContainer = new(left, leftMetadata);
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             ApiComparer differ = new();
             IEnumerable<(MetadataInformation left, MetadataInformation right, IEnumerable<CompatDifference> differences)> result =
@@ -208,7 +208,7 @@ namespace CompatTests
             MetadataInformation leftMetadata = new("left", @"ref\a.dll");
             ElementContainer<IAssemblySymbol> leftContainer = new(left, leftMetadata);
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             ApiComparer differ = new();
             differ.IncludeInternalSymbols = true;

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
@@ -337,7 +337,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
@@ -390,7 +390,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);
@@ -445,7 +445,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), expectedLeftMetadata);
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.Strict.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.Strict.cs
@@ -267,7 +267,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);
@@ -345,7 +345,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);
@@ -383,7 +383,7 @@ namespace CompatTests
             IEnumerable<string> references = new[] { forwardedTypeSyntax };
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references);
 
             ApiComparer differ = new();
             differ.StrictMode = true;

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
@@ -350,7 +350,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);
@@ -437,7 +437,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);
@@ -492,7 +492,7 @@ namespace CompatTests
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, "ref"));
 
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
 
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
                 differ.GetDifferences(left, right);
@@ -516,7 +516,7 @@ namespace CompatTests
             IEnumerable<string> references = new[] { forwardedTypeSyntax };
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(forwardedTypeSyntax), new MetadataInformation(string.Empty, "ref"));
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references);
 
             ApiComparer differ = new();
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
@@ -541,7 +541,7 @@ namespace CompatTests
             IEnumerable<string> references = new[] { forwardedTypeSyntax };
             ElementContainer<IAssemblySymbol> left =
                 new(SymbolFactory.GetAssemblyFromSyntax(forwardedTypeSyntax), new MetadataInformation(string.Empty, "ref"));
-            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references);
+            IReadOnlyList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references);
 
             ApiComparer differ = new();
             IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             // Mock the api comparer's GetDifferences method so that it returns items.
             Mock<IApiComparer> apiComparerMock = new();
             apiComparerMock
-                .Setup(y => y.GetDifferences(It.IsAny<ElementContainer<IAssemblySymbol>>(), It.IsAny<IList<ElementContainer<IAssemblySymbol>>>()))
+                .Setup(y => y.GetDifferences(It.IsAny<ElementContainer<IAssemblySymbol>>(), It.IsAny<IReadOnlyList<ElementContainer<IAssemblySymbol>>>()))
                 .Returns(new (MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)[]
                 {
                     new ( left, right, new CompatDifference[] { new CompatDifference("CP0001", "Invalid", DifferenceType.Removed, "X01") } )

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SymbolFactory.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SymbolFactory.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             return compilation.Assembly;
         }
 
-        internal static IList<ElementContainer<IAssemblySymbol>> GetElementContainersFromSyntaxes(IEnumerable<string> syntaxes, IEnumerable<string> referencesSyntax = null, bool enableNullable = false, byte[] publicKey = null, [CallerMemberName] string assemblyName = "")
+        internal static IReadOnlyList<ElementContainer<IAssemblySymbol>> GetElementContainersFromSyntaxes(IEnumerable<string> syntaxes, IEnumerable<string> referencesSyntax = null, bool enableNullable = false, byte[] publicKey = null, [CallerMemberName] string assemblyName = "")
         {
             int i = 0;
             List<ElementContainer<IAssemblySymbol>> result = new();


### PR DESCRIPTION
The existing logic allows to specify a left's name and multiple rights'
names. When comparing an assembly set against one or multiple other
assembly sets, the left and right names are different (for each
assembly).

To support multi assembly mode (assembly set comparison), remove the
hardcoded left and right names values in the runner and instead infer
the name from the mapped (containing) assembly. To faciltate that,
create a hierarchy in the element mapper types.