### PR TITLE
[dotnet new] telemetry for MSBuild evaluation

### DIFF
--- a/src/Cli/dotnet/Telemetry/Sha256Hasher.cs
+++ b/src/Cli/dotnet/Telemetry/Sha256Hasher.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 using System;
 using System.Security.Cryptography;
 using System.Text;

--- a/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
@@ -132,11 +132,11 @@
   <data name="CapabilityExpressionEvaluator_Exception_InvalidExpression" xml:space="preserve">
     <value>Invalid expression, position: {0}.</value>
   </data>
+  <data name="DisableProjectContextEval_OptionDescription" xml:space="preserve">
+    <value>Disables evaluating project context using MSBuild.</value>
+  </data>
   <data name="DisableSdkTemplates_OptionDescription" xml:space="preserve">
     <value>If present, prevents templates bundled in the SDK from being presented.</value>
-  </data>
-  <data name="EnableProjectContextEval_OptionDescription" xml:space="preserve">
-    <value>Enables evaluating project context using MSBuild.</value>
   </data>
   <data name="MSBuildEvaluationResult_Error_NoProjectFound" xml:space="preserve">
     <value>No project was found at the path: {0}.</value>

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluator.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/MSBuildEvaluator.cs
@@ -14,15 +14,14 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
-using Newtonsoft.Json.Linq;
 using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 
 namespace Microsoft.TemplateEngine.MSBuildEvaluation
 {
     internal class MSBuildEvaluator : IIdentifiedComponent
     {
-        private readonly ProjectCollection _projectCollection = new ProjectCollection();
-        private readonly object _lockObj = new object();
+        private readonly ProjectCollection _projectCollection = new();
+        private readonly object _lockObj = new();
 
         private IEngineEnvironmentSettings? _settings;
         private ILogger? _logger;
@@ -122,6 +121,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
             bool IsSdkStyleProject = false;
             IReadOnlyList<string>? targetFrameworks = null;
             string? targetFramework = null;
+            MSBuildEvaluationResult? result = null;
             
             try
             {
@@ -143,21 +143,21 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                     //For non SDK style project, we cannot evaluate more info. Also there is no indication, whether the project
                     //was restored or not, so it is not checked.
                     _logger?.LogDebug("Project is non-SDK style, cannot evaluate restore status, succeeding.");
-                    return NonSDKStyleEvaluationResult.CreateSuccess(projectPath, evaluatedProject);
+                    return result = NonSDKStyleEvaluationResult.CreateSuccess(projectPath, evaluatedProject);
                 }
 
                 //For SDK-style project, if the project was restored "RestoreSuccess" property will be set to true.
                 if (!evaluatedProject.GetProperty("RestoreSuccess")?.EvaluatedValue.Equals("true", StringComparison.OrdinalIgnoreCase) ?? true)
                 {
                     _logger?.LogDebug("Project is not restored, exiting.");
-                    return MSBuildEvaluationResult.CreateNoRestore(projectPath);
+                    return result = MSBuildEvaluationResult.CreateNoRestore(projectPath);
                 }
 
                 //If target framework is set, no further evaluation is needed.
                 if (!string.IsNullOrWhiteSpace(targetFramework))
                 {
                     _logger?.LogDebug("Project is SDK style, single TFM:{0}, evaluation succeeded.", targetFramework);
-                    return SDKStyleEvaluationResult.CreateSuccess(projectPath, targetFramework, evaluatedProject);
+                    return result = SDKStyleEvaluationResult.CreateSuccess(projectPath, targetFramework, evaluatedProject);
                 }
 
                 //If target framework is not set, then presumably it is multi-target project.
@@ -165,7 +165,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 if (targetFrameworks == null)
                 {
                     _logger?.LogDebug("Project is SDK style, but does not specify the framework.");
-                    return MSBuildEvaluationResult.CreateFailure(projectPath, string.Format(LocalizableStrings.MSBuildEvaluator_Error_NoTargetFramework, projectPath));
+                    return result = MSBuildEvaluationResult.CreateFailure(projectPath, string.Format(LocalizableStrings.MSBuildEvaluator_Error_NoTargetFramework, projectPath));
                 }
 
                 //For multi-target project, we need to do additional evaluation for each target framework.
@@ -178,33 +178,44 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 }
                 innerBuildWatch.Stop();
                 _logger?.LogDebug("Project is SDK style, multi-target, evaluation succeeded.");
-                return MultiTargetEvaluationResult.CreateSuccess(projectPath, evaluatedProject, evaluatedTfmBasedProjects);
+                return result = MultiTargetEvaluationResult.CreateSuccess(projectPath, evaluatedProject, evaluatedTfmBasedProjects);
 
             }
             catch (Exception e)
             {
                 _logger?.LogDebug("Unexpected error: {0}", e);
-                return MSBuildEvaluationResult.CreateFailure(projectPath, e.Message);
+                return result = MSBuildEvaluationResult.CreateFailure(projectPath, e.Message);
             }
             finally
             {
                 watch.Stop();
-                if (innerBuildWatch.IsRunning)
+                innerBuildWatch.Stop();
+
+                string? targetFrameworksString = null;
+
+                if (targetFrameworks != null)
                 {
-                    innerBuildWatch.Stop();
+                    targetFrameworksString = string.Join(",", targetFrameworks.Select(tfm => Sha256Hasher.HashWithNormalizedCasing(tfm)));
                 }
-                string? targetFrameworksString = targetFrameworks != null ? string.Join(",", targetFrameworks) : targetFramework;
+                else if (targetFramework != null)
+                {
+                    targetFrameworksString = Sha256Hasher.HashWithNormalizedCasing(targetFramework);
+                }
+
                 Dictionary<string, string> properties = new()
                 {
                     { "ProjectPath",  Sha256Hasher.HashWithNormalizedCasing(projectPath)},
                     { "SdkStyleProject", IsSdkStyleProject.ToString() },
+                    { "Status", result?.Status.ToString() ?? "<null>"},
                     { "TargetFrameworks", targetFrameworksString ?? "<null>"},
                 };
+
                 Dictionary<string, double> measurements = new()
                 {
                     { "EvaluationTime",  watch.ElapsedMilliseconds },
                     { "InnerEvaluationTime",  innerBuildWatch.ElapsedMilliseconds }
                 };
+
                 TelemetryEventEntry.TrackEvent("new/msbuild-eval", properties, measurements);
             }
         }

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Neplatný výraz, pozice: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">Pokud je k dispozici, zabrání zobrazení šablon, které jsou součástí sady SDK.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">Umožňuje vyhodnocovat kontext projektu pomocí nástroje MSBuild.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Ungültiger Ausdruck, Position: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">Falls vorhanden, wird verhindert, dass im SDK gebündelte Vorlagen präsentiert werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">Ermöglicht das Auswerten des Projektkontexts mit MSBuild.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Expresión no válida, posición: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">Si está presente, impide que se presenten las plantillas agrupadas en el SDK.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">Habilita la evaluación del contexto del proyecto mediante MSBuild.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Expression non valide, position : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">S'il est présent, empêche la présentation des modèles regroupés dans le SDK.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">Active l’évaluation du contexte de projet à l’aide de MSBuild.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Espressione non valida. Posizione: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">Se presente, impedisce la presentazione dei modelli forniti in bundle nell'SDK.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">Abilita la valutazione del contesto del progetto con MSBuild.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
@@ -22,14 +22,14 @@
         <target state="translated">式が無効です、位置: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">SDK にバンドルされているテンプレートがある場合にそれらが表示されないようにします。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">MSBuild を使用してプロジェクト コンテキストを評価できるようにします。</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
