### PR TITLE
added typo correction for `dotnet new` instantiate 

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/IReporter.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/IReporter.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace Microsoft.DotNet.Cli.Utils
 {
     public interface IReporter
@@ -8,6 +10,8 @@ namespace Microsoft.DotNet.Cli.Utils
         void WriteLine(string message);
 
         void WriteLine();
+
+        void WriteLine(string format, params object?[] args);
 
         void Write(string message);
     }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Reporter.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Reporter.cs
@@ -1,29 +1,31 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace Microsoft.DotNet.Cli.Utils
 {
     // Stupid-simple console manager
     public class Reporter : IReporter
     {
-        private static readonly Reporter NullReporter = new Reporter(console: null);
-        private static object _lock = new object();
+        private static readonly Reporter NullReporter = new(console: null);
+        private static readonly object _lock = new();
 
-        private readonly AnsiConsole _console;
+        private readonly AnsiConsole? _console;
 
         static Reporter()
         {
             Reset();
         }
 
-        private Reporter(AnsiConsole console)
+        private Reporter(AnsiConsole? console)
         {
             _console = console;
         }
 
-        public static Reporter Output { get; private set; }
-        public static Reporter Error { get; private set; }
-        public static Reporter Verbose { get; private set; }
+        public static Reporter Output { get; private set; } = NullReporter;
+        public static Reporter Error { get; private set; } = NullReporter;
+        public static Reporter Verbose { get; private set; } = NullReporter;
 
         /// <summary>
         /// Resets the Reporters to write to the current Console Out/Error.
@@ -79,5 +81,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 }
             }
         }
+
+        public void WriteLine(string format, params object?[] args) => WriteLine(string.Format(format, args));
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/TypoCorrection.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/TypoCorrection.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public static class TypoCorrection
+    {
+        /// <summary>
+        /// Gets the list of tokens similar to <paramref name="currentToken"/>.
+        /// </summary>
+        /// <param name="possibleTokens">List of tokens to select from.</param>
+        /// <param name="currentToken">The token that is being compared.</param>
+        /// <param name="maxLevenshteinDistance">the difference between two strings, default: 3.</param>
+        /// <returns>The enumerator to tokens similar to <paramref name="currentToken"/>.</returns>
+        public static IEnumerable<string> GetSimilarTokens(IEnumerable<string> possibleTokens, string currentToken, int maxLevenshteinDistance = 3)
+        {
+            int? bestDistance = null;
+            return possibleTokens
+                .Select(possibleMatch => (possibleMatch, distance: GetDistance(currentToken, possibleMatch)))
+                .Where(tuple => tuple.distance <= maxLevenshteinDistance)
+                .OrderBy(tuple => tuple.distance)
+                .ThenByDescending(tuple => GetStartsWithDistance(currentToken, tuple.possibleMatch))
+                .TakeWhile(tuple =>
+                {
+                    (string _, int distance) = tuple;
+                    bestDistance ??= distance;
+                    return distance == bestDistance;
+                })
+                .Select(tuple => tuple.possibleMatch);
+        }
+
+        private static int GetStartsWithDistance(string first, string second)
+        {
+            int i;
+            for (i = 0; i < first.Length && i < second.Length && first[i] == second[i]; i++)
+            { }
+            return i;
+        }
+
+        //Based on https://blogs.msdn.microsoft.com/toub/2006/05/05/generic-levenshtein-edit-distance-with-c/
+        private static int GetDistance(string first, string second)
+        {
+            // Validate parameters
+            if (first is null)
+            {
+                throw new ArgumentNullException(nameof(first));
+            }
+
+            if (second is null)
+            {
+                throw new ArgumentNullException(nameof(second));
+            }
+
+
+            // Get the length of both.  If either is 0, return
+            // the length of the other, since that number of insertions
+            // would be required.
+
+            int n = first.Length, m = second.Length;
+            if (n == 0) return m;
+            if (m == 0) return n;
+
+
+            // Rather than maintain an entire matrix (which would require O(n*m) space),
+            // just store the current row and the next row, each of which has a length m+1,
+            // so just O(m) space. Initialize the current row.
+
+            int curRow = 0, nextRow = 1;
+            int[][] rows = { new int[m + 1], new int[m + 1] };
+
+            for (int j = 0; j <= m; ++j)
+            {
+                rows[curRow][j] = j;
+            }
+
+            // For each virtual row (since we only have physical storage for two)
+            for (int i = 1; i <= n; ++i)
+            {
+                // Fill in the values in the row
+                rows[nextRow][0] = i;
+                for (int j = 1; j <= m; ++j)
+                {
+                    int dist1 = rows[curRow][j] + 1;
+                    int dist2 = rows[nextRow][j - 1] + 1;
+                    int dist3 = rows[curRow][j - 1] + (first[i - 1].Equals(second[j - 1]) ? 0 : 1);
+
+                    rows[nextRow][j] = Math.Min(dist1, Math.Min(dist2, dist3));
+                }
+
+
+                // Swap the current and next rows
+                if (curRow == 0)
+                {
+                    curRow = 1;
+                    nextRow = 0;
+                }
+                else
+                {
+                    curRow = 0;
+                    nextRow = 1;
+                }
+            }
+
+            // Return the computed edit distance
+            return rows[curRow][m];
+
+        }
+    }
+}

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
@@ -108,7 +108,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             if (returnCode != NewCommandStatus.Success)
             {
                 Reporter.Error.WriteLine();
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.BaseCommand_ExitCodeHelp, (int)returnCode));
+                Reporter.Error.WriteLine(LocalizableStrings.BaseCommand_ExitCodeHelp, (int)returnCode);
             }
 
             return (int)returnCode;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/Example.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/Example.cs
@@ -116,6 +116,20 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             return this;
         }
 
+        internal Example WithSubcommand(string token)
+        {
+            Command? commandToUse = _currentCommand.Children.OfType<Command>().FirstOrDefault(c => c.Aliases.Contains(token));
+
+            if (commandToUse is null)
+            {
+                throw new ArgumentException($"Command {_currentCommand.Name} does not have subcommand '{token}'.");
+            }
+
+            _commandParts.Add(token);
+            _currentCommand = commandToUse;
+            return this;
+        }
+
         internal Example WithSubcommand<T>() where T : Command
         {
             if (!_currentCommand.Children.OfType<Command>().Any( c => c is T))

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/GlobalArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/GlobalArgs.cs
@@ -19,6 +19,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             ParseResult = parseResult;
             Command = command;
             RootCommand = GetNewCommandFromParseResult(parseResult);
+            HasHelpOption = parseResult.CommandResult
+                .Children
+                .OfType<OptionResult>()
+                .Select(r => r.Option)
+                .Any(o => o.HasAlias(Constants.KnownHelpAliases[0]));
         }
 
         protected GlobalArgs(GlobalArgs args) : this(args.Command, args.ParseResult) { }
@@ -42,6 +47,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal bool DebugShowConfig { get; private set; }
 
         internal string? DebugCustomSettingsLocation { get; private set; }
+
+        internal bool HasHelpOption { get; private set; }
 
         protected static (bool, IReadOnlyList<string>?) ParseTabularOutputSettings(ITabularOutputCommand command, ParseResult parseResult)
         {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
@@ -143,8 +143,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             }
             else
             {
-                var tokens = args.ParseResult.Tokens.Select(t => t.Value);
-                reporter.WriteLine(string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, string.Join(" ", tokens)).Bold().Red());
+                var tokens = args.ParseResult.Tokens.Select(t => $"'{t.Value}'");
+                reporter.WriteLine(string.Format(LocalizableStrings.Generic_Info_NoMatchingTemplates, string.Join(" ", tokens)).Bold().Red());
             }
             reporter.WriteLine();
             //TODO: if we were not able to match the errors, print all the errors template by template.
@@ -189,7 +189,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 }
             }
 
