### PR TITLE
Support directories and globs as lefts and rights

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
@@ -36,17 +36,6 @@ namespace Microsoft.DotNet.ApiCompat
 
     internal static class ValidateAssemblies
     {
-        // The set of extensions that we probe for if a directory path is passed in as a left or right.
-        private static readonly string[] s_probingExtensions =
-        {
-            ".dll",
-            ".ildll",
-            ".ni.dll",
-            ".winmd",
-            ".exe",
-            ".ilexe"
-        };
-
         public static void Run(Func<ISuppressionEngine, ICompatibilityLogger> logFactory,
             bool generateSuppressionFile,
             string? suppressionFile,
@@ -157,15 +146,7 @@ namespace Microsoft.DotNet.ApiCompat
             // Check if the given path is a directory
             if (Directory.Exists(path))
             {
-                List<string> files = new();
-                // Probe for a set of file extensions
-                foreach (string probingExtension in s_probingExtensions)
-                {
-                    string searchPattern = "*" + probingExtension;
-                    files.AddRange(Directory.EnumerateFiles(path, searchPattern));
-                }
-
-                return files;
+                return Directory.EnumerateFiles(path, "*.dll");
             }
             // If the path isn't a directory, see if it's a glob expression.
             else

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
@@ -151,26 +151,24 @@ namespace Microsoft.DotNet.ApiCompat
             {
                 return Directory.EnumerateFiles(path, "*.dll");
             }
+
             // If the path isn't a directory, see if it's a glob expression.
-            else
-            {
-                string filename = Path.GetFileName(path);
+            string filename = Path.GetFileName(path);
 #if NETCOREAPP
-                if (filename.Contains('*'))
+            if (filename.Contains('*'))
 #else
-                if (filename.Contains("*"))
+            if (filename.Contains("*"))
 #endif
+            {
+                string? directoryName = Path.GetDirectoryName(path);
+                if (directoryName != null)
                 {
-                    string? directoryName = Path.GetDirectoryName(path);
-                    if (directoryName != null)
+                    try
                     {
-                        try
-                        {
-                            return Directory.EnumerateFiles(directoryName, filename);
-                        }
-                        catch (ArgumentException)
-                        {
-                        }
+                        return Directory.EnumerateFiles(directoryName, filename);
+                    }
+                    catch (ArgumentException)
+                    {
                     }
                 }
             }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
@@ -73,8 +73,8 @@ namespace Microsoft.DotNet.ApiCompat
 
                 for (int i = 0; i < leftAssemblies.Length; i++)
                 {
-                    IEnumerable<MetadataInformation> leftMetadataInformation = GetMetadataInformation(leftAssemblies[i], GetAssemblyReferences(leftAssembliesReferences, i), leftAssembliesStringTransformer);
-                    IEnumerable<MetadataInformation> rightMetadataInformation = GetMetadataInformation(rightAssemblies[i], GetAssemblyReferences(rightAssembliesReferences, i), rightAssembliesStringTransformer);
+                    IReadOnlyList<MetadataInformation> leftMetadataInformation = GetMetadataInformation(leftAssemblies[i], GetAssemblyReferences(leftAssembliesReferences, i), leftAssembliesStringTransformer);
+                    IReadOnlyList<MetadataInformation> rightMetadataInformation = GetMetadataInformation(rightAssemblies[i], GetAssemblyReferences(rightAssembliesReferences, i), rightAssembliesStringTransformer);
 
                     // Enqueue the work item
                     ApiCompatRunnerWorkItem workItem = new(leftMetadataInformation, apiCompatOptions, rightMetadataInformation);
@@ -127,18 +127,21 @@ namespace Microsoft.DotNet.ApiCompat
             return assemblyReferences[0];
         }
 
-        private static IEnumerable<MetadataInformation> GetMetadataInformation(string path,
+        private static IReadOnlyList<MetadataInformation> GetMetadataInformation(string path,
             IEnumerable<string>? assemblyReferences,
             RegexStringTransformer? regexStringTransformer)
         {
+            List<MetadataInformation> metadataInformation = new();
             foreach (string assembly in GetFilesFromPath(path))
             {
-                yield return new MetadataInformation(
+                metadataInformation.Add(new MetadataInformation(
                     assemblyName: Path.GetFileNameWithoutExtension(assembly),
                     assemblyId: regexStringTransformer?.Transform(assembly) ?? assembly,
                     fullPath: assembly,
-                    references: assemblyReferences);
+                    references: assemblyReferences));
             }
+
+            return metadataInformation;
         }
 
         private static IEnumerable<string> GetFilesFromPath(string path)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -38,14 +38,16 @@ namespace Microsoft.DotNet.ApiCompat.Tool
 
             // Root command
             Option<string[]> leftAssembliesOption = new(new string[] { "--left-assembly", "--left", "-l" },
-                "The path to one or more assemblies that serve as the left side to compare.")
+                description: "The path to one or more assemblies that serve as the left side to compare.",
+                parseArgument: ParseAssemblyArgument)
             {
                 AllowMultipleArgumentsPerToken = true,
                 Arity = ArgumentArity.OneOrMore,
                 IsRequired = true
             };
             Option<string[]> rightAssembliesOption = new(new string[] { "--right-assembly", "--right", "-r" },
-                "The path to one or more assemblies that serve as the right side to compare.")
+                description: "The path to one or more assemblies that serve as the right side to compare.",
+                parseArgument: ParseAssemblyArgument)
             {
                 AllowMultipleArgumentsPerToken = true,
                 Arity = ArgumentArity.OneOrMore,
@@ -53,7 +55,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             };
             Option<bool> strictModeOption = new("--strict-mode",
                 "If true, performs api compatibility checks in strict mode");
-            Option<string[][]?> leftAssembliesReferencesOption = new("--left-assembly-references",
+            Option<string[][]?> leftAssembliesReferencesOption = new(new string[] { "--left-assembly-references", "--lref" },
                 description: "Paths to assembly references or the underlying directories for a given left. Values must be separated by commas: ','.",
                 parseArgument: ParseAssemblyReferenceArgument)
             {
@@ -61,7 +63,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 Arity = ArgumentArity.ZeroOrMore,
                 ArgumentHelpName = "file1,file2,..."
             };
-            Option<string[][]?> rightAssembliesReferencesOption = new("--right-assembly-references",
+            Option<string[][]?> rightAssembliesReferencesOption = new(new string[] { "--right-assembly-references", "--rref" },
                 description: "Paths to assembly references or the underlying directories for a given right. Values must be separated by commas: ','.",
                 parseArgument: ParseAssemblyReferenceArgument)
             {
@@ -235,12 +237,23 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             return rootCommand.Invoke(args);
         }
 
-        private static string[][]? ParseAssemblyReferenceArgument(ArgumentResult argumentResult)
+        private static string[][] ParseAssemblyReferenceArgument(ArgumentResult argumentResult)
         {
             List<string[]> args = new();
             foreach (Token token in argumentResult.Tokens)
             {
                 args.Add(token.Value.Split(','));
+            }
+
+            return args.ToArray();
+        }
+
+        private static string[] ParseAssemblyArgument(ArgumentResult argumentResult)
+        {
+            List<string> args = new();
+            foreach (Token token in argumentResult.Tokens)
+            {
+                args.AddRange(token.Value.Split(','));
             }
 
             return args.ToArray();


### PR DESCRIPTION
Tested the changes locally in dotnet/runtime. Filed https://github.com/dotnet/sdk/issues/27196 to track adding tests for the ValidateAssemblies task when using directory and glob filter patterns.