### PR TITLE
Port pre-download changes into the 6.0.4xx branch

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -23,3 +23,6 @@ REM call dotnet new so the first run message doesn't interfere with the first te
 dotnet new
 REM avoid potetial cocurrency issues when nuget is creating nuget.config
 dotnet nuget list source
+REM We downloaded a special zip of files to the .nuget folder so add that as a source
+dotnet nuget add source %DOTNET_ROOT%\.nuget
+dir /B %DOTNET_ROOT%\.nuget

--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -20,7 +20,7 @@ mkdir %TestExecutionDirectory%
 robocopy %HELIX_CORRELATION_PAYLOAD%\t\TestExecutionDirectoryFiles %TestExecutionDirectory%
 
 REM call dotnet new so the first run message doesn't interfere with the first test
-dotnet new
+dotnet new --debug:ephemeral-hive
 REM avoid potetial cocurrency issues when nuget is creating nuget.config
 dotnet nuget list source
 REM We downloaded a special zip of files to the .nuget folder so add that as a source

--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -24,5 +24,5 @@ dotnet new
 REM avoid potetial cocurrency issues when nuget is creating nuget.config
 dotnet nuget list source
 REM We downloaded a special zip of files to the .nuget folder so add that as a source
-dotnet nuget add source %DOTNET_ROOT%\.nuget
-dir /B %DOTNET_ROOT%\.nuget
+dotnet new nugetconfig
+dotnet nuget add source %DOTNET_ROOT%\.nuget --configfile nuget.config

--- a/src/Tests/UnitTests.proj
+++ b/src/Tests/UnitTests.proj
@@ -107,6 +107,17 @@
         <Destination>r</Destination>
       </HelixCorrelationPayload>
 
+      <HelixCorrelationPayload Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="SDKTestPackages.System.zip">
+        <PayloadDirectory>$(TestDotnetRoot)</PayloadDirectory>
+        <Destination>d\.nuget</Destination>
+        <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestPackages.System.zip</Uri>
+      </HelixCorrelationPayload>
+
+      <HelixCorrelationPayload Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="SDKTestPackages.Runtime.zip">
+        <PayloadDirectory>$(TestDotnetRoot)</PayloadDirectory>
+        <Destination>d\.nuget</Destination>
+        <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestPackages.Runtime.zip</Uri>
+      </HelixCorrelationPayload>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
We're seeing time-outs in our internal codeflow PRs to the 6.0 branches. Our timeouts mostly went away in main after this set of changes so let's try porting these downlevel to see if that helps as well.