### PR TITLE
Clean-up rules (styling) and make CompatDifference a readonly struct

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/CompatDifference.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/CompatDifference.cs
@@ -10,27 +10,21 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// <summary>
     /// Class representing a difference of compatibility, containing detailed information about it.
     /// </summary>
-    public class CompatDifference : IDiagnostic, IEquatable<CompatDifference>
+    public readonly struct CompatDifference : IDiagnostic, IEquatable<CompatDifference>
     {
-        /// <summary>
-        /// The Diagnostic ID for this difference.
-        /// </summary>
-        public string DiagnosticId { get; }
+        /// <inheritdoc />
+        public readonly string DiagnosticId { get; }
 
         /// <summary>
         /// The <see cref="DifferenceType"/>.
         /// </summary>
-        public DifferenceType Type { get; }
+        public readonly DifferenceType Type { get; }
 
-        /// <summary>
-        /// A diagnostic message for the difference.
-        /// </summary>
-        public virtual string Message { get; }
+        /// <inheritdoc />
+        public readonly string Message { get; }
 
-        /// <summary>
-        /// A unique ID in order to identify the API that the difference was raised for.
-        /// </summary>
-        public string? ReferenceId { get; }
+        /// <inheritdoc />
+        public readonly string? ReferenceId { get; }
 
         /// <summary>
         /// Instantiate a new object representing the compatibility difference.
@@ -65,13 +59,16 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// <returns><see cref="string"/> describing the difference.</returns>
         public override string ToString() => $"{DiagnosticId} : {Message}";
 
-        public bool Equals(CompatDifference? other) => other != null &&
+        /// <inheritdoc />
+        public bool Equals(CompatDifference other) =>
             DiagnosticId.Equals(other.DiagnosticId, StringComparison.InvariantCultureIgnoreCase) &&
             Type.Equals(other.Type) &&
             string.Equals(ReferenceId, other.ReferenceId, StringComparison.InvariantCultureIgnoreCase);
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => obj is CompatDifference difference && Equals(difference);
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             int hashCode = 1447485498;
@@ -84,5 +81,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
 
             return hashCode;
         }
+
+        /// <inheritdoc />
+        public static bool operator ==(CompatDifference left, CompatDifference right) => left.Equals(right);
+        
+        /// <inheritdoc />
+        public static bool operator !=(CompatDifference left, CompatDifference right) => !(left == right);
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/IDiagnostic.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/IDiagnostic.cs
@@ -14,13 +14,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         string DiagnosticId { get; }
 
         /// <summary>
-        /// String representing the ID for the object that the diagnostic was created for.
-        /// </summary>
-        string? ReferenceId { get; }
-
-        /// <summary>
-        /// String describing the diagnostic.
+        /// A diagnostic message for the difference.
         /// </summary>
         string Message { get; }
