### PR TITLE
Migrated to newest version of `FluentAssertions`

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -180,8 +180,8 @@
   </PropertyGroup>
   <!-- Test Dependencies -->
   <PropertyGroup>
-    <FluentAssertionsVersion>4.19.2</FluentAssertionsVersion>
-    <FluentAssertionsJsonVersion>4.19.0</FluentAssertionsJsonVersion>
+    <FluentAssertionsVersion>6.7.0</FluentAssertionsVersion>
+    <FluentAssertionsJsonVersion>6.1.0</FluentAssertionsJsonVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22411.2</MicrosoftDotNetXUnitExtensionsVersion>
     <MoqPackageVersion>4.8.2</MoqPackageVersion>
     <MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>6.0.0-beta.22262.1</MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAAllowEmptyTelemetry.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAAllowEmptyTelemetry.cs
@@ -67,7 +67,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             Action a = () => telemetryTask.Execute();
 
-            a.ShouldThrow<ArgumentException>();
+            a.Should().Throw<ArgumentException>();
         }
 
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             CompilationOptions resultOptions = (CompilationOptions)s_convertFromMethod.Invoke(null, new object[] {taskItem});
 
-            resultOptions.ShouldBeEquivalentTo(expectedOptions);
+            resultOptions.Should().BeEquivalentTo(expectedOptions);
         }
 
         public static IEnumerable<object[]> CompilerOptionsData

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGenerateRuntimeConfigurationFiles.cs
@@ -57,7 +57,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             Action a = () => task.PublicExecuteCore();
-            a.ShouldNotThrow();
+            a.Should().NotThrow();
 
             File.ReadAllText(_runtimeConfigPath).Should()
                 .Be(
@@ -112,7 +112,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             Action a = () => task.PublicExecuteCore();
-            a.ShouldNotThrow();
+            a.Should().NotThrow();
 
             File.ReadAllText(_runtimeConfigPath).Should()
                 .Be(
@@ -165,7 +165,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             Action a = () => task.PublicExecuteCore();
-            a.ShouldNotThrow();
+            a.Should().NotThrow();
 
             File.ReadAllText(_runtimeConfigPath).Should()
                 .Be(
@@ -205,7 +205,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             Action a = () => task.PublicExecuteCore();
-            a.ShouldNotThrow();
+            a.Should().NotThrow();
 
             File.ReadAllText(_runtimeConfigPath).Should()
                 .Be(

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenALogger.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenALogger.cs
@@ -90,7 +90,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             Action logWithoutErrorCode = () => logger.LogError("No error code");
 
 #if DEBUG
-            logWithoutErrorCode.ShouldThrow<ArgumentException>();
+            logWithoutErrorCode.Should().Throw<ArgumentException>();
 #else
             logWithoutErrorCode();
             logger.Messages.Should().Equal(

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGenerateSupportedTargetFrameworkAlias.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGenerateSupportedTargetFrameworkAlias.cs
@@ -109,7 +109,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
             task.Execute();
 
-            task.SupportedTargetFrameworkAlias.ShouldBeEquivalentTo(convertToItems(expectedResult));
+            task.SupportedTargetFrameworkAlias.Should().BeEquivalentTo(convertToItems(expectedResult));
         }
     }
 }

--- a/src/Tests/Microsoft.DotNet.Cli.Sln.Internal.Tests/Microsoft.DotNet.Cli.Sln.Internal.Tests.cs
+++ b/src/Tests/Microsoft.DotNet.Cli.Sln.Internal.Tests/Microsoft.DotNet.Cli.Sln.Internal.Tests.cs
@@ -271,7 +271,7 @@ EndGlobal
             File.SetAttributes(tmpFile, attr);
         
             Action act = () => SlnFile.Read(tmpFile);
-            act.ShouldNotThrow("Because readonly file is not being modified.");
+            act.Should().NotThrow("Because readonly file is not being modified.");
         }
 
         [Fact]
@@ -332,7 +332,7 @@ EndGlobal
                 SlnFile.Read(tmpFile);
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(FormatError(lineNum, LocalizableStrings.FileHeaderMissingVersionError));
         }
 
@@ -350,7 +350,7 @@ EndGlobal
                 SlnFile.Read(tmpFile);
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(LocalizableStrings.FileHeaderMissingError);
         }
 
@@ -372,7 +372,7 @@ EndGlobal
                 SlnFile.Read(tmpFile);
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(FormatError(5, LocalizableStrings.GlobalSectionMoreThanOnceError));
         }
 
@@ -391,7 +391,7 @@ Global
                 SlnFile.Read(tmpFile);
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(FormatError(3, LocalizableStrings.GlobalSectionNotClosedError));
         }
 
@@ -410,7 +410,7 @@ Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""App"", ""App\App.csproj"
                 SlnFile.Read(tmpFile);
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(FormatError(3, LocalizableStrings.ProjectSectionNotClosedError));
         }
 
@@ -431,7 +431,7 @@ EndProject
                 SlnFile.Read(tmpFile);
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(FormatError(3, LocalizableStrings.ProjectParsingErrorFormatString, "(", 0));
         }
 
@@ -453,7 +453,7 @@ EndGlobal
                 SlnFile.Read(tmpFile);
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(FormatError(4, LocalizableStrings.InvalidSectionTypeError, "thisIsUnknown"));
         }
 
@@ -475,7 +475,7 @@ EndGlobal
                 SlnFile.Read(tmpFile);
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(FormatError(4, LocalizableStrings.SectionIdMissingError));
         }
 
@@ -496,7 +496,7 @@ EndGlobal
                 SlnFile.Read(tmpFile);
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(FormatError(6, LocalizableStrings.ClosingSectionTagNotFoundError));
         }
 
@@ -525,7 +525,7 @@ EndGlobal
                 }
             };
 
-            action.ShouldThrow<InvalidSolutionFormatException>()
+            action.Should().Throw<InvalidSolutionFormatException>()
                 .WithMessage(FormatError(7, LocalizableStrings.InvalidPropertySetFormatString, "."));
         }
 

--- a/src/Tests/Microsoft.DotNet.CommandFactory.Tests/GivenALocalToolsCommandResolver.cs
+++ b/src/Tests/Microsoft.DotNet.CommandFactory.Tests/GivenALocalToolsCommandResolver.cs
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.Tests
                 CommandName = $"dotnet-{toolCommandNameA.ToString()}",
             });
 
-            action.ShouldThrow<GracefulException>(string.Format(CommandFactory.LocalizableStrings.NeedRunToolRestore,
+            action.Should().Throw<GracefulException>(string.Format(CommandFactory.LocalizableStrings.NeedRunToolRestore,
                 toolCommandNameA.ToString()));
         }
 
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.Tests
                 CommandName = $"dotnet-{toolCommandNameA.ToString()}",
             });
 
-            action.ShouldThrow<GracefulException>(string.Format(CommandFactory.LocalizableStrings.NeedRunToolRestore,
+            action.Should().Throw<GracefulException>(string.Format(CommandFactory.LocalizableStrings.NeedRunToolRestore,
                 toolCommandNameA.ToString()));
         }
 

--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/LocalToolsResolverCacheTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/LocalToolsResolverCacheTests.cs
@@ -113,8 +113,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                     restoredCommands[1].Name),
                 out RestoredCommand tool2).Should().BeTrue();
 
-            tool1.ShouldBeEquivalentTo(restoredCommands[0]);
-            tool2.ShouldBeEquivalentTo(restoredCommands[1]);
+            tool1.Should().BeEquivalentTo(restoredCommands[0]);
+            tool2.Should().BeEquivalentTo(restoredCommands[1]);
         }
 
         [Fact]
@@ -153,8 +153,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 out RestoredCommand tool2);
 
 
-            tool1.ShouldBeEquivalentTo(restoredCommands[0]);
-            tool2.ShouldBeEquivalentTo(restoredCommands[1]);
+            tool1.Should().BeEquivalentTo(restoredCommands[0]);
+            tool2.Should().BeEquivalentTo(restoredCommands[1]);
         }
 
         [Fact]
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
             loadSuccess.Should().BeTrue();
 
-            loadedResolverCache.ShouldBeEquivalentTo(restoredCommandsV1[0]);
+            loadedResolverCache.Should().BeEquivalentTo(restoredCommandsV1[0]);
         }
 
         [Fact]
@@ -273,9 +273,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                     restoredCommandsNewer[1].Name),
                 out RestoredCommand tool2Newer);
 
-            tool1.ShouldBeEquivalentTo(restoredCommands[0]);
-            tool1Newer.ShouldBeEquivalentTo(restoredCommandsNewer[0]);
-            tool2Newer.ShouldBeEquivalentTo(restoredCommandsNewer[1]);
+            tool1.Should().BeEquivalentTo(restoredCommands[0]);
+            tool1Newer.Should().BeEquivalentTo(restoredCommandsNewer[0]);
+            tool2Newer.Should().BeEquivalentTo(restoredCommandsNewer[1]);
         }
 
         [Fact]
@@ -350,7 +350,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                     restoredCommands[0].Name),
                 out RestoredCommand restoredCommand);
 
