### PR TITLE
Only reference the needed packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <JabVersion>0.8.0</JabVersion>
+    <JabVersion>0.8.4</JabVersion>
     <MicrosoftBuildVersion>15.4.8</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>15.4.8</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.4.8</MicrosoftBuildUtilitiesCoreVersion>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -13,7 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(_MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(_MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(_MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Microsoft.CodeAnalysis package contains much that isn't needed by APICompat. Instead of referencing the "all-in-one package", use Microsoft.CodeAnalysis.Common and Microsoft.CodeAnalysis.CSharp.

This reduces the payload size of the tool package (which contains the CodeAnalysis assemblies) and minimizes dependencies.