### PR TITLE
Fix for --print-download-link only

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -19,8 +19,6 @@
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
-    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-    <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -19,6 +19,8 @@
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
+    <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -79,8 +79,8 @@ namespace Microsoft.DotNet.Workloads.Workload
             _packageSourceLocation = string.IsNullOrEmpty(configOption) && (sourceOption == null || !sourceOption.Any()) ? null :
                 new PackageSourceLocation(string.IsNullOrEmpty(configOption) ? null : new FilePath(configOption), sourceFeedOverrides: sourceOption);
                        
-            var sdkWorkloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(_dotnetPath, _sdkVersion.ToString(), userProfileDir);
-            _workloadResolver = workloadResolver ?? WorkloadResolver.Create(sdkWorkloadManifestProvider, _dotnetPath, _sdkVersion.ToString(), _userProfileDir);
+            var sdkWorkloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(_dotnetPath, _installedFeatureBand.ToString(), userProfileDir);
+            _workloadResolver = workloadResolver ?? WorkloadResolver.Create(sdkWorkloadManifestProvider, _dotnetPath, _installedFeatureBand.ToString(), _userProfileDir);
 
             _workloadInstallerFromConstructor = workloadInstaller;
             _workloadManifestUpdaterFromConstructor = workloadManifestUpdater;

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                         folderForManifestDownloads = tempPath.Value;
                     }
 
-                    var manifestDownloads = await _workloadManifestUpdater.GetManifestPackageDownloadsAsync(includePreview);
+                    var manifestDownloads = await _workloadManifestUpdater.GetManifestPackageDownloadsAsync(includePreview, new SdkFeatureBand(_sdkVersion), _installedFeatureBand);
 
                     if (!manifestDownloads.Any())
                     {

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.Workloads.Workload
         protected readonly string _userProfileDir;
         protected readonly bool _checkIfManifestExist;
         protected readonly ReleaseVersion _sdkVersion;
+        protected readonly ReleaseVersion _installedSdkVersion;
         protected readonly SdkFeatureBand _sdkFeatureBand;
         protected readonly SdkFeatureBand _installedFeatureBand;
         protected readonly string _fromRollbackDefinition;
@@ -70,8 +71,8 @@ namespace Microsoft.DotNet.Workloads.Workload
             _checkIfManifestExist = !(_printDownloadLinkOnly);      // don't check for manifest existence when print download link is passed
             _sdkVersion = WorkloadOptionsExtensions.GetValidatedSdkVersion(parseResult.GetValueForOption(InstallingWorkloadCommandParser.VersionOption), version, _dotnetPath, _userProfileDir, _checkIfManifestExist);
             _sdkFeatureBand = new SdkFeatureBand(_sdkVersion);
-
-            _installedFeatureBand = installedFeatureBand == null ? new SdkFeatureBand(Product.Version) : new SdkFeatureBand(installedFeatureBand);
+            _installedSdkVersion = new ReleaseVersion(version ?? Product.Version);
+            _installedFeatureBand = new SdkFeatureBand(installedFeatureBand ?? Product.Version);
 
             _fromRollbackDefinition = parseResult.GetValueForOption(InstallingWorkloadCommandParser.FromRollbackFileOption);
             var configOption = parseResult.GetValueForOption(InstallingWorkloadCommandParser.ConfigOption);
@@ -79,8 +80,8 @@ namespace Microsoft.DotNet.Workloads.Workload
             _packageSourceLocation = string.IsNullOrEmpty(configOption) && (sourceOption == null || !sourceOption.Any()) ? null :
                 new PackageSourceLocation(string.IsNullOrEmpty(configOption) ? null : new FilePath(configOption), sourceFeedOverrides: sourceOption);
                        
-            var sdkWorkloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(_dotnetPath, _installedFeatureBand.ToString(), userProfileDir);
-            _workloadResolver = workloadResolver ?? WorkloadResolver.Create(sdkWorkloadManifestProvider, _dotnetPath, _installedFeatureBand.ToString(), _userProfileDir);
+            var sdkWorkloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(_dotnetPath, _installedSdkVersion.ToString(), userProfileDir);
+            _workloadResolver = workloadResolver ?? WorkloadResolver.Create(sdkWorkloadManifestProvider, _dotnetPath, _installedSdkVersion.ToString(), _userProfileDir);
 
             _workloadInstallerFromConstructor = workloadInstaller;
             _workloadManifestUpdaterFromConstructor = workloadManifestUpdater;
@@ -109,7 +110,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                         folderForManifestDownloads = tempPath.Value;
                     }
 
