### PR TITLE
Include templating in source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,6 +4,7 @@
     <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.100-rc.1.22411.4">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>7549aa4defc9cd37fac676379bf4c3fdc073484b</Sha>
+      <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.1.22410.1">
       <Uri>https://github.com/dotnet/runtime</Uri>


### PR DESCRIPTION
This is blocking the dependency for into installer - https://github.com/dotnet/installer/pull/14281

This attribute got lost as part of the recent changes to pull in parts of templating into sdk - https://github.com/dotnet/sdk/commit/67b7550f0026d5ff77aa17c2c6e894735707f89a