-            restoredCommand.ShouldBeEquivalentTo(restoredCommands[0]);
+            restoredCommand.Should().BeEquivalentTo(restoredCommands[0]);
         }
 
         private static void WhenTheCacheIsCorruptedItShouldLoadAsEmpty(

--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/ToolConfigurationDeserializerTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/ToolConfigurationDeserializerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         public void GivenMalformedPathItThrows()
         {
             Action a = () => ToolConfigurationDeserializer.Deserialize("DotnetToolSettingsMalformed.xml");
-            a.ShouldThrow<ToolConfigurationException>()
+            a.Should().Throw<ToolConfigurationException>()
                 .And.Message.Should()
                 .Contain(string.Format(CommonLocalizableStrings.ToolSettingsInvalidXml, string.Empty));
         }
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         public void GivenMissingContentItThrows()
         {
             Action a = () => ToolConfigurationDeserializer.Deserialize("DotnetToolSettingsMissing.xml");
-            a.ShouldThrow<ToolConfigurationException>()
+            a.Should().Throw<ToolConfigurationException>()
                 .And.Message.Should()
                 .Contain(CommonLocalizableStrings.ToolSettingsMissingCommandName);
         }
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         {
             var invalidCommandName = "na\0me";
             Action a = () => new ToolConfiguration(invalidCommandName, "my.dll");
-            a.ShouldThrow<ToolConfigurationException>()
+            a.Should().Throw<ToolConfigurationException>()
                 .And.Message.Should()
                 .Contain(
                     string.Format(
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         {
             var invalidCommandName = ".mytool";
             Action a = () => new ToolConfiguration(invalidCommandName, "my.dll");
-            a.ShouldThrow<ToolConfigurationException>()
+            a.Should().Throw<ToolConfigurationException>()
                 .And.Message.Should()
                 .Contain(string.Format(
                         CommonLocalizableStrings.ToolSettingsInvalidLeadingDotCommandName,

--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             Action a = () => installer.InstallPackage(new PackageLocation(), packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion), targetFramework: _testTargetframework);
 
-            a.ShouldThrow<ToolPackageException>().WithMessage(Tools.Tool.Install.LocalizableStrings.ToolInstallationRestoreFailed);
+            a.Should().Throw<ToolPackageException>().WithMessage(Tools.Tool.Install.LocalizableStrings.ToolInstallationRestoreFailed);
 
             reporter.Lines.Count.Should().Be(1);
             reporter.Lines[0].Should().Contain(TestPackageId.ToString());
@@ -460,7 +460,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 }
             };
 
-            a.ShouldThrow<ToolPackageException>().WithMessage(Tools.Tool.Install.LocalizableStrings.ToolInstallationRestoreFailed);
+            a.Should().Throw<ToolPackageException>().WithMessage(Tools.Tool.Install.LocalizableStrings.ToolInstallationRestoreFailed);
 
             AssertInstallRollBack(fileSystem, store);
         }
@@ -494,7 +494,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 }
             };
 
-            a.ShouldThrow<GracefulException>().WithMessage("simulated error");
+            a.Should().Throw<GracefulException>().WithMessage("simulated error");
 
             AssertInstallRollBack(fileSystem, store);
         }
@@ -521,7 +521,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                         versionRange: VersionRange.Parse(TestPackageVersion),
                         targetFramework: _testTargetframework);
 
-                    first.ShouldNotThrow();
+                    first.Should().NotThrow();
 
                     installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { source }),
                         packageId: TestPackageId,
@@ -532,7 +532,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 }
             };
 
-            a.ShouldThrow<ToolPackageException>().Where(
+            a.Should().Throw<ToolPackageException>().Where(
                 ex => ex.Message ==
                       string.Format(
                           CommonLocalizableStrings.ToolPackageConflictPackageId,
@@ -567,7 +567,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
             reporter.Lines.Should().BeEmpty();
 
-            secondCall.ShouldThrow<ToolPackageException>().Where(
+            secondCall.Should().Throw<ToolPackageException>().Where(
                 ex => ex.Message ==
                       string.Format(
                           CommonLocalizableStrings.ToolPackageConflictPackageId,
@@ -821,7 +821,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                     versionRange: VersionRange.Parse(packageVersion),
                     targetFramework: _testTargetframework);
 
-                action.ShouldNotThrow<ToolConfigurationException>();
+                action.Should().NotThrow<ToolConfigurationException>();
 
                 fileSystem.File.Exists(package.Commands[0].Executable.Value).Should().BeTrue($"{package.Commands[0].Executable.Value} should exist");
 

--- a/src/Tests/Microsoft.DotNet.ShellShim.Tests/AppHostShellShimMakerTests.cs
+++ b/src/Tests/Microsoft.DotNet.ShellShim.Tests/AppHostShellShimMakerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         public void GivenNonWindowsMachineWhenCallWithWpfDllItCanCreateShimWithoutThrow()
         {
             Action a = () => CreateApphostAndReturnShimPath();
-            a.ShouldNotThrow("It should skip copying PE bits without throw");
+            a.Should().NotThrow("It should skip copying PE bits without throw");
         }
 
         private static string CreateApphostAndReturnShimPath()

--- a/src/Tests/Microsoft.DotNet.ShellShim.Tests/ShellShimRepositoryTests.cs
+++ b/src/Tests/Microsoft.DotNet.ShellShim.Tests/ShellShimRepositoryTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
 
             Action a = () => shellShimRepository.CreateShim(outputDll, new ToolCommandName(shellCommandName));
 
-            a.ShouldNotThrow<DirectoryNotFoundException>();
+            a.Should().NotThrow<DirectoryNotFoundException>();
         }
 
         [Theory]
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
                 }
             };
 
-            a.ShouldThrow<ShellShimException>().Where(
+            a.Should().Throw<ShellShimException>().Where(
                 ex => ex.Message ==
                     string.Format(
                         CommonLocalizableStrings.ShellShimConflict,
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
                     scope.Complete();
                 }
             };
-            a.ShouldThrow<ToolPackageException>().WithMessage("simulated error");
+            a.Should().Throw<ToolPackageException>().WithMessage("simulated error");
 
             Directory.EnumerateFileSystemEntries(pathToShim).Should().BeEmpty();
         }
@@ -397,7 +397,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
                 new ToolCommandName(shellCommandName),
                 new[] { new FilePath(dummyShimPath), new FilePath("path" + dummyShimPath) });
 
-            a.ShouldThrow<ShellShimException>()
+            a.Should().Throw<ShellShimException>()
                 .And.Message
                 .Should().Contain(
                     string.Format(

--- a/src/Tests/Microsoft.DotNet.Tools.Tests.Utilities.Tests/MockFileSystemTests.cs
+++ b/src/Tests/Microsoft.DotNet.Tools.Tests.Utilities.Tests/MockFileSystemTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             string nestedFilePath = Path.Combine(directory, "nonExits", "filename");
             Action a = () => fileSystem.File.CreateEmptyFile(nestedFilePath);
 
-            a.ShouldThrow<DirectoryNotFoundException>().And.Message.Should()
+            a.Should().Throw<DirectoryNotFoundException>().And.Message.Should()
                 .Contain("Could not find a part of the path");
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             string directory = fileSystem.Directory.CreateTemporaryDirectory().DirectoryPath;
 
             Action a = () => fileSystem.Directory.CreateDirectory(directory);
-            a.ShouldNotThrow();
+            a.Should().NotThrow();
         }
 
         [Theory]
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             string path = Path.Combine(directory, "sub");
             fileSystem.File.CreateEmptyFile(path);
             Action a = () => fileSystem.Directory.CreateDirectory(path);
-            a.ShouldThrow<IOException>();
+            a.Should().Throw<IOException>();
         }
 
         [WindowsOnlyTheory]
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             string directory = fileSystem.Directory.CreateTemporaryDirectory().DirectoryPath;
             string nestedFilePath = Path.Combine(directory, "subfolder", "filename");
             Action a = () => fileSystem.File.CreateEmptyFile(nestedFilePath);
-            a.ShouldThrow<DirectoryNotFoundException>();
+            a.Should().Throw<DirectoryNotFoundException>();
         }
 
         [Theory]
@@ -175,7 +175,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             string path = Path.Combine(directory, Path.GetRandomFileName());
 
             Action a = () => fileSystem.File.ReadAllText(path);
-            a.ShouldThrow<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
+            a.Should().Throw<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
         }
 
         [Theory]
@@ -190,7 +190,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             fileSystem.Directory.CreateDirectory(directory);
 
             Action a = () => fileSystem.File.ReadAllText(directory);
-            a.ShouldThrow<UnauthorizedAccessException>().And.Message.Should().Contain("Access to the path");
+            a.Should().Throw<UnauthorizedAccessException>().And.Message.Should().Contain("Access to the path");
         }
 
         [Theory]
@@ -249,7 +249,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.File.Move(sourceFile, destinationFile);
 
-            a.ShouldThrow<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
+            a.Should().Throw<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
         }
 
         [Theory]
@@ -266,7 +266,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.File.Move(badSourceFile, destinationFile);
 
-            a.ShouldThrow<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
+            a.Should().Throw<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
         }
 
         [Theory]
@@ -283,7 +283,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.File.Move(sourceFile, destinationFile);
 
