### PR TITLE
Corresponding PublishAOT changes to match the runtime cleanup changes

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -99,10 +99,10 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] Crossgen2Packs { get; set; }
 
         [Output]
-        public ITaskItem[] ILCompilerPacks { get; set; }
+        public ITaskItem[] HostILCompilerPacks { get; set; }
 
         [Output]
-        public ITaskItem[] ILCompilerPacks2 { get; set; }
+        public ITaskItem[] TargetILCompilerPacks { get; set; }
 
         //  Runtime packs which aren't available for the specified RuntimeIdentifier
         [Output]
@@ -620,20 +620,28 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                ILCompilerPacks = new[] { newItem };
+                HostILCompilerPacks = new[] { newItem };
                 // ILCompiler supports cross target compilation. If there is a cross-target request, we need to download that package as well
-                var targetsRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, RuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph2);
-                if (!hostRuntimeIdentifier.Equals(targetsRuntimeIdentifier))
+                // We expect RuntimeIdentifier to be defined during publish but can allow during build
+                if (RuntimeIdentifier != null)
                 {
-                    var runtimeIlcPackName = packPattern.Replace("**RID**", targetsRuntimeIdentifier);
-                    TaskItem runtime2PackToDownload = new TaskItem(runtimeIlcPackName);
-                    runtime2PackToDownload.SetMetadata(MetadataKeys.Version, packVersion);
-                    packagesToDownload.Add(runtime2PackToDownload);
+                    var targetsRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, RuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph2);
+                    if (targetsRuntimeIdentifier == null)
+                    {
+                        return false;
+                    }
+                    if (!hostRuntimeIdentifier.Equals(targetsRuntimeIdentifier))
+                    {
+                        var runtimeIlcPackName = packPattern.Replace("**RID**", targetsRuntimeIdentifier);
+                        TaskItem runtime2PackToDownload = new TaskItem(runtimeIlcPackName);
+                        runtime2PackToDownload.SetMetadata(MetadataKeys.Version, packVersion);
+                        packagesToDownload.Add(runtime2PackToDownload);
 
-                    var newItem2 = new TaskItem(runtimeIlcPackName);
-                    newItem2.SetMetadata(MetadataKeys.NuGetPackageId, runtimeIlcPackName);
-                    newItem2.SetMetadata(MetadataKeys.NuGetPackageVersion, packVersion);
-                    ILCompilerPacks2 = new[] { newItem2 };
+                        var newItem2 = new TaskItem(runtimeIlcPackName);
+                        newItem2.SetMetadata(MetadataKeys.NuGetPackageId, runtimeIlcPackName);
+                        newItem2.SetMetadata(MetadataKeys.NuGetPackageVersion, packVersion);
+                        TargetILCompilerPacks = new[] { newItem2 };
+                    }
                 }
             }            
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -625,17 +625,17 @@ namespace Microsoft.NET.Build.Tasks
                 // We expect RuntimeIdentifier to be defined during publish but can allow during build
                 if (RuntimeIdentifier != null)
                 {
-                    var targetsRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, RuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph2);
-                    if (targetsRuntimeIdentifier == null)
+                    var targetRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, RuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph2);
+                    if (targetRuntimeIdentifier == null)
                     {
                         return false;
                     }
                     if (!hostRuntimeIdentifier.Equals(targetRuntimeIdentifier))
                     {
-                        var runtimeIlcPackName = packPattern.Replace("**RID**", targetsRuntimeIdentifier);
-                        TaskItem runtime2PackToDownload = new TaskItem(runtimeIlcPackName);
-                        runtime2PackToDownload.SetMetadata(MetadataKeys.Version, packVersion);
-                        packagesToDownload.Add(runtime2PackToDownload);
+                        var runtimeIlcPackName = packPattern.Replace("**RID**", targetRuntimeIdentifier);
+                        TaskItem targetIlcPackToDownload = new TaskItem(runtimeIlcPackName);
+                        targetIlcPackToDownload.SetMetadata(MetadataKeys.Version, packVersion);
+                        packagesToDownload.Add(targetIlcPackToDownload);
 
                         var newItem2 = new TaskItem(runtimeIlcPackName);
                         newItem2.SetMetadata(MetadataKeys.NuGetPackageId, runtimeIlcPackName);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -630,7 +630,7 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         return false;
                     }