-                    var manifestDownloads = await _workloadManifestUpdater.GetManifestPackageDownloadsAsync(includePreview, new SdkFeatureBand(_sdkVersion), _installedFeatureBand);
+                    var manifestDownloads = await _workloadManifestUpdater.GetManifestPackageDownloadsAsync(includePreview, _sdkFeatureBand, _installedFeatureBand);
 
                     if (!manifestDownloads.Any())
                     {

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                     }
 
                     //  Use updated, extracted manifests to resolve packs
-                    var overlayProvider = new TempDirectoryWorkloadManifestProvider(extractedManifestsPath, _sdkVersion.ToString());
+                    var overlayProvider = new TempDirectoryWorkloadManifestProvider(extractedManifestsPath, _sdkFeatureBand.ToString());
 
                     var newResolver = _workloadResolver.CreateOverlayResolver(overlayProvider);
                     _workloadInstaller.ReplaceWorkloadResolver(newResolver);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         IEnumerable<ManifestVersionUpdate>
             CalculateManifestRollbacks(string rollbackDefinitionFilePath);
 
-        Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews);
+        Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand origSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand);
 
         IEnumerable<WorkloadId> GetUpdatableWorkloadsToAdvertise(IEnumerable<WorkloadId> installedWorkloads);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         IEnumerable<ManifestVersionUpdate>
             CalculateManifestRollbacks(string rollbackDefinitionFilePath);
 
-        Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand origSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand);
+        Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand providedSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand);
 
         IEnumerable<WorkloadId> GetUpdatableWorkloadsToAdvertise(IEnumerable<WorkloadId> installedWorkloads);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -46,14 +46,15 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             IWorkloadManifestInstaller workloadManifestInstaller,
             PackageSourceLocation packageSourceLocation = null,
             Func<string, string> getEnvironmentVariable = null,
-            bool displayManifestUpdates = true)
+            bool displayManifestUpdates = true,
+            SdkFeatureBand? sdkVersion = null)
         {
             _reporter = reporter;
             _workloadResolver = workloadResolver;
             _userProfileDir = userProfileDir;
             _tempDirPath = tempDirPath;
             _nugetPackageDownloader = nugetPackageDownloader;
-            _sdkFeatureBand = new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand());
+            _sdkFeatureBand = sdkVersion ?? new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand());
             _packageSourceLocation = packageSourceLocation;
             _getEnvironmentVariable = getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
             _workloadRecordRepo = workloadRecordRepo;

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -239,10 +239,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         }
 
 
-        public async Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews)
+        public async Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand origSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand)
         {
             var packageIds = GetInstalledManifestIds()
-                .Select(manifestId => _workloadManifestInstaller.GetManifestPackageId(manifestId, _sdkFeatureBand));
+                .Select(manifestId => _workloadManifestInstaller.GetManifestPackageId(manifestId, origSdkFeatureBand));
 
             var downloads = new List<WorkloadDownload>();
             foreach (var manifest in _workloadResolver.GetInstalledManifests())
@@ -250,7 +250,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 try
                 {
                     
-                    var packageId = _workloadManifestInstaller.GetManifestPackageId(new ManifestId(manifest.Id), _sdkFeatureBand);
+                    var packageId = _workloadManifestInstaller.GetManifestPackageId(new ManifestId(manifest.Id), origSdkFeatureBand);
 
                     bool success;
                     (success, var latestVersion) = await GetPackageVersion(packageId, packageSourceLocation: _packageSourceLocation, includePreview: includePreviews);
@@ -260,8 +260,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     }
                     if (!success)
                     {
-                        var newFeatureBand = new SdkFeatureBand(manifest.ManifestFeatureBand);
-                        var newPackageId = _workloadManifestInstaller.GetManifestPackageId(new ManifestId(manifest.Id), newFeatureBand);
+                        //var newFeatureBand = new SdkFeatureBand(manifest.ManifestFeatureBand);
+                        var newPackageId = _workloadManifestInstaller.GetManifestPackageId(new ManifestId(manifest.Id), installedSdkFeatureBand);
 
                         (success, latestVersion) = await GetPackageVersion(newPackageId, packageSourceLocation: _packageSourceLocation, includePreview: includePreviews);
                         

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -47,14 +47,14 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             PackageSourceLocation packageSourceLocation = null,
             Func<string, string> getEnvironmentVariable = null,
             bool displayManifestUpdates = true,
-            SdkFeatureBand? sdkVersion = null)
+            SdkFeatureBand? sdkFeatureBand = null)
         {
             _reporter = reporter;
             _workloadResolver = workloadResolver;
             _userProfileDir = userProfileDir;
             _tempDirPath = tempDirPath;
             _nugetPackageDownloader = nugetPackageDownloader;
-            _sdkFeatureBand = sdkVersion ?? new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand());
+            _sdkFeatureBand = sdkFeatureBand ?? new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand());
             _packageSourceLocation = packageSourceLocation;
             _getEnvironmentVariable = getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
             _workloadRecordRepo = workloadRecordRepo;

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                                 elevationRequired: !_printDownloadLinkOnly && !_printRollbackDefinitionOnly && string.IsNullOrWhiteSpace(_downloadToCacheOption));
 
             _workloadManifestUpdater = _workloadManifestUpdaterFromConstructor ?? new WorkloadManifestUpdater(Reporter, workloadResolver ?? _workloadResolver, PackageDownloader, _userProfileDir, TempDirectoryPath,
-                _workloadInstaller.GetWorkloadInstallationRecordRepository(), _workloadInstaller, _packageSourceLocation);
+                _workloadInstaller.GetWorkloadInstallationRecordRepository(), _workloadInstaller, _packageSourceLocation, null, true, _sdkFeatureBand);
         }
 
 

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                                 elevationRequired: !_printDownloadLinkOnly && !_printRollbackDefinitionOnly && string.IsNullOrWhiteSpace(_downloadToCacheOption));
 
             _workloadManifestUpdater = _workloadManifestUpdaterFromConstructor ?? new WorkloadManifestUpdater(Reporter, workloadResolver ?? _workloadResolver, PackageDownloader, _userProfileDir, TempDirectoryPath,
-                _workloadInstaller.GetWorkloadInstallationRecordRepository(), _workloadInstaller, _packageSourceLocation, null, true, _sdkFeatureBand);
+                _workloadInstaller.GetWorkloadInstallationRecordRepository(), _workloadInstaller, _packageSourceLocation, sdkFeatureBand: _sdkFeatureBand);
         }
 
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
@@ -13,10 +13,10 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         private readonly string _manifestsPath;
         private readonly string _sdkVersionBand;
 