-            a.ShouldThrow<DirectoryNotFoundException>()
+            a.Should().Throw<DirectoryNotFoundException>()
                 .And.Message.Should().Contain("Could not find a part of the path");
         }
 
@@ -315,7 +315,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.File.Copy(sourceFile, destinationFile);
 
-            a.ShouldThrow<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
+            a.Should().Throw<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
         }
 
         [Theory]
@@ -331,7 +331,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.File.Copy(badSourceFile, destinationFile);
 
-            a.ShouldThrow<UnauthorizedAccessException>().And.Message.Should().Contain("Access to the path");
+            a.Should().Throw<UnauthorizedAccessException>().And.Message.Should().Contain("Access to the path");
         }
 
         [Theory]
@@ -347,7 +347,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.File.Copy(sourceFile, destinationFile);
 
-            a.ShouldThrow<DirectoryNotFoundException>()
+            a.Should().Throw<DirectoryNotFoundException>()
                 .And.Message.Should().Contain("Could not find a part of the path");
         }
 
@@ -365,7 +365,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.File.Copy(sourceFile, destinationFile);
 
-            a.ShouldThrow<IOException>()
+            a.Should().Throw<IOException>()
                 .And.Message.Should().Contain("already exists");
         }
 
@@ -395,7 +395,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.File.Delete(file);
 
-            a.ShouldNotThrow();
+            a.Should().NotThrow();
         }
 
         // https://github.com/dotnet/corefx/issues/32110
@@ -412,7 +412,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.File.Delete(file);
 
-            a.ShouldThrow<DirectoryNotFoundException>().And.Message.Should().Contain("Could not find a part of the path");
+            a.Should().Throw<DirectoryNotFoundException>().And.Message.Should().Contain("Could not find a part of the path");
         }
 
         [Theory]
@@ -426,7 +426,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.Directory.EnumerateFiles(nonExistDirectory);
 
-            a.ShouldThrow<DirectoryNotFoundException>().And.Message.Should()
+            a.Should().Throw<DirectoryNotFoundException>().And.Message.Should()
                 .Contain("Could not find a part of the path");
         }
 
@@ -445,7 +445,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             // On Windows: The parameter is incorrect
             // On Linux: Not a directory
             // But the message is not important
-            a.ShouldThrow<IOException>();
+            a.Should().Throw<IOException>();
         }
 
         [Theory]
@@ -492,7 +492,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
 
             Action a = () => fileSystem.Directory.EnumerateFileSystemEntries(nonExistDirectory);
 
-            a.ShouldThrow<DirectoryNotFoundException>().And.Message.Should()
+            a.Should().Throw<DirectoryNotFoundException>().And.Message.Should()
                 .Contain("Could not find a part of the path");
         }
 
@@ -511,7 +511,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             // On Windows: The parameter is incorrect
             // On Linux: Not a directory
             // But the message is not important
-            a.ShouldThrow<IOException>();
+            a.Should().Throw<IOException>();
         }
 
         [Theory]
@@ -577,7 +577,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             string nonExistsTestDirectory = Path.Combine(tempDirectory, Path.GetRandomFileName());
 
             Action action = () => fileSystem.Directory.Delete(nonExistsTestDirectory, recursive);
-            action.ShouldThrow<DirectoryNotFoundException>().And.Message.Should()
+            action.Should().Throw<DirectoryNotFoundException>().And.Message.Should()
                 .Contain("Could not find a part of the path");
         }
 
@@ -594,7 +594,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             fileSystem.File.CreateEmptyFile(actuallyAFilePath);
 
             Action action = () => fileSystem.Directory.Delete(actuallyAFilePath, recursive);
-            action.ShouldThrow<IOException>();
+            action.Should().Throw<IOException>();
         }
 
         [Theory]
@@ -613,7 +613,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             // On Windows: The directory is not empty
             // On Linux: Directory not empty
             // But the message is not important
-            action.ShouldThrow<IOException>().And.Message.Should().Contain("not empty");
+            action.Should().Throw<IOException>().And.Message.Should().Contain("not empty");
         }
 
         [Theory]
@@ -667,7 +667,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             string testDestinationDirectoryPath = Path.Combine(tempDirectory, Path.GetRandomFileName());
 
             Action a = () => fileSystem.Directory.Move(testSourceDirectoryPath, testDestinationDirectoryPath);
-            a.ShouldThrow<DirectoryNotFoundException>().And.Message.Should()
+            a.Should().Throw<DirectoryNotFoundException>().And.Message.Should()
                 .Contain("Could not find a part of the path");
         }
 
@@ -685,7 +685,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             fileSystem.Directory.CreateDirectory(testDestinationDirectoryPath);
 
             Action a = () => fileSystem.Directory.Move(testSourceDirectoryPath, testDestinationDirectoryPath);
-            a.ShouldThrow<IOException>();
+            a.Should().Throw<IOException>();
         }
 
         [Theory]
@@ -702,7 +702,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             fileSystem.File.CreateEmptyFile(testDestinationDirectoryPath);
 
             Action a = () => fileSystem.Directory.Move(testSourceDirectoryPath, testDestinationDirectoryPath);
-            a.ShouldThrow<IOException>();
+            a.Should().Throw<IOException>();
         }
 
         [Theory]
@@ -716,7 +716,7 @@ namespace Microsoft.DotNet.Tools.Tests.Utilities.Tests
             fileSystem.Directory.CreateDirectory(testSourceDirectoryPath);
 
             Action a = () => fileSystem.Directory.Move(testSourceDirectoryPath, testSourceDirectoryPath);
-            a.ShouldThrow<IOException>().And.Message.Should().Contain("Source and destination path must be different");
+            a.Should().Throw<IOException>().And.Message.Should().Contain("Source and destination path must be different");
         }
 
         private static IFileSystem SetupSubjectFileSystem(bool testMockBehaviorIsInSync)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -628,7 +628,7 @@ class Program
                 .Should()
                 .Pass();
 
-            getValuesCommand.GetValues().ShouldBeEquivalentTo(new[] { "7.0" });
+            getValuesCommand.GetValues().Should().BeEquivalentTo(new[] { "7.0" });
         }
 
         private void TestInvalidTargetFramework(string testName, string targetFramework, bool useSolution, string expectedOutput)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -146,7 +146,7 @@ namespace Microsoft.NET.Build.Tests
             getValuesCommand.Execute()
                 .Should()
                 .Pass();
-            getValuesCommand.GetValues().ShouldBeEquivalentTo(new[] { "true" });
+            getValuesCommand.GetValues().Should().BeEquivalentTo(new[] { "true" });
         }
 
         [WindowsOnlyRequiresMSBuildVersionFact("17.0.0.32901")]

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NET.Build.Tests
                 }
                 else
                 {
-                    getValuesCommand.GetValues().ShouldBeEquivalentTo(new[] { expected }, $"Asserting \"{valueName}\"'s value");
+                    getValuesCommand.GetValues().Should().BeEquivalentTo(new[] { expected }, $"Asserting \"{valueName}\"'s value");
                 }
             };
 
@@ -80,7 +80,7 @@ namespace Microsoft.NET.Build.Tests
                 .Execute()
                 .Should()
                 .Pass();
-            getValuesCommand.GetValues().ShouldBeEquivalentTo(new[] { "Windows" });
+            getValuesCommand.GetValues().Should().BeEquivalentTo(new[] { "Windows" });
         }
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -103,7 +103,7 @@ namespace Microsoft.NET.Build.Tests
             var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
-            command.GetValues().ShouldBeEquivalentTo(new[] { "1.0.0" });
+            command.GetValues().Should().BeEquivalentTo(new[] { "1.0.0" });
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace Microsoft.NET.Build.Tests
             var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
-            command.GetValues().ShouldBeEquivalentTo(new[] { "1.0.0" });
+            command.GetValues().Should().BeEquivalentTo(new[] { "1.0.0" });
         }
 
         [Fact]
@@ -166,7 +166,7 @@ namespace Microsoft.NET.Build.Tests
             var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
-            command.GetValues().ShouldBeEquivalentTo(new[] { "1.0.0" });
+            command.GetValues().Should().BeEquivalentTo(new[] { "1.0.0" });
         }
 
         [Fact]
@@ -202,7 +202,7 @@ namespace Microsoft.NET.Build.Tests
             var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
-            command.GetValues().ShouldBeEquivalentTo(new[] { "1.0.0+xyz" });
+            command.GetValues().Should().BeEquivalentTo(new[] { "1.0.0+xyz" });
         }
 
         [Fact]
@@ -239,7 +239,7 @@ namespace Microsoft.NET.Build.Tests
             var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
-            command.GetValues().ShouldBeEquivalentTo(new[] { "1.2.3+abc.xyz" });
+            command.GetValues().Should().BeEquivalentTo(new[] { "1.2.3+abc.xyz" });
         }
 
         [WindowsOnlyTheory]
@@ -806,7 +806,7 @@ class Program
                 .WithWorkingDirectory(Path.Combine(testAsset.Path, testProject.Name))
                 .Execute();
             result.Should().Pass();
