### PR TITLE
Add error when failing to resolve SDK with workload sdk resolver

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
@@ -94,8 +94,8 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
                         return factory.IndicateSuccess(r.Paths, sdkReference.Version);
                     case EmptyResolutionResult r:
                         return factory.IndicateSuccess(Enumerable.Empty<string>(), sdkReference.Version, r.propertiesToAdd, r.itemsToAdd);
-                    case NullResolutionResult:
-                        return null;
+                    case NullResolutionResult r:
+                        return factory.IndicateFailure(r.failureReason);
                 }
 
                 throw new InvalidOperationException("Unknown resolutionResult type: " + this.GetType());

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using System.Collections.Immutable;
+using Microsoft.NET.Sdk.Localization;
 
 #if NET
 using Microsoft.DotNet.Cli;
@@ -114,7 +115,9 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
             IDictionary<string, SdkResultItem> itemsToAdd
         ) : ResolutionResult;
 
-        public sealed record NullResolutionResult() : ResolutionResult;
+        public sealed record NullResolutionResult(
+            IEnumerable<string> failureReason
+            ) : ResolutionResult;
 
         private static ResolutionResult Resolve(string sdkReferenceName, IWorkloadManifestProvider manifestProvider, IWorkloadResolver workloadResolver)
         {
@@ -169,15 +172,18 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
                         return new EmptyResolutionResult(propertiesToAdd, itemsToAdd);
                     }
                 }
+                else
+                {
+                    return new NullResolutionResult(new List<string>() { Strings.MissingWorkloadPathOrVersion });
+                }
             }
