### PR TITLE
Fix roslyn assemblies path not being respected

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidateAssembliesTask.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidateAssembliesTask.cs
@@ -29,8 +29,9 @@ namespace Microsoft.DotNet.ApiCompat.Task
         public string[]? RightAssemblies { get; set; }
 
         /// <summary>
-        /// If provided, the path to the roslyn assemblies that should be loaded.
+        /// The path to the roslyn assemblies that should be loaded.
         /// </summary>
+        [Required]
         public string? RoslynAssembliesPath { get; set; }
 
         /// <summary>
@@ -85,12 +86,7 @@ namespace Microsoft.DotNet.ApiCompat.Task
 
         public override bool Execute()
         {
-            if (RoslynAssembliesPath == null)
-            {
-                return base.Execute();
-            }
-
-            RoslynResolver roslynResolver = RoslynResolver.Register(RoslynAssembliesPath);
+            RoslynResolver roslynResolver = RoslynResolver.Register(RoslynAssembliesPath!);
             try
             {
                 return base.Execute();

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
@@ -24,8 +24,9 @@ namespace Microsoft.DotNet.ApiCompat.Task
         public string? PackageTargetPath { get; set; }
 
         /// <summary>
-        /// If provided, the path to the roslyn assemblies that should be loaded.
+        /// The path to the roslyn assemblies that should be loaded.
         /// </summary>
+        [Required]
         public string? RoslynAssembliesPath { get; set; }
 
         /// <summary>
@@ -85,12 +86,7 @@ namespace Microsoft.DotNet.ApiCompat.Task
 
         public override bool Execute()
         {
-            if (RoslynAssembliesPath == null)
-            {
-                return base.Execute();
-            }
-
-            RoslynResolver roslynResolver = RoslynResolver.Register(RoslynAssembliesPath);
+            RoslynResolver roslynResolver = RoslynResolver.Register(RoslynAssembliesPath!);
             try
             {
                 return base.Execute();

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
@@ -13,12 +13,31 @@
   <ItemGroup>
     <PackageReference Include="Jab" Version="$(JabVersion)" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <ProjectReference Include="..\Microsoft.DotNet.PackageValidation\Microsoft.DotNet.PackageValidation.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" />
-    <ProjectReference Include="..\Microsoft.DotNet.PackageValidation\Microsoft.DotNet.PackageValidation.csproj" />
+    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
   </ItemGroup>
+
+  <!-- Move code analysis assemblies into a sub directory so that they can be conditionally resolved. -->
+  <Target Name="UpdateMicrosoftCodeAnalysisFilesForBuild"
+          AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Condition="$([System.String]::new('%(Filename)').StartsWith('Microsoft.CodeAnalysis'))"
+                               DestinationSubDirectory="codeanalysis\%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="UpdateMicrosoftCodeAnalysisFilesForPublish"
+          AfterTargets="_ResolveCopyLocalAssetsForPublish"
+          BeforeTargets="_HandlePackageFileConflictsForPublish">
+    <ItemGroup>
+      <_ResolvedCopyLocalPublishAssets Condition="$([System.String]::new('%(Filename)').StartsWith('Microsoft.CodeAnalysis'))"
+                                       DestinationSubDirectory="codeanalysis\%(_ResolvedCopyLocalPublishAssets.DestinationSubDirectory)" />
+    </ItemGroup>
+  </Target>
 
   <Import Project="..\Microsoft.DotNet.ApiCompat.Shared\Microsoft.DotNet.ApiCompat.Shared.projitems" Label="Shared" />
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+    <IsShippingPackage>true</IsShippingPackage>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>apicompat</ToolCommandName>


### PR DESCRIPTION
In the tools package, the roslyn assemblies path wasn't respected
because it was always resolved from the app local path. By moving the
codeanalysis files out into a subdirectory, a different version can be
loaded instead. This is using the same approach as the msbuild task
which also needs to manually resolve the codeanalysis version.

Also fixing the default verbosity level of the global tool.