@@ -22,14 +22,14 @@
         <target state="translated">잘못된 식, 위치: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">있는 경우 SDK에 번들로 제공되는 템플릿이 표시되지 않도록 합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">MSBuild를 사용하여 프로젝트 컨텍스트를 평가할 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Nieprawidłowe wyrażenie, pozycja: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">Jeśli istnieją, uniemożliwia prezentowanie szablonów dołączonych do zestawu SDK.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">Umożliwia ocenę kontekstu projektu przy użyciu programu MSBuild.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Expressão inválida, posição: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">Se presente, impede que os modelos agrupados no SDK sejam apresentados.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">Habilita a avaliação do contexto do projeto usando o MSBuild.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Недопустимое выражение, позиция: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">При наличии этого параметра шаблоны, входящие в пакет SDK, не будут представлены.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">Позволяет оценивать контекст проекта с помощью MSBuild.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Geçersiz ifade, konum: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">Varsa, SDK'da paketlenmiş şablonların sunumlarını önler.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">MSBuild kullanarak proje bağlamının değerlendirilmesini sağlar.</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
@@ -22,14 +22,14 @@
         <target state="translated">表达式无效，位置: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">如果存在，则阻止显示捆绑在 SDK 中的模板。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">支持使用 MSBuild 评估项目上下文。</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
@@ -22,14 +22,14 @@
         <target state="translated">運算式無效，位置: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DisableProjectContextEval_OptionDescription">
+        <source>Disables evaluating project context using MSBuild.</source>
+        <target state="new">Disables evaluating project context using MSBuild.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DisableSdkTemplates_OptionDescription">
         <source>If present, prevents templates bundled in the SDK from being presented.</source>
         <target state="translated">如果存在，則會防止顯示 SDK 中套件組合的範本。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnableProjectContextEval_OptionDescription">
-        <source>Enables evaluating project context using MSBuild.</source>
-        <target state="translated">使用 MSBuild 啟用評估專案內容。</target>
         <note />
       </trans-unit>
       <trans-unit id="MSBuildEvaluationResult_Error_NoProjectFound">

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/DotnetNewCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/DotnetNewCommand.cs
@@ -15,6 +15,9 @@ namespace Microsoft.NET.TestFramework.Commands
         {
             Arguments.Add("new");
             Arguments.AddRange(args);
+
+            //opt out from telemetry
+            WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "true");
         }
 
         public DotnetNewCommand WithCustomHive(string path)


### PR DESCRIPTION
- added telemetry for MSBuild evalution
- reversed behavior of project context evaluation: now it is available by default with option/env variable to disable it
- disabled telemetry for `dotnet new` tests