### PR TITLE
Handle InvalidDataException when trying to write to cache and then read

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -469,6 +469,10 @@ namespace Microsoft.NET.Build.Tasks
                     // for the same project configured with the same intermediate directory. This can
                     // (for example) happen when design-time builds and real builds overlap.
                     //
+                    // There can be the case that two ore more projects have a project reference to a common
+                    // project through symbolic links with different paths.
+                    // https://github.com/dotnet/sdk/issues/22538
+                    //
                     // If there is an I/O error, then we fall back to the same in-memory approach below
                     // as when DisablePackageAssetsCache is set to true.
                     try
@@ -476,6 +480,7 @@ namespace Microsoft.NET.Build.Tasks
                         _reader = CreateReaderFromDisk(task, settingsHash);
                     }
                     catch (IOException) { }
+                    catch (InvalidDataException) { }
                     catch (UnauthorizedAccessException) { }
                 }
 


### PR DESCRIPTION
Based on the description provided in [#22538](https://github.com/dotnet/sdk/issues/22538)
It seems like : 
1 ) race condition specifically is on the second read of the cache file. 
2) On first read the cache file, the exception is caught.
3) Then the cache file is written to disk and the re-read from disk. 
4) If that 2nd read fails, the exception is not caught and fails the build.

After a code review we can see that `CreateReaderFromMemory()` can throw the exception `InvalidDataException`, which is not handled, when reader == null and `CanWriteToCacheFile` is true.

The change:
Catch the exception `InvalidDataException` in `CacheReader.ctor` so that we can try to execute again `CreateReaderFromMemory()` when `_reader == null`

What this change is saying: "If we fail to read from cache file in the second try due to Invalid data, then continue and use the memory cache".
Probably this is hiding an issue, and it would be good log it somewhere.

---------------------------
Note:
If handling the exception is not enough, then we can implement to retry N number of times before throwing an exception.

