### PR TITLE
Fix resolving assembly reference paths from dirs

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/AssemblySymbolLoader.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/AssemblySymbolLoader.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.ApiCompatibility
                         if (directoryName != null)
                         {
                             _referencePathFiles.Add(assemblyName, directoryName);
-                            _referencePathDirectories.Add(path);
+                            _referencePathDirectories.Add(directoryName);
                         }
                     }
                 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/AssemblySymbolLoader.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/AssemblySymbolLoader.cs
@@ -45,7 +45,8 @@ namespace Microsoft.DotNet.ApiCompatibility
             {
                 if (Directory.Exists(path))
                 {
-                    _referencePaths.Add(path, path);
+                    if (!_referencePaths.ContainsKey(path))
+                        _referencePaths.Add(path, path);
                 }
                 else
                 {

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/AssemblySymbolLoader.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/AssemblySymbolLoader.cs
@@ -257,7 +257,8 @@ namespace Microsoft.DotNet.ApiCompatibility
                 {
                     // If a directory is passed in as a path, add that to the reference paths.
                     // Otherwise, if a file is passed in, add its parent directory to the reference paths.
-                    _referencePaths.Add(path, path);
+                    if (!_referencePaths.ContainsKey(path))
+                        _referencePaths.Add(path, path);
 
                     foreach (string assembly in Directory.EnumerateFiles(path, "*.dll"))
                     {
@@ -269,7 +270,7 @@ namespace Microsoft.DotNet.ApiCompatibility
                     string? directory = Path.GetDirectoryName(path);
                     // If a directory is passed in as a path, add that to the reference paths.
                     // Otherwise, if a file is passed in, add its parent directory to the reference paths.
-                    if (!string.IsNullOrEmpty(directory))
+                    if (!string.IsNullOrEmpty(directory) && !_referencePaths.ContainsKey(directory))
                         _referencePaths.Add(directory, directory);
 
                     result.Add(CreateOrGetMetadataReferenceFromPath(path, referenceAssemblyNamesToIgnore));


### PR DESCRIPTION
This fixes the previous behavior that only probed for assemblies in the passed in assemblies' directories. This regressed with https://github.com/dotnet/sdk/commit/c4bf096954a96e0a2be7cfcbfe0c4aacca35c038.

Making sure that directories from the passed in assemblies and their references are used to probe for new reference assemblies.