+
+        /// <summary>
+        /// A unique ID in order to identify the API that the difference was raised for.
+        /// </summary>
+        string? ReferenceId { get; }
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AssemblyIdentityMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AssemblyIdentityMustMatch.cs
@@ -23,13 +23,21 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         {
             if (left == null && right != null)
             {
-                differences.Add(new CompatDifference(DiagnosticIds.MatchingAssemblyDoesNotExist, string.Format(Resources.AssemblyNameDoesNotExist, leftName, right.Identity.Name), DifferenceType.Removed, right.Identity.GetDisplayName()));
+                differences.Add(new CompatDifference(
+                    DiagnosticIds.MatchingAssemblyDoesNotExist,
+                    string.Format(Resources.AssemblyNameDoesNotExist, leftName, right.Identity.Name),
+                    DifferenceType.Removed,
+                    right.Identity.GetDisplayName()));
                 return;
             }
 
             if (left != null && right == null)
             {
-                differences.Add(new CompatDifference(DiagnosticIds.MatchingAssemblyDoesNotExist, string.Format(Resources.AssemblyNameDoesNotExist, rightName, left.Identity.Name), DifferenceType.Added, left.Identity.GetDisplayName()));
+                differences.Add(new CompatDifference(
+                    DiagnosticIds.MatchingAssemblyDoesNotExist,
+                    string.Format(Resources.AssemblyNameDoesNotExist, rightName, left.Identity.Name),
+                    DifferenceType.Added,
+                    left.Identity.GetDisplayName()));
                 return;
             }
 
@@ -49,21 +57,45 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
             if (leftAssemblyName != rightAssemblyName)
             {
-                differences.Add(CreateIdentityDifference(Resources.AssemblyNameDoesNotMatch, leftAssemblyName, rightAssemblyName, leftName, rightName, rightIdentity));
+                differences.Add(CreateIdentityDifference(
+                    Resources.AssemblyNameDoesNotMatch,
+                    leftAssemblyName,
+                    rightAssemblyName,
+                    leftName,
+                    rightName,
+                    rightIdentity));
             }
 
             if (leftAssemblyCulture != rightAssemblyCulture)
             {
-                differences.Add(CreateIdentityDifference(Resources.AssembyCultureDoesNotMatch, leftAssemblyCulture, rightAssemblyCulture, leftName, rightName, rightIdentity));
+                differences.Add(CreateIdentityDifference(
+                    Resources.AssembyCultureDoesNotMatch,
+                    leftAssemblyCulture,
+                    rightAssemblyCulture,
+                    leftName,
+                    rightName,
+                    rightIdentity));
             }
  
             if (rightAssemblyVersion < leftAssemblyVersion)
             {
-                differences.Add(CreateIdentityDifference(Resources.AssembyVersionIsNotCompatible, rightAssemblyVersion.ToString(), leftAssemblyVersion.ToString(), rightName, leftName, rightIdentity));
+                differences.Add(CreateIdentityDifference(
+                    Resources.AssembyVersionIsNotCompatible,
+                    rightAssemblyVersion.ToString(),
+                    leftAssemblyVersion.ToString(),
+                    rightName,
+                    leftName,
+                    rightIdentity));
             }
             else if (_settings.StrictMode && leftAssemblyVersion < rightAssemblyVersion)
             {
-                differences.Add(CreateIdentityDifference(Resources.AssembyVersionDoesNotMatch, leftAssemblyVersion.ToString(), rightAssemblyVersion.ToString(), leftName, rightName, leftIdentity));
+                differences.Add(CreateIdentityDifference(
+                    Resources.AssembyVersionDoesNotMatch,
+                    leftAssemblyVersion.ToString(),
+                    rightAssemblyVersion.ToString(),
+                    leftName,
+                    rightName,
+                    leftIdentity));
             }
 
             if (!leftAssemblyPublicKeyToken.IsEmpty && !leftIdentity.IsRetargetable && !leftAssemblyPublicKeyToken.SequenceEqual(rightAssemblyPublicKeyToken))
@@ -102,6 +134,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         }
 
         private static CompatDifference CreateIdentityDifference(string format, string leftProperty, string rightProperty, string leftName, string rightName, AssemblyIdentity identity) =>
-            new(DiagnosticIds.AssemblyIdentityMustMatch, string.Format(format, leftProperty, rightProperty, leftName, rightName), DifferenceType.Changed, identity.GetDisplayName());
+            new(DiagnosticIds.AssemblyIdentityMustMatch,
+                string.Format(format, leftProperty, rightProperty, leftName, rightName),
+                DifferenceType.Changed,
+                identity.GetDisplayName());
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddAbstractMember.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddAbstractMember.cs
@@ -35,7 +35,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 // checking for member additions on interfaces is checked on its own rule.
                 if (leftContainingType.TypeKind != TypeKind.Interface && !leftContainingType.IsEffectivelySealed(_settings.IncludeInternalSymbols))
                 {
-                    differences.Add(new CompatDifference(DiagnosticIds.CannotAddAbstractMember, string.Format(Resources.CannotAddAbstractMember, right.ToDisplayString(), rightName, leftName), DifferenceType.Added, right));
+                    differences.Add(new CompatDifference(
+                        DiagnosticIds.CannotAddAbstractMember,
+                        string.Format(Resources.CannotAddAbstractMember, right.ToDisplayString(), rightName, leftName),
+                        DifferenceType.Added,
+                        right));
                 }
             }
         }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     {
         public CannotAddMemberToInterface(RuleSettings settings, RuleRunnerContext context)
         {
-            // StrictMode scenario should be handled by MembersMustExist rule.
+            // StrictMode scenario are handled by the MembersMustExist rule.
             if (!settings.StrictMode)
             {
                 context.RegisterOnMemberSymbolAction(RunOnMemberSymbol);
@@ -34,7 +34,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 // If there is a default implementation provided is not a breaking change to add an interface member.
                 if (right.ContainingType.FindImplementationForInterfaceMember(right) == null)
                 {
-                    differences.Add(new CompatDifference(DiagnosticIds.CannotAddMemberToInterface, string.Format(Resources.CannotAddMemberToInterface, right.ToDisplayString(), rightName, leftName), DifferenceType.Added, right));
+                    differences.Add(new CompatDifference(
+                        DiagnosticIds.CannotAddMemberToInterface,
+                        string.Format(Resources.CannotAddMemberToInterface, right.ToDisplayString(), rightName, leftName),
+                        DifferenceType.Added,
+                        right));
                 }
             }
         }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddOrRemoveVirtualKeyword.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddOrRemoveVirtualKeyword.cs
@@ -43,8 +43,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 if (!right.IsVirtual)
                 {
                     differences.Add(new CompatDifference(
-                    DiagnosticIds.CannotRemoveVirtualFromMember, string.Format(
-                        Resources.CannotRemoveVirtualFromMember, left), DifferenceType.Removed, right));
+                        DiagnosticIds.CannotRemoveVirtualFromMember,
+                        string.Format(Resources.CannotRemoveVirtualFromMember, left),
+                        DifferenceType.Removed,
+                        right));
                 }
             }
             // If the left member is not virtual, ensure that we're in strict mode.