-                    if (!hostRuntimeIdentifier.Equals(targetsRuntimeIdentifier))
+                    if (!hostRuntimeIdentifier.Equals(targetRuntimeIdentifier))
                     {
                         var runtimeIlcPackName = packPattern.Replace("**RID**", targetsRuntimeIdentifier);
                         TaskItem runtime2PackToDownload = new TaskItem(runtimeIlcPackName);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -120,8 +120,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="TargetingPacks" ItemName="TargetingPack" />
       <Output TaskParameter="RuntimePacks" ItemName="RuntimePack" />
       <Output TaskParameter="Crossgen2Packs" ItemName="Crossgen2Pack" />
-      <Output TaskParameter="ILCompilerPacks" ItemName="ILCompilerPack" />
-      <Output TaskParameter="ILCompilerPacks2" ItemName="ILCompilerPack2" />
+      <Output TaskParameter="HostILCompilerPacks" ItemName="HostILCompilerPack" />
+      <Output TaskParameter="TargetILCompilerPacks" ItemName="TargetILCompilerPack" />
       <Output TaskParameter="UnavailableRuntimePacks" ItemName="UnavailableRuntimePack" />
 
     </ProcessFrameworkReferences>
@@ -253,17 +253,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetPackageDirectory>
 
     <GetPackageDirectory
-      Items="@(ILCompilerPack)"
+      Items="@(HostILCompilerPack)"
       PackageFolders="@(AssetsFilePackageFolder)">
 
       <Output TaskParameter="Output" ItemName="ResolvedILCompilerPack" />
     </GetPackageDirectory>
 
     <GetPackageDirectory
-      Items="@(ILCompilerPack2)"
+      Items="@(TargetILCompilerPack)"
       PackageFolders="@(AssetsFilePackageFolder)">
 
-      <Output TaskParameter="Output" ItemName="ResolvedILCompilerPack2" />
+      <Output TaskParameter="Output" ItemName="ResolvedTargetILCompilerPack" />
     </GetPackageDirectory>
 
     <GetPackageDirectory

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -121,6 +121,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="RuntimePacks" ItemName="RuntimePack" />
       <Output TaskParameter="Crossgen2Packs" ItemName="Crossgen2Pack" />
       <Output TaskParameter="ILCompilerPacks" ItemName="ILCompilerPack" />
+      <Output TaskParameter="ILCompilerPacks2" ItemName="ILCompilerPack2" />
       <Output TaskParameter="UnavailableRuntimePacks" ItemName="UnavailableRuntimePack" />
 
     </ProcessFrameworkReferences>
@@ -257,7 +258,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <Output TaskParameter="Output" ItemName="ResolvedILCompilerPack" />
     </GetPackageDirectory>
-    
+
+    <GetPackageDirectory
+      Items="@(ILCompilerPack2)"
+      PackageFolders="@(AssetsFilePackageFolder)">
+
+      <Output TaskParameter="Output" ItemName="ResolvedILCompilerPack2" />
+    </GetPackageDirectory>
+
     <GetPackageDirectory
       Items="@(PackAsToolShimAppHostPack)"
       PackageFolders="@(AssetsFilePackageFolder)">

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -82,7 +82,7 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void NativeAot_hw_runs_with_no_warnings_when_PublishAot_is_false(string targetFramework)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 var projectName = "HellowWorldNativeAotApp";
                 var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
@@ -100,8 +100,7 @@ namespace Microsoft.NET.Publish.Tests
                     .And.NotHaveStdErrContaining("warning");
 
                 var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
-                var sharedLibSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" : ".so";
-                var publishedDll = Path.Combine(publishDirectory, $"{projectName}{sharedLibSuffix}");
+                var publishedDll = Path.Combine(publishDirectory, $"{projectName}.dll");
                 var publishedExe = Path.Combine(publishDirectory, $"{testProject.Name}{Constants.ExeSuffix}");
 
                 // PublishAot=false will be a normal publish

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -280,7 +280,6 @@ namespace Microsoft.NET.Publish.Tests
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                    testProject.AdditionalProperties["StripSymbols"] = "true";
-                   testProject.AdditionalProperties["ObjCopyName"] = "objcopy";
                 }
                 var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -328,7 +327,6 @@ namespace Microsoft.NET.Publish.Tests
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     testProject.AdditionalProperties["StripSymbols"] = "true";
-                    testProject.AdditionalProperties["ObjCopyName"] = "objcopy";
                 }
                 var testAsset = _testAssetsManager.CreateTestProject(testProject);
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -80,6 +80,41 @@ namespace Microsoft.NET.Publish.Tests
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void NativeAot_hw_runs_with_no_warnings_when_PublishAot_is_false(string targetFramework)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var projectName = "HellowWorldNativeAotApp";
+                var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+                var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
+                testProject.AdditionalProperties["PublishAot"] = "false";
+                var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                publishCommand
+                    .Execute($"/p:RuntimeIdentifier={rid}")
+                    .Should().Pass()
+                    .And.NotHaveStdOutContaining("IL2026")
+                    .And.NotHaveStdErrContaining("NETSDK1179")
+                    .And.NotHaveStdErrContaining("warning");
+
+                var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+                var sharedLibSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" : ".so";
+                var publishedDll = Path.Combine(publishDirectory, $"{projectName}{sharedLibSuffix}");
+                var publishedExe = Path.Combine(publishDirectory, $"{testProject.Name}{Constants.ExeSuffix}");
+
+                // PublishAot=false will be a normal publish
+                File.Exists(publishedDll).Should().BeTrue();
+
+                var command = new RunExeCommand(Log, publishedExe)
+                    .Execute().Should().Pass()
+                    .And.HaveStdOutContaining("Hello World");
+            }
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void NativeAot_app_runs_in_debug_with_no_config_when_PublishAot_is_enabled(string targetFramework)
         {
             // NativeAOT application publish directory should not contain any <App>.deps.json or <App>.runtimeconfig.json
@@ -271,6 +306,103 @@ namespace Microsoft.NET.Publish.Tests
                 var command = new RunExeCommand(Log, publishedExe)
                     .Execute().Should().Pass()
                     .And.HaveStdOutContaining("Hello World");
+            }
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void NativeAot_hw_runs_with_PackageReference_PublishAot_is_empty(string targetFramework)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var projectName = "HellowWorldNativeAotApp";
+                var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+                var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
+
+                // This will add a reference to a package that will also be automatically imported by the SDK
+                testProject.PackageReferences.Add(new TestPackageReference("Microsoft.DotNet.ILCompiler", "7.0.0-*"));
+
+                // Linux symbol files are embedded and require additional steps to be stripped to a separate file
+                // assumes /bin (or /usr/bin) are in the PATH
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    testProject.AdditionalProperties["StripSymbols"] = "true";
+                    testProject.AdditionalProperties["ObjCopyName"] = "objcopy";
+                }
+                var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                publishCommand
+                    .Execute($"/p:RuntimeIdentifier={rid}")
+                    .Should().Pass();
+
+                var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+                var sharedLibSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" : ".so";
+                var publishedDll = Path.Combine(publishDirectory, $"{projectName}{sharedLibSuffix}");
+                var publishedExe = Path.Combine(publishDirectory, $"{testProject.Name}{Constants.ExeSuffix}");
+                var symbolSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".pdb" : ".dbg";
+                var publishedDebugFile = Path.Combine(publishDirectory, $"{testProject.Name}{symbolSuffix}");
+
+                // NativeAOT published dir should not contain a non-host stand alone package
+                File.Exists(publishedDll).Should().BeFalse();
+                // The exe exist and should be native
+                File.Exists(publishedExe).Should().BeTrue();
+                File.Exists(publishedDebugFile).Should().BeTrue();
+                IsNativeImage(publishedExe).Should().BeTrue();
+
+                var command = new RunExeCommand(Log, publishedExe)
+                    .Execute().Should().Pass()
+                    .And.HaveStdOutContaining("Hello World");
+            }
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void NativeAot_hw_runs_with_cross_PackageReference_PublishAot_is_enabled(string targetFramework)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && (RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.X64))
+            {
+                var projectName = "HellowWorldNativeAotApp";
+                var rid = "win-arm64";
+
+                var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
+                testProject.AdditionalProperties["PublishAot"] = "true";
+
+                // This will add a reference to a package that will also be automatically imported by the SDK
+                testProject.PackageReferences.Add(new TestPackageReference("Microsoft.DotNet.ILCompiler", "7.0.0-*"));
+                testProject.PackageReferences.Add(new TestPackageReference("runtime.win-x64.Microsoft.DotNet.ILCompiler", "7.0.0-*"));
+
+                var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                publishCommand
+                    .Execute($"/p:RuntimeIdentifier={rid}")
+                    .Should().Pass();
+            }
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void NativeAot_hw_runs_with_cross_PackageReference_PublishAot_is_empty(string targetFramework)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && (RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.X64))
+            {
+                var projectName = "HellowWorldNativeAotApp";
+                var rid = "win-arm64";
+
+                var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
+
+                // This will add a reference to a package that will also be automatically imported by the SDK
+                testProject.PackageReferences.Add(new TestPackageReference("Microsoft.DotNet.ILCompiler", "7.0.0-*"));
+                testProject.PackageReferences.Add(new TestPackageReference("runtime.win-x64.Microsoft.DotNet.ILCompiler", "7.0.0-*"));
+
+                var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                publishCommand
+                    .Execute($"/p:RuntimeIdentifier={rid}")
+                    .Should().Pass();
             }
         }
 


### PR DESCRIPTION
Supporting `PublishAOT` scenarios as described in https://github.com/dotnet/runtime/issues/72415 specifically, in the comments [here](https://github.com/dotnet/runtime/issues/72415#issuecomment-1205540035).