### PR TITLE
Added support of C#11 to templates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[project.json]
+[*.json]
 indent_size = 2
 
 # C# files

--- a/src/Tests/dotnet-new.Tests/CommonTemplatesTests.cs
+++ b/src/Tests/dotnet-new.Tests/CommonTemplatesTests.cs
@@ -295,9 +295,9 @@ Restore succeeded\.",
             };
 
             string[] unsupportedLanguageVersions = { "1", "ISO-1" };
-            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "11.0", "latest", "latestMajor", "default", "preview" };
 
-            string?[] topLevelStatementSupport = { null, "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+            string?[] topLevelStatementSupport = { null, "9.0", "10.0", "11.0", "latest", "latestMajor", "default", "preview" };
 
             foreach (var template in templatesToTest)
             {
@@ -400,6 +400,8 @@ Restore succeeded\.",
         }
 
         [Theory]
+        [InlineData("11.0")]
+        [InlineData("11")]
         [InlineData("10.0")]
         [InlineData("10")]
         [InlineData("preview")]
@@ -502,10 +504,10 @@ class Program
             };
 
             string[] unsupportedLanguageVersions = { "1", "ISO-1" };
-            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "11.0", "latest", "latestMajor", "default", "preview" };
 
             string?[] supportedInFrameworkByDefault = { null, "net7.0", "netstandard2.1" };
-            string?[] supportedInLanguageVersion = { "8.0", "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+            string?[] supportedInLanguageVersion = { "8.0", "9.0", "10.0", "11.0", "latest", "latestMajor", "default", "preview" };
 
             foreach (var template in templatesToTest)
             {
@@ -606,10 +608,10 @@ class Program
                 new { Template = "classlib", Frameworks = new[] { null, "net7.0", "netstandard2.0", "netstandard2.1" } }
             };
             string[] unsupportedLanguageVersions = { "1", "ISO-1" };
-            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "11.0", "latest", "latestMajor", "default", "preview" };
 
             string?[] supportedInFramework = { null, "net7.0" };
-            string?[] supportedInLangVersion = { null, "10.0", "latest", "latestMajor", "default", "preview" };
+            string?[] supportedInLangVersion = { null, "10.0", "11.0", "latest", "latestMajor", "default", "preview" };
 
             foreach (var template in templatesToTest)
             {
@@ -707,10 +709,10 @@ class Program
                 new { Template = "classlib", Frameworks = new[] { null, "net7.0", "netstandard2.0", "netstandard2.1" } }
             };
             string[] unsupportedLanguageVersions = { "1", "ISO-1" };
-            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "11.0", "latest", "latestMajor", "default", "preview" };
 
             string?[] supportedFrameworks = { null, "net7.0" };
-            string?[] fileScopedNamespacesSupportedLanguages = { "10.0", "latest", "latestMajor", "default", "preview" };
+            string?[] fileScopedNamespacesSupportedLanguages = { "10.0", "11.0", "latest", "latestMajor", "default", "preview" };
 
             foreach (var template in templatesToTest)
             {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -90,7 +90,7 @@
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(|11|11\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
         "source": "langVersion"
       }
     },
@@ -99,7 +99,7 @@
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|11|11\\.0|preview|latest|default|latestMajor)$",
         "source": "langVersion"
       }
     },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -73,7 +73,7 @@
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(|10\\.0|10|11|11\\.0|preview|latest|default|latestMajor)$",
         "source": "langVersion"
       }
     },
@@ -82,7 +82,7 @@
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|9|9\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(|9|9\\.0|10\\.0|10|11|11\\.0|preview|latest|default|latestMajor)$",
         "source": "langVersion"
       }
     },
@@ -91,7 +91,7 @@
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|11|11\\.0|preview|latest|default|latestMajor)$",
         "source": "langVersion"
       }
     },


### PR DESCRIPTION
## Problem
In the templates, the generators which determine minimum language version in use were not considering C#11. 
Fixed regex to support it.

## Customer impact 
Without this fix, using C# 11.0 via `--langVersion` option will result in old style template (no top level statements, file scoped namespaces, implicit usings)

## Testing
Automated

## Risk
Very low. 
Language version option is only available in CLI and not exposed in Visual Studio.