-            Reporter.Error.WriteLine(string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, baseInputParameters).Bold().Red());
+            Reporter.Error.WriteLine(string.Format(LocalizableStrings.Generic_Info_NoMatchingTemplates, baseInputParameters).Bold().Red());
             foreach (var option in new[]
                 {
                     new { Option = languageOption, Condition = matchInfos.All(mi => !mi.IsLanguageMatch), AllowedValues = templateGroup.Languages },
@@ -206,14 +206,14 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             Reporter.Error.WriteLine();
 
-            Reporter.Error.WriteLine(LocalizableStrings.ListTemplatesCommand);
+            Reporter.Error.WriteLine(LocalizableStrings.Generic_CommandHints_List);
 
             Reporter.Error.WriteCommand(
                  Example
                      .For<NewCommand>(args.ParseResult)
                      .WithSubcommand<ListCommand>());
 
-            Reporter.Error.WriteLine(LocalizableStrings.SearchTemplatesCommand);
+            Reporter.Error.WriteLine(LocalizableStrings.Generic_CommandHints_Search);
             Reporter.Error.WriteCommand(
                   Example
                       .For<NewCommand>(args.ParseResult)

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.TabCompletion.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.TabCompletion.cs
@@ -90,7 +90,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                         }
                         catch (InvalidTemplateParametersException e)
                         {
-                            Reporter.Error.WriteLine(string.Format(LocalizableStrings.GenericWarning, e.Message));
+                            Reporter.Error.WriteLine(LocalizableStrings.GenericWarning, e.Message);
                         }
                     }
                 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
@@ -453,7 +453,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             }
             catch (InvalidTemplateParametersException e)
             {
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.GenericWarning, e.Message));
+                Reporter.Error.WriteLine(LocalizableStrings.GenericWarning, e.Message);
                 return null;
             }
         }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
@@ -43,7 +42,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             IsHidden = true;
         }
 
-        internal Argument<string> ShortNameArgument { get; } = new Argument<string>("template-short-name")
+        internal static Argument<string> ShortNameArgument { get; } = new Argument<string>("template-short-name")
         {
             Description = SymbolStrings.Command_Instantiate_Argument_ShortName,
             Arity = new ArgumentArity(0, 1)
@@ -68,15 +67,13 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             return ExecuteIntAsync(InstantiateCommandArgs.FromNewCommandArgs(newCommandArgs), environmentSettings, context);
         }
 
-        internal static async Task<IEnumerable<TemplateGroup>> GetMatchingTemplateGroupsAsync(
-            InstantiateCommandArgs instantiateArgs,
+        internal static async Task<IEnumerable<TemplateGroup>> GetTemplateGroupsAsync(
             TemplatePackageManager templatePackageManager,
             HostSpecificDataLoader hostSpecificDataLoader,
             CancellationToken cancellationToken)
         {
-            var templates = await templatePackageManager.GetTemplatesAsync(cancellationToken).ConfigureAwait(false);
-            var templateGroups = TemplateGroup.FromTemplateList(CliTemplateInfo.FromTemplateInfo(templates, hostSpecificDataLoader));
-            return templateGroups.Where(template => template.ShortNames.Contains(instantiateArgs.ShortName));
+            IReadOnlyList<ITemplateInfo> templates = await templatePackageManager.GetTemplatesAsync(cancellationToken).ConfigureAwait(false);
+            return TemplateGroup.FromTemplateList(CliTemplateInfo.FromTemplateInfo(templates, hostSpecificDataLoader));
         }
 
         internal static HashSet<TemplateCommand> GetTemplateCommand(
@@ -118,16 +115,18 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             return new HashSet<TemplateCommand>();
         }
 
-        internal static void HandleNoMatchingTemplateGroup(InstantiateCommandArgs instantiateArgs, Reporter reporter)
+        internal static void HandleNoMatchingTemplateGroup(InstantiateCommandArgs instantiateArgs, IEnumerable<TemplateGroup> templateGroups, IReporter reporter)
         {
             reporter.WriteLine(
-                string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, $"'{instantiateArgs.ShortName}'").Bold().Red());
+                string.Format(LocalizableStrings.InstantiateCommand_Info_NoMatchingTemplatesSubCommands, instantiateArgs.ShortName).Bold().Red());
+
+            SuggestTypoCorrections(instantiateArgs, templateGroups, reporter);
             reporter.WriteLine();
 
-            reporter.WriteLine(LocalizableStrings.ListTemplatesCommand);
+            reporter.WriteLine(LocalizableStrings.Generic_CommandHints_List);
             reporter.WriteCommand(Example.For<NewCommand>(instantiateArgs.ParseResult).WithSubcommand<ListCommand>());
 
-            reporter.WriteLine(LocalizableStrings.SearchTemplatesCommand);
+            reporter.WriteLine(LocalizableStrings.Generic_CommandHints_Search);
 
             if (string.IsNullOrWhiteSpace(instantiateArgs.ShortName))
             {
@@ -145,7 +144,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                       .WithSubcommand<SearchCommand>()
                       .WithArgument(SearchCommand.NameArgument, instantiateArgs.ShortName));
             }
-
             reporter.WriteLine();
         }
 
@@ -185,8 +183,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 }
                 catch (Exception ex)
                 {
-                    environmentSettings.Host.Logger.LogWarning($"Failed to get information about template packages for template group {templateGroup.GroupIdentity}.");
-                    environmentSettings.Host.Logger.LogDebug($"Details: {ex}.");
+                    environmentSettings.Host.Logger.LogWarning("Failed to get information about template packages for template group {groupIdentity}.", templateGroup.GroupIdentity);
+                    environmentSettings.Host.Logger.LogDebug("Details: {ex}", ex);
                     return string.Empty;
                 }
             }
