### PR TITLE
added and altered readme files after moving `dotnet new` and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repo contains core functionality needed to create .NET projects that is sha
 
 Please refer to [dotnet/project-system](https://github.com/dotnet/project-system) for the project system work that is specific to Visual Studio.
 
+This repo also contains [common project and item templates](https://github.com/dotnet/sdk/tree/main/template_feed).
+
 ## Build status
 
 |Windows x64 |

--- a/src/Cli/dotnet/commands/dotnet-new/README.md
+++ b/src/Cli/dotnet/commands/dotnet-new/README.md
@@ -1,0 +1,25 @@
+## `dotnet new`
+
+This is a home for `dotnet new` command.
+
+The issues for `dotnet new` be opened in dotnet/sdk repo with label [`area: dotnet new`](https://github.com/dotnet/sdk/labels/area%3A%20dotnet%20new).
+
+To contribute or debug, follow [`dotnet/sdk` guideline](https://github.com/dotnet/sdk#how-do-i-engage-and-contribute).
+
+Main `muscles` of `dotnet new` are implemented in [`Microsoft.TemplateEngine.Cli`](https://github.com/dotnet/sdk/tree/main/src/Cli/Microsoft.TemplateEngine.Cli).
+`dotnet` mainly contains the functionality that needs other `dotnet` tools, as:
+- MSBuild evaluation and related components ([project capability constraint](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs), [project context symbol source](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectContextSymbolSource.cs))
+- [post actions](https://github.com/dotnet/sdk/tree/main/src/Cli/dotnet/commands/dotnet-new/PostActions) running other `dotnet` commands 
+- providers for the template packages built-in to SDK, other SDK information and optional workloads 
+
+Consider adding unit tests and/or integration tests when contributing.
+The unit tests are located in:
+- [`dotnet` unit tests](https://github.com/dotnet/sdk/tree/main/src/Tests/dotnet.Tests/dotnet-new)
+- [`Microsoft.TemplateEngine.Cli`](https://github.com/dotnet/sdk/tree/main/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests)
+
+The integration tests are located [here](https://github.com/dotnet/sdk/tree/main/src/Tests/dotnet-new.Tests).
+Please follow existing tests to see how to run `dotnet new` under different conditions.
+
+Assets for unit and integration tests are defined [here](https://github.com/dotnet/sdk/tree/main/src/Assets/TestPackages/dotnet-new).
+
+To work with `dotnet new`, you may also use [solution filter](https://github.com/dotnet/sdk/blob/main/TemplateEngine.slnf).

--- a/template_feed/README.md
+++ b/template_feed/README.md
@@ -1,0 +1,24 @@
+## Common project and item templates
+
+[.NET default templates](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates) are located in several repositories.
+
+This folder contains common project and item templates:
+- Console App (`console`)
+- Class Library (`classlib`)
+- .NET `gitignore` (`gitignore`)
+- Editor config (`editorconfig`)
+and some others
+
+The issues for these templates content should be opened in dotnet/sdk repo with label [`Area-Templates`](https://github.com/dotnet/sdk/issues?q=is%3Aopen+is%3Aissue+label%3AArea-Templates).
+
+The other templates are located in the following repositories:
+| Templates | Repository |
+|---|---|
+|ASP.NET and Blazor templates|[dotnet/aspnetcore](https://github.com/dotnet/aspnetcore)|
+|ASP.NET Single Page Application templates| [dotnet/spa-templates](https://github.com/dotnet/spa-templates)|
+|WPF templates|[dotnet/wpf](https://github.com/dotnet/wpf)|
+|Windows Forms templates|[dotnet/winforms](https://github.com/dotnet/winforms)|
+|Test templates|[dotnet/test-templates](https://github.com/dotnet/test-templates)|
+|MAUI templates|[dotnet/maui](https://github.com/dotnet/maui)|
+
+Issues for the template content should be opened in the corresponding repository.

--- a/template_feed/README.md
+++ b/template_feed/README.md
@@ -9,7 +9,7 @@ This folder contains common project and item templates:
 - Editor config (`editorconfig`)
 and some others
 
-The issues for these templates content should be opened in dotnet/sdk repo with label [`Area-Templates`](https://github.com/dotnet/sdk/issues?q=is%3Aopen+is%3Aissue+label%3AArea-Templates).
+The issues for the content of these templates should be opened in dotnet/sdk repo with label [`Area-Templates`](https://github.com/dotnet/sdk/issues?q=is%3Aopen+is%3Aissue+label%3AArea-Templates).
 
 The other templates are located in the following repositories:
 | Templates | Repository |


### PR DESCRIPTION
Since new projects and template packages are moved to dotnet/sdk repo, added and altered readme files.