-            result.StdOut.Should().Equals(expectedFrameworkDisplayName);
+            result.StdOut.Should().BeEquivalentTo(expectedFrameworkDisplayName);
 
         }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -62,27 +62,31 @@ namespace Microsoft.NET.Build.Tests
             switch (language)
             {
                 case "C#":
-                    analyzers.Select(x => GetPackageAndPath(x)).Should().BeEquivalentTo(
-                        ("Microsoft.NET.Sdk", (string) null, "analyzers/Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll"),
-                        ("Microsoft.NET.Sdk", (string)null, "analyzers/Microsoft.CodeAnalysis.NetAnalyzers.dll"),
-                        ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/System.Text.Json.SourceGeneration.dll"),
-                        ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/System.Text.RegularExpressions.Generator.dll"),
-                        ("microsoft.codequality.analyzers", "2.6.0", "analyzers/dotnet/cs/Microsoft.CodeQuality.Analyzers.dll"),
-                        ("microsoft.codequality.analyzers", "2.6.0", "analyzers/dotnet/cs/Microsoft.CodeQuality.CSharp.Analyzers.dll"),
-                        ("microsoft.dependencyvalidation.analyzers", "0.9.0", "analyzers/dotnet/Microsoft.DependencyValidation.Analyzers.dll"),
-                        ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/Microsoft.Interop.LibraryImportGenerator.dll"),
-                        ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/Microsoft.Interop.JavaScript.JSImportGenerator.dll"),
-                        ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/Microsoft.Interop.SourceGeneration.dll")
+                    analyzers.Select(x => GetPackageAndPath(x)).Should().BeEquivalentTo(new[]
+                            {
+                                ("Microsoft.NET.Sdk", (string) null, "analyzers/Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll"),
+                                ("Microsoft.NET.Sdk", (string)null, "analyzers/Microsoft.CodeAnalysis.NetAnalyzers.dll"),
+                                ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/System.Text.Json.SourceGeneration.dll"),
+                                ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/System.Text.RegularExpressions.Generator.dll"),
+                                ("microsoft.codequality.analyzers", "2.6.0", "analyzers/dotnet/cs/Microsoft.CodeQuality.Analyzers.dll"),
+                                ("microsoft.codequality.analyzers", "2.6.0", "analyzers/dotnet/cs/Microsoft.CodeQuality.CSharp.Analyzers.dll"),
+                                ("microsoft.dependencyvalidation.analyzers", "0.9.0", "analyzers/dotnet/Microsoft.DependencyValidation.Analyzers.dll"),
+                                ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/Microsoft.Interop.LibraryImportGenerator.dll"),
+                                ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/Microsoft.Interop.JavaScript.JSImportGenerator.dll"),
+                                ("microsoft.netcore.app.ref", (string)null, "analyzers/dotnet/cs/Microsoft.Interop.SourceGeneration.dll")
+                            }
                         );
                     break;
 
                 case "VB":
-                    analyzers.Select(x => GetPackageAndPath(x)).Should().BeEquivalentTo(
-                        ("Microsoft.NET.Sdk", (string)null, "analyzers/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.dll"),
-                        ("Microsoft.NET.Sdk", (string)null, "analyzers/Microsoft.CodeAnalysis.NetAnalyzers.dll"),
-                        ("microsoft.codequality.analyzers", "2.6.0", "analyzers/dotnet/vb/Microsoft.CodeQuality.Analyzers.dll"),
-                        ("microsoft.codequality.analyzers", "2.6.0", "analyzers/dotnet/vb/Microsoft.CodeQuality.VisualBasic.Analyzers.dll"),
-                        ("microsoft.dependencyvalidation.analyzers", "0.9.0", "analyzers/dotnet/Microsoft.DependencyValidation.Analyzers.dll")
+                    analyzers.Select(x => GetPackageAndPath(x)).Should().BeEquivalentTo( new[]
+                        {
+                            ("Microsoft.NET.Sdk", (string)null, "analyzers/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.dll"),
+                            ("Microsoft.NET.Sdk", (string)null, "analyzers/Microsoft.CodeAnalysis.NetAnalyzers.dll"),
+                            ("microsoft.codequality.analyzers", "2.6.0", "analyzers/dotnet/vb/Microsoft.CodeQuality.Analyzers.dll"),
+                            ("microsoft.codequality.analyzers", "2.6.0", "analyzers/dotnet/vb/Microsoft.CodeQuality.VisualBasic.Analyzers.dll"),
+                            ("microsoft.dependencyvalidation.analyzers", "0.9.0", "analyzers/dotnet/Microsoft.DependencyValidation.Analyzers.dll")
+                        }
                         );
                     break;
 
@@ -135,7 +139,7 @@ namespace Microsoft.NET.Build.Tests
                 return getValuesCommand.GetValues().Select(x => GetPackageAndPath(x)).ToList();
             }
 
-            GetAnalyzersForTargetFramework(ToolsetInfo.CurrentTargetFramework).Should().BeEquivalentTo(("system.text.json", "6.0.0-preview.4.21253.7", "analyzers/dotnet/cs/System.Text.Json.SourceGeneration.dll"));
+            GetAnalyzersForTargetFramework(ToolsetInfo.CurrentTargetFramework).Should().BeEquivalentTo(new[] { ("system.text.json", "6.0.0-preview.4.21253.7", "analyzers/dotnet/cs/System.Text.Json.SourceGeneration.dll") });
             GetAnalyzersForTargetFramework("net472").Should().BeEmpty();
         }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -409,7 +409,7 @@ namespace Microsoft.NET.Build.Tests
 
             var compileItems = getCompileItemsCommand.GetValues();
             RemoveGeneratedCompileItems(compileItems);
-            compileItems.ShouldBeEquivalentTo(new[] { testProject.Name + ".cs" });
+            compileItems.Should().BeEquivalentTo(new[] { testProject.Name + ".cs" });
 
             // Validate None items.
             var getNoneItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "None", GetValuesCommand.ValueType.Item);
@@ -799,7 +799,7 @@ public class Class1
                 .Pass();
 
             var getPRIResourceItems = getPRIResourceItemsCommand.GetValues();
-            getPRIResourceItems.ShouldBeEquivalentTo(new[] { "ResourcesResw.resw" });
+            getPRIResourceItems.Should().BeEquivalentTo(new[] { "ResourcesResw.resw" });
 
             // Validate Content items.
             var getContentItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "Content", GetValuesCommand.ValueType.Item);
@@ -808,7 +808,7 @@ public class Class1
                 .Pass();
 
             var getContentItems = getContentItemsCommand.GetValues();
-            getContentItems.ShouldBeEquivalentTo(imageFiles);
+            getContentItems.Should().BeEquivalentTo(imageFiles);
         }
 
         [Fact]
@@ -842,7 +842,7 @@ public class Class1
             var getNoneItems = getNoneItemsCommand.GetValues();
             List<string> expectedFiles = imageFiles;
             expectedFiles.Add("ResourcesResw.resw");
-            getNoneItems.ShouldBeEquivalentTo(expectedFiles.ToArray());
+            getNoneItems.Should().BeEquivalentTo(expectedFiles.ToArray());
 
             // Validate PRIResource items.
             var getPRIResourceItemsCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks, "PRIResource", GetValuesCommand.ValueType.Item);

--- a/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -87,11 +87,11 @@ namespace Microsoft.NET.Build.Tests
 
             getValuesCommand.GetValuesWithMetadata().Select(valueAndMetadata => (valueAndMetadata.value, valueAndMetadata.metadata["VisualStudioComponentId"]))
                 .Should()
-                .BeEquivalentTo(("microsoft-net-sdk-missingtestworkload", "microsoft.net.sdk.missingtestworkload"));
+                .BeEquivalentTo(new[] { ("microsoft-net-sdk-missingtestworkload", "microsoft.net.sdk.missingtestworkload") });
 
             getValuesCommand.GetValuesWithMetadata().Select(valueAndMetadata => (valueAndMetadata.value, valueAndMetadata.metadata["VisualStudioComponentIds"]))
                 .Should()
-                .BeEquivalentTo(("microsoft-net-sdk-missingtestworkload", "microsoft.net.sdk.missingtestworkload"));
+                .BeEquivalentTo(new[] { ("microsoft-net-sdk-missingtestworkload", "microsoft.net.sdk.missingtestworkload") });
         }
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
@@ -190,7 +190,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                     .OrderBy(f => f, StringComparer.Ordinal)
                     .ToArray();
 