@@ -207,12 +205,12 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             IEngineEnvironmentSettings environmentSettings,
             InvocationContext context)
         {
-            var cancellationToken = context.GetCancellationToken();
-            using TemplatePackageManager templatePackageManager = new TemplatePackageManager(environmentSettings);
-            HostSpecificDataLoader hostSpecificDataLoader = new HostSpecificDataLoader(environmentSettings);
+            CancellationToken cancellationToken = context.GetCancellationToken();
+            using TemplatePackageManager templatePackageManager = new(environmentSettings);
+            HostSpecificDataLoader hostSpecificDataLoader = new(environmentSettings);
             if (string.IsNullOrWhiteSpace(instantiateArgs.ShortName))
             {
-                TemplateListCoordinator templateListCoordinator = new TemplateListCoordinator(
+                TemplateListCoordinator templateListCoordinator = new(
                     environmentSettings,
                     templatePackageManager,
                     hostSpecificDataLoader);
@@ -220,15 +218,16 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 return await templateListCoordinator.DisplayCommandDescriptionAsync(instantiateArgs, cancellationToken).ConfigureAwait(false);
             }
 
-            var selectedTemplateGroups = await GetMatchingTemplateGroupsAsync(
-                instantiateArgs,
+            IEnumerable<TemplateGroup> allTemplateGroups = await GetTemplateGroupsAsync(
                 templatePackageManager,
                 hostSpecificDataLoader,
                 cancellationToken).ConfigureAwait(false);
 
+            IEnumerable<TemplateGroup> selectedTemplateGroups = allTemplateGroups.Where(template => template.ShortNames.Contains(instantiateArgs.ShortName));
+
             if (!selectedTemplateGroups.Any())
             {
-                HandleNoMatchingTemplateGroup(instantiateArgs, Reporter.Error);
+                HandleNoMatchingTemplateGroup(instantiateArgs, allTemplateGroups, Reporter.Error);
                 return NewCommandStatus.NotFound;
             }
             if (selectedTemplateGroups.Count() > 1)
@@ -368,8 +367,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 }
                 catch (Exception ex)
                 {
-                    environmentSettings.Host.Logger.LogWarning($"Failed to get information about template packages for template group {template.Identity}.");
-                    environmentSettings.Host.Logger.LogDebug($"Details: {ex}.");
+                    environmentSettings.Host.Logger.LogWarning("Failed to get information about template packages for template group {identity}.", template.Identity);
+                    environmentSettings.Host.Logger.LogDebug("Details: {ex}.", ex);
                     return string.Empty;
                 }
             }
@@ -384,7 +383,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             out bool languageOptionSpecified)
         {
             languageOptionSpecified = false;
-            HashSet<TemplateCommand> candidates = new HashSet<TemplateCommand>();
+            HashSet<TemplateCommand> candidates = new();
             foreach (CliTemplateInfo template in templatesToReparse)
             {
                 if (ReparseForTemplate(args, environmentSettings, templatePackageManager, templateGroup, template) is (TemplateCommand command, ParseResult parseResult))
@@ -407,8 +406,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             TemplateGroup templateGroup,
             HashSet<TemplateCommand> candidates)
         {
-            HashSet<TemplateCommand> languageAwareCandidates = new HashSet<TemplateCommand>();
-            foreach (var templateCommand in candidates)
+            HashSet<TemplateCommand> languageAwareCandidates = new();
+            foreach (TemplateCommand templateCommand in candidates)
             {
                 if (ReparseForTemplate(
                     args,
@@ -439,7 +438,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         {
             try
             {
-                TemplateCommand command = new TemplateCommand(
+                TemplateCommand command = new(
                     args.Command,
                     environmentSettings,
                     templatePackageManager,
@@ -455,6 +454,64 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             {
                 Reporter.Error.WriteLine(LocalizableStrings.GenericWarning, e.Message);
                 return null;
+            }
+        }
+
+        private static void SuggestTypoCorrections(InstantiateCommandArgs instantiateArgs, IEnumerable<TemplateGroup> templateGroups, IReporter reporter)
+        {
+            if (string.IsNullOrWhiteSpace(instantiateArgs.ShortName))
+            {
+                return;
+            }
+
+            IEnumerable<string> possibleTemplates = templateGroups
+                .SelectMany(g => g.ShortNames);
+
+            bool useInstantiateCommand = instantiateArgs.Command is InstantiateCommand;
+            bool helpOption = instantiateArgs.HasHelpOption;
+            IEnumerable<string> possibleTemplateMatches = TypoCorrection.GetSimilarTokens(possibleTemplates, instantiateArgs.ShortName);
+
+            if (possibleTemplateMatches.Any())
+            {
+
+                reporter.WriteLine(LocalizableStrings.InstantiateCommand_Info_TypoCorrection_Templates);
+                foreach (string possibleMatch in possibleTemplateMatches)
+                {
+                    Example example = useInstantiateCommand
+                        ? Example.For<InstantiateCommand>(instantiateArgs.ParseResult).WithArgument(InstantiateCommand.ShortNameArgument, possibleMatch)
+                        : Example.For<NewCommand>(instantiateArgs.ParseResult).WithArgument(NewCommand.ShortNameArgument, possibleMatch);
+                    if (helpOption)
+                    {
+                        example = example.WithHelpOption();
+                    }
+                    reporter.WriteCommand(example);
+                }
+            }
+
+            if (useInstantiateCommand)
+            {
+                //no subcommands in dotnet new create
+                return;
+            }
+
+            IEnumerable<string> possibleSubcommands =
+                instantiateArgs.Command.Subcommands
+                    .Where(sc => !sc.IsHidden)
+                    .SelectMany(sc => sc.Aliases);
+
+            IEnumerable<string> possibleSubcommandsMatches = TypoCorrection.GetSimilarTokens(possibleSubcommands, instantiateArgs.ShortName);
+            if (possibleSubcommandsMatches.Any())
+            {
+                reporter.WriteLine(LocalizableStrings.InstantiateCommand_Info_TypoCorrection_Subcommands);
+                foreach (string possibleMatch in possibleSubcommandsMatches)
+                {
+                    Example example = Example.For<NewCommand>(instantiateArgs.ParseResult).WithSubcommand(possibleMatch);
+                    if (helpOption)
+                    {
+                        example = example.WithHelpOption();
+                    }
+                    reporter.WriteCommand(example);
+                }
             }
         }
     }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommandArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommandArgs.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         public InstantiateCommandArgs(InstantiateCommand command, ParseResult parseResult) : base(command, parseResult)
         {
             RemainingArguments = parseResult.GetValueForArgument(command.RemainingArguments) ?? Array.Empty<string>();
-            ShortName = parseResult.GetValueForArgument(command.ShortNameArgument);
+            ShortName = parseResult.GetValueForArgument(InstantiateCommand.ShortNameArgument);
 
             var tokens = new List<string>();
             if (!string.IsNullOrWhiteSpace(ShortName))

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -221,11 +221,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             if (templateArgs.IsForceFlagSpecified)
             {
-                reporter.WriteLine(string.Format(LocalizableStrings.TemplateCommand_DisplayConstraintResults_Warning, templateArgs.Template.Name));
+                reporter.WriteLine(LocalizableStrings.TemplateCommand_DisplayConstraintResults_Warning, templateArgs.Template.Name);
             }
             else
             {
-                reporter.WriteLine(string.Format(LocalizableStrings.TemplateCommand_DisplayConstraintResults_Error, templateArgs.Template.Name));
+                reporter.WriteLine(LocalizableStrings.TemplateCommand_DisplayConstraintResults_Error, templateArgs.Template.Name);
             }
 
             foreach (var constraint in constraintResults.Where(cr => cr.EvaluationStatus != TemplateConstraintResult.Status.Allowed))
@@ -236,7 +236,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             if (!templateArgs.IsForceFlagSpecified)
             {
-                reporter.WriteLine(string.Format(LocalizableStrings.TemplateCommand_DisplayConstraintResults_Hint, SharedOptions.ForceOption.Aliases.First()));
+                reporter.WriteLine(LocalizableStrings.TemplateCommand_DisplayConstraintResults_Hint, SharedOptions.ForceOption.Aliases.First());
                 reporter.WriteCommand(Example.FromExistingTokens(templateArgs.ParseResult).WithOption(SharedOptions.ForceOption));
             }
             else

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -749,6 +749,24 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to To list installed templates, run:.
+        /// </summary>
+        internal static string Generic_CommandHints_List {
+            get {
+                return ResourceManager.GetString("Generic_CommandHints_List", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To search for the templates on NuGet.org, run:.
+        /// </summary>
+        internal static string Generic_CommandHints_Search {
+            get {
+                return ResourceManager.GetString("Generic_CommandHints_Search", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Details: {0}.
         /// </summary>
         internal static string Generic_Details {
@@ -781,6 +799,15 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string Generic_ExamplesHeader {
             get {
                 return ResourceManager.GetString("Generic_ExamplesHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No templates found matching: {0}..
+        /// </summary>
+        internal static string Generic_Info_NoMatchingTemplates {
+            get {
+                return ResourceManager.GetString("Generic_Info_NoMatchingTemplates", resourceCulture);
             }
         }
         
@@ -826,6 +853,33 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string HostSpecificDataLoader_Warning_FailedToReadFromFile {
             get {
                 return ResourceManager.GetString("HostSpecificDataLoader_Warning_FailedToReadFromFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No templates or subcommands found matching: &apos;{0}&apos;..
+        /// </summary>
+        internal static string InstantiateCommand_Info_NoMatchingTemplatesSubCommands {
+            get {
+                return ResourceManager.GetString("InstantiateCommand_Info_NoMatchingTemplatesSubCommands", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Did you mean one of the following subcommands?.
+        /// </summary>
+        internal static string InstantiateCommand_Info_TypoCorrection_Subcommands {
+            get {
+                return ResourceManager.GetString("InstantiateCommand_Info_TypoCorrection_Subcommands", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Did you mean one of the following templates?.
+        /// </summary>
+        internal static string InstantiateCommand_Info_TypoCorrection_Templates {
+            get {
+                return ResourceManager.GetString("InstantiateCommand_Info_TypoCorrection_Templates", resourceCulture);
             }
         }
         
@@ -893,15 +947,6 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To list installed templates, run:.
-        /// </summary>
-        internal static string ListTemplatesCommand {
-            get {
-                return ResourceManager.GetString("ListTemplatesCommand", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Mandatory option &apos;{0}&apos; is missing for the template &apos;{1}&apos;..
         /// </summary>
         internal static string MissingRequiredParameter {
@@ -943,15 +988,6 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string NoTemplatesFound {
             get {
                 return ResourceManager.GetString("NoTemplatesFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to No templates found matching: {0}..
-        /// </summary>
-        internal static string NoTemplatesMatchingInputParameters {
-            get {
-                return ResourceManager.GetString("NoTemplatesMatchingInputParameters", resourceCulture);
             }
         }
         
@@ -1222,15 +1258,6 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string RunningCommand {
             get {
                 return ResourceManager.GetString("RunningCommand", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to To search for the templates on NuGet.org, run:.
-        /// </summary>
-        internal static string SearchTemplatesCommand {
-            get {
-                return ResourceManager.GetString("SearchTemplatesCommand", resourceCulture);
             }
         }
         

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -178,7 +178,7 @@
   <data name="NoParameters" xml:space="preserve">
     <value>    (No Parameters)</value>
   </data>
-  <data name="NoTemplatesMatchingInputParameters" xml:space="preserve">
+  <data name="Generic_Info_NoMatchingTemplates" xml:space="preserve">
     <value>No templates found matching: {0}.</value>
   </data>
   <data name="OptionalWorkloadsSyncFailed" xml:space="preserve">
@@ -385,7 +385,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="InvalidParameterTemplateHint" xml:space="preserve">
     <value>For more information, run:</value>
   </data>
-  <data name="ListTemplatesCommand" xml:space="preserve">
+  <data name="Generic_CommandHints_List" xml:space="preserve">
     <value>To list installed templates, run:</value>
   </data>
   <data name="ColumnNameAuthor" xml:space="preserve">
@@ -415,7 +415,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="ColumnNameTotalDownloads" xml:space="preserve">
     <value>Downloads</value>
   </data>
-  <data name="SearchTemplatesCommand" xml:space="preserve">
+  <data name="Generic_CommandHints_Search" xml:space="preserve">
     <value>To search for the templates on NuGet.org, run:</value>
   </data>
   <data name="AmbiguousParameterDetail" xml:space="preserve">
@@ -781,5 +781,16 @@ The header is followed by the list of parameters and their errors (might be seve
   <data name="TemplateCreator_Hint_Uninstall" xml:space="preserve">
     <value>To uninstall the template package, run:</value>
     <comment>The sentence is followed by the command to run the action</comment>
+  </data>
+  <data name="InstantiateCommand_Info_TypoCorrection_Templates" xml:space="preserve">
+    <value>Did you mean one of the following templates?</value>
+    <comment>Followed by the list of suggestions</comment>
+  </data>
+  <data name="InstantiateCommand_Info_NoMatchingTemplatesSubCommands" xml:space="preserve">
+    <value>No templates or subcommands found matching: '{0}'.</value>
+  </data>
+  <data name="InstantiateCommand_Info_TypoCorrection_Subcommands" xml:space="preserve">
+    <value>Did you mean one of the following subcommands?</value>
+    <comment>Followed by the list of suggestions</comment>
   </data>
 </root>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
@@ -110,10 +110,10 @@ namespace Microsoft.TemplateEngine.Cli
 
                 if (actionProcessor == null)
                 {
-                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostActionDispatcher_Error_NotSupported, action.ActionId));
+                    Reporter.Error.WriteLine(LocalizableStrings.PostActionDispatcher_Error_NotSupported, action.ActionId);
                     if (!string.IsNullOrWhiteSpace(action.Description))
                     {
-                        Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostActionDescription, action.Description));
+                        Reporter.Error.WriteLine(LocalizableStrings.PostActionDescription, action.Description);
                     }
                     // The host doesn't know how to handle this action, just display manual instructions.
                     DisplayInstructionsForAction(action, useErrorOutput: true);
@@ -126,7 +126,7 @@ namespace Microsoft.TemplateEngine.Cli
                         Reporter.Error.WriteLine(LocalizableStrings.PostActionDispatcher_Error_RunScriptNotAllowed);
                         if (!string.IsNullOrWhiteSpace(action.Description))
                         {
-                            Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostActionDescription, action.Description));
+                            Reporter.Error.WriteLine(LocalizableStrings.PostActionDescription, action.Description);
                         }
                         DisplayInstructionsForAction(action, useErrorOutput: true);
                         result |= PostActionExecutionStatus.Cancelled;
@@ -179,7 +179,7 @@ namespace Microsoft.TemplateEngine.Cli
             Reporter.Output.WriteLine(LocalizableStrings.PostActionPromptHeader);
             if (!string.IsNullOrWhiteSpace(action.Description))
             {
-                Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionDescription, action.Description));
+                Reporter.Output.WriteLine(LocalizableStrings.PostActionDescription, action.Description);
             }
             // actual command that will be run by 'Run script' post action
             if (action.Args != null && action.Args.TryGetValue("executable", out string? executable))
@@ -187,7 +187,7 @@ namespace Microsoft.TemplateEngine.Cli
                 action.Args.TryGetValue("args", out string? commandArgs);
                 Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionCommand, $"{executable} {commandArgs}").Bold().Red());
             }
-            Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionPromptRequest, YesAnswer, NoAnswer));
+            Reporter.Output.WriteLine(LocalizableStrings.PostActionPromptRequest, YesAnswer, NoAnswer);
 
             do
             {
@@ -202,7 +202,7 @@ namespace Microsoft.TemplateEngine.Cli
                     return false;
                 }
 
-                Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionInvalidInputRePrompt, input, YesAnswer, NoAnswer));
+                Reporter.Output.WriteLine(LocalizableStrings.PostActionInvalidInputRePrompt, input, YesAnswer, NoAnswer);
             }
             while (true);
         }
@@ -230,7 +230,7 @@ namespace Microsoft.TemplateEngine.Cli
             catch (Exception e)
             {
                 Reporter.Error.WriteLine(LocalizableStrings.PostActionFailedInstructionHeader);
-                Reporter.Verbose.WriteLine(string.Format(LocalizableStrings.Generic_Details, e.ToString()));
+                Reporter.Verbose.WriteLine(LocalizableStrings.Generic_Details, e.ToString());
                 DisplayInstructionsForAction(action, useErrorOutput: true);
                 return PostActionExecutionStatus.Failure;
             }
@@ -246,7 +246,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             Reporter stream = useErrorOutput ? Reporter.Error : Reporter.Output;
-            stream.WriteLine(string.Format(LocalizableStrings.PostActionInstructions, action.ManualInstructions));
+            stream.WriteLine(LocalizableStrings.PostActionInstructions, action.ManualInstructions);
 
             // if the post action executes the command ('Run script' post action), additionally display command to be executed.
             if (action.Args != null && action.Args.TryGetValue("executable", out string? executable))

--- a/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/ChmodPostActionProcessor.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/ChmodPostActionProcessor.cs
@@ -52,7 +52,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
                         if (commandResult == null)
                         {
-                            Reporter.Error.WriteLine(string.Format(LocalizableStrings.UnableToSetPermissions, entry.Key, file));
+                            Reporter.Error.WriteLine(LocalizableStrings.UnableToSetPermissions, entry.Key, file);
                             Reporter.Verbose.WriteLine("Unable to start sub-process.");
                             allSucceeded = false;
                             continue;
@@ -62,14 +62,14 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
                         if (commandResult.ExitCode != 0)
                         {
-                            Reporter.Error.WriteLine(string.Format(LocalizableStrings.UnableToSetPermissions, entry.Key, file));
+                            Reporter.Error.WriteLine(LocalizableStrings.UnableToSetPermissions, entry.Key, file);
                             allSucceeded = false;
                         }
                     }
                     catch (Exception ex)
                     {
-                        Reporter.Error.WriteLine(string.Format(LocalizableStrings.UnableToSetPermissions, entry.Key, file));
-                        Reporter.Verbose.WriteLine(string.Format(LocalizableStrings.Generic_Details, ex.ToString()));
+                        Reporter.Error.WriteLine(LocalizableStrings.UnableToSetPermissions, entry.Key, file);
+                        Reporter.Verbose.WriteLine(LocalizableStrings.Generic_Details, ex.ToString());
                         allSucceeded = false;
                     }
                 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
@@ -14,8 +14,8 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
         protected override bool ProcessInternal(IEngineEnvironmentSettings environment, IPostAction actionConfig, ICreationEffects creationEffects, ICreationResult templateCreationResult, string outputBasePath)
         {
-            Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionDescription, actionConfig.Description));
-            Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionInstructions, actionConfig.ManualInstructions));
+            Reporter.Output.WriteLine(LocalizableStrings.PostActionDescription, actionConfig.Description);
+            Reporter.Output.WriteLine(LocalizableStrings.PostActionInstructions, actionConfig.ManualInstructions);
 
             if (actionConfig.Args != null && actionConfig.Args.TryGetValue("executable", out string? executable))
             {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/ProcessStartPostActionProcessor.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/ProcessStartPostActionProcessor.cs
@@ -47,7 +47,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                 {
                     command = command + " " + args;
                 }
-                Reporter.Output.WriteLine(string.Format(LocalizableStrings.RunningCommand, command));
+                Reporter.Output.WriteLine(LocalizableStrings.RunningCommand, command);
                 string resolvedExecutablePath = ResolveExecutableFilePath(environment.Host.FileSystem, executable, outputBasePath);
 
                 Process? commandResult = System.Diagnostics.Process.Start(new ProcessStartInfo
@@ -88,7 +88,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                 Reporter.Error.WriteLine(LocalizableStrings.CommandFailed);
                 Reporter.Error.WriteLine(ex.Message);
                 Reporter.Error.WriteLine(string.Empty);
-                Reporter.Verbose.WriteLine(string.Format(LocalizableStrings.Generic_Details, ex.ToString()));
+                Reporter.Verbose.WriteLine(LocalizableStrings.Generic_Details, ex.ToString());
                 return false;
             }
         }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/ReporterExtensions.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/ReporterExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Cli
         /// <param name="reporter"></param>
         /// <param name="command"></param>
         /// <param name="indentLevel"></param>
-        internal static void WriteCommand(this Reporter reporter, string command, int indentLevel = 0)
+        internal static void WriteCommand(this IReporter reporter, string command, int indentLevel = 0)
         {
             reporter.WriteLine(command.Indent(indentLevel + 1));
         }
@@ -45,7 +45,7 @@ namespace Microsoft.TemplateEngine.Cli
         /// <summary>
         /// Writes string <paramref name="output"/> formatted as standard output.
         /// </summary>
-        internal static void WriteStdOut(this Reporter reporter, string output)
+        internal static void WriteStdOut(this IReporter reporter, string output)
         {
             reporter.WriteLine("StdOut:");
             reporter.WriteLine(string.IsNullOrWhiteSpace(output) ? LocalizableStrings.Generic_Empty : output);
@@ -54,7 +54,7 @@ namespace Microsoft.TemplateEngine.Cli
         /// <summary>
         /// Writes string <paramref name="output"/> formatted as standard error.
         /// </summary>
-        internal static void WriteStdErr(this Reporter reporter, string output)
+        internal static void WriteStdErr(this IReporter reporter, string output)
         {
             reporter.WriteLine("StdErr:");
             reporter.WriteLine(string.IsNullOrWhiteSpace(output) ? LocalizableStrings.Generic_Empty : output);

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -185,7 +185,7 @@ namespace Microsoft.TemplateEngine.Cli
                 case CreationResultStatus.Success:
                     if (!templateArgs.IsDryRun)
                     {
-                        Reporter.Output.WriteLine(string.Format(LocalizableStrings.CreateSuccessful, resultTemplateName));
+                        Reporter.Output.WriteLine(LocalizableStrings.CreateSuccessful, resultTemplateName);
                     }
                     else
                     {
@@ -201,7 +201,7 @@ namespace Microsoft.TemplateEngine.Cli
 
                     if (!string.IsNullOrEmpty(templateArgs.Template.ThirdPartyNotices))
                     {
-                        Reporter.Output.WriteLine(string.Format(LocalizableStrings.ThirdPartyNotices, templateArgs.Template.ThirdPartyNotices));
+                        Reporter.Output.WriteLine(LocalizableStrings.ThirdPartyNotices, templateArgs.Template.ThirdPartyNotices);
                     }
 
                     return HandlePostActions(instantiateResult, templateArgs);

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateListCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateListCoordinator.cs
@@ -87,7 +87,7 @@ namespace Microsoft.TemplateEngine.Cli
                 // No templates found matching the following input parameter(s): {0}.
                 Reporter.Error.WriteLine(
                     string.Format(
-                        LocalizableStrings.InstantiateCommand_Info_NoMatchingTemplates,
+                        LocalizableStrings.Generic_Info_NoMatchingTemplates,
                         GetInputParametersString(args/*, appliedParameterMatches*/))
                     .Bold().Red());
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateListCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateListCoordinator.cs
@@ -51,10 +51,7 @@ namespace Microsoft.TemplateEngine.Cli
             //IReadOnlyDictionary<string, string?>? appliedParameterMatches = resolutionResult.GetAllMatchedParametersList();
             if (resolutionResult.TemplateGroupsWithMatchingTemplateInfoAndParameters.Any())
             {
-                Reporter.Output.WriteLine(
-                    string.Format(
-                        LocalizableStrings.TemplatesFoundMatchingInputParameters,
-                       GetInputParametersString(args/*, appliedParameterMatches*/)));
+                Reporter.Output.WriteLine(LocalizableStrings.TemplatesFoundMatchingInputParameters, GetInputParametersString(args));
                 Reporter.Output.WriteLine();
 
                 TabularOutputSettings settings = new TabularOutputSettings(_engineEnvironmentSettings.Environment, args);
@@ -76,7 +73,7 @@ namespace Microsoft.TemplateEngine.Cli
                     Reporter.Output.WriteLine(LocalizableStrings.NoTemplatesFound);
                     Reporter.Output.WriteLine();
                     // To search for the templates on NuGet.org, run:
-                    Reporter.Output.WriteLine(LocalizableStrings.SearchTemplatesCommand);
+                    Reporter.Output.WriteLine(LocalizableStrings.Generic_CommandHints_Search);
                     Reporter.Output.WriteCommand(
                        Example
                            .For<NewCommand>(args.ParseResult)
@@ -90,7 +87,7 @@ namespace Microsoft.TemplateEngine.Cli
                 // No templates found matching the following input parameter(s): {0}.
                 Reporter.Error.WriteLine(
                     string.Format(
-                        LocalizableStrings.NoTemplatesMatchingInputParameters,
+                        LocalizableStrings.InstantiateCommand_Info_NoMatchingTemplates,
                         GetInputParametersString(args/*, appliedParameterMatches*/))
                     .Bold().Red());
 
@@ -119,7 +116,7 @@ namespace Microsoft.TemplateEngine.Cli
 
                 Reporter.Error.WriteLine();
                 // To search for the templates on NuGet.org, run:
-                Reporter.Error.WriteLine(LocalizableStrings.SearchTemplatesCommand);
+                Reporter.Error.WriteLine(LocalizableStrings.Generic_CommandHints_Search);
                 if (string.IsNullOrWhiteSpace(args.ListNameCriteria))
                 {
                     Reporter.Error.WriteCommand(
@@ -153,15 +150,11 @@ namespace Microsoft.TemplateEngine.Cli
         {
             IEnumerable<ITemplateInfo> curatedTemplates = await GetCuratedListAsync(cancellationToken).ConfigureAwait(false);
 
-            Reporter.Output.WriteLine(string.Format(
-                LocalizableStrings.TemplateInformationCoordinator_DotnetNew_Description,
-                Example.For<NewCommand>(args.ParseResult)));
+            Reporter.Output.WriteLine(LocalizableStrings.TemplateInformationCoordinator_DotnetNew_Description, Example.For<NewCommand>(args.ParseResult));
 
             Reporter.Output.WriteLine();
 
-            Reporter.Output.WriteLine(string.Format(
-              LocalizableStrings.TemplateInformationCoordinator_DotnetNew_TemplatesHeader,
-              Example.For<NewCommand>(args.ParseResult)));
+            Reporter.Output.WriteLine(LocalizableStrings.TemplateInformationCoordinator_DotnetNew_TemplatesHeader, Example.For<NewCommand>(args.ParseResult));
             TemplateGroupDisplay.DisplayTemplateList(
                 _engineEnvironmentSettings,
                 curatedTemplates,

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -64,7 +64,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
             catch (Exception)
             {
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Error_PackageForTemplateNotFound, args.Template.Identity));
+                Reporter.Error.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Error_PackageForTemplateNotFound, args.Template.Identity);
                 return null;
             }
 
@@ -90,7 +90,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
             catch (Exception)
             {
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Error_PackageForTemplateNotFound, template.Identity));
+                Reporter.Error.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Error_PackageForTemplateNotFound, template.Identity);
                 return default;
             }
 
@@ -140,7 +140,7 @@ namespace Microsoft.TemplateEngine.Cli
                 if (!versionCheckResult.IsLatestVersion)
                 {
                     string displayString = $"{versionCheckResult.TemplatePackage?.Identifier}::{versionCheckResult.TemplatePackage?.Version}";         // the package::version currently installed
-                    Reporter.Output.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Update_Info_UpdateAvailable, displayString));
+                    Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Update_Info_UpdateAvailable, displayString);
 
                     Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader);
                     Reporter.Output.WriteCommand(
@@ -160,11 +160,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         internal void DisplayBuiltInPackagesCheckResult(string packageId, string version, string provider, ICommandArgs args)
         {
-            Reporter.Output.WriteLine(
-                string.Format(
-                    LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable,
-                    $"{packageId}::{version}",
-                    provider));
+            Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable, $"{packageId}::{version}", provider);
             Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage);
             Reporter.Output.WriteCommand(
                 Example
@@ -229,7 +225,7 @@ namespace Microsoft.TemplateEngine.Cli
                 {
                     continue;
                 }
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Install_Error_SameInstallRequests, installRequest.PackageIdentifier));
+                Reporter.Error.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Install_Error_SameInstallRequests, installRequest.PackageIdentifier);
                 return NewCommandStatus.InstallFailed;
             }
 
@@ -348,14 +344,11 @@ namespace Microsoft.TemplateEngine.Cli
                 {
                     if (uninstallResult.Success)
                     {
-                        Reporter.Output.WriteLine(
-                            string.Format(
-                                LocalizableStrings.TemplatePackageCoordinator_Uninstall_Info_Success,
-                                uninstallResult.TemplatePackage.DisplayName));
+                        Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Uninstall_Info_Success, uninstallResult.TemplatePackage.DisplayName);
                     }
                     else
                     {
-                        Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Uninstall_Error_GenericError, uninstallResult.TemplatePackage.DisplayName, uninstallResult.ErrorMessage));
+                        Reporter.Error.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Uninstall_Error_GenericError, uninstallResult.TemplatePackage.DisplayName, uninstallResult.ErrorMessage);
                         result = NewCommandStatus.InstallFailed;
                     }
                 }
@@ -373,10 +366,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
             catch (Exception ex)
             {
-                Reporter.Verbose.WriteLine(
-                    string.Format(
-                        LocalizableStrings.TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError,
-                        ex.ToString()));
+                Reporter.Verbose.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError, ex.ToString());
             }
         }
 
@@ -414,7 +404,7 @@ namespace Microsoft.TemplateEngine.Cli
 
                 if (!args.Force)
                 {
-                    reporter.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Install_Info_UseForceToOverride, SharedOptions.ForceOption.Aliases.First()));
+                    reporter.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Install_Info_UseForceToOverride, SharedOptions.ForceOption.Aliases.First());
                     reporter.WriteCommand(
                         Example
                             .For<InstallCommand>(args.ParseResult)
@@ -500,10 +490,7 @@ namespace Microsoft.TemplateEngine.Cli
                     var managedPackages = packages.OfType<IManagedTemplatePackage>();
                     if (managedPackages.Any())
                     {
-                        Reporter.Error.WriteLine(
-                              string.Format(
-                                  LocalizableStrings.TemplatePackageCoordinator_Error_TemplateIncludedToPackages,
-                                  notFoundPackage));
+                        Reporter.Error.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Error_TemplateIncludedToPackages, notFoundPackage);
                         foreach (IManagedTemplatePackage managedPackage in managedPackages)
                         {
                             IEnumerable<ITemplateInfo> templates = await _templatePackageManager.GetTemplatesAsync(managedPackage, cancellationToken).ConfigureAwait(false);
@@ -727,10 +714,7 @@ namespace Microsoft.TemplateEngine.Cli
                 IEnumerable<ITemplateInfo> templates = await _templatePackageManager.GetTemplatesAsync(result.TemplatePackage, cancellationToken).ConfigureAwait(false);
                 if (templates.Any())
                 {
-                    Reporter.Output.WriteLine(
-                        string.Format(
-                            LocalizableStrings.TemplatePackageCoordinator_lnstall_Info_Success,
-                            result.TemplatePackage.DisplayName));
+                    Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_lnstall_Info_Success, result.TemplatePackage.DisplayName);
                     TemplateGroupDisplay.DisplayTemplateList(
                         _engineEnvironmentSettings,
                         templates,
@@ -740,9 +724,7 @@ namespace Microsoft.TemplateEngine.Cli
                 }
                 else
                 {
-                    Reporter.Output.WriteLine(string.Format(
-                            LocalizableStrings.TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package,
-                            result.TemplatePackage.DisplayName));
+                    Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package, result.TemplatePackage.DisplayName);
                 }
             }
             else
@@ -779,7 +761,7 @@ namespace Microsoft.TemplateEngine.Cli
                               string.Format(
                                   LocalizableStrings.TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled,
                                   packageToInstall).Bold().Red());
-                        Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled_Hint, InstallCommand.ForceOption.Aliases.First()));
+                        Reporter.Error.WriteLine(LocalizableStrings.TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled_Hint, InstallCommand.ForceOption.Aliases.First());
                         Reporter.Error.WriteCommand(Example.For<InstallCommand>(parseResult).WithArgument(BaseInstallCommand.NameArgument, packageToInstall).WithOption(BaseInstallCommand.ForceOption));
 
                         break;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -79,7 +79,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                     // No templates found matching the following input parameter(s): {0}.
                     Reporter.Error.WriteLine(
                         string.Format(
-                            LocalizableStrings.InstantiateCommand_Info_NoMatchingTemplates,
+                            LocalizableStrings.Generic_Info_NoMatchingTemplates,
                             GetInputParametersString(commandArgs))
                         .Bold().Red());
                 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -62,12 +62,12 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             {
                 if (!result.Success)
                 {
-                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.CliTemplateSearchCoordinator_Info_MatchesFromSource, result.Provider.Factory.DisplayName));
+                    Reporter.Error.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Info_MatchesFromSource, result.Provider.Factory.DisplayName);
                     Reporter.Error.WriteLine(string.Format(LocalizableStrings.CliTemplateSearchCoordinator_Error_SearchFailure, result.ErrorMessage).Red().Bold());
                     continue;
                 }
 
-                Reporter.Output.WriteLine(string.Format(LocalizableStrings.CliTemplateSearchCoordinator_Info_MatchesFromSource, result.Provider.Factory.DisplayName));
+                Reporter.Output.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Info_MatchesFromSource, result.Provider.Factory.DisplayName);
                 if (result.SearchHits.Any())
                 {
                     DisplayResultsForPack(result.SearchHits, environmentSettings, commandArgs, defaultLanguage);
@@ -79,7 +79,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                     // No templates found matching the following input parameter(s): {0}.
                     Reporter.Error.WriteLine(
                         string.Format(
-                            LocalizableStrings.NoTemplatesMatchingInputParameters,
+                            LocalizableStrings.InstantiateCommand_Info_NoMatchingTemplates,
                             GetInputParametersString(commandArgs))
                         .Bold().Red());
                 }
@@ -134,10 +134,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
         {
             //TODO: implement it for template options matching
             //IReadOnlyDictionary<string, string?>? appliedParameterMatches = TemplateCommandInput.GetTemplateParametersFromCommand(commandArgs);
-            Reporter.Output.WriteLine(
-                string.Format(
-                    LocalizableStrings.TemplatesFoundMatchingInputParameters,
-                    GetInputParametersString(commandArgs)));
+            Reporter.Output.WriteLine(LocalizableStrings.TemplatesFoundMatchingInputParameters, GetInputParametersString(commandArgs));
             Reporter.Output.WriteLine();
             IReadOnlyCollection<SearchResultTableRow> data = GetSearchResultsForDisplay(results, commandArgs.Language, defaultLanguage, environmentSettings.Environment);
 
@@ -184,7 +181,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             // && !commandInput.RemainingParameters.Any())
             {
                 Reporter.Error.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Error_NoTemplateName.Red().Bold());
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.CliTemplateSearchCoordinator_Info_SearchHelp, string.Join(", ", SearchCommand.SupportedFilters.Select(f => $"'{f.OptionFactory().Aliases.First()}'"))));
+                Reporter.Error.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Info_SearchHelp, string.Join(", ", SearchCommand.SupportedFilters.Select(f => $"'{f.OptionFactory().Aliases.First()}'")));
                 Reporter.Error.WriteLine(LocalizableStrings.Generic_ExamplesHeader);
                 Reporter.Error.WriteCommand(
                     Example

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Upozornění: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">Podrobnosti: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Příklady:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">Není nakonfigurováno žádné zpětné volání. Spuštění akce příspěvku není možné.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">Nepovedlo se načíst data hostitele dotnet CLI pro šablonu {0} z {1}. Data hostitele se budou ignorovat.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Neplatná syntaxe příkazu: místo toho použijte {0}.</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">Pokud chcete vypsat nainstalované šablony, spusťte:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">U šablony {1} chybí povinná možnost {0}.</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Nejsou nainstalované žádné šablony.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">Nenašly se žádné šablony, které by odpovídaly tomuto hledání: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">Spouští se příkaz {0}...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">Pokud chcete hledat šablony na NuGet.org, spusťte:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Warnung: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">Details: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Beispiele:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">Es ist kein Rückruf konfiguriert. Das Ausführen von Post-Aktionen ist nicht möglich.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">Fehler beim Laden der dotnet CLI-Hostdaten für vorlagenbasierte {0} aus {1}. Die Hostdaten werden ignoriert.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Ungültige Befehlssyntax: Verwenden Sie stattdessen "{0}".</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">Um installierte Vorlagen aufzulisten, führen Sie folgende Aktion aus:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">Die obligatorische Option „{0}“ fehlt für die Vorlage „{1}“.</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Keine Vorlagen installiert.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">Keine Vorlagen gefunden, die "{0}" entsprechen.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">Befehl "{0}" wird ausgeführt...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">Um nach den Vorlagen unter NuGet.org zu suchen, führen Sie folgende Aktion aus:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Advertencia: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">Detalles: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Ejemplos:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">No se ha configurado ninguna devolución de llamada. No es posible ejecutar la acción posterior.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">No se pudieron cargar los datos del host de la CLI de dotnet para la plantilla {0} desde {1}. Se omitirán los datos del host.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Sintaxis de comando no válida: utilice "{0}" en su lugar.</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">Para mostrar la lista de plantillas instaladas, ejecute:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">Falta la opción obligatoria '{0}' para la plantilla '{1}'.</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">No hay plantillas instaladas.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">No se encontró ninguna plantilla que coincida con: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">Ejecutando comando "{0}"...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">Para buscar las plantillas en NuGet.org, ejecute:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Avertissement : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">Détails : {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Exemples :</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">Aucun rappel n’est configuré. L’exécution de l’action de publication n’est pas possible.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">Échec du chargement des données d’hôte de l’interface CLI dotnet pour le modèle {0} à partir de {1}. Les données de l’hôte seront ignorées.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Syntaxe de commande non valide : utilisez «{0}» à la place.</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">Pour répertorier les modèles installés, exécutez :</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">L’option obligatoire '{0}' est manquante pour le modèle '{1}'.</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Aucun modèle installé</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">Aucun modèle trouvé correspondant : {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">Exécution de la commande « {0} »...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">Pour rechercher les modèles sur NuGet.org, exécutez :</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Avviso: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">Dettagli: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Esempi:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">Nessun callback configurato. Non p possibile l'esecuzione dell'azione successiva.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">Non è stato possibile caricare i dati dell'host dell'interfaccia della riga di comando di .NET per il modello {0} da {1}. I dati dell'host verranno ignorati.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Sintassi del comando non valida: usare '{0}'.</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">Per elencare i modelli installati, eseguire:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">Manca '{0}' l'opzione obbligatoria per il modello '{1}'.</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Nessun modello installato.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">Nessun modello corrispondente trovato: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">Esecuzione del comando: ‘{0}’...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">Per cercare i modelli in NuGet.org, eseguire:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">警告: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">詳細: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">例:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">コールバックが構成されていません。POST アクションを実行できません。</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">テンプレート {0} の dotnet CLI ホスト データを {1} から読み込むことができませんでした。ホストデータは無視されます。</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">コマンドの構文が無効です: 代わりに '{0}' をお使いください。</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">インストールされているテンプレートを一覧表示するには、次を実行してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">テンプレート '{1}' の必須パラメーター '{0}' がありません。</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">テンプレートがインストールされていません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">テンプレートが見つかりません: {0}。</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">実行中のコマンド: {0}...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">NuGet.org のテンプレートを検索するには、次を実行してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">경고 :{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">세부 정보 :{0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">예:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">콜백이 구성되지 않았습니다. 게시 작업을 실행할 수 없습니다.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">{1}에서 템플릿 {0}에 대한 dotnet CLI 호스트 데이터를 로드하지 못했습니다. 호스트 데이터는 무시됩니다.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">잘못된 명령 구문: 대신 '{0}'을(를) 사용하세요.</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">설치된 템플릿을 나열하려면 다음을 실행하세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">'{1}' 템플릿에 대한 '{0}' 필수 옵션이 없습니다.</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">템플릿이 설치되어 있지 않습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">일치하는 템플릿이 없음:{0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">'{0}' 명령 실행 중 ...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">NuGet.org에서 템플릿을 검색하려면 다음을 실행하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Ostrzeżenie: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">Szczegóły: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Przykłady:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">Nie skonfigurowano wywołania zwrotnego. Uruchomienie akcji publikowania nie jest możliwe.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">Nie udało się załadować danych hosta dotnet CLI dla szablonu {0} z {1}. Dane hosta zostaną zignorowane.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Nieprawidłowa składnia polecenia: zamiast tego użyj "{0}".</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">Aby wyświetlić listę zainstalowanych szablonów, uruchom:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">W przypadku szablonu „{1}” brakuje opcji obowiązkowej „{0}”.</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Nie zainstalowano żadnych szablonów.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">Nie stwierdzono dopasowania żadnych szablonów: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">Trwa uruchamianie polecenia "{0}"...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">Aby wyszukać szablonów na stronie NuGet.org, uruchom:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Aviso: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">Detalhes: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Exemplos:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">Nenhum retorno de chamada está configurado. Não é possível executar a ação de postagem.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">Falha ao carregar os dados do host CLI do dotnet para o modelo {0} de {1}. Os dados do host serão ignorados.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Sintaxe de comando inválida: usar '{0}' em seu lugar.</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">Para listar os modelos instalados, execute:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">A opção obrigatória '{0}' está faltando para o modelo '{1}'.</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Nenhum modelo instalado.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">Nenhum modelo encontrado: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">Comando em execução '{0}'...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">Para pesquisar os modelos no NuGet.org, execute:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Предупреждение: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">Сведения: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Примеры:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">Обратный вызов не настроен. Запуск пост-экшена невозможен.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">Не удалось загрузить данные узла CLI DotNet для шаблона {0} из {1}. Данные узла будут пропущены.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Недопустимый синтаксис команды: используйте "{0}" вместо ранее использованного.</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">Чтобы перечислить установленные шаблоны, выполните следующую команду:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">Отсутствует обязательный параметр "{0}" для шаблона "{1}".</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Шаблоны не установлены.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">Соответствующие шаблоны не найдены: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">Запуск команды: "{0}"...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">Чтобы найти шаблоны на NuGet.org, выполните следующую команду:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Uyarı: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">Ayrıntılar: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Örnekler:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">Geri arama yapılandırılmamış. Post eyleminin çalıştırılması mümkün değildir.</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">{0} şablonu için dotnet CLI konak verileri {1} konumundan yüklenemedi. Konak verileri yoksayılacak.</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Geçersiz komut söz dizimi: bunun yerine '{0}' kullanın.</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">Yüklü şablonları listelemek için şunu çalıştırın:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">'{1}' şablonunda zorunlu '{0}' seçeneği eksik.</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">Yüklü şablon yok.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">Eşleşen şablon bulunamadı: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">'{0}' komutu çalıştırılıyor...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">NuGet.org sitesinde şablon aramak için şunu çalıştırın:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">警告: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">详细信息: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">示例: </target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">未配置回调。无法运行发布操作。</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">无法从 {1} 加载模板 {0} 的 dotnet CLI 主机数据。将忽略主机数据。</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">命令语法无效: 请改用 "{0}"。</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">若要列出已安装的模板，请运行:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">模板“{1}”缺少必备选项“{0}”。</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">未安装模板。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">找不到匹配的模板: {0}。</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">正在运行命令:“{0}”...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">要在 NuGet.org 上搜索模板，请运行:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -403,6 +403,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">警告: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List">
+        <source>To list installed templates, run:</source>
+        <target state="new">To list installed templates, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Generic_CommandHints_Search">
+        <source>To search for the templates on NuGet.org, run:</source>
+        <target state="new">To search for the templates on NuGet.org, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_Details">
         <source>Details: {0}</source>
         <target state="translated">詳細資料: {0}</target>
@@ -423,6 +433,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">範例:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Info_NoMatchingTemplates">
+        <source>No templates found matching: {0}.</source>
+        <target state="new">No templates found matching: {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_NoCallbackError">
         <source>No callback is configured. Running post action is not possible.</source>
         <target state="translated">未設定回呼。無法執行張貼動作。</target>
@@ -437,6 +452,21 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
         <target state="translated">無法從 {1} 載入範本 {0} 的 dotnet CLI 主機資料。將略過主機資料。</target>
         <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_NoMatchingTemplatesSubCommands">
+        <source>No templates or subcommands found matching: '{0}'.</source>
+        <target state="new">No templates or subcommands found matching: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Subcommands">
+        <source>Did you mean one of the following subcommands?</source>
+        <target state="new">Did you mean one of the following subcommands?</target>
+        <note>Followed by the list of suggestions</note>
+      </trans-unit>
+      <trans-unit id="InstantiateCommand_Info_TypoCorrection_Templates">
+        <source>Did you mean one of the following templates?</source>
+        <target state="new">Did you mean one of the following templates?</target>
+        <note>Followed by the list of suggestions</note>
       </trans-unit>
       <trans-unit id="InvalidCommandOptions">
         <source>Error: Invalid option(s):</source>
@@ -473,11 +503,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">命令語法無效: 請改為使用 '{0}'。</target>
         <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
       </trans-unit>
-      <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run:</source>
-        <target state="translated">若要列出已安裝的範本，請執行:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MissingRequiredParameter">
         <source>Mandatory option '{0}' is missing for the template '{1}'.</source>
         <target state="translated">範本 '{1}'缺少強制選項 '{0}'。</target>
@@ -501,11 +526,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="NoTemplatesFound">
         <source>No templates installed.</source>
         <target state="translated">未安裝範本。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoTemplatesMatchingInputParameters">
-        <source>No templates found matching: {0}.</source>
-        <target state="translated">找不到符合的範本: {0}。</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionalWorkloadsSyncFailed">
@@ -674,11 +694,6 @@ The header is followed by the list of parameters and their errors (might be seve
       <trans-unit id="RunningCommand">
         <source>Running command '{0}'...</source>
         <target state="translated">正在執行命令 '{0}'...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run:</source>
-        <target state="translated">若要在範本上搜尋 NuGet.org，請執行:</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NullReporter.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NullReporter.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install
@@ -10,5 +12,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         public void Write(string message) { }
         public void WriteLine(string message) { }
         public void WriteLine() { }
+
+        public void WriteLine(string format, params object?[] args) => WriteLine(string.Format(format, args));
     }
 }

--- a/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/TypoCorrectionTests.cs
+++ b/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/TypoCorrectionTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable enable
+
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    public class TypoCorrectionTests
+    {
+        [InlineData("wbe", "web|webapp|wpf|install|uninstall", "web|wpf")]
+        [InlineData("uninstal", "web|webapp|install|uninstall", "uninstall")]
+        [InlineData("console", "web|webapp|install|uninstall", "")]
+        [Theory]
+        public void TypoCorrection_BasicTest(string token, string possibleTokens, string expectedTokens)
+        {
+            TypoCorrection.GetSimilarTokens(possibleTokens.Split('|'), token)
+                .Should().BeEquivalentTo(expectedTokens.Split('|', System.StringSplitOptions.RemoveEmptyEntries));
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/Utilities/BufferedReporter.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Utilities/BufferedReporter.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using Microsoft.DotNet.Cli.Utils;
 
@@ -55,5 +57,7 @@ namespace Microsoft.NET.TestFramework.Utilities
         {
             Lines.Clear();
         }
+
+        public void WriteLine(string format, params object?[] args) => WriteLine(string.Format(format, args));
     }
 }

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CannotShowHelpForTemplate_FullNameMatch.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CannotShowHelpForTemplate_FullNameMatch.verified.txt
@@ -1,4 +1,4 @@
-﻿No templates found matching: 'Console App'.
+﻿No templates or subcommands found matching: 'Console App'.
 
 To list installed templates, run:
    dotnet new list

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CannotShowHelpForTemplate_PartialNameMatch.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CannotShowHelpForTemplate_PartialNameMatch.verified.txt
@@ -1,4 +1,8 @@
-﻿No templates found matching: 'class'.
+﻿No templates or subcommands found matching: 'class'.
+Did you mean one of the following templates?
+   dotnet new classlib -h
+Did you mean one of the following subcommands?
+   dotnet new list -h
 
 To list installed templates, run:
    dotnet new list

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiate.CanSuggestTypoCorrection_Command.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiate.CanSuggestTypoCorrection_Command.verified.txt
@@ -1,9 +1,11 @@
-﻿No templates or subcommands found matching: 'unknownapp'.
+﻿No templates or subcommands found matching: 'uninstal'.
+Did you mean one of the following subcommands?
+   dotnet new uninstall
 
 To list installed templates, run:
    dotnet new list
 To search for the templates on NuGet.org, run:
-   dotnet new search unknownapp
+   dotnet new search uninstal
 
 
 For details on the exit code, refer to https://aka.ms/templating-exit-codes#103

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiate.CanSuggestTypoCorrection_Template.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiate.CanSuggestTypoCorrection_Template.verified.txt
@@ -1,9 +1,11 @@
-﻿No templates or subcommands found matching: 'unknownapp'.
+﻿No templates or subcommands found matching: 'cnsle'.
+Did you mean one of the following templates?
+   dotnet new console
 
 To list installed templates, run:
    dotnet new list
 To search for the templates on NuGet.org, run:
-   dotnet new search unknownapp
+   dotnet new search cnsle
 
 
 For details on the exit code, refer to https://aka.ms/templating-exit-codes#103

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenFullNameIsUsed.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenFullNameIsUsed.verified.txt
@@ -1,4 +1,4 @@
-﻿No templates found matching: 'Console App'.
+﻿No templates or subcommands found matching: 'Console App'.
 
 To list installed templates, run:
    dotnet new list

--- a/src/Tests/dotnet-new.Tests/DotnetNewDebugOptions.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewDebugOptions.cs
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             commandResult
                 .Should()
                 .Fail()
-                .And.HaveStdErrContaining("No templates found matching: 'console'.");
+                .And.HaveStdErrContaining("No templates or subcommands found matching: 'console'.");
         }
     }
 }

