### PR TITLE
Fix templating to be source-buildable

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,6 +57,7 @@
     <MicrosoftNETHostModelVersion>7.0.0-rc.1.22410.1</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>6.0.0-preview.7.21363.9</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <SystemServiceProcessServiceControllerVersion>7.0.0-preview.4.22201.3</SystemServiceProcessServiceControllerVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/source-build.slnf
+++ b/source-build.slnf
@@ -17,7 +17,6 @@
       "src\\Cli\\Microsoft.DotNet.Configurer\\Microsoft.DotNet.Configurer.csproj",
       "src\\Cli\\Microsoft.DotNet.InternalAbstractions\\Microsoft.DotNet.InternalAbstractions.csproj",
       "src\\Cli\\Microsoft.TemplateEngine.Cli\\Microsoft.TemplateEngine.Cli.csproj",
-      "src\\Cli\\dotnet-new3\\dotnet-new3.csproj",
       "src\\Cli\\dotnet\\dotnet.csproj",
       "src\\Layout\\redist\\redist.csproj",
       "src\\Layout\\tool_fsharp\\tool_fsc.csproj",

--- a/source-build.slnf
+++ b/source-build.slnf
@@ -2,6 +2,10 @@
   "solution": {
     "path": "sdk.sln",
     "projects": [
+      "src\\ApiCompat\\Microsoft.DotNet.ApiCompat.Shared\\Microsoft.DotNet.ApiCompat.Shared.shproj",
+      "src\\ApiCompat\\Microsoft.DotNet.ApiCompat.Task\\Microsoft.DotNet.ApiCompat.Task.csproj",
+      "src\\ApiCompat\\Microsoft.DotNet.ApiCompatibility\\Microsoft.DotNet.ApiCompatibility.csproj",
+      "src\\ApiCompat\\Microsoft.DotNet.PackageValidation\\Microsoft.DotNet.PackageValidation.csproj",
       "src\\BlazorWasmSdk\\Tasks\\Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.csproj",
       "src\\BlazorWasmSdk\\Tool\\Microsoft.NET.Sdk.BlazorWebAssembly.Tool.csproj",
       "src\\BuiltInTools\\BrowserRefresh\\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj",
@@ -12,11 +16,9 @@
       "src\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj",
       "src\\Cli\\Microsoft.DotNet.Configurer\\Microsoft.DotNet.Configurer.csproj",
       "src\\Cli\\Microsoft.DotNet.InternalAbstractions\\Microsoft.DotNet.InternalAbstractions.csproj",
+      "src\\Cli\\Microsoft.TemplateEngine.Cli\\Microsoft.TemplateEngine.Cli.csproj",
+      "src\\Cli\\dotnet-new3\\dotnet-new3.csproj",
       "src\\Cli\\dotnet\\dotnet.csproj",
-      "src\\ApiCompat\\Microsoft.DotNet.ApiCompat.Shared\\Microsoft.DotNet.ApiCompat.Shared.shproj",
-      "src\\ApiCompat\\Microsoft.DotNet.ApiCompat.Task\\Microsoft.DotNet.ApiCompat.Task.csproj",
-      "src\\ApiCompat\\Microsoft.DotNet.ApiCompatibility\\Microsoft.DotNet.ApiCompatibility.csproj",
-      "src\\ApiCompat\\Microsoft.DotNet.PackageValidation\\Microsoft.DotNet.PackageValidation.csproj",
       "src\\Layout\\redist\\redist.csproj",
       "src\\Layout\\tool_fsharp\\tool_fsc.csproj",
       "src\\Layout\\tool_msbuild\\tool_msbuild.csproj",
@@ -37,7 +39,9 @@
       "src\\WebSdk\\ProjectSystem\\Tasks\\Microsoft.NET.Sdk.Web.ProjectSystem.Tasks.csproj",
       "src\\WebSdk\\Publish\\Tasks\\Microsoft.NET.Sdk.Publish.Tasks.csproj",
       "src\\WebSdk\\Web\\Tasks\\Microsoft.NET.Sdk.Web.Tasks.csproj",
-      "src\\WebSdk\\Worker\\Tasks\\Microsoft.NET.Sdk.Worker.Tasks.csproj"
+      "src\\WebSdk\\Worker\\Tasks\\Microsoft.NET.Sdk.Worker.Tasks.csproj",
+      "template_feed\\Microsoft.DotNet.Common.ItemTemplates\\Microsoft.DotNet.Common.ItemTemplates.csproj",
+      "template_feed\\Microsoft.DotNet.Common.ProjectTemplates.7.0\\Microsoft.DotNet.Common.ProjectTemplates.7.0.csproj"
     ]
   }
 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="$(MicrosoftTemplateEngineEdgePackageVersion)" />
     <PackageReference Include="Microsoft.TemplateSearch.Common" Version="$(MicrosoftTemplateSearchCommonPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageReference Include="Wcwidth.Sources" Version="0.6.0" ExcludeAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>


### PR DESCRIPTION
fixes https://github.com/dotnet/sdk/issues/27089

1. Add templating non-test projects added with https://github.com/dotnet/sdk/pull/26521 to the source-build solution filter.  This removes Microsoft.DotNet.Common.ItemTemplates,7.0.x and Microsoft.DotNet.Common.ProjectTemplates,7.0.x as prebuilts.
2. Refactor the Microsoft.Extensions.Logging.Console reference in Microsoft.TemplateEngine.Cli.csproj to be source-build compatible by utilizing a versions.props.  This removes Microsoft.Extensions.Logging.Console,6.0.0 as a prebuilt.