### PR TITLE
Remove obsolete diagnostic message in ApiCompatRunner

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
@@ -219,9 +219,6 @@
   <data name="ApiCompatibilityHeader" xml:space="preserve">
     <value>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</value>
   </data>
-  <data name="ApiCompatibilityFooter" xml:space="preserve">
-    <value>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</value>
-  </data>
   <data name="ApiCompatRunnerExecutingWorkItems" xml:space="preserve">
     <value>Executing {0} work item(s)...</value>
   </data>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
@@ -100,13 +100,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
                             difference.DiagnosticId,
                             difference.Message);
                     }
-
-                    _log.LogMessage(MessageImportance.Low,
-                        Resources.ApiCompatibilityFooter,
-                        differenceGroup.Key.Left.AssemblyId,
-                        differenceGroup.Key.Right.AssemblyId,
-                        workItem.Options.IsBaselineComparison ? differenceGroup.Key.Left.FullPath : "left",
-                        workItem.Options.IsBaselineComparison ? differenceGroup.Key.Right.FullPath : "right");
                 }
             }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Spouští se pracovní položky ({0})...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">Provedlo se ověření rozhraní API pro {0} ({2}) a {1} ({3}).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">Chyby kompatibility rozhraní API mezi {0} ({2}) a {1} ({3}):</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
@@ -7,11 +7,6 @@
         <target state="translated">{0} Arbeitselement(e) wird/werden ausgeführt...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">API-Überprüfung für „{0}“ ({2}) und „{1}“ ({3}) wurde durchgeführt.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">API-Kompatibilitätsfehler zwischen „{0}“ ({2}) und „{1}“ ({3}):</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Ejecutando {0} elemento(s) de trabajo....</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">Se realizó la validación de API en "{0}" ({2}) y "{1}" ({3}).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">Errores de compatibilidad de API entre "{0}" ({2}) y "{1}" ({3}):</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Exécution {0} d'élément(s) de travail...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">Validation de l’API effectuée sur '{0}' ({2}) et '{1}' ({3})</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">Erreurs de compatibilité des API entre '{0}' ({2}) et '{1}' ({3}) :</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Esecuzione {0} elementi di lavoro in corso...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">Convalida API eseguita su '{0}' ({2}) e '{1}' ({3}).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">Errori di compatibilità dell'API tra '{0}' ({2}) e '{1}' ({3}):</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
@@ -7,11 +7,6 @@
         <target state="translated">{0} 件の作業項目を移動しています...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">'{0}' ({2}) と '{1}' ({3}) に API 検証を実行しました。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">'{0}' ({2}) と '{1}' ({3}) の API 互換性エラーは、以下のとおりです。</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
@@ -7,11 +7,6 @@
         <target state="translated">{0} 작업 항목을 실행하는 중...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">'{0}'({2}) 및 '{1}'({3})에서 API 유효성 검사를 수행했습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">'{0}'({2}) 및 '{1}'({3}) 사이의 API 호환성 오류:</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Trwa wykonywanie następującej liczby elementów roboczych: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">Wykonano weryfikację interfejsu API dla elementu „{0}” ({2}) i „{1}” ({3}).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">Błędy zgodności interfejsu API między elementem „{0}” ({2}) i „{1}” ({3}):</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Executando {0} item(ns) de trabalho...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">Validação de API realizada em '{0}' ({2}) e ​​'{1}' ({3}).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">Erros de compatibilidade de API entre '{0}' ({2}) e ​​'{1}' ({3}):</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Выполнение рабочих элементов:{0}....</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">Выполнена проверка API для "{0}" ({2} ) и "{1}" ({3}).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">Ошибки совместимости API между "{0}" ({2} &gt;) и "{1}" ({3}):</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
@@ -7,11 +7,6 @@
         <target state="translated">{0} iş öğesi yürütülüyor...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">'{0}' ({2}) ve '{1}' ({3}) üzerinde API doğrulaması gerçekleştirildi.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">'{0}' ({2}) ile '{1}' ({3}) arasında API uyumluluğu hataları var:</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
@@ -7,11 +7,6 @@
         <target state="translated">正在执行 {0} 工作项...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">已对“{0}”({2})和“{1}”({3})执行 API 验证。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">“{0}”({2})和“{1}”({3})之间的 API 兼容性错误:</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
@@ -7,11 +7,6 @@
         <target state="translated">正在執行 {0} 工作項目...</target>
         <note />
       </trans-unit>
-      <trans-unit id="ApiCompatibilityFooter">
-        <source>Performed api validation on '{0}' ({2}) and '{1}' ({3}).</source>
-        <target state="translated">已在 '{0}' ({2}) 與 '{1}' ({3}) 上執行 API 驗證。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApiCompatibilityHeader">
         <source>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</source>
         <target state="translated">'{0}' ({2}) 與 '{1}' ({3}) 之間的 API 相容性錯誤:</target>


### PR DESCRIPTION
The message in the ApiCompatRunner isn't correct anymore as it's now
only logged for assemblies that differ. This changed with the multi
assembly change that made ApiComparer only return items with actual
changes.

The header logging remains which is useful for identifying the
assembly tuples that have differences.