--- a/src/Tests/dotnet-new.Tests/DotnetNewInstantiate.Approval.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewInstantiate.Approval.cs
@@ -606,7 +606,38 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                     output.Replace("{TempPath}", "/tmp/");
                     output.Replace(templateLocation, "%template location%");
                 });
-                
+        }
+
+        [Fact]
+        public Task CanSuggestTypoCorrection_Template()
+        {
+            CommandResult commandResult = new DotnetNewCommand(_log, "cnsle")
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Fail()
+                .And.NotHaveStdOut();
+
+            return Verify(commandResult.StdErr);
+        }
+
+        [Fact]
+        public Task CanSuggestTypoCorrection_Command()
+        {
+            CommandResult commandResult = new DotnetNewCommand(_log, "uninstal")
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Fail()
+                .And.NotHaveStdOut();
+
+            return Verify(commandResult.StdErr);
         }
 
     }

--- a/src/Tests/dotnet-new.Tests/DotnetNewInstantiate.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewInstantiate.cs
@@ -359,7 +359,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             if (!TestContext.IsLocalized())
             {
-                cmd.StdErr.Should().StartWith("No templates found");
+                cmd.StdErr.Should().StartWith("No templates or subcommands found");
             }
         }
 
@@ -419,7 +419,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             if (!TestContext.IsLocalized())
             {
-                cmd.StdErr.Should().StartWith("No templates found matching: 'c'.");
+                cmd.StdErr.Should().StartWith("No templates or subcommands found matching: 'c'.");
             }
         }
 


### PR DESCRIPTION
fixes https://github.com/dotnet/templating/issues/4989

Implemented offering suggestions for `dotnet new` in case the template was not found.

Refactoring:
- added `WriteLine` overload to `IReporter` accepting format and args.