-        public TempDirectoryWorkloadManifestProvider(string manifestsPath, string sdkVersion)
+        public TempDirectoryWorkloadManifestProvider(string manifestsPath, string sdkFeatureBand)
         {
             _manifestsPath = manifestsPath;
-            _sdkVersionBand = sdkVersion;
+            _sdkVersionBand = sdkFeatureBand;
         }
 
         public IEnumerable<ReadableWorkloadManifest>

--- a/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             return _manifestUpdates;
         }
 
-        public Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand origSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand)
+        public Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand providedSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand)
         {
             GetManifestPackageDownloadsCallCount++;
             return Task.FromResult<IEnumerable<WorkloadDownload>>(new List<WorkloadDownload>()

--- a/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             return _manifestUpdates;
         }
 
-        public Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews)
+        public Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand origSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand)
         {
             GetManifestPackageDownloadsCallCount++;
             return Task.FromResult<IEnumerable<WorkloadDownload>>(new List<WorkloadDownload>()


### PR DESCRIPTION
Fixes --print-download-links for VSMac

## Description

The prior fix for this https://github.com/dotnet/sdk/pull/26369 had some limitations. It didn't work correctly in non-band versions of the SDK (ie 6.0.401 wouldn't work even though 6.0.400 would work). It also didn't correctly fall back. In the case that we're likely to see in VSMac, a 6.0.4xx SDK will have 6.0.3xx manifests and running with --sdk-version 7.0.100. Without this change, it was finding the 7.0.100 versions of manifests but not falling back to both 6.0.400 and 6.0.300. As such, the 6.0.300 manifests were being left as older versions. Now we check the –sdk-version value, the current sdk band, and the fallback band.

## Customer Impact

VSMac upgrades customers would be left on older versions of the workloads

## Testing

See below. Tested using sdk-version for both future and past versions. Tested install still works. Tested with fallback and without. Tested that it would only print links for components not currently installed.

## Risk

This is fairly limited in scope to just the print-download link scnario.

## Regression

No, the prior fix was incomplete.

6.0.4xx port of the changes from https://github.com/dotnet/sdk/pull/27011
Updated the fix to clean up the code, fallback to the installed manifest band, and use the installed sdk for the workload resolver.

Testing:
6.0.401-dev SDK with maui installed and 6.0.300 manifests

no SDK version --> 6.0.300 for runtime and 6.0.400 for the rest of the workloads
PS C:\test\bug> dotnet workload update --print-download-link-only
==allPackageLinksJsonOutputStart==
[
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.android.manifest-6.0.400/32.0.448/microsoft.net.sdk.android.manifest-6.0.400.32.0.448.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.ios.manifest-6.0.400/15.4.447/microsoft.net.sdk.ios.manifest-6.0.400.15.4.447.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.maccatalyst.manifest-6.0.400/15.4.447/microsoft.net.sdk.maccatalyst.manifest-6.0.400.15.4.447.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.macos.manifest-6.0.400/12.3.447/microsoft.net.sdk.macos.manifest-6.0.400.12.3.447.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.maui.manifest-6.0.400/6.0.486/microsoft.net.sdk.maui.manifest-6.0.400.6.0.486.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.tvos.manifest-6.0.400/15.4.447/microsoft.net.sdk.tvos.manifest-6.0.400.15.4.447.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.workload.mono.toolchain.manifest-6.0.300/6.0.8/microsoft.net.workload.mono.toolchain.manifest-6.0.300.6.0.8.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.workload.emscripten.manifest-6.0.300/6.0.4/microsoft.net.workload.emscripten.manifest-6.0.300.6.0.4.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.maui.core.ref.android/6.0.486/microsoft.maui.core.ref.android.6.0.486.nupkg",
...
Future version --> 7.0.100 for runtime, 6.0.400 for the rest of the workloads
PS C:\test\bug> dotnet workload update --print-download-link-only --sdk-version 7.0.100
==allPackageLinksJsonOutputStart==
[
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.android.manifest-6.0.400/32.0.448/microsoft.net.sdk.android.manifest-6.0.400.32.0.448.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.ios.manifest-6.0.400/15.4.447/microsoft.net.sdk.ios.manifest-6.0.400.15.4.447.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.maccatalyst.manifest-6.0.400/15.4.447/microsoft.net.sdk.maccatalyst.manifest-6.0.400.15.4.447.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.macos.manifest-6.0.400/12.3.447/microsoft.net.sdk.macos.manifest-6.0.400.12.3.447.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.maui.manifest-6.0.400/6.0.486/microsoft.net.sdk.maui.manifest-6.0.400.6.0.486.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.tvos.manifest-6.0.400/15.4.447/microsoft.net.sdk.tvos.manifest-6.0.400.15.4.447.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.workload.mono.toolchain.manifest-7.0.100/7.0.0-preview.7.22375.6/microsoft.net.workload.mono.toolchain.manifest-7.0.100.7.0.0-preview.7.22375.6.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.workload.emscripten.manifest-7.0.100/7.0.0-preview.7.22361.2/microsoft.net.workload.emscripten.manifest-7.0.100.7.0.0-preview.7.22361.2.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.maui.core.ref.android/6.0.486/microsoft.maui.core.ref.android.6.0.486.nupkg",
...

Past version --> this used the 6.0.300 versions for all manifests and packs
PS C:\test\bug> dotnet workload update --print-download-link-only --sdk-version 6.0.300
==allPackageLinksJsonOutputStart==
[
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.android.manifest-6.0.300/32.0.440/microsoft.net.sdk.android.manifest-6.0.300.32.0.440.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.ios.manifest-6.0.300/15.4.328/microsoft.net.sdk.ios.manifest-6.0.300.15.4.328.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.maccatalyst.manifest-6.0.300/15.4.328/microsoft.net.sdk.maccatalyst.manifest-6.0.300.15.4.328.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.macos.manifest-6.0.300/12.3.328/microsoft.net.sdk.macos.manifest-6.0.300.12.3.328.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.maui.manifest-6.0.300/6.0.419/microsoft.net.sdk.maui.manifest-6.0.300.6.0.419.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.tvos.manifest-6.0.300/15.4.328/microsoft.net.sdk.tvos.manifest-6.0.300.15.4.328.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.workload.mono.toolchain.manifest-6.0.300/6.0.8/microsoft.net.workload.mono.toolchain.manifest-6.0.300.6.0.8.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.net.workload.emscripten.manifest-6.0.300/6.0.4/microsoft.net.workload.emscripten.manifest-6.0.300.6.0.4.nupkg",
"https://api.nuget.org/v3-flatcontainer/microsoft.maui.core.ref.android/6.0.419/microsoft.maui.core.ref.android.6.0.419.nupkg",

7.0.200 was the same as no version.