-            return new NullResolutionResult();
         }
 
         public ResolutionResult Resolve(string sdkReferenceName, string dotnetRootPath, string sdkVersion, string userProfileDir)
         {
             if (!_enabled)
             {
-                return new NullResolutionResult();
+                return new NullResolutionResult(new List<string>() { Strings.WorkloadResolverDisabled });
             }
 
             ResolutionResult resolutionResult;

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="..\Microsoft.NET.Sdk.WorkloadManifestReader\Strings.resx" LinkBase="Resources" GenerateSource="True" Namespace="Microsoft.NET.Sdk.Localization"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.NET.Sdk.WorkloadManifestReader\Microsoft.NET.Sdk.WorkloadManifestReader.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.NativeWrapper\Microsoft.DotNet.NativeWrapper.csproj" />
     <Compile Include="..\..\Cli\dotnet\commands\dotnet-workload\install\WorkloadInstallRecords\**\*.cs" 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
@@ -147,6 +147,12 @@
   <data name="MissingWorkloadPackVersion" xml:space="preserve">
     <value>Missing version for workload pack '{0}'</value>
   </data>
+  <data name="MissingWorkloadPathOrVersion" xml:space="preserve">
+    <value>The WorkloadResolver failed to find workload path "{0}" or its version.</value>
+  </data>
+  <data name="WorkloadResolverDisabled" xml:space="preserve">
+    <value>The WorkloadResolver was disabled.</value>
+  </data>
   <data name="UnexpectedTokenAtOffset" xml:space="preserve">
     <value>Unexpected token '{0}' at offset {1}</value>
   </data>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Chybějící verze pro sadu úloh {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Přesměrování úlohy {0} má jiné klíče než redirect-to.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">Nevyřešený cíl {0} pro přesměrování úlohy {1} v manifestu {2} [{3}]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Version für Workloadpaket "{0}" fehlt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Die Umleitungsworkload „{0}“ hat andere Schlüssel als „redirect-to“.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">Nicht aufgelöstes Ziel „{0}“ für die Workloadumleitung „{1}“ im Manifest „{2}“ [{3}]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Falta la versión del paquete de carga de trabajo "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La carga de trabajo de redireccionamiento '{0}' tiene claves distintas que las de 'redirect-to'</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">Destino sin resolver '{0}' para redirección de carga de trabajo '{1}' en el manifiesto '{2}' [{3}]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Version manquante pour le pack de charges de travail '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La charge de travail de redirection « {0} » a des clés autres que « redirection vers ».</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">Cible non résolue « {0} » pour la redirection de charge de travail « {1} » dans le manifeste « {2} » [{3}]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Versione mancante per il pacchetto '{0}' del carico di lavoro</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Il carico di lavoro '{0}' di reindirizzamento ha chiavi diverse da ' Redirect-to '</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">Destinazione non risolta '{0}' per il reindirizzamento del carico di lavoro '{1}' nel manifesto '{2}' [{3}]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
@@ -92,6 +92,11 @@
         <target state="translated">ワークロード パック '{0}' のバージョンがありません</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">リダイレクト ワークロード '{0}' に 'redirect-to' 以外のキーがあります</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">マニフェスト '{2}' [{3}] 内のワークロード リダイレクト '{1}' に対する未解決のターゲット '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
@@ -92,6 +92,11 @@
         <target state="translated">워크로드 팩 '{0}'에 대한 버전이 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">리디렉션 워크로드 '{0}'에 'redirect-to' 이외의 다른 키가 있습니다</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">매니페스트 '{2}' [{3}]의 워크로드 리디렉션 '{1}'에 대한 확인되지 않는 대상 '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Brak wersji dla pakietu obciążenia „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Obciążenie przekierowania „{0}” ma klucze inne niż „redirect-to”</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">Nierozpoznany element docelowy „{0}” przekierowania obciążenia „{1}” w manifeście „{2}” [{3}]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Versão do pacote de carga de trabalho '{0}' ausente</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">A carga de trabalho de redirecionamento '{0}' tem chaves diferentes além de 'redirecionar-para'</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">Destino '{0}' não resolvido para o redirecionamento de carga de trabalho '{1}' no manifesto '{2}' [{3}]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Отсутствует версия для пакета рабочей нагрузки "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Перенаправление рабочей нагрузки "{0}" содержит ключи, отличные от "redirect-to"</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">Неразрешенный целевой объект "{0}" для перенаправления рабочей нагрузки "{1}" в манифесте "{2}" [{3}]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">'{0}' iş yükü paketi için sürüm eksik</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">'{0}' yeniden yönlendirme iş yükünde 'redirect-to' dışında anahtarlar var</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">'{2}' [{3}] bildirimindeki '{1}' iş akışı yeniden yönlendirmesi için '{0}' hedefi çözümlenemedi</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
@@ -92,6 +92,11 @@
         <target state="translated">工作负载包“{0}”版本缺失</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重定向工作负荷“{0}”具有“重定向到”以外的键</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">工作负载未解析的目标“{0}”重定向到清单“{2}”[{3}] 中的“{1}”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
@@ -92,6 +92,11 @@
         <target state="translated">缺少工作負載套件 '{0}' 的版本</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingWorkloadPathOrVersion">
+        <source>The WorkloadResolver failed to find workload path "{0}" or its version.</source>
+        <target state="new">The WorkloadResolver failed to find workload path "{0}" or its version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重新導向工作負載 '{0}' 具有 'redirect-to' 以外的其他金鑰</target>
@@ -120,6 +125,11 @@
       <trans-unit id="UnresolvedWorkloadRedirect">
         <source>Unresolved target '{0}' for workload redirect '{1}' in manifest '{2}' [{3}]</source>
         <target state="translated">資訊清單 '{2}' [{3}] 中工作負載重新導向 '{1}' 的未解析目標 '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WorkloadResolverDisabled">
+        <source>The WorkloadResolver was disabled.</source>
+        <target state="new">The WorkloadResolver was disabled.</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
If one SDK resolver fails to load an SDK, it's no big deal, but if they all fail, it typically indicates the user did something wrong. We just resolve a generic "something went wrong" kind of error. We should instead log real errors for each SDK resolver indicating what went wrong. This does so for the workload SDK resolver.