### PR TITLE
Support different Windows SDK package versions for different target frameworks

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -403,6 +403,50 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework + useWindowsSDKPreview + windowsSdkPackageVersion);
 
+            string referencedWindowsSdkVersion =  GetReferencedWindowsSdkVersion(testAsset);
+
+            //  The patch version of the Windows SDK Ref pack will change over time, so we use a '*' in the expected version to indicate that and replace it with
+            //  the 4th part of the version number of the resolved package.
+            if (expectedWindowsSdkPackageVersion.Contains('*'))
+            {
+                expectedWindowsSdkPackageVersion = expectedWindowsSdkPackageVersion.Replace("*", new Version(referencedWindowsSdkVersion).Revision.ToString());
+            }
+
+            referencedWindowsSdkVersion.Should().Be(expectedWindowsSdkPackageVersion);
+        }
+
+        [Theory]
+        [InlineData("net5.0-windows10.0.22000.0", "10.0.22000.25")]
+        [InlineData("net6.0-windows10.0.22000.0", "10.0.22000.26")]
+        public void ItUsesTheHighestMatchingWindowsSdkPackageVersion2(string targetFramework, string expectedWindowsSdkPackageVersion)
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = targetFramework
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(project =>
+                {
+                    //  Add items for available SDK versions for test
+                    var testItems = XElement.Parse(@"
+  <ItemGroup>
+    <WindowsSdkSupportedTargetPlatformVersion Remove=""@(WindowsSdkSupportedTargetPlatformVersion)"" />
+
+    <WindowsSdkSupportedTargetPlatformVersion Include=""10.0.22000.0"" WindowsSdkPackageVersion=""10.0.22000.26"" MinimumNETVersion=""6.0"" />
+    <WindowsSdkSupportedTargetPlatformVersion Include=""10.0.22000.0"" WindowsSdkPackageVersion=""10.0.22000.25"" MinimumNETVersion=""5.0"" />
+  </ItemGroup>");
+
+                    project.Root.Add(testItems);
+                });
+
+            string referencedWindowsSdkVersion = GetReferencedWindowsSdkVersion(testAsset);
+            referencedWindowsSdkVersion.Should().Be(expectedWindowsSdkPackageVersion);
+
+        }
+
+        private string GetReferencedWindowsSdkVersion(TestAsset testAsset)
+        {
             var getValueCommand = new GetValuesCommand(testAsset, "PackageDownload", GetValuesCommand.ValueType.Item);
             getValueCommand.ShouldRestore = false;
             getValueCommand.DependsOnTargets = "_CheckForInvalidConfigurationAndPlatform;CollectPackageDownloads";
@@ -419,15 +463,7 @@ namespace Microsoft.NET.Build.Tests
             packageDownloadVersion[0].Should().Be('[');
             packageDownloadVersion.Last().Should().Be(']');
 
-            //  The patch version of the Windows SDK Ref pack will change over time, so we use a '*' in the expected version to indicate that and replace it with
-            //  the 4th part of the version number of the resolved package.
-            var trimmedPackageDownloadVersion = packageDownloadVersion.Substring(1, packageDownloadVersion.Length - 2);
-            if (expectedWindowsSdkPackageVersion.Contains('*'))
-            {
-                expectedWindowsSdkPackageVersion = expectedWindowsSdkPackageVersion.Replace("*", new Version(trimmedPackageDownloadVersion).Revision.ToString());
-            }
-
-            trimmedPackageDownloadVersion.Should().Be(expectedWindowsSdkPackageVersion);
+            return packageDownloadVersion.Substring(1, packageDownloadVersion.Length - 2);
         }
 
         private string GetPropertyValue(TestAsset testAsset, string propertyName)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -426,7 +426,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = targetFramework
             };
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework)
                 .WithProjectChanges(project =>
                 {
                     //  Add items for available SDK versions for test

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -415,10 +415,11 @@ namespace Microsoft.NET.Build.Tests
             referencedWindowsSdkVersion.Should().Be(expectedWindowsSdkPackageVersion);
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("net5.0-windows10.0.22000.0", "10.0.22000.25")]
         [InlineData("net6.0-windows10.0.22000.0", "10.0.22000.26")]
-        public void ItUsesTheHighestMatchingWindowsSdkPackageVersion2(string targetFramework, string expectedWindowsSdkPackageVersion)
+        [InlineData("net6.0-windows10.0.19041.0", "10.0.19041.25")]
+        public void ItUsesTheHighestMatchingWindowsSdkPackageVersion(string targetFramework, string expectedWindowsSdkPackageVersion)
         {
             var testProject = new TestProject()
             {
@@ -433,8 +434,12 @@ namespace Microsoft.NET.Build.Tests
   <ItemGroup>
     <WindowsSdkSupportedTargetPlatformVersion Remove=""@(WindowsSdkSupportedTargetPlatformVersion)"" />
 
+    <WindowsSdkSupportedTargetPlatformVersion Include=""10.0.22621.0"" WindowsSdkPackageVersion=""10.0.22621.26"" MinimumNETVersion=""6.0"" />
+
     <WindowsSdkSupportedTargetPlatformVersion Include=""10.0.22000.0"" WindowsSdkPackageVersion=""10.0.22000.26"" MinimumNETVersion=""6.0"" />
     <WindowsSdkSupportedTargetPlatformVersion Include=""10.0.22000.0"" WindowsSdkPackageVersion=""10.0.22000.25"" MinimumNETVersion=""5.0"" />
+
+    <WindowsSdkSupportedTargetPlatformVersion Include=""10.0.19041.0"" WindowsSdkPackageVersion=""10.0.19041.25"" MinimumNETVersion=""5.0"" />
   </ItemGroup>");
 
                     project.Root.Add(testItems);


### PR DESCRIPTION
If there are multiple matching WindowsSdkSupportedTargetPlatformVersion items, choose the one with the highest minimum version.  That way it is possible to use older packages when targeting older versions of .NET, and newer packages for newer versions of .NET.

Alternate implementation for #27179, and targeting release/6.0.4xx branch instead of main.

## Description

The Windows SDK projection package included by the .NET SDK has been shipped as .NET 5 binaries up until now.  The Windows SDK projection package is going to start shipping .NET 6 binaries, but right now the .NET SDK uses the same version of the package for all .NET TFMs (.NET 5, 6, 7, etc.).  Given someone can use the .NET 6 SDK to still target .NET 5, this can cause issues.  Due to this, this change allows to lock the version of the Windows SDK projection package used for .NET 5 while allowing for the version used for later TFMs to still be updated.

## Customer Impact
Enlighten the .NET SDK to the different Windows SDK packages so customers do not experience build failures when targeting net5 with .NET 6 or later SDK.

## Regression

No

## Risk 
Low. We added some locked (constant) versions for the .NET 5 packages, and added a few lines of code to the SDK to pick the package version where constraints on the target framework version are met.

## Testing 
The test for this (included in change) is a test app that targets .NET 6 and .NET 5. we see that in the case of .NET 6 we get the latest Windows SDK package version, and in the case of .NET 5 the last known good version of the Windows SDK package is used.