### PR TITLE
Don't run CG in public builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -28,6 +28,8 @@ variables:
       value: ''
     - name: _OfficialBuildArgs
       value: ''
+    - name: "skipComponentGovernanceDetection"
+      value: "true"
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - name: _DotNetPublishToBlobFeed
       value: true


### PR DESCRIPTION
This is so that CG stops tracking our public branches as we already track in our internal branches.