-                existingFiles.ShouldBeEquivalentTo(expected);
+                existingFiles.Should().BeEquivalentTo(expected);
             }
             else
             {
@@ -250,7 +250,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 existingFiles = existingFiles.Select(f => Regex.Replace(f, DotNetJSHashRegexPattern, DotNetJSHashTemplate)).ToArray();
 
                 var expected = LoadExpectedFilesBaseline(manifest.ManifestType, publishFolder, intermediateOutputPath, suffix, name);
-                existingFiles.ShouldBeEquivalentTo(expected);
+                existingFiles.Should().BeEquivalentTo(expected);
             }
             else
             {
@@ -355,9 +355,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 manifest.ReferencedProjectsConfiguration.OrderBy(cm => cm.Identity)
                     .Should()
                     .BeEquivalentTo(expected.ReferencedProjectsConfiguration.OrderBy(cm => cm.Identity));
-                manifest.DiscoveryPatterns.OrderBy(dp => dp.Name).ShouldBeEquivalentTo(expected.DiscoveryPatterns.OrderBy(dp => dp.Name));
+                manifest.DiscoveryPatterns.OrderBy(dp => dp.Name).Should().BeEquivalentTo(expected.DiscoveryPatterns.OrderBy(dp => dp.Name));
                 manifest.Assets.OrderBy(a => a.BasePath).ThenBy(a => a.RelativePath).ThenBy(a => a.AssetKind)
-                    .ShouldBeEquivalentTo(expected.Assets.OrderBy(a => a.BasePath).ThenBy(a => a.RelativePath).ThenBy(a => a.AssetKind));
+                    .Should().BeEquivalentTo(expected.Assets.OrderBy(a => a.BasePath).ThenBy(a => a.RelativePath).ThenBy(a => a.AssetKind));
             }
             else
             {

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/GenerateStaticWebAssetsDevelopmentManifestTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/GenerateStaticWebAssetsDevelopmentManifestTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -216,7 +216,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -248,7 +248,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -278,7 +278,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -309,7 +309,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -346,7 +346,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -384,7 +384,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -420,7 +420,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -456,7 +456,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         [Fact]
@@ -500,7 +500,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var manifest = task.ComputeDevelopmentManifest(assets, patterns);
 
             // Assert
-            manifest.ShouldBeEquivalentTo(expectedManifest);
+            manifest.Should().BeEquivalentTo(expectedManifest);
         }
 
         private static StaticWebAssetsManifest.DiscoveryPattern CreatePattern(

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
@@ -148,21 +148,21 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             task.DiscoveryPatterns.Should().BeEmpty();
             task.Assets.Length.Should().Be(1);
             var asset = task.Assets[0];
-            asset.GetMetadata(nameof(StaticWebAsset.Identity)).ShouldBeEquivalentTo($"{identity}");
-            asset.GetMetadata(nameof(StaticWebAsset.SourceId)).ShouldBeEquivalentTo("ComponentApp");
-            asset.GetMetadata(nameof(StaticWebAsset.SourceType)).ShouldBeEquivalentTo("Computed");
-            asset.GetMetadata(nameof(StaticWebAsset.ContentRoot)).ShouldBeEquivalentTo($"{contentRoot}");
-            asset.GetMetadata(nameof(StaticWebAsset.BasePath)).ShouldBeEquivalentTo("_content/ComponentApp");
-            asset.GetMetadata(nameof(StaticWebAsset.RelativePath)).ShouldBeEquivalentTo("ComponentApp.styles.css");
-            asset.GetMetadata(nameof(StaticWebAsset.AssetKind)).ShouldBeEquivalentTo("All");
-            asset.GetMetadata(nameof(StaticWebAsset.AssetMode)).ShouldBeEquivalentTo("CurrentProject");
-            asset.GetMetadata(nameof(StaticWebAsset.AssetRole)).ShouldBeEquivalentTo("Primary");
-            asset.GetMetadata(nameof(StaticWebAsset.RelatedAsset)).ShouldBeEquivalentTo("");
-            asset.GetMetadata(nameof(StaticWebAsset.AssetTraitName)).ShouldBeEquivalentTo("ScopedCss");
-            asset.GetMetadata(nameof(StaticWebAsset.AssetTraitValue)).ShouldBeEquivalentTo("ApplicationBundle");
-            asset.GetMetadata(nameof(StaticWebAsset.CopyToOutputDirectory)).ShouldBeEquivalentTo("Never");
-            asset.GetMetadata(nameof(StaticWebAsset.CopyToPublishDirectory)).ShouldBeEquivalentTo("PreserveNewest");
-            asset.GetMetadata(nameof(StaticWebAsset.OriginalItemSpec)).ShouldBeEquivalentTo($"{identity}");
+            asset.GetMetadata(nameof(StaticWebAsset.Identity)).Should().BeEquivalentTo($"{identity}");
+            asset.GetMetadata(nameof(StaticWebAsset.SourceId)).Should().BeEquivalentTo("ComponentApp");
+            asset.GetMetadata(nameof(StaticWebAsset.SourceType)).Should().BeEquivalentTo("Computed");
+            asset.GetMetadata(nameof(StaticWebAsset.ContentRoot)).Should().BeEquivalentTo($"{contentRoot}");
+            asset.GetMetadata(nameof(StaticWebAsset.BasePath)).Should().BeEquivalentTo("_content/ComponentApp");
+            asset.GetMetadata(nameof(StaticWebAsset.RelativePath)).Should().BeEquivalentTo("ComponentApp.styles.css");
+            asset.GetMetadata(nameof(StaticWebAsset.AssetKind)).Should().BeEquivalentTo("All");
+            asset.GetMetadata(nameof(StaticWebAsset.AssetMode)).Should().BeEquivalentTo("CurrentProject");
+            asset.GetMetadata(nameof(StaticWebAsset.AssetRole)).Should().BeEquivalentTo("Primary");
+            asset.GetMetadata(nameof(StaticWebAsset.RelatedAsset)).Should().BeEquivalentTo("");
+            asset.GetMetadata(nameof(StaticWebAsset.AssetTraitName)).Should().BeEquivalentTo("ScopedCss");
+            asset.GetMetadata(nameof(StaticWebAsset.AssetTraitValue)).Should().BeEquivalentTo("ApplicationBundle");
+            asset.GetMetadata(nameof(StaticWebAsset.CopyToOutputDirectory)).Should().BeEquivalentTo("Never");
+            asset.GetMetadata(nameof(StaticWebAsset.CopyToPublishDirectory)).Should().BeEquivalentTo("PreserveNewest");
+            asset.GetMetadata(nameof(StaticWebAsset.OriginalItemSpec)).Should().BeEquivalentTo($"{identity}");
         }
 
         [Fact]
@@ -216,15 +216,15 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             task.Assets.Should().BeEmpty();
             task.DiscoveryPatterns.Should().BeEmpty();
             var projectConfiguration = task.ReferencedProjectsConfiguration[0];
-            projectConfiguration.ItemSpec.ShouldBeEquivalentTo(identity);
-            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.Version)).ShouldBeEquivalentTo(2);
-            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.Source)).ShouldBeEquivalentTo("AnotherClassLib");
-            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.GetPublishAssetsTargets)).ShouldBeEquivalentTo("ComputeReferencedStaticWebAssetsPublishManifest;GetCurrentProjectPublishStaticWebAssetItems");
-            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.AdditionalPublishProperties)).ShouldBeEquivalentTo(";");
-            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.AdditionalPublishPropertiesToRemove)).ShouldBeEquivalentTo(";WebPublishProfileFile");
-            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.GetBuildAssetsTargets)).ShouldBeEquivalentTo("GetCurrentProjectBuildStaticWebAssetItems");
-            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.AdditionalBuildProperties)).ShouldBeEquivalentTo(";");
-            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.AdditionalBuildPropertiesToRemove)).ShouldBeEquivalentTo(";WebPublishProfileFile");
+            projectConfiguration.ItemSpec.Should().BeEquivalentTo(identity);
+            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.Version)).Should().BeEquivalentTo("2");
+            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.Source)).Should().BeEquivalentTo("AnotherClassLib");
+            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.GetPublishAssetsTargets)).Should().BeEquivalentTo("ComputeReferencedStaticWebAssetsPublishManifest;GetCurrentProjectPublishStaticWebAssetItems");
+            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.AdditionalPublishProperties)).Should().BeEquivalentTo(";");
+            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.AdditionalPublishPropertiesToRemove)).Should().BeEquivalentTo(";WebPublishProfileFile");
+            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.GetBuildAssetsTargets)).Should().BeEquivalentTo("GetCurrentProjectBuildStaticWebAssetItems");
+            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.AdditionalBuildProperties)).Should().BeEquivalentTo(";");
+            projectConfiguration.GetMetadata(nameof(StaticWebAssetsManifest.ReferencedProjectConfiguration.AdditionalBuildPropertiesToRemove)).Should().BeEquivalentTo(";WebPublishProfileFile");
         }
 
         [Fact]
@@ -274,11 +274,11 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             task.Assets.Should().BeEmpty();
             var discoveryPattern = task.DiscoveryPatterns[0];
 
-            discoveryPattern.ItemSpec.ShouldBeEquivalentTo(Path.Combine("AnotherClassLib", "wwwroot"));
-            discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.Source)).ShouldBeEquivalentTo("AnotherClassLib");
-            discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.ContentRoot)).ShouldBeEquivalentTo($"{contentRoot}");
-            discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.BasePath)).ShouldBeEquivalentTo("_content/AnotherClassLib");
-            discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.Pattern)).ShouldBeEquivalentTo("**");
+            discoveryPattern.ItemSpec.Should().BeEquivalentTo(Path.Combine("AnotherClassLib", "wwwroot"));
+            discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.Source)).Should().BeEquivalentTo("AnotherClassLib");
+            discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.ContentRoot)).Should().BeEquivalentTo($"{contentRoot}");
+            discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.BasePath)).Should().BeEquivalentTo("_content/AnotherClassLib");
+            discoveryPattern.GetMetadata(nameof(StaticWebAssetsManifest.DiscoveryPattern.Pattern)).Should().BeEquivalentTo("**");
         }
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -100,7 +100,7 @@ namespace ManifestReaderTests
                 return true;
             }).ToList();
 