@@ -57,8 +59,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 if (right.IsVirtual)
                 {
                     differences.Add(new CompatDifference(
-                    DiagnosticIds.CannotAddVirtualToMember, string.Format(
-                        Resources.CannotAddVirtualToMember, right), DifferenceType.Added, right));
+                        DiagnosticIds.CannotAddVirtualToMember,
+                        string.Format(Resources.CannotAddVirtualToMember, right),
+                        DifferenceType.Added,
+                        right));
                 }
             }
         }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotSealType.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotSealType.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
 using Microsoft.DotNet.ApiCompatibility.Extensions;
@@ -29,19 +28,23 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
             if (!isLeftSealed && isRightSealed)
             {
-                differences.Add(CreateDifference(right, leftName, rightName));
+                differences.Add(new CompatDifference(
+                    DiagnosticIds.CannotSealType,
+                    string.Format(GetResourceStringForTypeState(right), right.ToDisplayString(), rightName, leftName),
+                    DifferenceType.Changed,
+                    right));
             }
             else if (_settings.StrictMode && !isRightSealed && isLeftSealed)
             {
-                differences.Add(CreateDifference(left, rightName, leftName));
+                differences.Add(new CompatDifference(
+                    DiagnosticIds.CannotSealType,
+                    string.Format(GetResourceStringForTypeState(left), left.ToDisplayString(), leftName, rightName),
+                    DifferenceType.Changed,
+                    left));
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private CompatDifference CreateDifference(ISymbol symbol, string leftName, string rightName) =>
-            new(DiagnosticIds.CannotSealType,
-                string.Format(symbol.IsSealed ? Resources.TypeIsActuallySealed : Resources.TypeIsEffectivelySealed, symbol.ToDisplayString(), rightName, leftName),
-                DifferenceType.Changed,
-                symbol);
+        private static string GetResourceStringForTypeState(ISymbol symbol) =>
+            symbol.IsSealed ? Resources.TypeIsActuallySealed : Resources.TypeIsEffectivelySealed;
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/EnumsMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/EnumsMustMatch.cs
@@ -41,40 +41,45 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 return;
             }
 
-            // Check that the underlying types are equal.
-            if (_settings.SymbolComparer.Equals(leftType, rightType))
+            // Check that the underlying types are equal and if not, emit a diagnostic.
+            if (!_settings.SymbolComparer.Equals(leftType, rightType))
             {
-                // If so, compare their fields.
-                // Build a map of the enum's fields, keyed by the field names.
-                Dictionary<string, IFieldSymbol> leftMembers = left.GetMembers()
-                    .Where(a => a.Kind == SymbolKind.Field)
-                    .Select(a => (IFieldSymbol)a)
-                    .ToDictionary(a => a.Name);
-                Dictionary<string, IFieldSymbol> rightMembers = right.GetMembers()
-                    .Where(a => a.Kind == SymbolKind.Field)
-                    .Select(a => (IFieldSymbol)a)
-                    .ToDictionary(a => a.Name);
-
-                // For each field that is present in the left and right, check that their constant values match.
-                // Otherwise, emit a diagnostic.
-                foreach (KeyValuePair<string, IFieldSymbol> lEntry in leftMembers)
-                {
-                    if (!rightMembers.TryGetValue(lEntry.Key, out IFieldSymbol? rField))
-                    {
-                        continue;
-                    }
-                    if (lEntry.Value.ConstantValue is not object lval || rField.ConstantValue is not object rval || !lval.Equals(rval))
-                    {
-                        string msg = string.Format(Resources.EnumValuesMustMatch, left.Name, lEntry.Key, lEntry.Value.ConstantValue, rField.ConstantValue);
-                        differences.Add(new CompatDifference(DiagnosticIds.EnumValuesMustMatch, msg, DifferenceType.Changed, rField));
-                    }
-                }
+                differences.Add(new CompatDifference(
+                    DiagnosticIds.EnumTypesMustMatch,
+                    string.Format(Resources.EnumTypesMustMatch, left.Name, leftType, rightType),
+                    DifferenceType.Changed,
+                    right));
+                return;
             }
