### PR TITLE
.NET 6 Fix .NET MAUI Blazor Scoped CSS Hot Reload

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -296,8 +296,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="ResolveStaticWebAssetsConfiguration">
     <PropertyGroup>
-      <_StaticWebAssetsManifestBase>$(BaseIntermediateOutputPath)$(Configuration)\</_StaticWebAssetsManifestBase>
-      <_StaticWebAssetsManifestBase Condition="'$(AppendTargetFrameworkToOutputPath)' != 'false'">$(_StaticWebAssetsManifestBase)$(TargetFramework.ToLowerInvariant())\</_StaticWebAssetsManifestBase>
+      <_StaticWebAssetsManifestBase>$(IntermediateOutputPath)</_StaticWebAssetsManifestBase>
       <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">_content/$(PackageId)</StaticWebAssetBasePath>
       <StaticWebAssetProjectMode Condition="'$(StaticWebAssetProjectMode)' == ''">Default</StaticWebAssetProjectMode>
       <StaticWebAssetBuildManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.build.json</StaticWebAssetBuildManifestPath>

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -296,7 +296,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="ResolveStaticWebAssetsConfiguration">
     <PropertyGroup>
-      <_StaticWebAssetsManifestBase>$(IntermediateOutputPath)</_StaticWebAssetsManifestBase>
+      <_StaticWebAssetsManifestBase Condition="'$(_StaticWebAssetsManifestBase)' == ''">$(IntermediateOutputPath)</_StaticWebAssetsManifestBase>
       <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">_content/$(PackageId)</StaticWebAssetBasePath>
       <StaticWebAssetProjectMode Condition="'$(StaticWebAssetProjectMode)' == ''">Default</StaticWebAssetProjectMode>
       <StaticWebAssetBuildManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.build.json</StaticWebAssetBuildManifestPath>


### PR DESCRIPTION
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1589099

## Description

Scoped CSS Hot Reload doesn't work for .NET 6.0 MAUI Blazor apps, this is part one of a [two part](https://github.com/dotnet/maui/pull/9393) fix which resolves this issue in .NET 6.

Original Issue: https://github.com/dotnet/sdk/issues/26762
VSTS issue requesting backport: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1589099

Backports:
- https://github.com/dotnet/sdk/pull/26765
- https://github.com/dotnet/sdk/pull/27102

Will also need: https://github.com/dotnet/maui/pull/9348 -> https://github.com/dotnet/maui/pull/9393

## Customer Impact

Hot reload of scoped CSS fails for .NET 6.0 MAUI Blazor applications without this ([and the complementary dotnet/maui](https://github.com/dotnet/maui/pull/9393)) change.

## Regression?

- [x] Yes
- [ ] No

Computation of these values were moved to a target resulting in this regression.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Low risk, we've already made these changes in main/net7.

## Verification

- [x] Manual (required)
- [x] Automated