-            a.ShouldThrow<FileNotFoundException>();
+            a.Should().Throw<FileNotFoundException>();
         }
 
         [Fact]

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 .Distinct()
                 .Select(packId => workloadResolver.TryGetPackInfo(packId))
                 .Where(pack => pack != null);
-            installer.RolledBackPacks.ShouldBeEquivalentTo(expectedPacks);
+            installer.RolledBackPacks.Should().BeEquivalentTo(expectedPacks);
             installer.InstallationRecordRepository.WorkloadInstallRecord.Should().BeEmpty();
         }
 

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using ManifestReaderTests;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.ToolPackage;
@@ -260,9 +261,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 //  6.0.300 manifest was requested and then 6.0.200 manifest was requested
                 // we can't assert this for the offline cache
                 nugetDownloader.DownloadCallParams[0].id.ToString().Should().Be($"{testManifestName}.manifest-6.0.300");
-                nugetDownloader.DownloadCallParams[0].version.ShouldBeEquivalentTo(null);
+                nugetDownloader.DownloadCallParams[0].version.Should().BeNull();
                 nugetDownloader.DownloadCallParams[1].id.ToString().Should().Be($"{testManifestName}.manifest-6.0.200");
-                nugetDownloader.DownloadCallParams[1].version.ShouldBeEquivalentTo(null);
+                nugetDownloader.DownloadCallParams[1].version.Should().BeNull();
                 nugetDownloader.DownloadCallParams.Count.Should().Be(2);    
                 
             }
@@ -337,9 +338,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 //  6.0.300 manifest was requested and then 6.0.200 manifest was requested
                 // we can't assert this for the offline cache
                 nugetDownloader.DownloadCallParams[0].id.ToString().Should().Be($"{testManifestName}.manifest-6.0.300");
-                nugetDownloader.DownloadCallParams[0].version.ShouldBeEquivalentTo(null);
+                nugetDownloader.DownloadCallParams[0].version.Should().BeNull();
                 nugetDownloader.DownloadCallParams[1].id.ToString().Should().Be($"{testManifestName}.manifest-6.0.200");
-                nugetDownloader.DownloadCallParams[1].version.ShouldBeEquivalentTo(null);
+                nugetDownloader.DownloadCallParams[1].version.Should().BeNull();
                 nugetDownloader.DownloadCallParams.Count.Should().Be(2);
             }
 
@@ -403,7 +404,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 // only 6.0.300 manifest was requested
                 // we can't assert this for the offline cache
                 nugetDownloader.DownloadCallParams[0].id.ToString().Should().Be($"{testManifestName}.manifest-6.0.300");
-                nugetDownloader.DownloadCallParams[0].version.ShouldBeEquivalentTo(null);
+                nugetDownloader.DownloadCallParams[0].version.Should().BeNull();
             }
 
             //  Assert
@@ -671,7 +672,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             updater2.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync().Wait();
             // var updateTime1 = DateTime.Now;
             downloader2.DownloadCallParams.Should().BeEmpty();
-            File.GetLastAccessTime(sentinelPath2).Should().BeCloseTo(updateTime2);
+            File.GetLastAccessTime(sentinelPath2).Should().BeCloseTo(updateTime2, 1.Seconds());
         }
 
         private List<(PackageId, NuGetVersion, DirectoryPath?, PackageSourceLocation)> GetExpectedDownloadedPackages(string sdkFeatureBand = "6.0.100")

--- a/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
+++ b/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 workloadRecordRepo: new MockMatchingFeatureBandInstallationRecordRepository());
 
             Action a = () => _workloadListCommand.Execute();
-            a.ShouldThrow<ArgumentException>();
+            a.Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 workloadRecordRepo: new MockMatchingFeatureBandInstallationRecordRepository());
 
             Action a = () => _workloadListCommand.Execute();
-            a.ShouldNotThrow();
+            a.Should().NotThrow();
         }
 
         internal class MockMatchingFeatureBandInstallationRecordRepository : IWorkloadInstallationRecordRepository

--- a/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 .Distinct()
                 .Select(packId => workloadResolver.TryGetPackInfo(packId))
                 .Where(pack => pack != null);
-            installer.RolledBackPacks.ShouldBeEquivalentTo(expectedPacks);
+            installer.RolledBackPacks.Should().BeEquivalentTo(expectedPacks);
             installer.InstallationRecordRepository.WorkloadInstallRecord.Should().BeEmpty();
         }
 

--- a/src/Tests/dotnet.Tests/BuildServerTests/RazorServerTests.cs
+++ b/src/Tests/dotnet.Tests/BuildServerTests/RazorServerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tests.BuildServerTests
 
             Action a = () => server.Shutdown();
 
-            a.ShouldThrow<BuildServerException>().WithMessage(
+            a.Should().Throw<BuildServerException>().WithMessage(
                 string.Format(
                     LocalizableStrings.ShutdownCommandFailed,
                     ErrorMessage));

--- a/src/Tests/dotnet.Tests/BuildServerTests/VBCSCompilerServerTests.cs
+++ b/src/Tests/dotnet.Tests/BuildServerTests/VBCSCompilerServerTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tests.BuildServerTests
 
             Action a = () => server.Shutdown();
 
-            a.ShouldThrow<BuildServerException>().WithMessage(
+            a.Should().Throw<BuildServerException>().WithMessage(
                 string.Format(
                     LocalizableStrings.ShutdownCommandFailed,
                     ErrorMessage));

--- a/src/Tests/dotnet.Tests/CommandObjectTests.cs
+++ b/src/Tests/dotnet.Tests/CommandObjectTests.cs
@@ -23,14 +23,14 @@ namespace Microsoft.DotNet.Tests
         public void WhenItCannotResolveCommandItThrows()
         {
             Action a = () => { CommandFactoryUsingResolver.Create(new ResolveNothingCommandResolverPolicy(), "non-exist-command", Array.Empty<string>() ); };
-            a.ShouldThrow<CommandUnknownException>();
+            a.Should().Throw<CommandUnknownException>();
         }
 
         [Fact]
         public void WhenItCannotResolveCommandButCommandIsInListOfKnownToolsItThrows()
         {
             Action a = () => { CommandFactoryUsingResolver.Create(new ResolveNothingCommandResolverPolicy(), "non-exist-command", Array.Empty<string>()); };
-            a.ShouldThrow<CommandUnknownException>();
+            a.Should().Throw<CommandUnknownException>();
         }
 
         private class ResolveNothingCommandResolverPolicy : ICommandResolverPolicy

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(string.Format(
                     LocalizableStrings.InstallToolCommandInvalidGlobalAndLocalAndToolPath,
                     "global tool-path"));
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(
                     string.Format(LocalizableStrings.InstallToolCommandInvalidGlobalAndLocalAndToolPath,
                         "local tool-path"));
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(Tools.Tool.Common.LocalizableStrings.OnlyLocalOptionSupportManifestFileOption);
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(Tools.Tool.Common.LocalizableStrings.OnlyLocalOptionSupportManifestFileOption);
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(LocalizableStrings.LocalOptionDoesNotSupportFrameworkOption);
         }
     }

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallGlobalOrToolPathCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(
                     ErrorMessage +
                     Environment.NewLine +
@@ -236,7 +236,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallGlobalOrToolPathCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(string.Format(
                     CommonLocalizableStrings.ShellShimConflict,
                     ToolCommandName));
@@ -260,7 +260,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallGlobalOrToolPathCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(
                     string.Format(
                         LocalizableStrings.InvalidToolConfiguration,
@@ -307,7 +307,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             Action action = () => toolInstallGlobalOrToolPathCommand.Execute();
 
             action
-                .ShouldThrow<GracefulException>()
+                .Should().Throw<GracefulException>()
                 .WithMessage(string.Format(
                     LocalizableStrings.InvalidNuGetVersionRange,
                     invalidVersion));
@@ -402,7 +402,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 _reporter);
 
             Action a = () => toolInstallGlobalOrToolPathCommand.Execute();
-            a.ShouldThrow<GracefulException>();
+            a.Should().Throw<GracefulException>();
         }
 
         private IToolPackageInstaller GetToolToolPackageInstallerWithPreviewInFeed()
@@ -447,7 +447,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallGlobalOrToolPathCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(
                     LocalizableStrings.ToolInstallationRestoreFailed +
                     Environment.NewLine + string.Format(LocalizableStrings.ToolInstallationFailedWithRestoreGuidance, PackageId));

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallLocalCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallLocalCommandTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             var toolInstallLocalCommand = GetDefaultTestToolInstallLocalCommand();
 
             Action a = () => toolInstallLocalCommand.Execute();
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And.Message.Should()
                 .Contain(ToolManifest.LocalizableStrings.CannotFindAManifestFile);
         }
@@ -125,15 +125,15 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             var toolInstallLocalCommand = GetDefaultTestToolInstallLocalCommand();
 
             Action a = () => toolInstallLocalCommand.Execute();
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And.Message.Should()
                 .Contain(LocalizableStrings.NoManifestGuide);
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And.Message.Should()
                 .Contain(ToolManifest.LocalizableStrings.CannotFindAManifestFile);
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And.VerboseMessage.Should().Contain(string.Format(ToolManifest.LocalizableStrings.ListOfSearched, ""));
         }
 
