### PR TITLE
[Templates] marked template packages as shipping

### DIFF
--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -9,14 +9,27 @@
     <Exec Command="$(DotnetTool) --version" ConsoleToMsbuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="Stage0SdkVersion"/>
     </Exec>
-    <!--Prepare Microsoft.DotNet.Common.*.nupkg instead of copying from LKG SDK-->
-    <Exec Command="$(DotnetTool) pack $(RepoRoot)template_feed\Microsoft.DotNet.Common.ProjectTemplates.7.0 --configuration $(Configuration)" />
-    <Exec Command="$(DotnetTool) pack $(RepoRoot)template_feed\Microsoft.DotNet.Common.ItemTemplates --configuration $(Configuration)" />
 
     <PropertyGroup>
       <Stage0IncludedWorkloadManifestsFile>$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/IncludedWorkloadManifests.txt</Stage0IncludedWorkloadManifestsFile>
     </PropertyGroup>
 
+    <!-- Prepare the templates -->
+    <!-- 1. Pack the template packages in the repo -->
+    <!-- the templates packages are located in <sdk root>\templates\<runtime version> folder. Get the runtime version of SDK Stage 0. -->
+    <ItemGroup>
+      <TemplatesFolderPath Include="$([System.IO.Directory]::GetDirectories(`$(_DotNetHiveRoot)templates`,`*.*`))" />
+      <TemplatesFolderPath>
+        <FolderName>$([System.IO.Path]::GetFileName(`%(Identity)`))</FolderName>
+      </TemplatesFolderPath>
+    </ItemGroup>
+    <Error Text="SDK Stage 0 has more than one folder with templates: @(TemplatesFolderPath->'%(FolderName)')" Condition="@(TemplatesFolderPath->Count()) > 1"></Error>
+
+    <!--Prepare Microsoft.DotNet.Common.*.nupkg and pack them directly to target <redist root>\templates\<runtime version> folder. -->
+    <Exec Command="$(DotnetTool) pack $(RepoRoot)template_feed\Microsoft.DotNet.Common.ProjectTemplates.7.0 --configuration $(Configuration) --output $(RedistLayoutPath)\templates\@(TemplatesFolderPath->'%(FolderName)')\" />
+    <Exec Command="$(DotnetTool) pack $(RepoRoot)template_feed\Microsoft.DotNet.Common.ItemTemplates --configuration $(Configuration) --output $(RedistLayoutPath)\templates\@(TemplatesFolderPath->'%(FolderName)')\"  />
+
+    <!-- 2. Other template packages will be included from SDK Stage 0. -->
     <ItemGroup>
       <OverlaySDK Include="$(_DotNetHiveRoot)/**/*" Exclude="$(_DotNetHiveRoot)sdk/**/*;$(_DotNetHiveRoot)templates/**/microsoft.dotnet.common.*.nupkg"/>
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/Microsoft.NETCoreSdk.BundledCliTools.props" />
@@ -28,14 +41,10 @@
         Exclude="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/DotnetTools/dotnet-watch/**" />
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/AppHostTemplate/**/*" RelativeDestination="AppHostTemplate"/>
       <ToolsetToOverlay Include="$(OutputPath)/**/*" />
-      <ExcludeTemplatesFromSDK Include="$(_DotNetHiveRoot)templates/**/microsoft.dotnet.common.*.nupkg" />
-      <DotNetCommonTemplates Include="$(ArtifactsNonShippingPackagesDir)Microsoft.DotNet.Common.*.nupkg" Exclude="$(ArtifactsNonShippingPackagesDir)Microsoft.DotNet.Common.*.symbols.nupkg" />
     </ItemGroup>
 
     <Copy SourceFiles="@(OverlaySDK)"
           DestinationFiles="@(OverlaySDK->'$(RedistLayoutPath)\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(DotNetCommonTemplates)"
-          DestinationFolder="$(RedistLayoutPath)\templates\%(ExcludeTemplatesFromSDK.RecursiveDir)" />
 
     <PropertyGroup>
       <SdkOutputDirectory>$(RedistLayoutPath)/sdk/$(Version)</SdkOutputDirectory>

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/Microsoft.DotNet.Common.ItemTemplates.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/Microsoft.DotNet.Common.ItemTemplates.csproj
@@ -8,6 +8,8 @@
         <EnableDefaultItems>False</EnableDefaultItems>
         <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
         <IsPackable>true</IsPackable>
+        <IsShipping>true</IsShipping>
+        <IsShippingPackage>true</IsShippingPackage>
         <NoWarn>$(NoWarn);2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ItemTemplates</PackageId>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/Microsoft.DotNet.Common.ProjectTemplates.7.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/Microsoft.DotNet.Common.ProjectTemplates.7.0.csproj
@@ -8,6 +8,8 @@
         <EnableDefaultItems>False</EnableDefaultItems>
         <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
         <IsPackable>true</IsPackable>
+        <IsShipping>true</IsShipping>
+        <IsShippingPackage>true</IsShippingPackage>
         <NoWarn>2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.7.0</PackageId>


### PR DESCRIPTION
Marked template packages as shipping as they should be shipped to NuGet.
For testing, pack template packages directly to `redist`. This should avoid publishing dev version of package.