-            else
+
+            // If so, compare their fields.
+            // Build a map of the enum's fields, keyed by the field names.
+            Dictionary<string, IFieldSymbol> leftMembers = left.GetMembers()
+                .Where(a => a.Kind == SymbolKind.Field)
+                .Select(a => (IFieldSymbol)a)
+                .ToDictionary(a => a.Name);
+            Dictionary<string, IFieldSymbol> rightMembers = right.GetMembers()
+                .Where(a => a.Kind == SymbolKind.Field)
+                .Select(a => (IFieldSymbol)a)
+                .ToDictionary(a => a.Name);
+
+            // For each field that is present in the left and right, check that their constant values match.
+            // Otherwise, emit a diagnostic.
+            foreach (KeyValuePair<string, IFieldSymbol> lEntry in leftMembers)
             {
-                // Otherwise, emit a diagnostic.
-                string msg = string.Format(Resources.EnumTypesMustMatch, left.Name, leftType, rightType);
-                differences.Add(new CompatDifference(DiagnosticIds.EnumTypesMustMatch, msg, DifferenceType.Changed, right));
+                if (!rightMembers.TryGetValue(lEntry.Key, out IFieldSymbol? rField))
+                {
+                    continue;
+                }
+
+                if (lEntry.Value.ConstantValue is not object lval || rField.ConstantValue is not object rval || !lval.Equals(rval))
+                {
+                    differences.Add(new CompatDifference(
+                        DiagnosticIds.EnumValuesMustMatch,
+                        string.Format(Resources.EnumValuesMustMatch, left.Name, lEntry.Key, lEntry.Value.ConstantValue, rField.ConstantValue),
+                        DifferenceType.Changed,
+                        rField));
+                }
             }
         }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
 using Microsoft.DotNet.ApiCompatibility.Extensions;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
@@ -33,11 +32,19 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         {
             if (left != null && right == null)
             {
-                differences.Add(CreateDifference(left, DiagnosticIds.TypeMustExist, DifferenceType.Removed, Resources.TypeExistsOnLeft, leftName, rightName));
+                differences.Add(new CompatDifference(
+                    DiagnosticIds.TypeMustExist,
+                    string.Format(Resources.TypeExistsOnLeft, left.ToDisplayString(), leftName, rightName),
+                    DifferenceType.Removed,
+                    left));
             }
             else if (_settings.StrictMode && left == null && right != null)
             {
-                differences.Add(CreateDifference(right, DiagnosticIds.TypeMustExist, DifferenceType.Added, Resources.TypeExistsOnRight, leftName, rightName));
+                differences.Add(new CompatDifference(
+                    DiagnosticIds.TypeMustExist,
+                    string.Format(Resources.TypeExistsOnRight, right.ToDisplayString(), leftName, rightName),
+                    DifferenceType.Added,
+                    right));
             }
         }
 
@@ -52,21 +59,25 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             {
                 if (ShouldReportMissingMember(left, rightContainingType))
                 {
-                    differences.Add(CreateDifference(left, DiagnosticIds.MemberMustExist, DifferenceType.Removed, Resources.MemberExistsOnLeft, leftName, rightName));
+                    differences.Add(new CompatDifference(
+                        DiagnosticIds.MemberMustExist,
+                        string.Format(Resources.MemberExistsOnLeft, left.ToDisplayString(), leftName, rightName),
+                        DifferenceType.Removed,
+                        left));
                 }
             }
             else if (_settings.StrictMode && left == null && right != null)
             {
                 if (ShouldReportMissingMember(right, leftContainingType))
                 {
-                    differences.Add(CreateDifference(right, DiagnosticIds.MemberMustExist, DifferenceType.Added, Resources.MemberExistsOnRight, leftName, rightName));
+                    differences.Add(new CompatDifference(
+                        DiagnosticIds.MemberMustExist,
+                        string.Format(Resources.MemberExistsOnRight, right.ToDisplayString(), leftName, rightName),
+                        DifferenceType.Added,
+                        right));
                 }
             }
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static CompatDifference CreateDifference(ISymbol symbol, string id, DifferenceType type, string format, string leftName, string rightName) =>
-            new(id, string.Format(format, symbol.ToDisplayString(), leftName, rightName), type, symbol);
 
         private static bool ShouldReportMissingMember(ISymbol symbol, ITypeSymbol containingType)
         {

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -71,6 +71,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                             differences);
                     }
                 }
+                else
+                {
+                    throw new ArgumentOutOfRangeException(nameof(mapper));
+                }
 
                 result[rightIndex] = differences;
             }


### PR DESCRIPTION
@smasher164 this addresses the styling nits that we talked about on Friday in the existing rules. No behavioral changes.