@@ -204,7 +204,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 _reporter);
 
             Action a = () => installLocalCommand.Execute();
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And.Message.Should()
                 .Contain(LocalizableStrings.ToolInstallationRestoreFailed);
 
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             var toolInstallLocalCommand = GetDefaultTestToolInstallLocalCommand();
 
             Action a = () => toolInstallLocalCommand.Execute();
-            a.ShouldThrow<GracefulException>();
+            a.Should().Throw<GracefulException>();
 
             _localToolsResolverCache.TryLoad(new RestoredCommandIdentifier(
                     _packageIdA,

--- a/src/Tests/dotnet.Tests/CommandTests/ToolListCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolListCommandTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(string.Format(
                     LocalizableStrings.ListToolCommandInvalidGlobalAndLocalAndToolPath,
                     "global tool-path"));
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolInstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(
                     string.Format(LocalizableStrings.ListToolCommandInvalidGlobalAndLocalAndToolPath,
                         "local tool-path"));

--- a/src/Tests/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => command.Execute();
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
              .And
              .Message
              .Should()

--- a/src/Tests/dotnet.Tests/CommandTests/ToolManifestEditorTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolManifestEditorTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 manifestFile,
                 nuGetVersion.ToNormalizedString());
 
-            a.ShouldThrow<ToolManifestException>()
+            a.Should().Throw<ToolManifestException>()
                 .And.Message.Should().Contain(expectedString);
 
             _fileSystem.File.ReadAllText(manifestFile).Should().Be(_jsonContent);
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 nuGetVersion,
                 new[] {new ToolCommandName("dotnetsay")});
 
-            a.ShouldNotThrow();
+            a.Should().NotThrow();
 
             _fileSystem.File.ReadAllText(manifestFile).Should().Be(_jsonContent);
         }
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 nuGetVersion,
                 new[] {new ToolCommandName("dotnetsay")});
 
-            a.ShouldThrow<ToolManifestException>()
+            a.Should().Throw<ToolManifestException>()
                 .And.Message.Should().Contain(
                     string.Format(LocalizableStrings.InvalidManifestFilePrefix,
                         manifestFile,
@@ -181,7 +181,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             Action a = () =>
                 toolManifestFileEditor.Read(new FilePath(manifestFile), new DirectoryPath(_testDirectoryRoot));
 
-            a.ShouldNotThrow<ToolManifestException>();
+            a.Should().NotThrow<ToolManifestException>();
         }
 
         [Fact]
@@ -222,7 +222,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 new FilePath(manifestFile),
                 new PackageId("non-exist"));
 
-            a.ShouldThrow<ToolManifestException>()
+            a.Should().Throw<ToolManifestException>()
                 .And.Message.Should().Contain(string.Format(
                     LocalizableStrings.CannotFindPackageIdInManifest, "non-exist"));
 
@@ -241,7 +241,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 new FilePath(manifestFile),
                 new PackageId("dotnetsay"));
 
-            a.ShouldThrow<ToolManifestException>()
+            a.Should().Throw<ToolManifestException>()
                 .And.Message.Should().Contain(
                     string.Format(LocalizableStrings.InvalidManifestFilePrefix,
                         manifestFile,
@@ -263,7 +263,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 NuGetVersion.Parse("3.0.0"),
                 new[] {new ToolCommandName("t-rex3")});
 
-            a.ShouldThrow<ArgumentException>().And.Message.Should()
+            a.Should().Throw<ArgumentException>().And.Message.Should()
                 .Contain($"Manifest {manifestFile} does not contain package id 'non-exist'.");
         }
 

--- a/src/Tests/dotnet.Tests/CommandTests/ToolManifestFinderTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolManifestFinderTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolManifest.Find();
 
-            a.ShouldThrow<ToolManifestException>().And.Message.Should()
+            a.Should().Throw<ToolManifestException>().And.Message.Should()
                 .Contain(string.Format(string.Format(LocalizableStrings.MultipleSamePackageId,
                     string.Join(", ", "t-rex")), ""));
         }
@@ -150,10 +150,10 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     new FakeDangerousFileDetector());
 
             Action a = () => toolManifest.Find(new FilePath(Path.Combine(_testDirectoryRoot, "non-exists")));
-            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.Message.Should()
+            a.Should().Throw<ToolManifestCannotBeFoundException>().And.Message.Should()
                 .Contain(LocalizableStrings.CannotFindAManifestFile);
 
-            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
+            a.Should().Throw<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
                 .Contain(string.Format(LocalizableStrings.ListOfSearched, ""))
                 .And.Contain(
                     Path.Combine(_testDirectoryRoot, "non-exists"),
@@ -170,10 +170,10 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     new FakeDangerousFileDetector());
 
             Action a = () => toolManifest.Find();
-            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.Message.Should()
+            a.Should().Throw<ToolManifestCannotBeFoundException>().And.Message.Should()
                  .Contain(LocalizableStrings.CannotFindAManifestFile);
 
-            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
+            a.Should().Throw<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
                 .Contain(string.Format(LocalizableStrings.ListOfSearched, ""));
         }
 
@@ -189,7 +189,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolManifest.Find();
 
-            a.ShouldThrow<ToolManifestException>().And.Message.Should().Contain(
+            a.Should().Throw<ToolManifestException>().And.Message.Should().Contain(
                 string.Format(LocalizableStrings.InvalidManifestFilePrefix,
                     Path.Combine(_testDirectoryRoot, _manifestFilename),
                     "\t" + string.Format(LocalizableStrings.InPackage, "t-rex",
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolManifest.Find();
 
-            a.ShouldThrow<ToolManifestException>().And.Message.Should()
+            a.Should().Throw<ToolManifestException>().And.Message.Should()
                 .Contain(string.Format(LocalizableStrings.VersionIsInvalid, "1.*"));
         }
 
@@ -226,7 +226,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolManifest.Find();
 
-            a.ShouldThrow<ToolManifestException>()
+            a.Should().Throw<ToolManifestException>()
                 .And.Message.Should().Contain(string.Format(LocalizableStrings.UnexpectedTypeInJson, "True|False" ,"isRoot"));
         }
 
@@ -243,7 +243,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolManifest.Find();
 
-            a.ShouldThrow<ToolManifestException>();
+            a.Should().Throw<ToolManifestException>();
         }
 
         [Fact]
@@ -337,10 +337,10 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolManifest.FindByPackageId(new PackageId("t-rex"));
 
-            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.Message.Should()
+            a.Should().Throw<ToolManifestCannotBeFoundException>().And.Message.Should()
                 .Contain(LocalizableStrings.CannotFindAManifestFile);
 
-            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
+            a.Should().Throw<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
                 .Contain(string.Format(LocalizableStrings.ListOfSearched, ""));
         }
 
@@ -376,7 +376,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolManifest.Find();
 
-            a.ShouldThrow<ToolManifestException>().And.Message.Should().Contain(string.Format(
+            a.Should().Throw<ToolManifestException>().And.Message.Should().Contain(string.Format(
                             LocalizableStrings.ManifestVersionHigherThanSupported,
                             99, 1));
         }
@@ -393,7 +393,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolManifest.Find();
 
-            a.ShouldThrow<ToolManifestException>().And.Message.Should().Contain(LocalizableStrings.ManifestMissingIsRoot);
+            a.Should().Throw<ToolManifestException>().And.Message.Should().Contain(LocalizableStrings.ManifestMissingIsRoot);
         }
 
         [Fact]
@@ -477,7 +477,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     new FakeDangerousFileDetector());
 
             Action a = () => toolManifest.TryFind(new ToolCommandName("dotnetSay"), out var result);
-            a.ShouldThrow<ToolManifestException>();
+            a.Should().Throw<ToolManifestException>();
         }
 
         [Fact]
@@ -491,7 +491,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     new FakeDangerousFileDetector());
 
             Action a = () => toolManifest.TryFind(new ToolCommandName("dotnetSay"), out var result);
-            a.ShouldThrow<ToolManifestException>();
+            a.Should().Throw<ToolManifestException>();
         }
 
         [Fact]
@@ -505,7 +505,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     new FakeDangerousFileDetector());
 
             Action a = () => toolManifest.TryFind(new ToolCommandName("dotnetSay"), out var result);
-            a.ShouldThrow<ToolManifestException>();
+            a.Should().Throw<ToolManifestException>();
         }
 
         [Fact]
@@ -562,7 +562,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             var toolManifest
                 = new ToolManifestFinder(new DirectoryPath(_testDirectoryRoot), _fileSystem, fakeMarkOfTheWebDetector);
             Action a = () => toolManifest.Find();
-            a.ShouldThrow<ToolManifestException>()
+            a.Should().Throw<ToolManifestException>()
                 .And.Message
 
                 .Should().Contain(
@@ -583,7 +583,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
 
             Action a = () => toolManifest.TryFind(new ToolCommandName("dotnetsay"), out var result);
-            a.ShouldThrow<ToolManifestException>();
+            a.Should().Throw<ToolManifestException>();
         }
 
         [Fact]
