### PR TITLE
Fix AttributesMustMatch InvalidOperationException

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -341,6 +341,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         if (!x.Values.SequenceEqual(y.Values, this))
                             return false;
                         break;
+                    case TypedConstantKind.Type:
+                        if (!_settings.SymbolComparer.Equals((x.Value as INamedTypeSymbol)!, (y.Value as INamedTypeSymbol)!))
+                            return false;
+                        break;
                     default:
                         if (!Equals(x.Value, y.Value))
                             return false;

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -21,10 +21,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         private readonly RuleSettings _settings;
         private readonly HashSet<string>? _attributesToExclude;
 
-        public AttributesMustMatch(RuleSettings settings, IRuleRegistrationContext context, IEnumerable<string>? excludeAttributesFiles)
+        public AttributesMustMatch(RuleSettings settings, IRuleRegistrationContext context, IReadOnlyCollection<string>? excludeAttributesFiles)
         {
             _settings = settings;
-            if (excludeAttributesFiles != null)
+            if (excludeAttributesFiles != null && excludeAttributesFiles.Count > 0)
             {
                 IEnumerable<string> attributesToExclude = ReadExclusions(excludeAttributesFiles);
                 _attributesToExclude = new HashSet<string>(attributesToExclude);
@@ -330,8 +330,25 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
             public ConstantComparer(RuleSettings settings) => _settings = settings;
 
-            public bool Equals(TypedConstant x, TypedConstant y) =>
-                x.Kind == y.Kind && x.Value!.Equals(y.Value) && _settings.SymbolComparer.Equals(x.Type!, y.Type!);
+            public bool Equals(TypedConstant x, TypedConstant y)
+            {
+                if (x.Kind != y.Kind)
+                    return false;
+
+                switch (x.Kind)
+                {
+                    case TypedConstantKind.Array:
+                        if (!x.Values.SequenceEqual(y.Values, this))
+                            return false;
+                        break;
+                    default:
+                        if (!Equals(x.Value, y.Value))
+                            return false;
+                        break;
+                }
+
+                return _settings.SymbolComparer.Equals(x.Type!, y.Type!);
+            }
 
             public int GetHashCode([DisallowNull] TypedConstant obj) => throw new NotImplementedException();
         }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleFactory.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleFactory.cs
@@ -13,9 +13,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     {
         private readonly ICompatibilityLogger _log;
 
-        private readonly IEnumerable<string>? _excludeAttributesFiles;
+        private readonly IReadOnlyCollection<string>? _excludeAttributesFiles;
 
-        public RuleFactory(ICompatibilityLogger log, IEnumerable<string>? excludeAttributesFiles = null)
+        public RuleFactory(ICompatibilityLogger log, IReadOnlyCollection<string>? excludeAttributesFiles = null)
         {
             _log = log;
             _excludeAttributesFiles = excludeAttributesFiles;


### PR DESCRIPTION
Two fixes:
1. Don't run the rule if no exclusion files are supplied. Currently as msbuild provides an empty item group, the IEnumerable<T> would never be null.
2. The AttributesMustMatch.ConstantComparer type's Equals method must check the TypedConstant's kind as the Value property throws an InvalidOperationException if the kind is array and vice versa the Values property throws if the kind is not an array.

@smasher164 I noticed this when I ran your changes in dotnet/runtime. It might make sense to add an additional test with an attribute for which the TypedConstant is an array and a type.