@@ -629,10 +629,10 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolManifest.FindFirst();
 
-            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.Message.Should()
+            a.Should().Throw<ToolManifestCannotBeFoundException>().And.Message.Should()
                 .Contain(LocalizableStrings.CannotFindAManifestFile);
 
-            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
+            a.Should().Throw<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
                 .Contain(string.Format(LocalizableStrings.ListOfSearched, ""));
         }
 
@@ -664,7 +664,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             var testRoot = Path.Combine(_testDirectoryRoot);
             var toolManifest = new ToolManifestFinder(new DirectoryPath(testRoot), _fileSystem);
             Action a = () => toolManifest.Inspect();
-            a.ShouldNotThrow();
+            a.Should().NotThrow();
         }
 
         private string _jsonContent =

--- a/src/Tests/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
@@ -231,7 +231,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             };
 
             Action a = () => toolRestoreCommand.Execute();
-            a.ShouldThrow<ToolPackageException>()
+            a.Should().Throw<ToolPackageException>()
                 .And.Message
                 .Should().BeOneOf(allPossibleErrorMessage, "Run in parallel, no order guarantee");
         }

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolUninstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(string.Format(
                     LocalizableStrings.UninstallToolCommandInvalidGlobalAndLocalAndToolPath,
                     "global tool-path"));
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolUninstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(
                     string.Format(LocalizableStrings.UninstallToolCommandInvalidGlobalAndLocalAndToolPath,
                         "local tool-path"));
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             
             Action a = () => toolUninstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(Tools.Tool.Common.LocalizableStrings.OnlyLocalOptionSupportManifestFileOption);
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolUninstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(Tools.Tool.Common.LocalizableStrings.OnlyLocalOptionSupportManifestFileOption);
         }
     }

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUninstallGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUninstallGlobalOrToolPathCommandTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => command.Execute();
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And
                 .Message
                 .Should()
@@ -203,7 +203,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 uninstallCallback: () => throw new IOException("simulated error"))
                 .Execute();
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And
                 .Message
                 .Should()
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => uninstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And
                 .Message
                 .Should()

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUninstallLocalCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUninstallLocalCommandTests.cs
@@ -69,15 +69,15 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             _fileSystem.File.Delete(_manifestFilePath);
             Action a = () => _defaultToolUninstallLocalCommand.Execute().Should().Be(0);
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                .And.Message.Should()
                .Contain(Tools.Tool.Common.LocalizableStrings.NoManifestGuide);
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And.Message.Should()
                 .Contain(ToolManifest.LocalizableStrings.CannotFindAManifestFile);
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And.VerboseMessage.Should().Contain(string.Format(ToolManifest.LocalizableStrings.ListOfSearched, ""));
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => _defaultToolUninstallLocalCommand.Execute().Should().Be(0);
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                .And.Message.Should()
                .Contain(string.Format(LocalizableStrings.NoManifestFileContainPackageId, _packageIdDotnsay));
         }

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolUpdateCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(string.Format(
                     LocalizableStrings.UpdateToolCommandInvalidGlobalAndLocalAndToolPath,
                     "global tool-path"));
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolUpdateCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(
                     string.Format(LocalizableStrings.UpdateToolCommandInvalidGlobalAndLocalAndToolPath,
                         "local tool-path"));
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolUpdateCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(Tools.Tool.Common.LocalizableStrings.OnlyLocalOptionSupportManifestFileOption);
         }
 
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => toolUpdateCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(Tools.Tool.Common.LocalizableStrings.OnlyLocalOptionSupportManifestFileOption);
         }
     }

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => command.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(
                    Tools.Tool.Install.LocalizableStrings.ToolInstallationRestoreFailed);
         }
@@ -203,7 +203,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             Action a = () => command.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
+            a.Should().Throw<GracefulException>().And.Message
                 .Should().Contain(
                     string.Format(LocalizableStrings.UpdateToLowerVersion,
                         LowerPackageVersion,
@@ -267,7 +267,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 _reporter);
 
             Action a = () => command.Execute();
-            a.ShouldThrow<GracefulException>().And.Message.Should().Contain(
+            a.Should().Throw<GracefulException>().And.Message.Should().Contain(
                 string.Format(LocalizableStrings.UpdateToolFailed, _packageId) + Environment.NewLine +
                 string.Format(Tools.Tool.Install.LocalizableStrings.InvalidToolConfiguration, "Simulated error"));
         }

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUpdateLocalCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUpdateLocalCommandTests.cs
@@ -177,11 +177,11 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             _fileSystem.File.Delete(_manifestFilePath);
             Action a = () => _defaultToolUpdateLocalCommand.Execute().Should().Be(0);
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And.Message.Should()
                 .Contain(ToolManifest.LocalizableStrings.CannotFindAManifestFile);
 
-            a.ShouldThrow<GracefulException>()
+            a.Should().Throw<GracefulException>()
                 .And.VerboseMessage.Should().Contain(string.Format(ToolManifest.LocalizableStrings.ListOfSearched, ""));
         }
 
@@ -313,7 +313,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             _reporter.Clear();
             Action a = () => _defaultToolUpdateLocalCommand.Execute();
-            a.ShouldThrow<GracefulException>().And.Message.Should().Contain(string.Format(
+            a.Should().Throw<GracefulException>().And.Message.Should().Contain(string.Format(
                 LocalizableStrings.UpdateLocaToolToLowerVersion,
                 "0.9.0",
                 _packageOriginalVersionA.ToNormalizedString(),

--- a/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
         public void GetSubArgumentsRemovesTopLevelCommands(string[] input, string[] expected)
         {
             input.GetSubArguments()
-                .ShouldBeEquivalentTo(expected);
+                .Should().BeEquivalentTo(expected);
         }
     }
 }

--- a/src/Tests/dotnet.Tests/ParserTests/ToolSearchParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ToolSearchParserTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
         {
             var result = Parser.Instance.Parse("dotnet tool search");
             Action a = () => new ToolSearchCommand(result);
-            a.ShouldThrow<CommandParsingException>();
+            a.Should().Throw<CommandParsingException>();
         }
 
         [Fact]

--- a/src/Tests/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
 
             // Act
             new VSTestArgumentConverter().Invoking(i => i.Convert(args, out _))
-                .ShouldThrow<ArgumentException>()
+                .Should().Throw<ArgumentException>()
                 .WithMessage("Inline settings should not be passed to Convert.");
         }
 

--- a/src/Tests/dotnet.Tests/RuntimeConfigTests.cs
+++ b/src/Tests/dotnet.Tests/RuntimeConfigTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Tests
             var tempPath = GetTempPath();
             File.WriteAllText(tempPath, "");
             Action a = () => new RuntimeConfig(tempPath);
-            a.ShouldThrow<System.Text.Json.JsonException>();
+            a.Should().Throw<System.Text.Json.JsonException>();
         }
 
         [Fact]

--- a/src/Tests/dotnet.Tests/TelemetryCommandTest.cs
+++ b/src/Tests/dotnet.Tests/TelemetryCommandTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tests
         {
             string[] args = { "publish", "-r"};
             Action a = () => { Cli.Program.ProcessArgs(args); };
-            a.ShouldNotThrow<ArgumentOutOfRangeException>();
+            a.Should().NotThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tests
         {
             string[] args = { "restore", "-v" };
             Action a = () => { Cli.Program.ProcessArgs(args); };
-            a.ShouldNotThrow<ArgumentOutOfRangeException>();
+            a.Should().NotThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]

--- a/src/Tests/dotnet.Tests/ToolSearchTests/NugetSearchApiParameterTests.cs
+++ b/src/Tests/dotnet.Tests/ToolSearchTests/NugetSearchApiParameterTests.cs
@@ -19,7 +19,7 @@ namespace dotnet.Tests.ToolSearchTests
         {
             var result = Parser.Instance.Parse("dotnet tool search mytool --skip wrongtype");
             Action a = () => new NugetSearchApiParameter(result);
-            a.ShouldThrow<GracefulException>();
+            a.Should().Throw<GracefulException>();
         }
         
         [Fact]
@@ -28,7 +28,7 @@ namespace dotnet.Tests.ToolSearchTests
             var result = Parser.Instance.Parse("dotnet tool search mytool --take wrongtype");
 
             Action a = () => new NugetSearchApiParameter(result);
-            a.ShouldThrow<GracefulException>();
+            a.Should().Throw<GracefulException>();
         }
         
         [Fact]

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             MSBuildLogger.FormatAndSend(fakeTelemetry, telemetryEventArgs);
 
-            fakeTelemetry.LogEntry.Properties.ShouldBeEquivalentTo(new Dictionary<string, string>
+            fakeTelemetry.LogEntry.Properties.Should().BeEquivalentTo(new Dictionary<string, string>
                 {
                     { "TargetFrameworkVersion", "9a871d7066260764d4cb5047e4b10570271d04bd1da275681a4b12bce0b27496"},
                     { "RuntimeIdentifier", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},


### PR DESCRIPTION
Migrated to latest version of `FluentAssertions` (templating using latest)
~~Removed duplicate `TestHelper` code and referenced package from templating instead.~~  will be done in separate PR