### PR TITLE
Moved the options to new \ new create level

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
@@ -36,33 +36,13 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         protected IEngineEnvironmentSettings CreateEnvironmentSettings(GlobalArgs args, ParseResult parseResult)
         {
-            //reparse to get output option if present
-            //it's kept private so it is not reused for any other purpose except initializing host
-            //for template instantiaton it has to be reparsed
-            string? outputPath = ParseOutputOption(parseResult);
             IEngineEnvironmentSettings environmentSettings = new EngineEnvironmentSettings(
-                new CliTemplateEngineHost(_hostBuilder(parseResult), outputPath),
+                _hostBuilder(parseResult),
                 settingsLocation: args.DebugCustomSettingsLocation,
                 virtualizeSettings: args.DebugVirtualizeSettings,
                 environment: new CliEnvironment());
             return environmentSettings;
         }
-
-        private static string? ParseOutputOption(ParseResult commandParseResult)
-        {
-            Option<string> outputOption = SharedOptionsFactory.CreateOutputOption();
-            Command helperCommand = new Command("parse-output")
-            {
-                outputOption
-            };
-
-            ParseResult reparseResult = ParserFactory
-                .CreateParser(helperCommand, disableHelp: true)
-                .Parse(commandParseResult.Tokens.Select(t => t.Value).ToArray());
-
-            return reparseResult.GetValueForOption<string>(outputOption);
-        }
-
     }
 
     internal abstract class BaseCommand<TArgs> : BaseCommand, ICommandHandler where TArgs : GlobalArgs

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.Help.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.Help.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-using System.CommandLine;
 using System.CommandLine.Help;
-using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli.Commands

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.Legacy.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.Legacy.cs
@@ -76,7 +76,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             ValidateArgumentUsage(commandResult, ShortNameArgument, RemainingArguments);
         }
 
-        private static void ValidateOptionUsage(CommandResult commandResult, Option option)
+        internal void ValidateOptionUsage(CommandResult commandResult, Option option)
         {
             OptionResult? optionResult = commandResult.Parent?.Children.FirstOrDefault(symbol => symbol.Symbol == option) as OptionResult;
             if (optionResult != null)

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.CommandLine.Completions;
 using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge.Settings;
 
@@ -22,7 +21,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             //it is important that legacy commands are built before non-legacy, as non legacy commands are building validators that rely on legacy stuff
             BuildLegacySymbols(hostBuilder);
 
-            this.Add(new InstantiateCommand(hostBuilder));
+            this.Add(new InstantiateCommand(this, hostBuilder));
             this.Add(new InstallCommand(this, hostBuilder));
             this.Add(new UninstallCommand(this, hostBuilder));
             this.Add(new UpdateCommand(this, hostBuilder));
@@ -36,6 +35,13 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             this.AddGlobalOption(DebugReinitOption);
             this.AddGlobalOption(DebugRebuildCacheOption);
             this.AddGlobalOption(DebugShowConfigOption);
+
+            this.AddOption(SharedOptions.OutputOption);
+            this.AddOption(SharedOptions.NameOption);
+            this.AddOption(SharedOptions.DryRunOption);
+            this.AddOption(SharedOptions.ForceOption);
+            this.AddOption(SharedOptions.NoUpdateCheckOption);
+            this.AddOption(SharedOptions.ProjectPathOption);
         }
 
         internal static Option<string?> DebugCustomSettingsLocationOption { get; } = new("--debug:custom-hive")
@@ -87,6 +93,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Arity = new ArgumentArity(0, 999),
             IsHidden = true
         };
+
+        internal IReadOnlyList<Option> PassByOptions { get; } = new Option[]
+        {
+            SharedOptions.ForceOption,
+            SharedOptions.NameOption,
+            SharedOptions.DryRunOption,
+            SharedOptions.NoUpdateCheckOption
+        };
+   
 
         protected internal override IEnumerable<CompletionItem> GetCompletions(CompletionContext context, IEngineEnvironmentSettings environmentSettings)
         {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommandArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommandArgs.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     {
                         continue;
                     }
-                    if (!command.LegacyOptions.Contains(o.Option))
+                    if (!command.LegacyOptions.Contains(o.Option) && !command.PassByOptions.Contains(o.Option))
                     {
                         continue;
                     }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SharedOptions.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SharedOptions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.CommandLine;
+
+namespace Microsoft.TemplateEngine.Cli.Commands
+{
+    public static class SharedOptions
+    {
+        internal static Option<bool> ForceOption { get; } = SharedOptionsFactory.CreateForceOption();
+
+        public static Option<FileInfo> OutputOption { get; } = new Option<FileInfo>(new string[] { "-o", "--output" })
+        {
+            Description = SymbolStrings.Option_Output,
+            IsRequired = false,
+            Arity = new ArgumentArity(1, 1)
+        };
+
+        internal static Option<string> NameOption { get; } = new Option<string>(new string[] { "-n", "--name" })
+        {
+            Description = SymbolStrings.TemplateCommand_Option_Name,
+            Arity = new ArgumentArity(1, 1)
+        };
+
+        internal static Option<bool> DryRunOption { get; } = new Option<bool>("--dry-run")
+        {
+            Description = SymbolStrings.TemplateCommand_Option_DryRun,
+            Arity = new ArgumentArity(0, 1)
+        };
+
+        internal static Option<bool> NoUpdateCheckOption { get; } = new Option<bool>("--no-update-check")
+        {
+            Description = SymbolStrings.TemplateCommand_Option_NoUpdateCheck,
+            Arity = new ArgumentArity(0, 1)
+        };
+
+        public static Option<FileInfo> ProjectPathOption { get; } = new Option<FileInfo>("--project", SymbolStrings.Option_ProjectPath).ExistingOnly();
+    }
+}

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SharedOptionsFactory.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SharedOptionsFactory.cs
@@ -117,20 +117,10 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             return option;
         }
 
-        internal static Option<string> CreateOutputOption()
-        {
-            return new Option<string>(new string[] { "-o", "--output" })
-            {
-                Description = SymbolStrings.Option_Output,
-                IsRequired = false,
-                Arity = new ArgumentArity(1, 1)
-            };
-        }
-
         internal static string[] ParseCommaSeparatedValues(ArgumentResult result)
         {
-            List<string> values = new List<string>();
-            foreach (var value in result.Tokens.Select(t => t.Value))
+            List<string> values = new();
+            foreach (string value in result.Tokens.Select(t => t.Value))
             {
                 values.AddRange(value.Split(",", StringSplitOptions.TrimEntries).Where(s => !string.IsNullOrWhiteSpace(s)));
             }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.Designer.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.Designer.cs
@@ -379,6 +379,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The project that should be used for context evaluation..
+        /// </summary>
+        internal static string Option_ProjectPath {
+            get {
+                return ResourceManager.GetString("Option_ProjectPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Filters the templates based on the tag..
         /// </summary>
         internal static string Option_TagFilter {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
@@ -225,6 +225,9 @@ If command is specified without the argument, it lists all the template packages
   <data name="Option_PackageFilter" xml:space="preserve">
     <value>Filters the templates based on NuGet package ID.</value>
   </data>
+  <data name="Option_ProjectPath" xml:space="preserve">
+    <value>The project that should be used for context evaluation.</value>
+  </data>
   <data name="Option_TagFilter" xml:space="preserve">
     <value>Filters the templates based on the tag.</value>
   </data>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.Help.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.Help.cs
@@ -81,7 +81,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             ShowTemplateDetailHeaders(preferredTemplate.Template, context.Output);
             //we need to show all possible short names (not just the one specified)
             ShowUsage(instantiateCommandArgs.Command, templateGroup.ShortNames, context);
-            ShowCommandOptions(templatesToShow, preferredTemplate, context);
+            ShowCommandOptions(templatesToShow, context);
             ShowTemplateSpecificOptions(templatesToShow, context);
             ShowHintForOtherTemplates(templateGroup, preferredTemplate.Template, instantiateCommandArgs, context.Output);
         }
@@ -278,16 +278,16 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         internal static void ShowCommandOptions(
             IEnumerable<TemplateCommand> templatesToShow,
-            TemplateCommand preferredTemplate,
             HelpContext context)
         {
             List<Option> optionsToShow = new List<Option>()
             {
-                preferredTemplate.NameOption,
-                preferredTemplate.OutputOption,
-                preferredTemplate.DryRunOption,
-                TemplateCommand.ForceOption,
-                preferredTemplate.NoUpdateCheckOption
+                SharedOptions.NameOption,
+                SharedOptions.OutputOption,
+                SharedOptions.DryRunOption,
+                SharedOptions.ForceOption,
+                SharedOptions.NoUpdateCheckOption,
+                SharedOptions.ProjectPathOption
             };
 
             foreach (var template in templatesToShow)

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
@@ -18,11 +18,28 @@ namespace Microsoft.TemplateEngine.Cli.Commands
     internal partial class InstantiateCommand : BaseCommand<InstantiateCommandArgs>, ICustomHelp
     {
         internal InstantiateCommand(
+            NewCommand parentCommand,
             Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(hostBuilder, "create", SymbolStrings.Command_Instantiate_Description)
         {
             this.AddArgument(ShortNameArgument);
             this.AddArgument(RemainingArguments);
+
+            this.AddOption(SharedOptions.OutputOption);
+            this.AddOption(SharedOptions.NameOption);
+            this.AddOption(SharedOptions.DryRunOption);
+            this.AddOption(SharedOptions.ForceOption);
+            this.AddOption(SharedOptions.NoUpdateCheckOption);
+            this.AddOption(SharedOptions.ProjectPathOption);
+
+            parentCommand.AddNoLegacyUsageValidators(this);
+            this.AddValidator(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.OutputOption));
+            this.AddValidator(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.NameOption));
+            this.AddValidator(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.DryRunOption));
+            this.AddValidator(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.ForceOption));
+            this.AddValidator(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.NoUpdateCheckOption));
+            this.AddValidator(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.ProjectPathOption));
+
             IsHidden = true;
         }
 
@@ -36,6 +53,14 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         {
             Description = SymbolStrings.Command_Instantiate_Argument_TemplateOptions,
             Arity = new ArgumentArity(0, 999)
+        };
+
+        internal IReadOnlyList<Option> PassByOptions { get; } = new Option[]
+        {
+            SharedOptions.ForceOption,
+            SharedOptions.NameOption,
+            SharedOptions.DryRunOption,
+            SharedOptions.NoUpdateCheckOption
         };
 
         internal static Task<NewCommandStatus> ExecuteAsync(NewCommandArgs newCommandArgs, IEngineEnvironmentSettings environmentSettings, InvocationContext context)

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommandArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommandArgs.cs
@@ -19,6 +19,18 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 tokens.Add(ShortName);
             }
             tokens.AddRange(RemainingArguments);
+
+            foreach (OptionResult optionResult in parseResult.CommandResult.Children.OfType<OptionResult>())
+            {
+                if (command.PassByOptions.Contains(optionResult.Option))
+                {
+                    if (optionResult.Token is { } token) 
+                    { 
+                        tokens.Add(token.Value); 
+                    }
+                    tokens.AddRange(optionResult.Tokens.Select(t => t.Value));
+                }
+            }
             TokensToInvoke = tokens.ToArray();
         }
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -50,11 +50,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 AddAlias(item);
             }
 
-            this.AddOption(OutputOption);
-            this.AddOption(NameOption);
-            this.AddOption(DryRunOption);
-            this.AddOption(ForceOption);
-            this.AddOption(NoUpdateCheckOption);
+            this.AddOption(SharedOptions.OutputOption);
+            this.AddOption(SharedOptions.NameOption);
+            this.AddOption(SharedOptions.DryRunOption);
+            this.AddOption(SharedOptions.ForceOption);
+            this.AddOption(SharedOptions.NoUpdateCheckOption);
 
             string? templateLanguage = template.GetLanguage();
             string? defaultLanguage = environmentSettings.GetDefaultLanguage();
@@ -114,32 +114,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         }
 
         internal static IReadOnlyList<string> KnownHelpAliases => _helpAliases;
-
-        internal static Option<bool> ForceOption { get; } = new Option<bool>("--force")
-        {
-            Description = SymbolStrings.TemplateCommand_Option_Force,
-            Arity = new ArgumentArity(0, 1)
-        };
-
-        internal Option<string> OutputOption { get; } = SharedOptionsFactory.CreateOutputOption();
-
-        internal Option<string> NameOption { get; } = new Option<string>(new string[] { "-n", "--name" })
-        {
-            Description = SymbolStrings.TemplateCommand_Option_Name,
-            Arity = new ArgumentArity(1, 1)
-        };
-
-        internal Option<bool> DryRunOption { get; } = new Option<bool>("--dry-run")
-        {
-            Description = SymbolStrings.TemplateCommand_Option_DryRun,
-            Arity = new ArgumentArity(0, 1)
-        };
-
-        internal Option<bool> NoUpdateCheckOption { get; } = new Option<bool>("--no-update-check")
-        {
-            Description = SymbolStrings.TemplateCommand_Option_NoUpdateCheck,
-            Arity = new ArgumentArity(0, 1)
-        };
 
         internal Option<AllowRunScripts>? AllowScriptsOption { get; }
 
@@ -262,8 +236,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             if (!templateArgs.IsForceFlagSpecified)
             {
-                reporter.WriteLine(string.Format(LocalizableStrings.TemplateCommand_DisplayConstraintResults_Hint, TemplateCommand.ForceOption.Aliases.First()));
-                reporter.WriteCommand(Example.FromExistingTokens(templateArgs.ParseResult).WithOption(TemplateCommand.ForceOption));
+                reporter.WriteLine(string.Format(LocalizableStrings.TemplateCommand_DisplayConstraintResults_Hint, SharedOptions.ForceOption.Aliases.First()));
+                reporter.WriteCommand(Example.FromExistingTokens(templateArgs.ParseResult).WithOption(SharedOptions.ForceOption));
             }
             else
             {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommandArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommandArgs.cs
@@ -18,11 +18,10 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             ParentCommand = parentCommand ?? throw new ArgumentNullException(nameof(parentCommand));
             RootCommand = GetRootCommand(parentCommand);
 
-            Name = parseResult.GetValueForOptionOrNull(command.NameOption);
-            OutputPath = parseResult.GetValueForOptionOrNull(command.OutputOption);
-            IsForceFlagSpecified = parseResult.GetValueForOption(TemplateCommand.ForceOption);
-            IsDryRun = parseResult.GetValueForOption(command.DryRunOption);
-            NoUpdateCheck = parseResult.GetValueForOption(command.NoUpdateCheckOption);
+            Name = parseResult.GetValueForOptionOrNull(SharedOptions.NameOption);
+            IsForceFlagSpecified = parseResult.GetValueForOption(SharedOptions.ForceOption);
+            IsDryRun = parseResult.GetValueForOption(SharedOptions.DryRunOption);
+            NoUpdateCheck = parseResult.GetValueForOption(SharedOptions.NoUpdateCheckOption);
 
             if (command.LanguageOption != null)
             {
@@ -53,8 +52,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         public string? Name { get; }
 
-        public string? OutputPath { get; }
-
         public bool IsForceFlagSpecified { get; }
 
         public string? Language { get; }
@@ -79,7 +76,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     .Where(kvp => kvp.Item2 != null)
                     .ToDictionary(kvp => kvp.Key, kvp => kvp.Item2);
             }
-
         }
 
         public ParseResult ParseResult { get; }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
@@ -42,10 +42,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             IEngineEnvironmentSettings environmentSettings,
             InvocationContext context)
         {
-            using TemplatePackageManager templatePackageManager = new TemplatePackageManager(environmentSettings);
-            TemplatePackageCoordinator templatePackageCoordinator = new TemplatePackageCoordinator(
-                environmentSettings,
-                templatePackageManager);
+            using TemplatePackageManager templatePackageManager = new(environmentSettings);
+            TemplatePackageCoordinator templatePackageCoordinator = new(environmentSettings, templatePackageManager);
 
             //we need to await, otherwise templatePackageManager will be disposed.
             return await templatePackageCoordinator.EnterInstallFlowAsync(args, context.GetCancellationToken()).ConfigureAwait(false);

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/BaseListCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/BaseListCommand.cs
@@ -31,6 +31,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             this.AddArgument(NameArgument);
             this.AddOption(IgnoreConstraintsOption);
+            this.AddOption(SharedOptions.OutputOption);
+            this.AddOption(SharedOptions.ProjectPathOption);
             SetupTabularOutputOptions(this);
         }
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/ListCommandArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/ListCommandArgs.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Parsing;
 
 namespace Microsoft.TemplateEngine.Cli.Commands
 {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
@@ -183,6 +183,11 @@ Pokud je příkaz zadán bez argumentu, zobrazí seznam všech nainstalovaných 
         <target state="translated">Filtruje šablony podle ID balíčku NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">Filtruje šablony na základě značky.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
@@ -183,6 +183,11 @@ Wenn der Befehl ohne Argument angegeben wird, werden alle installierten Vorlagen
         <target state="translated">Filtert die Vorlagen basierend auf der NuGet-Paket-ID.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">Filtert die Vorlagen basierend auf dem Tag.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
@@ -183,6 +183,11 @@ Si el comando se especifica sin el argumento, muestra todos los paquetes de plan
         <target state="translated">Filtra las plantillas en función del id. del paquete NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">Filtra las plantillas en función de la etiqueta.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
@@ -183,6 +183,11 @@ Si la commande est spécifiée sans l’argument, elle répertorie tous les pack
         <target state="translated">Filtre les modèles en fonction de l’ID de package NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">Filtre les modèles en fonction de la balise.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
@@ -183,6 +183,11 @@ Se il comando è specificato senza l'argomento, vengono elencati tutti i pacchet
         <target state="translated">Filtra i modelli basati sull'ID pacchetto NuGet. Si applica a--search.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">Filtra i modelli in base al tag.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
@@ -183,6 +183,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">NuGet パッケージ ID に基づいてテンプレートをフィルターします。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">タグに基づいてテンプレートのフィルター処理を行います。</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
@@ -183,6 +183,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">NuGet 패키지 ID를 기준으로 템플릿을 필터링합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">태그를 기준으로 템플릿을 필터링합니다.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
@@ -183,6 +183,11 @@ Jeśli polecenie zostanie określone bez argumentu, zostanie wyświetlona lista 
         <target state="translated">Filtruje szablony na podstawie identyfikatora pakietu NuGet..</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">Filtruje szablony na podstawie tagu.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
@@ -183,6 +183,11 @@ Se o comando for especificado sem o argumento, ele listará todos os pacotes de 
         <target state="translated">Filtra os modelos com base na ID do pacote NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">Filtra os modelos com base na marca.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
@@ -183,6 +183,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">Фильтрация шаблонов по идентификатору пакета NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">Фильтрация шаблонов по тегу.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
@@ -183,6 +183,11 @@ Eğer komut bağımsız değişken olmadan belirtilirse yüklü tüm şablon pak
         <target state="translated">Şablonları NuGet paketi kimliğine göre filtreler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">Şablonları etikete göre filtreler.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
@@ -183,6 +183,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">根据 NuGet 包 ID 筛选模板。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">根据标记筛选模板。</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
@@ -183,6 +183,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">根據 NuGet 套件識別碼篩選範本。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_ProjectPath">
+        <source>The project that should be used for context evaluation.</source>
+        <target state="new">The project that should be used for context evaluation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_TagFilter">
         <source>Filters the templates based on the tag.</source>
         <target state="translated">根據標記篩選範本。</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/ICliTemplateEngineHost.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/ICliTemplateEngineHost.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    public interface ICliTemplateEngineHost : ITemplateEngineHost
+    {
+
+        /// <summary>
+        /// True when output path was specified additionally (i.e. no fallback to default(current directory)).
+        /// </summary>
+        public bool IsCustomOutputPath { get; }
+
+        /// <summary>
+        /// Gets the output path for execution results.
+        /// </summary>
+        public string OutputPath { get; }
+    }
+}

--- a/src/Cli/Microsoft.TemplateEngine.Cli/NewCommandFactory.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/NewCommandFactory.cs
@@ -10,7 +10,7 @@ namespace Microsoft.TemplateEngine.Cli
 {
     public static class NewCommandFactory
     {
-        public static Command Create(string commandName, Func<ParseResult, ITemplateEngineHost> hostBuilder)
+        public static Command Create(string commandName, Func<ParseResult, ICliTemplateEngineHost> hostBuilder)
         {
             if (string.IsNullOrWhiteSpace(commandName))
             {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -414,14 +414,12 @@ namespace Microsoft.TemplateEngine.Cli
 
                 if (!args.Force)
                 {
-                    Option forceOption = SharedOptionsFactory.CreateForceOption();
-
-                    reporter.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Install_Info_UseForceToOverride, forceOption.Aliases.First()));
+                    reporter.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Install_Info_UseForceToOverride, SharedOptions.ForceOption.Aliases.First()));
                     reporter.WriteCommand(
                         Example
                             .For<InstallCommand>(args.ParseResult)
                             .WithArgument(InstallCommand.NameArgument, installRequests.Select(ir => ir.DisplayName).ToArray())
-                            .WithOption(forceOption));
+                            .WithOption(SharedOptions.ForceOption));
                     return false;
                 }
             }

--- a/src/Cli/dotnet-new3/HostFactory.cs
+++ b/src/Cli/dotnet-new3/HostFactory.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Globalization;
-using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
-using Microsoft.TemplateEngine.Edge;
+using Microsoft.TemplateEngine.Cli;
 
 namespace Dotnet_new3
 {
@@ -18,7 +16,7 @@ namespace Dotnet_new3
         private const string VsLanguageOverrideEnvironmentVar = "VSLANG";
         private const string CompilerLanguageEnvironmentVar = "PreferredUILang";
 
-        internal static DefaultTemplateEngineHost CreateHost(bool disableSdkTemplates)
+        internal static CliTemplateEngineHost CreateHost(bool disableSdkTemplates, string? outputPath)
         {
             var preferences = new Dictionary<string, string>
             {
@@ -49,12 +47,13 @@ namespace Dotnet_new3
 
             ConfigureLocale();
 
-            DefaultTemplateEngineHost host = new DefaultTemplateEngineHost(
+            var host = new CliTemplateEngineHost(
                 HostIdentifier,
                 HostVersion,
                 preferences,
                 builtIns,
-                new[] { "dotnetcli" });
+                new[] { "dotnetcli" },
+                outputPath);
 
             return host;
         }
@@ -116,7 +115,7 @@ namespace Dotnet_new3
             Dotnet versionCommand = Dotnet.Version();
             versionCommand.CaptureStdOut();
 
-            var result = versionCommand.Execute();
+            Dotnet.Result result = versionCommand.Execute();
             if (result.ExitCode != 0)
             {
                 return null;

--- a/src/Cli/dotnet-new3/New3CommandFactory.cs
+++ b/src/Cli/dotnet-new3/New3CommandFactory.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Cli;
+using Microsoft.TemplateEngine.Cli.Commands;
 
 namespace Dotnet_new3
 {
@@ -25,35 +25,16 @@ namespace Dotnet_new3
         {
             Command newCommand = NewCommandFactory.Create(
                 CommandName,
-                (ParseResult parseResult) => HostFactory.CreateHost(parseResult.GetValueForOption(_debugDisableBuiltInTemplatesOption)));
+                (ParseResult parseResult) =>
+                {
+                    FileInfo? outputPath = parseResult.GetValueForOption(SharedOptions.OutputOption);
+                    return HostFactory.CreateHost(parseResult.GetValueForOption(_debugDisableBuiltInTemplatesOption), outputPath?.FullName);
+                });
 
             newCommand.AddGlobalOption(_debugEmitTelemetryOption);
             newCommand.AddGlobalOption(_debugDisableBuiltInTemplatesOption);
             newCommand.AddCommand(new CompleteCommand());
             return newCommand;
-        }
-
-        private static bool ExecuteDotnetCommand(Dotnet command)
-        {
-            command.CaptureStdOut();
-            command.CaptureStdErr();
-            Console.WriteLine($"Running '{command.Command}':");
-            var result = command.Execute();
-            Console.WriteLine(result.ExitCode == 0 ? "Command succeeded." : "Command failed.");
-            WriteCommandOutput(result);
-            return result.ExitCode == 0;
-        }
-
-        /// <summary>
-        /// Writes formatted command output from <paramref name="process"/>.
-        /// </summary>
-        private static void WriteCommandOutput(Dotnet.Result process)
-        {
-            Console.WriteLine("Output from command:");
-            Console.WriteLine("StdOut:");
-            Console.WriteLine(string.IsNullOrWhiteSpace(process.StdOut) ? "(empty)" : process.StdOut.Trim('\n', '\r'));
-            Console.WriteLine("StdErr:");
-            Console.WriteLine(string.IsNullOrWhiteSpace(process.StdErr) ? "(empty)" : process.StdErr.Trim('\n', '\r'));
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
@@ -275,9 +275,6 @@
   <data name="ProjectContextSymbolSource_DisplayName" xml:space="preserve">
     <value>Project context</value>
   </data>
-  <data name="ProjectPath_OptionDescription" xml:space="preserve">
-    <value>The project that should be used for context evaluation.</value>
-  </data>
   <data name="SdkInfoProvider_Message_InstallSdk" xml:space="preserve">
     <value>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</value>
     <comment>{0} is the list of supported versions.</comment>

--- a/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/MSBuildEvaluation/ProjectCapabilityConstraint.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.Cli;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Constraints;
+using Microsoft.TemplateEngine.Cli.Commands;
 using Newtonsoft.Json.Linq;
 using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 
@@ -120,7 +121,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                     return TemplateConstraintResult.CreateRestricted(
                         this,
                         _evaluationResult.ErrorMessage ?? string.Format(LocalizableStrings.MultipleProjectsEvaluationResult_Error, foundProjects),
-                        string.Format(LocalizableStrings.ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA, NewCommandParser.ProjectPathOption.Aliases.First()));
+                        string.Format(LocalizableStrings.ProjectCapabilityConstraint_Restricted_MultipleProjectsFound_CTA, SharedOptions.ProjectPathOption.Aliases.First()));
                 }
                 if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.NoRestore)
                 {
@@ -161,9 +162,9 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 }
             }
 
-            private IReadOnlyList<string> GetProjectCapabilities(MSBuildEvaluationResult result)
+            private static IReadOnlyList<string> GetProjectCapabilities(MSBuildEvaluationResult result)
             {
-                HashSet<string> capabilities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                HashSet<string> capabilities = new(StringComparer.OrdinalIgnoreCase);
                 AddProjectCapabilities(capabilities, result.EvaluatedProject);
 
                 //in case of multi-target project, consider project capabilities for all target frameworks
@@ -176,7 +177,7 @@ namespace Microsoft.TemplateEngine.MSBuildEvaluation
                 }
                 return capabilities.ToArray();
 
-                void AddProjectCapabilities (HashSet<string> collection, Project? evaluatedProject)
+                static void AddProjectCapabilities (HashSet<string> collection, Project? evaluatedProject)
                 {
                     if (evaluatedProject == null)
                     {

--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
@@ -6,31 +6,21 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Configurer;
-using Microsoft.DotNet.Tools.MSBuild;
 using Microsoft.DotNet.Tools.New;
-using Microsoft.DotNet.Tools.Restore;
 using Microsoft.TemplateEngine.Cli;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
-using Microsoft.TemplateEngine.Edge;
-using System.Linq;
 using Microsoft.DotNet.Workloads.Workload.List;
 using Microsoft.TemplateEngine.Abstractions.Components;
-using Microsoft.DotNet.Tools.Add.PackageReference;
-using Microsoft.DotNet.Tools.Add.ProjectToProjectReference;
-using Microsoft.DotNet.Tools.Sln.Add;
-using Microsoft.DotNet.Tools;
-using Microsoft.DotNet.Tools.Common;
 using LocalizableStrings = Microsoft.DotNet.Tools.New.LocalizableStrings;
 using Microsoft.TemplateEngine.MSBuildEvaluation;
 using Microsoft.TemplateEngine.Abstractions.Constraints;
 using System.IO;
-using NuGet.Packaging;
 using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 using Microsoft.DotNet.Tools.New.PostActionProcessors;
+using Microsoft.TemplateEngine.Cli.Commands;
+using Command = System.CommandLine.Command;
 
 namespace Microsoft.DotNet.Cli
 {
@@ -38,39 +28,44 @@ namespace Microsoft.DotNet.Cli
     {
         public static readonly string DocsLink = "https://aka.ms/dotnet-new";
         public const string CommandName = "new";
-        private const string EnableProjectContextEvaluationEnvVar = "DOTNET_CLI_DISABLE_PROJECT_EVAL";
+        private const string EnableProjectContextEvaluationEnvVarName = "DOTNET_CLI_DISABLE_PROJECT_EVAL";
+        private const string PrefferedLangEnvVarName = "DOTNET_NEW_PREFERRED_LANG";
 
         private const string HostIdentifier = "dotnetcli";
-        private static readonly Option<bool> _disableSdkTemplates = new Option<bool>("--debug:disable-sdk-templates", () => false, LocalizableStrings.DisableSdkTemplates_OptionDescription).Hide();
+        
+        private static readonly Option<bool> s_disableSdkTemplatesOption = new Option<bool>(
+            "--debug:disable-sdk-templates",
+            () => false,
+            LocalizableStrings.DisableSdkTemplates_OptionDescription).Hide();
 
-        private static readonly Option<bool> _disableProjectContextEvaluation = new Option<bool>("--debug:disable-project-context", () => false, LocalizableStrings.DisableProjectContextEval_OptionDescription).Hide();
+        private static readonly Option<bool> s_disableProjectContextEvaluationOption = new Option<bool>(
+            "--debug:disable-project-context",
+            () => false,
+            LocalizableStrings.DisableProjectContextEval_OptionDescription).Hide();
 
-        internal static Option<FileInfo> ProjectPathOption { get; } = new Option<FileInfo>("--project", LocalizableStrings.ProjectPath_OptionDescription).ExistingOnly().Hide();
+        internal static readonly Command s_command = GetCommand();
 
-        internal static readonly System.CommandLine.Command Command = GetCommand();
-
-        public static System.CommandLine.Command GetCommand()
+        public static Command GetCommand()
         {
-            var getEngineHost = (ParseResult parseResult) => {
-                bool disableSdkTemplates = parseResult.GetValueForOption(_disableSdkTemplates);
-                bool disableProjectContext = parseResult.GetValueForOption(_disableProjectContextEvaluation)
-                    || Env.GetEnvironmentVariableAsBool(EnableProjectContextEvaluationEnvVar);
-                FileInfo? projectPath = parseResult.GetValueForOption(ProjectPathOption);
+            Command command = NewCommandFactory.Create(CommandName, (Func<ParseResult, CliTemplateEngineHost>)GetEngineHost);
 
-                //TODO: read and pass output directory
-                return CreateHost(disableSdkTemplates, disableProjectContext, projectPath);
-            };
-
-            var command = NewCommandFactory.Create(CommandName, getEngineHost);
-
-            // adding this option lets us look for its bound value during binding in a typed way
-            command.AddGlobalOption(_disableSdkTemplates);
-            command.AddGlobalOption(_disableProjectContextEvaluation);
-            command.AddGlobalOption(ProjectPathOption);
+            command.AddGlobalOption(s_disableSdkTemplatesOption);
+            command.AddGlobalOption(s_disableProjectContextEvaluationOption);
             return command;
+
+            static CliTemplateEngineHost GetEngineHost(ParseResult parseResult)
+            {
+                bool disableSdkTemplates = parseResult.GetValueForOption(s_disableSdkTemplatesOption);
+                bool disableProjectContext = parseResult.GetValueForOption(s_disableProjectContextEvaluationOption)
+                    || Env.GetEnvironmentVariableAsBool(EnableProjectContextEvaluationEnvVarName);
+                FileInfo? projectPath = parseResult.GetValueForOption(SharedOptions.ProjectPathOption);
+                FileInfo? outputPath = parseResult.GetValueForOption(SharedOptions.OutputOption);
+
+                return CreateHost(disableSdkTemplates, disableProjectContext, projectPath, outputPath);
+            }
         }
 
-        private static ITemplateEngineHost CreateHost(bool disableSdkTemplates, bool disableProjectContext, FileInfo? projectPath)
+        private static CliTemplateEngineHost CreateHost(bool disableSdkTemplates, bool disableProjectContext, FileInfo? projectPath, FileInfo? outputPath)
         {
             var builtIns = new List<(Type InterfaceType, IIdentifiedComponent Instance)>();
             builtIns.AddRange(Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Components.AllComponents);
@@ -94,12 +89,12 @@ namespace Microsoft.DotNet.Cli
             {
                 builtIns.Add((typeof(IBindSymbolSource), new ProjectContextSymbolSource()));
                 builtIns.Add((typeof(ITemplateConstraintFactory), new ProjectCapabilityConstraintFactory()));
-                builtIns.Add((typeof(MSBuildEvaluator), new MSBuildEvaluator(outputDirectory: null, projectPath: projectPath?.FullName)));
+                builtIns.Add((typeof(MSBuildEvaluator), new MSBuildEvaluator(outputDirectory: outputPath?.FullName, projectPath: projectPath?.FullName)));
             }
             builtIns.Add((typeof(IWorkloadsInfoProvider), new WorkloadsInfoProvider(new WorkloadInfoHelper())));
             builtIns.Add((typeof(ISdkInfoProvider), new SdkInfoProvider()));
 
-            string? preferredLangEnvVar = Environment.GetEnvironmentVariable("DOTNET_NEW_PREFERRED_LANG");
+            string? preferredLangEnvVar = Environment.GetEnvironmentVariable(PrefferedLangEnvVarName);
             string preferredLang = string.IsNullOrWhiteSpace(preferredLangEnvVar)? "C#" : preferredLangEnvVar;
 
             var preferences = new Dictionary<string, string>
@@ -109,10 +104,14 @@ namespace Microsoft.DotNet.Cli
                 { "RuntimeFrameworkVersion", new Muxer().SharedFxVersion },
                 { "NetStandardImplicitPackageVersion", new FrameworkDependencyFile().GetNetStandardLibraryVersion() },
             };
-
-            return new DefaultTemplateEngineHost(HostIdentifier, "v" + Product.Version, preferences, builtIns);
+            bool enableVerboseLogging = Reporter.IsVerbose;
+            return new CliTemplateEngineHost(
+                HostIdentifier,
+                "v" + Product.Version,
+                preferences,
+                builtIns,
+                outputPath: outputPath?.FullName,
+                enableVerboseLogging: enableVerboseLogging);
         }
-
-
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
@@ -233,11 +233,6 @@
         <target state="translated">Kontext projektu</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">Projekt, který by se měl použít pro vyhodnocení kontextu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">Přejděte na aka.ms/get-dotnet a nainstalujte některou z podporovaných verzí sady SDK:{0}.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
@@ -233,11 +233,6 @@
         <target state="translated">Projektkontext</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">Das Projekt, das für die Kontextauswertung verwendet werden soll.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">Wechseln Sie zu aka.ms/get-dotnet, und installieren Sie eine der unterstützten SDK-Versionen: „{0}“.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
@@ -233,11 +233,6 @@
         <target state="translated">Contexto del proyecto</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">Proyecto que se debe usar para la evaluación de contexto.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">Vaya a aka.ms/get-dotnet e instale cualquiera de las versiones de SDK admitidas: "{0}".</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
@@ -233,11 +233,6 @@
         <target state="translated">Contexte du projet</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">Projet à utiliser pour l’évaluation du contexte</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">Accédez à aka.ms/get-dotnet et installez l'une des versions de SDK prises en charge : '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
@@ -233,11 +233,6 @@
         <target state="translated">Contesto progetto</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">Progetto da usare per la valutazione del contesto.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">Passare a aka.ms/get-dotnet e installare una delle versioni supportate dell'SDK: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
@@ -233,11 +233,6 @@
         <target state="translated">プロジェクト コンテキスト</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">コンテキストの評価に使用する必要があるプロジェクトです。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">aka.ms/get-dotnet に移動し、サポートされている SDK バージョン '{0}' のいずれかをインストールします。</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
@@ -233,11 +233,6 @@
         <target state="translated">프로젝트 컨텍스트</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">컨텍스트 평가에 사용해야 하는 프로젝트입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">aka.ms/get-dotnet으로 이동하여 지원되는 SDK 버전 '{0}'을(를) 설치합니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
@@ -233,11 +233,6 @@
         <target state="translated">Kontekst projektu</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">Projekt, który powinien być używany do oceny kontekstu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">Przejdź do aka.ms/get-dotnet i zainstaluj dowolną z obsługiwanych wersji zestawu SDK: „{0}”.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
@@ -233,11 +233,6 @@
         <target state="translated">Contexto do projeto</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">O projeto que deve ser usado para avaliação de contexto.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">Acesse aka.ms/get-dotnet e instale qualquer uma das versões do SDK compatíveis: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
@@ -233,11 +233,6 @@
         <target state="translated">Контекст проекта</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">Проект, который следует использовать для оценки контекста.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">Перейдите aka.ms/get-dotnet и установите любую из поддерживаемых версий пакета SDK: "{0}".</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
@@ -233,11 +233,6 @@
         <target state="translated">Proje bağlamı</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">Bağlam değerlendirmesi için kullanılacak proje.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">Desteklenen SDK sürümlerinden herhangi birini aka.ms/get-dotnet’e gidin ve yükleyin: '{0}'.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
@@ -233,11 +233,6 @@
         <target state="translated">项目上下文</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">应用于上下文评估的项目。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">转到 aka.ms/get-dotnet 并安装任何受支持的 SDK 版本:“{0}”。</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
@@ -233,11 +233,6 @@
         <target state="translated">專案內容</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectPath_OptionDescription">
-        <source>The project that should be used for context evaluation.</source>
-        <target state="translated">應該用於內容評估的專案。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SdkInfoProvider_Message_InstallSdk">
         <source>Go to aka.ms/get-dotnet and install any of the supported SDK versions: '{0}'.</source>
         <target state="translated">移至 aka.ms/get-dotnet 並安裝任何支援的 SDK 版本: '{0}'。</target>

--- a/src/Tests/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs
@@ -172,8 +172,8 @@ namespace Microsoft.NET.TestFramework.Assertions
         private string AppendDiagnosticsTo(string s)
         {
             return s + $"{Environment.NewLine}" +
-                       $"File Name: {_commandResult.StartInfo.FileName}{Environment.NewLine}" +
-                       $"Arguments: {_commandResult.StartInfo.Arguments}{Environment.NewLine}" +
+                       $"File Name: {_commandResult.StartInfo?.FileName}{Environment.NewLine}" +
+                       $"Arguments: {_commandResult.StartInfo?.Arguments}{Environment.NewLine}" +
                        $"Exit Code: {_commandResult.ExitCode}{Environment.NewLine}" +
                        $"StdOut:{Environment.NewLine}{_commandResult.StdOut}{Environment.NewLine}" +
                        $"StdErr:{Environment.NewLine}{_commandResult.StdErr}{Environment.NewLine}"; ;

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/CliTestHostFactory.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/CliTestHostFactory.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
+using Microsoft.TemplateEngine.Edge;
+using Microsoft.TemplateEngine.TestHelper;
+using Microsoft.TemplateEngine.Utils;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests
+{
+    internal static class CliTestHostFactory
+    {
+        public static ICliTemplateEngineHost GetVirtualHost(
+                [CallerMemberName] string hostIdentifier = "",
+                IEnvironment? environment = null,
+                IReadOnlyList<(Type, IIdentifiedComponent)>? additionalComponents = null,
+                IReadOnlyDictionary<string, string>? defaultParameters = null)
+        {
+            CliTestHost host = new(hostIdentifier: hostIdentifier, additionalComponents: additionalComponents);
+            environment ??= new DefaultEnvironment();
+
+            if (defaultParameters != null)
+            {
+                foreach (KeyValuePair<string, string> parameter in defaultParameters)
+                {
+                    host.HostParamDefaults[parameter.Key] = parameter.Value;
+                }
+            }
+            ((ITemplateEngineHost)host).VirtualizeDirectory(new DefaultPathInfo(environment, host).GlobalSettingsDir);
+            return host;
+        }
+
+        private class CliTestHost : ICliTemplateEngineHost
+        {
+            private readonly ILoggerFactory _loggerFactory;
+            private readonly ILogger _logger;
+            private readonly string _hostIdentifier;
+            private readonly string _version;
+            private readonly IReadOnlyList<(Type, IIdentifiedComponent)> _builtIns;
+            private readonly IReadOnlyList<string> _fallbackNames;
+
+            internal CliTestHost(
+                [CallerMemberName] string hostIdentifier = "",
+                string version = "1.0.0",
+                bool loadDefaultGenerator = true,
+                IReadOnlyList<(Type, IIdentifiedComponent)>? additionalComponents = null,
+                IPhysicalFileSystem? fileSystem = null,
+                IReadOnlyList<string>? fallbackNames = null,
+                IEnumerable<ILoggerProvider>? addLoggerProviders = null)
+            {
+                _hostIdentifier = string.IsNullOrWhiteSpace(hostIdentifier) ? "TestRunner" : hostIdentifier;
+                _version = string.IsNullOrWhiteSpace(version) ? "1.0.0" : version;
+
+                var builtIns = new List<(Type, IIdentifiedComponent)>();
+                if (additionalComponents != null)
+                {
+                    builtIns.AddRange(additionalComponents);
+                }
+                builtIns.AddRange(Edge.Components.AllComponents);
+                if (loadDefaultGenerator)
+                {
+                    builtIns.AddRange(Orchestrator.RunnableProjects.Components.AllComponents);
+                }
+
+                _builtIns = builtIns;
+                HostParamDefaults = new Dictionary<string, string>();
+                FileSystem = fileSystem ?? new PhysicalFileSystem();
+
+                _loggerFactory = new TestLoggerFactory();
+                addLoggerProviders?.ToList().ForEach(_loggerFactory.AddProvider);
+                _logger = _loggerFactory.CreateLogger("Cli Test Host");
+                _fallbackNames = fallbackNames ?? new[] { "dotnetcli" };
+            }
+
+            internal Dictionary<string, string> HostParamDefaults { get; set; } = new Dictionary<string, string>();
+
+            public IPhysicalFileSystem FileSystem { get; private set; }
+
+            string ITemplateEngineHost.HostIdentifier => _hostIdentifier;
+
+            IReadOnlyList<string> ITemplateEngineHost.FallbackHostTemplateConfigNames => _fallbackNames;
+
+            string ITemplateEngineHost.Version => _version;
+
+            IReadOnlyList<(Type, IIdentifiedComponent)> ITemplateEngineHost.BuiltInComponents => _builtIns;
+
+            ILogger ITemplateEngineHost.Logger => _logger;
+
+            ILoggerFactory ITemplateEngineHost.LoggerFactory => _loggerFactory;
+
+            public string OutputPath => FileSystem.GetCurrentDirectory();
+
+            public bool IsCustomOutputPath => false;
+
+            bool ITemplateEngineHost.TryGetHostParamDefault(string paramName, out string? value)
+            {
+                return HostParamDefaults.TryGetValue(paramName, out value);
+            }
+
+            void ITemplateEngineHost.VirtualizeDirectory(string path)
+            {
+                FileSystem = new InMemoryFileSystem(path, FileSystem);
+            }
+
+            public void Dispose()
+            {
+                _loggerFactory?.Dispose();
+            }
+
+            #region Obsolete methods
+#pragma warning disable CA1041 // Provide ObsoleteAttribute message
+            [Obsolete]
+            void ITemplateEngineHost.OnSymbolUsed(string symbol, object value)
+            {
+                //do nothing
+            }
+            [Obsolete]
+            bool ITemplateEngineHost.OnParameterError(ITemplateParameter parameter, string receivedValue, string message, out string newValue)
+            {
+                //do nothing
+                newValue = receivedValue;
+                return false;
+            }
+            [Obsolete]
+            bool ITemplateEngineHost.OnNonCriticalError(string code, string message, string currentFile, long currentPosition)
+            {
+                //do nothing
+                return false;
+            }
+            [Obsolete]
+            void ITemplateEngineHost.OnCriticalError(string code, string message, string currentFile, long currentPosition)
+            {
+                //do nothing
+            }
+            [Obsolete]
+            void ITemplateEngineHost.LogMessage(string message)
+            {
+                //do nothing
+            }
+            [Obsolete]
+            bool ITemplateEngineHost.OnPotentiallyDestructiveChangesDetected(IReadOnlyList<IFileChange> changes, IReadOnlyList<IFileChange> destructiveChanges)
+            {
+                //do nothing
+                return false;
+            }
+            [Obsolete]
+            bool ITemplateEngineHost.OnConfirmPartialMatch(string name)
+            {
+                //do nothing
+                return false;
+            }
+            [Obsolete]
+            void ITemplateEngineHost.LogDiagnosticMessage(string message, string category, params string[] details)
+            {
+                //do nothing
+            }
+            [Obsolete]
+            void ITemplateEngineHost.LogTiming(string label, TimeSpan duration, int depth)
+            {
+                //do nothing
+            }
+#pragma warning restore CA1041 // Provide ObsoleteAttribute message
+            #endregion
+        }
+    }
+}

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowCommandOptions_Basic.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowCommandOptions_Basic.verified.txt
@@ -4,4 +4,5 @@
   --dry-run              Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                Forces content to be generated even if it would change existing files.
   --no-update-check      Disables checking for the template package updates when instantiating a template.
+  --project <project>    The project that should be used for context evaluation.
 

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowCommandOptions_Language.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowCommandOptions_Language.verified.txt
@@ -4,5 +4,6 @@
   --dry-run                   Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                     Forces content to be generated even if it would change existing files.
   --no-update-check           Disables checking for the template package updates when instantiating a template.
+  --project <project>         The project that should be used for context evaluation.
   -lang, --language <MyLang>  Specifies the template language to instantiate.
 

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowCommandOptions_Type.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.CanShowCommandOptions_Type.verified.txt
@@ -4,5 +4,6 @@
   --dry-run              Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                Forces content to be generated even if it would change existing files.
   --no-update-check      Disables checking for the template package updates when instantiating a template.
+  --project <project>    The project that should be used for context evaluation.
   --type <MyType>        Specifies the template type to instantiate.
 

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Create_GetAllSuggestions.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Create_GetAllSuggestions.verified.txt
@@ -68,5 +68,61 @@
     SortText: webconfig,
     InsertText: webconfig,
     Documentation: A file used to configure Web Application settings
+  },
+  {
+    Label: --dry-run,
+    Kind: Keyword,
+    SortText: --dry-run,
+    InsertText: --dry-run,
+    Detail: Displays a summary of what would happen if the given command line were run if it would result in a template creation.
+  },
+  {
+    Label: --force,
+    Kind: Keyword,
+    SortText: --force,
+    InsertText: --force,
+    Detail: Forces content to be generated even if it would change existing files.
+  },
+  {
+    Label: --name,
+    Kind: Keyword,
+    SortText: --name,
+    InsertText: --name,
+    Detail: The name for the output being created. If no name is specified, the name of the output directory is used.
+  },
+  {
+    Label: --no-update-check,
+    Kind: Keyword,
+    SortText: --no-update-check,
+    InsertText: --no-update-check,
+    Detail: Disables checking for the template package updates when instantiating a template.
+  },
+  {
+    Label: --output,
+    Kind: Keyword,
+    SortText: --output,
+    InsertText: --output,
+    Detail: Location to place the generated output.
+  },
+  {
+    Label: --project,
+    Kind: Keyword,
+    SortText: --project,
+    InsertText: --project,
+    Detail: The project that should be used for context evaluation.
+  },
+  {
+    Label: -n,
+    Kind: Keyword,
+    SortText: -n,
+    InsertText: -n,
+    Detail: The name for the output being created. If no name is specified, the name of the output directory is used.
+  },
+  {
+    Label: -o,
+    Kind: Keyword,
+    SortText: -o,
+    InsertText: -o,
+    Detail: Location to place the generated output.
   }
 ]

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.List_GetAllSuggestions.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.List_GetAllSuggestions.verified.txt
@@ -35,6 +35,20 @@
     Detail: Filters templates based on language.
   },
   {
+    Label: --output,
+    Kind: Keyword,
+    SortText: --output,
+    InsertText: --output,
+    Detail: Location to place the generated output.
+  },
+  {
+    Label: --project,
+    Kind: Keyword,
+    SortText: --project,
+    InsertText: --project,
+    Detail: The project that should be used for context evaluation.
+  },
+  {
     Label: --tag,
     Kind: Keyword,
     SortText: --tag,
@@ -54,5 +68,12 @@
     SortText: -lang,
     InsertText: -lang,
     Detail: Filters templates based on language.
+  },
+  {
+    Label: -o,
+    Kind: Keyword,
+    SortText: -o,
+    InsertText: -o,
+    Detail: Location to place the generated output.
   }
 ]

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.RootCommand_GetAllSuggestions.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.RootCommand_GetAllSuggestions.verified.txt
@@ -70,11 +70,53 @@
     Documentation: A file used to configure Web Application settings
   },
   {
+    Label: --dry-run,
+    Kind: Keyword,
+    SortText: --dry-run,
+    InsertText: --dry-run,
+    Detail: Displays a summary of what would happen if the given command line were run if it would result in a template creation.
+  },
+  {
+    Label: --force,
+    Kind: Keyword,
+    SortText: --force,
+    InsertText: --force,
+    Detail: Forces content to be generated even if it would change existing files.
+  },
+  {
     Label: --help,
     Kind: Keyword,
     SortText: --help,
     InsertText: --help,
     Detail: Show help and usage information
+  },
+  {
+    Label: --name,
+    Kind: Keyword,
+    SortText: --name,
+    InsertText: --name,
+    Detail: The name for the output being created. If no name is specified, the name of the output directory is used.
+  },
+  {
+    Label: --no-update-check,
+    Kind: Keyword,
+    SortText: --no-update-check,
+    InsertText: --no-update-check,
+    Detail: Disables checking for the template package updates when instantiating a template.
+  },
+  {
+    Label: --output,
+    Kind: Keyword,
+    SortText: --output,
+    InsertText: --output,
+    Detail: Location to place the generated output.
+  },
+  {
+    Label: --project,
+    Kind: Keyword,
+    SortText: --project,
+    InsertText: --project,
+    Detail: The project that should be used for context evaluation.
   },
   {
     Label: -?,
@@ -89,6 +131,20 @@
     SortText: -h,
     InsertText: -h,
     Detail: Show help and usage information
+  },
+  {
+    Label: -n,
+    Kind: Keyword,
+    SortText: -n,
+    InsertText: -n,
+    Detail: The name for the output being created. If no name is specified, the name of the output directory is used.
+  },
+  {
+    Label: -o,
+    Kind: Keyword,
+    SortText: -o,
+    InsertText: -o,
+    Detail: Location to place the generated output.
   },
   {
     Label: /?,

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.RootCommand_GetStartsWtihSuggestions.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.RootCommand_GetStartsWtihSuggestions.verified.txt
@@ -19,5 +19,26 @@
     SortText: search,
     InsertText: search,
     Detail: Searches for the templates on NuGet.org.
+  },
+  {
+    Label: --force,
+    Kind: Keyword,
+    SortText: --force,
+    InsertText: --force,
+    Detail: Forces content to be generated even if it would change existing files.
+  },
+  {
+    Label: --project,
+    Kind: Keyword,
+    SortText: --project,
+    InsertText: --project,
+    Detail: The project that should be used for context evaluation.
+  },
+  {
+    Label: --no-update-check,
+    Kind: Keyword,
+    SortText: --no-update-check,
+    InsertText: --no-update-check,
+    Detail: Disables checking for the template package updates when instantiating a template.
   }
 ]

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.cs
@@ -10,14 +10,12 @@ using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Mocks;
-using Microsoft.TemplateEngine.TestHelper;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 {
     public partial class HelpTests
     {
         [Theory]
-#pragma warning disable SA1117 // ParameterDefinitionSet should be on same line or separate lines
         [InlineData("Template Name", "Language", "Me", "Template Description",
 @"Template Name (Language)
 Author: Me
@@ -44,10 +42,9 @@ Author: Me
 @"Template Name
 
 ")]
-#pragma warning restore SA1117 // ParameterDefinitionSet should be on same line or separate lines
         public void CanShowTemplateDescription(string name, string? language, string? author, string? description, string expected)
         {
-            MockTemplateInfo templateInfo = new MockTemplateInfo(
+            MockTemplateInfo templateInfo = new(
                 "console2",
                 name: name,
                 identity: "Console.App2",
@@ -59,8 +56,8 @@ Author: Me
                 templateInfo.WithTag("language", language);
             }
 
-            CliTemplateInfo cliTemplateInfo = new CliTemplateInfo(templateInfo, HostSpecificTemplateData.Default);
-            StringWriter sw = new StringWriter();
+            CliTemplateInfo cliTemplateInfo = new(templateInfo, HostSpecificTemplateData.Default);
+            StringWriter sw = new();
             InstantiateCommand.ShowTemplateDetailHeaders(cliTemplateInfo, sw);
             Assert.Equal(expected, sw.ToString());
         }
@@ -68,11 +65,11 @@ Author: Me
         [Fact]
         public void CanShowUsage()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
             InstantiateCommand.ShowUsage(myCommand, new[] { "short-name" }, helpContext);
             Assert.Equal($"Usage:{Environment.NewLine}  new short-name [options] [template options]{Environment.NewLine}{Environment.NewLine}", sw.ToString());
@@ -81,11 +78,11 @@ Author: Me
         [Fact]
         public void CanShowUsage_ForMultipleShortNames()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
             InstantiateCommand.ShowUsage(myCommand, new[] { "short-name1", "short-name2" }, helpContext);
             Assert.Equal($"Usage:{Environment.NewLine}  new short-name1 [options] [template options]{Environment.NewLine}  new short-name2 [options] [template options]{Environment.NewLine}{Environment.NewLine}", sw.ToString());
@@ -99,85 +96,85 @@ Author: Me
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
-            InstantiateCommand.ShowCommandOptions(new[] { templateCommand }, templateCommand, helpContext);
+            InstantiateCommand.ShowCommandOptions(new[] { templateCommand }, helpContext);
             return Verify(sw.ToString());
         }
 
         [Fact]
         public Task CanShowCommandOptions_Language()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("language", "MyLang");
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("language", "MyLang");
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
-            InstantiateCommand.ShowCommandOptions(new[] { templateCommand }, templateCommand, helpContext);
+            InstantiateCommand.ShowCommandOptions(new[] { templateCommand }, helpContext);
             return Verify(sw.ToString());
         }
 
         [Fact]
         public Task CanShowCommandOptions_Type()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("type", "MyType");
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("type", "MyType");
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
-            InstantiateCommand.ShowCommandOptions(new[] { templateCommand }, templateCommand, helpContext);
+            InstantiateCommand.ShowCommandOptions(new[] { templateCommand }, helpContext);
             return Verify(sw.ToString());
         }
 
         [Fact]
         public void CanShowCommandOptions_NoOptions()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("type", "MyType");
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("type", "MyType");
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand }, helpContext);
             Assert.Equal($"Template options:{Environment.NewLine}   (No options){Environment.NewLine}", sw.ToString());
@@ -186,22 +183,22 @@ Author: Me
         [Fact]
         public Task CanShowTemplateOptions_SingleTemplate_Choice()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("choice", new[] { "val1", "val2" }, description: "my description", defaultValue: "def-val", defaultIfNoOptionValue: "def-val-no-arg" );
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand }, helpContext);
             return Verify(sw.ToString());
@@ -210,25 +207,25 @@ Author: Me
         [Fact]
         public Task CanShowTemplateOptions_MultipleTemplate_CombinedChoice()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group", precedence: 0)
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group", precedence: 0)
                 .WithChoiceParameter("choice", new[] { "val1", "val2" }, description: "my description", defaultValue: "def-val-not-shown", defaultIfNoOptionValue: "def-val-not-shown");
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 2)
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 2)
              .WithChoiceParameter("choice", new[] { "val1", "val3" }, description: "my description", defaultValue: "def-val", defaultIfNoOptionValue: "def-val-no-arg");
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand1 = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[0]);
-            TemplateCommand templateCommand2 = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[1]);
+            TemplateCommand templateCommand1 = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[0]);
+            TemplateCommand templateCommand2 = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[1]);
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand2, templateCommand1 }, helpContext);
             return Verify(sw.ToString());
@@ -237,22 +234,22 @@ Author: Me
         [Fact]
         public Task CanShowTemplateOptions_SingleTemplate_NonChoice()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithParameter("non-choice", paramType: "text", description: "my description", defaultValue: "def-val", defaultIfNoOptionValue: "def-val-no-arg");
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand }, helpContext);
             return Verify(sw.ToString());
@@ -261,27 +258,27 @@ Author: Me
         [Fact]
         public Task CanShowTemplateOptions_MultipleTemplate_MultipleParams()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group", precedence: 0)
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group", precedence: 0)
                 .WithChoiceParameter("choice", new[] { "val1", "val2" }, description: "my description", defaultValue: "def-val-not-shown", defaultIfNoOptionValue: "def-val-not-shown")
                 .WithParameter("bool", paramType: "boolean", description: "my bool", defaultValue: "false", defaultIfNoOptionValue: "false");
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 2)
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 2)
              .WithChoiceParameter("choice", new[] { "val1", "val3" }, description: "my description", defaultValue: "def-val", defaultIfNoOptionValue: "def-val-no-arg")
              .WithParameter("int", paramType: "integer", description: "my int", defaultValue: "0", defaultIfNoOptionValue: "10");
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand1 = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[0]);
-            TemplateCommand templateCommand2 = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[1]);
+            TemplateCommand templateCommand1 = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[0]);
+            TemplateCommand templateCommand2 = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[1]);
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand2, templateCommand1 }, helpContext);
             return Verify(sw.ToString());
@@ -290,22 +287,22 @@ Author: Me
         [Fact]
         public Task CanShowTemplateOptions_SingleTemplate_Choice_Required()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("choice", new[] { "val1", "val2" }, description: "my description", defaultIfNoOptionValue: "def-val-no-arg", isRequired: true);
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand }, helpContext);
             return Verify(sw.ToString());
@@ -314,22 +311,22 @@ Author: Me
         [Fact]
         public void CanShowTemplateOptions_RequiredIsNotShownWhenDefaultValueIsGiven()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("choice", new[] { "val1", "val2" }, description: "my description", defaultValue: "def-val", defaultIfNoOptionValue: "def-val-no-arg", isRequired: true);
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand }, helpContext);
             Assert.DoesNotContain("(REQUIRED)", sw.ToString());
@@ -338,20 +335,20 @@ Author: Me
         [Fact]
         public Task CanShowHintsForOtherTemplates()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("language", "Lang1").WithTag("type", "project");
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithTag("language", "Lang2").WithTag("type", "item");
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("language", "Lang1").WithTag("type", "project");
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithTag("language", "Lang2").WithTag("type", "item");
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
             ParseResult parseResult = myCommand.Parse("new -h");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
-            StringWriter sw = new StringWriter();
+            StringWriter sw = new();
 
             InstantiateCommand.ShowHintForOtherTemplates(templateGroup, templateGroup.Templates[0], args, sw);
             return Verify(sw.ToString());
@@ -360,22 +357,22 @@ Author: Me
         [Fact]
         public Task CanShowTemplateOptions_SingleTemplate_Choice_ShortenedUsage_FirstTwoValuesFit()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("choice", new[] { "val1", "val2", "val3", "val4", "val5", "val6" }, description: "my description", defaultValue: "def-val", defaultIfNoOptionValue: "def-val-no-arg");
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance, maxWidth: 100), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance, maxWidth: 100), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand }, helpContext);
             return Verify(sw.ToString());
@@ -384,22 +381,22 @@ Author: Me
         [Fact]
         public Task CanShowTemplateOptions_SingleTemplate_Choice_ShortenedUsage()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("choice", new[] { "val1", "val2", "val3", "val4", "val5", "val6" }, description: "my description", defaultValue: "def-val", defaultIfNoOptionValue: "def-val-no-arg");
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance, maxWidth: 50), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance, maxWidth: 50), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand }, helpContext);
             return Verify(sw.ToString());
@@ -408,10 +405,10 @@ Author: Me
         [Fact]
         public Task DoesNotCombineParametersWhenAliasesAreDifferent()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("Choice", new[] { "val1" }, description: "my description", defaultValue: "def-val", defaultIfNoOptionValue: "def-val-no-arg");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
                 .WithChoiceParameter("Choice", new[] { "val2" }, description: "my description", defaultValue: "def-val", defaultIfNoOptionValue: "def-val-no-arg");
 
             IHostSpecificDataLoader hostDataLoader = A.Fake<IHostSpecificDataLoader>();
@@ -432,17 +429,17 @@ Author: Me
                CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, hostDataLoader))
                .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            TemplateCommand templateCommand1 = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[0]);
-            TemplateCommand templateCommand2 = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[1]);
+            TemplateCommand templateCommand1 = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[0]);
+            TemplateCommand templateCommand2 = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates[1]);
 
-            StringWriter sw = new StringWriter();
-            HelpContext helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance, maxWidth: 50), myCommand, sw);
+            StringWriter sw = new();
+            HelpContext helpContext = new(new HelpBuilder(LocalizationResources.Instance, maxWidth: 50), myCommand, sw);
 
             InstantiateCommand.ShowTemplateSpecificOptions(new[] { templateCommand1, templateCommand2 }, helpContext);
             return Verifier.Verify(sw.ToString());

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstallTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstallTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.TestHelper;
 
@@ -15,11 +14,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("--nuget-source")]
         public void Install_CanParseAddSourceOption(string optionName)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new install source {optionName} my-custom-source");
-            InstallCommandArgs args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new install source {optionName} my-custom-source");
+            InstallCommandArgs args = new((InstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Single(args.AdditionalSources);
             Assert.Contains("my-custom-source", args.AdditionalSources);
@@ -30,10 +29,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Install_Error_NoArguments()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new install");
+            ParseResult parseResult = myCommand.Parse($"new install");
 
             Assert.True(parseResult.Errors.Any());
             Assert.Contains(parseResult.Errors, error => error.Message.Contains("Required argument missing"));
@@ -44,10 +43,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Install_Legacy_Error_NoArguments()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new --install --interactive");
+            ParseResult parseResult = myCommand.Parse($"new --install --interactive");
 
             Assert.True(parseResult.Errors.Any());
             Assert.Contains(parseResult.Errors, error => error.Message.Contains("Required argument missing"));
@@ -60,10 +59,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new install source --add-source my-custom-source1 --add-source my-custom-source2")]
         public void Install_CanParseAddSourceOption_MultipleEntries(string testCase)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse(testCase);
-            InstallCommandArgs args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(testCase);
+            InstallCommandArgs args = new((InstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Equal(2, args.AdditionalSources?.Count);
             Assert.Contains("my-custom-source1", args.AdditionalSources);
@@ -75,11 +74,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Install_CanParseInteractiveOption()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new install source --interactive");
-            InstallCommandArgs args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new install source --interactive");
+            InstallCommandArgs args = new((InstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.True(args.Interactive);
             Assert.Single(args.TemplatePackages);
@@ -96,11 +95,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Install_CanParseForceOption()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new install source --force");
-            InstallCommandArgs args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new install source --force");
+            InstallCommandArgs args = new((InstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.True(args.Force);
             Assert.Single(args.TemplatePackages);
@@ -117,11 +116,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Install_CanParseMultipleArgs()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new install source1 source2");
-            InstallCommandArgs args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new install source1 source2");
+            InstallCommandArgs args = new((InstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Equal(2, args.TemplatePackages.Count);
             Assert.Contains("source1", args.TemplatePackages);
@@ -134,11 +133,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new --nuget-source my-custom-source --install source")]
         public void Install_Legacy_CanParseAddSourceOption(string testCase)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(testCase);
-            InstallCommandArgs args = new InstallCommandArgs((LegacyInstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(testCase);
+            InstallCommandArgs args = new((LegacyInstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Single(args.AdditionalSources);
             Assert.Contains("my-custom-source", args.AdditionalSources);
@@ -151,11 +150,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new --interactive --install source")]
         public void Install_Legacy_CanParseInteractiveOption(string testCase)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(testCase);
-            InstallCommandArgs args = new InstallCommandArgs((LegacyInstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(testCase);
+            InstallCommandArgs args = new((LegacyInstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.True(args.Interactive);
             Assert.Single(args.TemplatePackages);
@@ -167,11 +166,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new --install source1 source2")]
         public void Install_Legacy_CanParseMultipleArgs(string testCase)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-             
-            var parseResult = myCommand.Parse(testCase);
-            InstallCommandArgs args = new InstallCommandArgs((LegacyInstallCommand)parseResult.CommandResult.Command, parseResult);
+
+            ParseResult parseResult = myCommand.Parse(testCase);
+            InstallCommandArgs args = new((LegacyInstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Equal(2, args.TemplatePackages.Count);
             Assert.Contains("source1", args.TemplatePackages);
@@ -184,10 +183,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new --add-source my-custom-source1 --install source --add-source my-custom-source2")]
         public void Install_Legacy_CanParseAddSourceOption_MultipleEntries(string testCase)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse(testCase);
-            InstallCommandArgs args = new InstallCommandArgs((LegacyInstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(testCase);
+            InstallCommandArgs args = new((LegacyInstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Equal(2, args.AdditionalSources?.Count);
             Assert.Contains("my-custom-source1", args.AdditionalSources);
@@ -205,17 +204,17 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new source1 --install source", "'source1'")]
         public void Install_CanReturnParseError(string command, string expectedInvalidTokens)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
-            var errorMessages = parseResult.Errors.Select(error => error.Message);
+            ParseResult parseResult = myCommand.Parse(command);
+            IEnumerable<string> errorMessages = parseResult.Errors.Select(error => error.Message);
 
-            var expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
+            string[] expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
 
             Assert.NotEmpty(parseResult.Errors);
             Assert.Equal(expectedInvalidTokenSets.Length, parseResult.Errors.Count);
-            foreach (var tokenSet in expectedInvalidTokenSets)
+            foreach (string tokenSet in expectedInvalidTokenSets)
             {
                 Assert.True(errorMessages.Contains($"Unrecognized command or argument(s): {tokenSet}.") || errorMessages.Contains($"Unrecognized command or argument {tokenSet}."));
             }
@@ -224,14 +223,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CommandExampleCanShowParentCommandsBeyondNew()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            Command rootCommand = new Command("dotnet")
+            Command rootCommand = new("dotnet")
             {
                 myCommand
             };
 
-            var parseResult = rootCommand.Parse("dotnet new install source");
+            ParseResult parseResult = rootCommand.Parse("dotnet new install source");
             Assert.Equal("dotnet new install my-source", Example.For<NewCommand>(parseResult).WithSubcommand<InstallCommand>().WithArgument(InstallCommand.NameArgument, "my-source"));
         }
 

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.Subcommand.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.Subcommand.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using FakeItEasy;
+using FluentAssertions;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.Edge;
@@ -18,13 +19,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Create_CanParseTemplateWithOptions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse("new create console --framework net5.0");
-            InstantiateCommandArgs args = new InstantiateCommandArgs((InstantiateCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse("new create console --framework net5.0");
+            InstantiateCommandArgs args = new((InstantiateCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Equal("console", args.ShortName);
-            Assert.Equal(2, args.RemainingArguments.Count());
+            Assert.Equal(2, args.RemainingArguments.Length);
             Assert.Contains("--framework", args.RemainingArguments);
             Assert.Contains("net5.0", args.RemainingArguments);
         }
@@ -45,20 +46,24 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 defaultParams["prefs:language"] = defaultLanguage;
             }
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(defaultParameters: defaultParams);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(defaultParameters: defaultParams);
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($"new create {command}");
+            ParseResult parseResult = myCommand.Parse($"new create {command}");
             var instantiateCommand = (InstantiateCommand)parseResult.CommandResult.Command;
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
-            Assert.Equal(expectedIdentities.Count(), templateCommands.Count);
+            HashSet<TemplateCommand> templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            Assert.Equal(expectedIdentities.Length, templateCommands.Count);
             Assert.Equal(expectedIdentities.OrderBy(s => s), templateCommands.Select(templateCommand => templateCommand.Template.Identity).OrderBy(s => s));
         }
 
         [Theory]
-        [MemberData(nameof(CanParseNameOptionData))]
+        [InlineData("new create foo --name name", "name")]
+        [InlineData("new create foo -n name", "name")]
+        [InlineData("new create foo", null)]
+        [InlineData("new create --name name foo ", "name")]
+        [InlineData("new create -n name foo", "name")]
         internal void Create_CanParseNameOption(string command, string? expectedValue)
         {
             var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group");
@@ -67,20 +72,54 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
+            RootCommand rootCommand = new();
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($"new create {command}");
+            rootCommand.Add(myCommand);
+
+            ParseResult parseResult = rootCommand.Parse(command);
+
             var instantiateCommand = (InstantiateCommand)parseResult.CommandResult.Command;
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            TemplateCommand templateCommand = new TemplateCommand(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
-            ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
+            ParseResult templateParseResult = parser.Parse(args.TokensToInvoke ?? Array.Empty<string>());
             var templateArgs = new TemplateCommandArgs(templateCommand, instantiateCommand, templateParseResult);
 
             Assert.Equal(expectedValue, templateArgs.Name);
+        }
+
+        [Theory]
+        [InlineData("new --name name create foo", "Unrecognized command or argument(s): '--name','name'.")]
+        [InlineData("--name name new create foo", "Unrecognized command or argument '--name'.|Unrecognized command or argument 'name'.")]
+        [InlineData("new --output name create foo", "Unrecognized command or argument(s): '--output','name'.")]
+        [InlineData("new --project name create foo", "Unrecognized command or argument(s): '--project','name'.|File does not exist: 'name'.")]
+        [InlineData("new --force create foo", "Unrecognized command or argument(s): '--force'.")]
+        [InlineData("new --dry-run create foo", "Unrecognized command or argument(s): '--dry-run'.")]
+        [InlineData("new --no-update-check create foo", "Unrecognized command or argument(s): '--no-update-check'.")]
+        internal void Create_CanValidateOptionUsage_InNewCommand(string command, string? expectedErrors)
+        {
+            string[] expectedErrorsParsed = expectedErrors?.Split("|") ?? Array.Empty<string>();
+            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group");
+
+            TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
+                .Single();
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            RootCommand rootCommand = new();
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            rootCommand.Add(myCommand);
+
+            ParseResult parseResult = rootCommand.Parse(command);
+
+            parseResult.Errors.Select(e => e.Message).Should().BeEquivalentTo(expectedErrorsParsed);
         }
 
         [Theory]
@@ -93,22 +132,22 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 command = "foo -i 30"; //for dotnet new create "-i" is not occupied, so we can use it.
             }
 
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithParameter(parameterName, parameterType, defaultValue: defaultValue, defaultIfNoOptionValue: defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);  
-            var parseResult = myCommand.Parse($"new create {command}");
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            ParseResult parseResult = myCommand.Parse($"new create {command}");
             var instantiateCommand = (InstantiateCommand)parseResult.CommandResult.Command;
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            TemplateCommand templateCommand = new TemplateCommand(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
             var templateArgs = new TemplateCommandArgs(templateCommand, instantiateCommand, templateParseResult);
@@ -128,22 +167,22 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [MemberData(nameof(CanParseChoiceTemplateOptionsData))]
         internal void Create_CanParseChoiceTemplateOptions(string command, string parameterName, string parameterValues, string? defaultIfNoOptionValue, string? expectedValue)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter(parameterName, parameterValues.Split("|"), defaultIfNoOptionValue: defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($"new create {command}");
+            ParseResult parseResult = myCommand.Parse($"new create {command}");
             var instantiateCommand = (InstantiateCommand)parseResult.CommandResult.Command;
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            TemplateCommand templateCommand = new TemplateCommand(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
             var templateArgs = new TemplateCommandArgs(templateCommand, instantiateCommand, templateParseResult);
@@ -170,23 +209,23 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             string? defaultIfNoOptionValue,
             string expectedError)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithParameter(parameterName, parameterType, isRequired, defaultValue: defaultValue, defaultIfNoOptionValue: defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($"new create {command}");
+            ParseResult parseResult = myCommand.Parse($"new create {command}");
             var instantiateCommand = (InstantiateCommand)parseResult.CommandResult.Command;
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
 
-            TemplateCommand templateCommand = new TemplateCommand(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
             Assert.True(templateParseResult.Errors.Any());
@@ -204,23 +243,23 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
               string? defaultIfNoOptionValue,
               string expectedError)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter(parameterName, parameterValues.Split("|"), isRequired, defaultValue, defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new create {command}");
+            ParseResult parseResult = myCommand.Parse($" new create {command}");
             var instantiateCommand = (InstantiateCommand)parseResult.CommandResult.Command;
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
 
-            TemplateCommand templateCommand = new TemplateCommand(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
             Assert.True(templateParseResult.Errors.Any());
@@ -232,22 +271,22 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("list", "listTemplate")]
         internal void Create_CanEvaluateTemplateWithSubcommandShortName(string command, string? expectedIdentitiesStr)
         {
-            MockTemplateInfo template = new MockTemplateInfo(command, identity: $"{command}Template");
+            MockTemplateInfo template = new(command, identity: $"{command}Template");
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
             string[] expectedIdentities = expectedIdentitiesStr?.Split("|") ?? Array.Empty<string>();
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($"new create {command}");
+            ParseResult parseResult = myCommand.Parse($"new create {command}");
             var instantiateCommand = (InstantiateCommand)parseResult.CommandResult.Command;
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
-            Assert.Equal(expectedIdentities.Count(), templateCommands.Count);
+            HashSet<TemplateCommand> templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            Assert.Equal(expectedIdentities.Length, templateCommands.Count);
             Assert.Equal(expectedIdentities.OrderBy(s => s), templateCommands.Select(templateCommand => templateCommand.Template.Identity).OrderBy(s => s));
         }
     }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.cs
@@ -19,9 +19,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Instantiate_CanParseTemplateWithOptions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse("new console --framework net5.0");
+            ParseResult parseResult = myCommand.Parse("new console --framework net5.0");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
             Assert.Equal("console", args.ShortName);
@@ -29,7 +29,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             Assert.Contains("net5.0", args.RemainingArguments);
         }
 
-        private IReadOnlyDictionary<string, IReadOnlyList<MockTemplateInfo>> _testSets = new Dictionary<string, IReadOnlyList<MockTemplateInfo>>()
+        private readonly IReadOnlyDictionary<string, IReadOnlyList<MockTemplateInfo>> _testSets = new Dictionary<string, IReadOnlyList<MockTemplateInfo>>()
         {
             {
                 "BasicSet2Templates",
@@ -221,45 +221,43 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 defaultParams["prefs:language"] = defaultLanguage;
             }
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(defaultParameters: defaultParams);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(defaultParameters: defaultParams);
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new {command}");
+            ParseResult parseResult = myCommand.Parse($" new {command}");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
-            var templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
-            Assert.Equal(expectedIdentities.Count(), templateCommands.Count);
+            HashSet<TemplateCommand> templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            Assert.Equal(expectedIdentities.Length, templateCommands.Count);
             Assert.Equal(expectedIdentities.OrderBy(s => s), templateCommands.Select(templateCommand => templateCommand.Template.Identity).OrderBy(s => s));
         }
 
-        public static IEnumerable<object?[]> CanParseNameOptionData =>
-            new object?[][]
-            {
-                new [] { "foo --name name", "name" },
-                new [] { "foo -n name", "name" },
-                new [] { "foo", null },
-            };
-
         [Theory]
-        [MemberData(nameof(CanParseNameOptionData))]
+        [InlineData("new foo --name name", "name")]
+        [InlineData("new foo -n name", "name")]
+        [InlineData("new foo", null)]
+        [InlineData("new --name name foo ", "name")]
+        [InlineData("new -n name foo", "name")]
         internal void CanParseNameOption(string command, string? expectedValue)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group");
+            MockTemplateInfo template = new("foo", identity: "foo.1", groupIdentity: "foo.group");
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
+            RootCommand rootCommand = new();
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($"new {command}");
+            rootCommand.AddCommand(myCommand);
+            ParseResult parseResult = rootCommand.Parse(command);
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
-            ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
+            ParseResult templateParseResult = parser.Parse(args.TokensToInvoke ?? Array.Empty<string>());
             var templateArgs = new TemplateCommandArgs(templateCommand, myCommand, templateParseResult);
 
             Assert.Equal(expectedValue, templateArgs.Name);
@@ -308,22 +306,22 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [MemberData(nameof(CanParseTemplateOptionsData))]
         internal void CanParseTemplateOptions(string command, string parameterName, string parameterType, string? defaultValue, string? defaultIfNoOptionValue, string? expectedValue)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithParameter(parameterName, parameterType, defaultValue: defaultValue, defaultIfNoOptionValue: defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
             Parser parser = ParserFactory.CreateParser(myCommand);
-            var parseResult = parser.Parse($" new {command}");
+            ParseResult parseResult = parser.Parse($" new {command}");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser templateCommandParser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = templateCommandParser.Parse(args.RemainingArguments ?? Array.Empty<string>());
             var templateArgs = new TemplateCommandArgs(templateCommand, myCommand, templateParseResult);
@@ -352,21 +350,21 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [MemberData(nameof(CanParseChoiceTemplateOptionsData))]
         internal void CanParseChoiceTemplateOptions(string command, string parameterName, string parameterValues, string? defaultIfNoOptionValue, string? expectedValue)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter(parameterName, parameterValues.Split("|"), defaultIfNoOptionValue: defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new {command}");
+            ParseResult parseResult = myCommand.Parse($" new {command}");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
             var templateArgs = new TemplateCommandArgs(templateCommand, myCommand, templateParseResult);
@@ -396,21 +394,21 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [MemberData(nameof(CanParseMultiChoiceTemplateOptionsData))]
         internal void CanParseMultiChoiceTemplateOptions(string command, string parameterName, string parameterValues, string? defaultIfNoOptionValue, string? expectedValue)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter(parameterName, parameterValues.Split("|"), defaultIfNoOptionValue: defaultIfNoOptionValue, allowMultipleValues: true);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new {command}");
+            ParseResult parseResult = myCommand.Parse($" new {command}");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
             var templateArgs = new TemplateCommandArgs(templateCommand, myCommand, templateParseResult);
@@ -466,22 +464,22 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             string? defaultIfNoOptionValue,
             string expectedError)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithParameter(parameterName, parameterType, isRequired, defaultValue: defaultValue, defaultIfNoOptionValue: defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new {command}");
+            ParseResult parseResult = myCommand.Parse($" new {command}");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
             Assert.True(templateParseResult.Errors.Any());
@@ -509,23 +507,23 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
               string? defaultIfNoOptionValue,
               string expectedError)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter(parameterName, parameterValues.Split("|"), isRequired, defaultValue, defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
             Parser parser = ParserFactory.CreateParser(myCommand);
-            var parseResult = parser.Parse($" new {command}");
+            ParseResult parseResult = parser.Parse($" new {command}");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser templateCommandParser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = templateCommandParser.Parse(args.RemainingArguments ?? Array.Empty<string>());
             Assert.True(templateParseResult.Errors.Any());
@@ -541,19 +539,19 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo");
+            ParseResult parseResult = myCommand.Parse($" new foo");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
 
-            TemplateCommandArgs templateArgs = new TemplateCommandArgs(templateCommand, myCommand, templateParseResult);
+            TemplateCommandArgs templateArgs = new(templateCommand, myCommand, templateParseResult);
             Assert.Null(templateArgs.AllowScripts);
         }
 
@@ -567,26 +565,26 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("foo --allow-scripts NO", AllowRunScripts.No)]
         internal void CanParseAllowScriptsOption(string command, AllowRunScripts? result)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithPostActions(ProcessStartPostActionProcessor.ActionProcessorId);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse(command);
+            ParseResult parseResult = myCommand.Parse(command);
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
-            TemplateCommand templateCommand = new TemplateCommand(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            TemplateCommand templateCommand = new(myCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
             Parser parser = ParserFactory.CreateParser(templateCommand);
             ParseResult templateParseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
 
-            TemplateCommandArgs templateArgs = new TemplateCommandArgs(templateCommand, myCommand, templateParseResult);
+            TemplateCommandArgs templateArgs = new(templateCommand, myCommand, templateParseResult);
             Assert.Equal(result, templateArgs.AllowScripts);
         }
 
@@ -608,13 +606,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 { "prefs:language", "C#" }
             };
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(defaultParameters: defaultParams);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(defaultParameters: defaultParams);
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($"new {shortName}");
+            ParseResult parseResult = myCommand.Parse($"new {shortName}");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
-            var templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            HashSet<TemplateCommand> templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Single(templateCommands);
             Assert.Equal("MultiName.Test.High.CSharp", templateCommands.Single().Template.Identity);
         }
@@ -636,14 +634,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 { "prefs:language", "C#" }
             };
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(defaultParameters: defaultParams);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(defaultParameters: defaultParams);
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
             string command = $"new {shortName} --language F#";
-            var parseResult = myCommand.Parse(command);
+            ParseResult parseResult = myCommand.Parse(command);
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
-            var templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            HashSet<TemplateCommand> templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Single(templateCommands);
             Assert.Equal("Multiname.Test.Only.FSharp", templateCommands.Single().Template.Identity);
 
@@ -666,15 +664,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 { "prefs:language", "C#" }
             };
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(defaultParameters: defaultParams);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(defaultParameters: defaultParams);
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
             string command = $"new {name} --foo {fooChoice}";
-            var parseResult = myCommand.Parse($" new {command}");
+            ParseResult parseResult = myCommand.Parse($" new {command}");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
-            var templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            HashSet<TemplateCommand> templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Single(templateCommands);
             Assert.Equal(expectedIdentity, templateCommands.Single().Template.Identity);
         }
@@ -696,18 +694,62 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 { "prefs:language", "C#" }
             };
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(defaultParameters: defaultParams);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(defaultParameters: defaultParams);
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
             string command = $"new {name} --{paramName} {paramValue}";
-            var parseResult = myCommand.Parse($" new {command}");
+            ParseResult parseResult = myCommand.Parse($" new {command}");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
-            var templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            HashSet<TemplateCommand> templateCommands = InstantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Single(templateCommands);
             Assert.Equal(expectedIdentity, templateCommands.Single().Template.Identity);
         }
         #endregion
+
+        [Theory]
+        [InlineData("new foo --dry-run", "dry-run")]
+        [InlineData("new --dry-run foo", "dry-run")]
+        [InlineData("new foo --force", "force")]
+        [InlineData("new --force foo", "force")]
+        [InlineData("new foo --no-update-check", "no-update-check")]
+        [InlineData("new --no-update-check foo", "no-update-check")]
+        internal void CanParseFlagsOption(string command, string action)
+        {
+            Func<TemplateCommandArgs, bool> expectedAction = action switch
+            {
+                "dry-run" => (TemplateCommandArgs ta) => ta.IsDryRun,
+                "force" => (TemplateCommandArgs ta) => ta.IsForceFlagSpecified,
+                "no-update-check" => (TemplateCommandArgs ta) => ta.NoUpdateCheck,
+                _ => throw new Exception("Not expected value")
+            };
+
+            MockTemplateInfo template = new("foo", identity: "foo.1", groupIdentity: "foo.group");
+            TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
+                .Single();
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            RootCommand rootCommand = new();
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            rootCommand.AddCommand(myCommand);
+            ParseResult parseResult = rootCommand.Parse(command);
+            InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
+            TemplateCommand templateCommand = new(
+                instantiateCommand: myCommand,
+                environmentSettings: settings,
+                templatePackageManager: packageManager,
+                templateGroup: templateGroup,
+                template: templateGroup.Templates.Single());
+            Parser parser = ParserFactory.CreateParser(templateCommand);
+            ParseResult templateParseResult = parser.Parse(args.TokensToInvoke ?? Array.Empty<string>());
+            var templateArgs = new TemplateCommandArgs(templateCommand, myCommand, templateParseResult);
+
+            Assert.True(expectedAction(templateArgs));
+        }
     }
 }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/MiscTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/MiscTests.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.CommandLine.Completions;
 using System.CommandLine.Parsing;
-using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.TestHelper;
 
@@ -18,12 +17,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void KnownHelpAliasesAreCorrect()
         {
-            var result = new CommandLineBuilder()
+            ParseResult result = new CommandLineBuilder()
                 .UseDefaults()
                 .Build()
                 .Parse(Constants.KnownHelpAliases[0]);
 
-            var aliases = result.CommandResult
+            IReadOnlyCollection<string> aliases = result.CommandResult
                 .Children
                 .OfType<OptionResult>()
                 .Select(r => r.Option)
@@ -67,7 +66,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 
         public void DebugFlagCanBeParsedOnNewLevel(string command, string option)
         {
-             Dictionary<string, Func<GlobalArgs, bool>> optionsMap = new Dictionary<string, Func<GlobalArgs, bool>>()
+             Dictionary<string, Func<GlobalArgs, bool>> optionsMap = new()
             {
                 { "--debug:attach", args => args.DebugAttach },
                 { "--debug:ephemeral-hive", args => args.DebugVirtualizeSettings },
@@ -76,10 +75,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 { "--debug:show-config", args => args.DebugShowConfig }
             };
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = ParserFactory.CreateParser(myCommand).Parse(command);
-            NewCommandArgs args = new NewCommandArgs(myCommand, parseResult);
+            ParseResult parseResult = ParserFactory.CreateParser(myCommand).Parse(command);
+            NewCommandArgs args = new(myCommand, parseResult);
 
             Assert.True(optionsMap[option](args));
         }
@@ -97,7 +96,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 
         public void DebugFlagCanBeParsedOnSubcommandLevel(string command, string option)
         {
-            Dictionary<string, Func<GlobalArgs, bool>> optionsMap = new Dictionary<string, Func<GlobalArgs, bool>>()
+            Dictionary<string, Func<GlobalArgs, bool>> optionsMap = new()
             {
                 { "--debug:attach", args => args.DebugAttach },
                 { "--debug:ephemeral-hive", args => args.DebugVirtualizeSettings },
@@ -106,10 +105,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 { "--debug:show-config", args => args.DebugShowConfig }
             };
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = ParserFactory.CreateParser(myCommand).Parse(command);
-            InstallCommandArgs args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = ParserFactory.CreateParser(myCommand).Parse(command);
+            InstallCommandArgs args = new((InstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.True(optionsMap[option](args));
         }
@@ -127,7 +126,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 
         public void DebugFlagCanBeParsedOnTemplateSubcommandLevel(string command, string option)
         {
-            Dictionary<string, Func<GlobalArgs, bool>> optionsMap = new Dictionary<string, Func<GlobalArgs, bool>>()
+            Dictionary<string, Func<GlobalArgs, bool>> optionsMap = new()
             {
                 { "--debug:attach", args => args.DebugAttach },
                 { "--debug:ephemeral-hive", args => args.DebugVirtualizeSettings },
@@ -136,9 +135,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 { "--debug:show-config", args => args.DebugShowConfig }
             };
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse(command);
+            ParseResult parseResult = myCommand.Parse(command);
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
             Assert.True(optionsMap[option](args));
@@ -149,19 +148,57 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void ManuallyAddedOptionIsPreservedOnTemplateSubcommandLevel()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
             var customOption = new Option<string>("--newOption");
             myCommand.AddGlobalOption(customOption);
 
-            var parseResult = myCommand.Parse("new console --newOption val");
+            ParseResult parseResult = myCommand.Parse("new console --newOption val");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
             Assert.NotNull(args.ParseResult);
             Assert.Equal("console", args.ShortName);
             Assert.Empty(args.RemainingArguments);
             Assert.Equal("val", args.ParseResult.GetValueForOption(customOption));
+        }
+
+        [Theory]
+        [InlineData ("new --output test console", "test")]
+        [InlineData("new console --output test", "test")]
+        [InlineData("new -o test console", "test")]
+        [InlineData("new console -o test", "test")]
+        [InlineData("new console --framework net6.0 --output test", "test")]
+        [InlineData("--output test new console", null)]
+        public void CanParseOutputOption(string command, string? expected)
+        {
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+
+            RootCommand rootCommand = new();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            rootCommand.Add(myCommand);
+
+            ParseResult parseResult = rootCommand.Parse(command);
+            Assert.Equal(expected, parseResult.GetValueForOption(SharedOptions.OutputOption)?.Name);
+        }
+
+        [Theory]
+        [InlineData("new --project test console", "test")]
+        [InlineData("new console --project test", "test")]
+        [InlineData("new console --framework net6.0 --project test", "test")]
+        [InlineData("--project test new console", null)]
+        public void CanParseProjectOption(string command, string? expected)
+        {
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+
+            RootCommand rootCommand = new();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            rootCommand.Add(myCommand);
+
+            ParseResult parseResult = rootCommand.Parse(command);
+            Assert.Equal(expected, parseResult.GetValueForOption(SharedOptions.ProjectPathOption)?.Name);
         }
     }
 }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/SearchTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/SearchTests.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
-using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.TestHelper;
 
@@ -11,7 +10,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 {
     public class SearchTests : BaseTest
     {
-        private static Dictionary<string, FilterOptionDefinition> _stringToFilterDefMap = new Dictionary<string, FilterOptionDefinition>()
+        private static Dictionary<string, FilterOptionDefinition> _stringToFilterDefMap = new()
         {
             { "package", FilterOptionDefinition.PackageFilter },
             { "author", FilterOptionDefinition.AuthorFilter },
@@ -61,11 +60,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         {
             FilterOptionDefinition expectedDef = _stringToFilterDefMap[expectedFilter];
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
-            SearchCommandArgs args = new SearchCommandArgs((BaseSearchCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(command);
+            SearchCommandArgs args = new((BaseSearchCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Single(args.AppliedFilters);
             Assert.Contains("filter-value", args.GetFilterValue(expectedDef));
@@ -95,11 +94,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         {
             FilterOptionDefinition expectedDef = _stringToFilterDefMap[expectedFilter];
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
-            SearchCommandArgs args = new SearchCommandArgs((BaseSearchCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(command);
+            SearchCommandArgs args = new((BaseSearchCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Single(args.AppliedFilters);
             Assert.Contains("filter-value", args.GetFilterValue(expectedDef));
@@ -111,24 +110,24 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new search cr1 cr2")]
         public void Search_CannotParseMultipleArgs(string command)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
+            ParseResult parseResult = myCommand.Parse(command);
 
             Assert.NotEmpty(parseResult.Errors);
-            Assert.Equal("Unrecognized command or argument 'cr2'.", parseResult.Errors.First().Message);
+            Assert.Equal("Unrecognized command or argument 'cr2'.", parseResult.Errors[0].Message);
         }
 
         [Fact]
         public void Search_CannotParseArgsAtNewLevel()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse("new smth search");
+            ParseResult parseResult = myCommand.Parse("new smth search");
 
             Assert.NotEmpty(parseResult.Errors);
-            Assert.Equal("Unrecognized command or argument(s): 'smth'.", parseResult.Errors.First().Message);
+            Assert.Equal("Unrecognized command or argument(s): 'smth'.", parseResult.Errors[0].Message);
         }
 
         [Theory]
@@ -140,25 +139,25 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new -lang filter-value search source", "-lang")]
         public void Search_CannotParseOptionsAtNewLevel(string command, string expectedFilter)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
+            ParseResult parseResult = myCommand.Parse(command);
 
             Assert.NotEmpty(parseResult.Errors);
-            Assert.Equal($"Unrecognized command or argument(s): '{expectedFilter}','filter-value'.", parseResult.Errors.First().Message);
+            Assert.Equal($"Unrecognized command or argument(s): '{expectedFilter}','filter-value'.", parseResult.Errors[0].Message);
         }
 
         [Fact]
         public void Search_Legacy_CannotParseArgsAtBothLevels()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new smth --search smth-else");
+            ParseResult parseResult = myCommand.Parse("new smth --search smth-else");
 
             Assert.NotEmpty(parseResult.Errors);
-            Assert.Equal("Unrecognized command or argument(s): 'smth'.", parseResult.Errors.First().Message);
+            Assert.Equal("Unrecognized command or argument(s): 'smth'.", parseResult.Errors[0].Message);
         }
 
         [Theory]
@@ -168,17 +167,17 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new foo bar search source", "'foo'")] //only first error is added
         public void Search_HandleParseErrors(string command, string expectedInvalidTokens)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
-            var errorMessages = parseResult.Errors.Select(error => error.Message);
+            ParseResult parseResult = myCommand.Parse(command);
+            IEnumerable<string> errorMessages = parseResult.Errors.Select(error => error.Message);
 
-            var expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
+            string[] expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
 
             Assert.NotEmpty(parseResult.Errors);
             Assert.Equal(expectedInvalidTokenSets.Length, parseResult.Errors.Count);
-            foreach (var tokenSet in expectedInvalidTokenSets)
+            foreach (string tokenSet in expectedInvalidTokenSets)
             {
                 Assert.True(errorMessages.Contains($"Unrecognized command or argument(s): {tokenSet}.") || errorMessages.Contains($"Unrecognized command or argument {tokenSet}."));
             }
@@ -190,12 +189,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new search --columns-all")]
         public void Search_CanParseColumnsAll(string command)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
+            ParseResult parseResult = myCommand.Parse(command);
 
-            SearchCommandArgs args = new SearchCommandArgs((BaseSearchCommand)parseResult.CommandResult.Command, parseResult);
+            SearchCommandArgs args = new((BaseSearchCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.True(args.DisplayAllColumns);
         }
@@ -210,17 +209,17 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         //[InlineData("new --search --columns author,type", new[] { "author", "type" })]
         public void Search_CanParseColumns(string command, string[] expectedColumns)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
+            ParseResult parseResult = myCommand.Parse(command);
 
-            SearchCommandArgs args = new SearchCommandArgs((BaseSearchCommand)parseResult.CommandResult.Command, parseResult);
+            SearchCommandArgs args = new((BaseSearchCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.False(args.DisplayAllColumns);
             Assert.NotEmpty(args.ColumnsToDisplay);
             Assert.Equal(expectedColumns.Length, args.ColumnsToDisplay?.Count);
-            foreach (var column in expectedColumns)
+            foreach (string column in expectedColumns)
             {
                 Assert.Contains(column, args.ColumnsToDisplay);
             }
@@ -231,54 +230,54 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new search --columns c1 c2")]
         public void Search_CannotParseUnknownColumns(string command)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
+            ParseResult parseResult = myCommand.Parse(command);
 
             Assert.NotEmpty(parseResult.Errors);
-            Assert.Contains("Argument 'c1' not recognized. Must be one of:", parseResult.Errors.First().Message);
+            Assert.Contains("Argument 'c1' not recognized. Must be one of:", parseResult.Errors[0].Message);
         }
 
         [Fact]
         public void CommandExampleCanShowParentCommandsBeyondNew()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            Command rootCommand = new Command("dotnet")
+            Command rootCommand = new("dotnet")
             {
                 myCommand
             };
 
-            var parseResult = rootCommand.Parse("dotnet new search template");
+            ParseResult parseResult = rootCommand.Parse("dotnet new search template");
             Assert.Equal("dotnet new search my-template", Example.For<NewCommand>(parseResult).WithSubcommand<SearchCommand>().WithArgument(SearchCommand.NameArgument, "my-template"));
         }
 
         [Fact]
         public void CommandExampleShowsMandatoryArg()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            Command rootCommand = new Command("dotnet")
+            Command rootCommand = new("dotnet")
             {
                 myCommand
             };
 
-            var parseResult = rootCommand.Parse("dotnet new search template");
+            ParseResult parseResult = rootCommand.Parse("dotnet new search template");
             Assert.Equal("dotnet new search [<template-name>]", Example.For<NewCommand>(parseResult).WithSubcommand<SearchCommand>().WithArgument(SearchCommand.NameArgument));
         }
 
         [Fact]
         public void CommandExampleShowsOptionalArgWhenOptionsAreGiven()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            Command rootCommand = new Command("dotnet")
+            Command rootCommand = new("dotnet")
             {
                 myCommand
             };
 
-            var parseResult = rootCommand.Parse("dotnet new search template");
+            ParseResult parseResult = rootCommand.Parse("dotnet new search template");
             Assert.Equal("dotnet new search [<template-name>] --author Microsoft", Example.For<NewCommand>(parseResult).WithSubcommand<SearchCommand>().WithArgument(SearchCommand.NameArgument).WithOption(SharedOptionsFactory.CreateAuthorOption(), "Microsoft"));
         }
     }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TabCompletionTests.Approval.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TabCompletionTests.Approval.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
-using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.TestHelper;
 
@@ -16,11 +15,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task RootCommand_GetAllSuggestions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = ParserFactory.CreateParser(myCommand).Parse("new ");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = ParserFactory.CreateParser(myCommand).Parse("new ");
+            System.CommandLine.Completions.CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             return Verify(result);
         }
@@ -28,11 +27,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task RootCommand_GetStartsWtihSuggestions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new c");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = myCommand.Parse("new c");
+            System.CommandLine.Completions.CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             return Verify(result);
         }
@@ -40,11 +39,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task Install_GetAllSuggestions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new install ");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = myCommand.Parse("new install ");
+            System.CommandLine.Completions.CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             return Verify(result);
         }
@@ -52,11 +51,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task Uninstall_GetAllSuggestions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new uninstall ");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = myCommand.Parse("new uninstall ");
+            System.CommandLine.Completions.CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             return Verify(result);
         }
@@ -64,11 +63,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task Update_GetAllSuggestions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new update ");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = myCommand.Parse("new update ");
+            System.CommandLine.Completions.CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             return Verify(result);
         }
@@ -76,11 +75,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task List_GetAllSuggestions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new list ");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = myCommand.Parse("new list ");
+            System.CommandLine.Completions.CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             return Verify(result);
         }
@@ -88,11 +87,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task Search_GetAllSuggestions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new search ");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = myCommand.Parse("new search ");
+            System.CommandLine.Completions.CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             return Verify(result);
         }
@@ -100,11 +99,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task Create_GetAllSuggestions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new create ");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = myCommand.Parse("new create ");
+            System.CommandLine.Completions.CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             return Verify(result);
         }
@@ -112,11 +111,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task TemplateCommand_GetAllSuggestions()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new console ");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = myCommand.Parse("new console ");
+            System.CommandLine.Completions.CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             return Verify(result);
         }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TabCompletionTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TabCompletionTests.cs
@@ -20,11 +20,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Instantiate_CanSuggestTemplateOption_StartsWith()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new console --framework net7.0 --l");
-            var suggestions = parseResult.GetCompletions().Select(l => l.Label).ToArray();
+            ParseResult parseResult = myCommand.Parse("new console --framework net7.0 --l");
+            string[] suggestions = parseResult.GetCompletions().Select(l => l.Label).ToArray();
 
             Assert.Equal(2, suggestions.Length);
             Assert.Contains("--langVersion", suggestions);
@@ -36,11 +36,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 #pragma warning restore xUnit1004 // Test methods should not be skipped
         public void Instantiate_CanSuggestLanguages()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new console --language ");
-            var suggestions = parseResult.GetCompletions().Select(l => l.Label).ToArray();
+            ParseResult parseResult = myCommand.Parse("new console --language ");
+            string[] suggestions = parseResult.GetCompletions().Select(l => l.Label).ToArray();
 
             Assert.Equal(3, suggestions.Length);
             Assert.Contains("C#", suggestions);
@@ -53,11 +53,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 #pragma warning restore xUnit1004 // Test methods should not be skipped
         public void Install_GetSuggestionsAfterInteractive()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new install --interactive ");
-            var result = parseResult.GetCompletions().Select(l => l.Label).ToArray();
+            ParseResult parseResult = myCommand.Parse("new install --interactive ");
+            string[] result = parseResult.GetCompletions().Select(l => l.Label).ToArray();
 
             Assert.Equal(2, result.Length);
             Assert.Contains("--nuget-source", result);
@@ -66,11 +66,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Install_GetSuggestionsAfterOptionWithoutArg()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new install --nuget-source ");
-            var result = parseResult.GetCompletions().ToArray();
+            ParseResult parseResult = myCommand.Parse("new install --nuget-source ");
+            CompletionItem[] result = parseResult.GetCompletions().ToArray();
 
             Assert.Empty(result);
         }
@@ -80,11 +80,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 #pragma warning restore xUnit1004 // Test methods should not be skipped
         public void Install_GetSuggestionsAfterOptionWithArg()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new install --nuget-source me");
-            var result = parseResult.GetCompletions().Select(l => l.Label).ToArray();
+            ParseResult parseResult = myCommand.Parse("new install --nuget-source me");
+            string[] result = parseResult.GetCompletions().Select(l => l.Label).ToArray();
 
             Assert.Single(result);
             Assert.Contains("--interactive", result);
@@ -93,11 +93,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Instantiate_CanSuggestTemplate_StartsWith()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
-            var myCommand = NewCommandFactory.Create("new", _ => host);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            Command myCommand = NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new co");
-            var suggestions = parseResult.GetCompletions().Select(l => l.Label).ToArray();
+            ParseResult parseResult = myCommand.Parse("new co");
+            string[] suggestions = parseResult.GetCompletions().Select(l => l.Label).ToArray();
 
             Assert.Single(suggestions);
             Assert.Equal("console", suggestions.Single());
@@ -106,24 +106,24 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanCompleteChoice_FromSingleTemplate()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val1", "val2", "val3");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo --testChoice ");
+            ParseResult parseResult = myCommand.Parse($" new foo --testChoice ");
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Equal(new[] { "val1", "val2", "val3" }, result);
         }
@@ -135,24 +135,24 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         //  Skip = "Multiple arity option completion does not work. https://github.com/dotnet/command-line-api/issues/1727")]
         public void CanCompleteChoice_MultichoiceTabCompletion(string command, string[] suggestions)
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithMultiChoiceParameter("testChoice", "val1", "val2", "val3");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse(command);
+            ParseResult parseResult = myCommand.Parse(command);
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Equal(suggestions, result);
         }
@@ -160,23 +160,23 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanCompleteChoice_FromSingleTemplate_StartsWith()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val1", "val2", "boo");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo --testChoice v");
+            ParseResult parseResult = myCommand.Parse($" new foo --testChoice v");
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Equal(new[] { "val1", "val2" }, result);
         }
@@ -184,24 +184,24 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanCompleteChoice_FromSingleTemplate_InTheMiddle()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val1", "val2", "boo");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo --testChoice v --name test");
+            ParseResult parseResult = myCommand.Parse($" new foo --testChoice v --name test");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
             completionContext = completionContext!.AtCursorPosition(23);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Equal(new[] { "val1", "val2" }, result);
         }
@@ -209,26 +209,26 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanCompleteChoice_FromMultipleTemplates()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val1");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val2", "val3");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo --testChoice ");
+            ParseResult parseResult = myCommand.Parse($" new foo --testChoice ");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Equal(new[] { "val1", "val2", "val3" }, result);
         }
@@ -236,26 +236,26 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanCompleteChoice_FromMultipleTemplates_StartsWith()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val1");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val2", "boo");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo --testChoice v");
+            ParseResult parseResult = myCommand.Parse($" new foo --testChoice v");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Equal(new[] { "val1", "val2" }, result);
         }
@@ -263,28 +263,28 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanCompleteParameters_FromMultipleTemplates()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val1")
                 .WithParameters("foo", "bar");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val2", "val3")
                 .WithParameters("param");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo ");
+            ParseResult parseResult = myCommand.Parse($" new foo ");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Contains("--param", result);
             Assert.Contains("--testChoice", result);
@@ -304,28 +304,28 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanCompleteParameters_StartsWith_FromMultipleTemplates()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val1")
                 .WithParameters("foo", "bar");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val2", "val3")
                 .WithParameters("test");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo --t");
+            ParseResult parseResult = myCommand.Parse($" new foo --t");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Contains("--test", result);
             Assert.Contains("--testChoice", result);
@@ -347,28 +347,28 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 #pragma warning restore xUnit1004 // Test methods should not be skipped
         public void CanCompleteParameters_StartsWith_AfterOption()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val1")
                 .WithParameters("foo", "bar");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
                 .WithChoiceParameter("testChoice", "val2", "val3")
                 .WithParameters("test");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo --foo val1 --bar val2 --t");
+            ParseResult parseResult = myCommand.Parse($" new foo --foo val1 --bar val2 --t");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.DoesNotContain("--test", result);
             Assert.Contains("--testChoice", result);
@@ -390,26 +390,26 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("--language")]
         public void CanCompleteLanguages(string optionName)
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithTag("language", "C#");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
                 .WithTag("language", "F#");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo {optionName} ");
+            ParseResult parseResult = myCommand.Parse($" new foo {optionName} ");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Equal(new[] { "C#", "F#" }, result);
         }
@@ -417,26 +417,26 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanCompleteTypes()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithTag("type", "project");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
                 .WithTag("type", "solution");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo --type ");
+            ParseResult parseResult = myCommand.Parse($" new foo --type ");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Equal(new[] { "project", "solution" }, result);
         }
@@ -444,29 +444,29 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanIgnoreTemplateGroupsWithConstraints()
         {
-            var template1 = new MockTemplateInfo("foo1", identity: "foo.1")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo1", identity: "foo.1")
                 .WithConstraints(new TemplateConstraintInfo("test", "yes"));
 
-            var template2 = new MockTemplateInfo("foo2", identity: "foo.2")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo2", identity: "foo.2")
                 .WithConstraints(new TemplateConstraintInfo("test", "no"));
 
-            var template3 = new MockTemplateInfo("foo3", identity: "foo.3")
+            MockTemplateInfo template3 = new MockTemplateInfo("foo3", identity: "foo.3")
              .WithConstraints(new TemplateConstraintInfo("test", "bad-params"));
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new fo");
+            ParseResult parseResult = myCommand.Parse($" new fo");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateNameCompletions(args.ShortName, templateGroups, settings).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateNameCompletions(args.ShortName, templateGroups, settings).Select(l => l.Label);
 
             Assert.Equal(new[] { "foo1" }, result);
         }
@@ -474,29 +474,29 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanIgnoreTemplateGroupsWithConstraints_IgnoresLongEvaluationTemplateGroups()
         {
-            var template1 = new MockTemplateInfo("foo1", identity: "foo.1")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo1", identity: "foo.1")
                 .WithConstraints(new TemplateConstraintInfo("test", "yes"));
 
-            var template2 = new MockTemplateInfo("foo2", identity: "foo.2")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo2", identity: "foo.2")
                 .WithConstraints(new TemplateConstraintInfo("test", "no"));
 
-            var template3 = new MockTemplateInfo("foo3", identity: "foo.3")
+            MockTemplateInfo template3 = new MockTemplateInfo("foo3", identity: "foo.3")
              .WithConstraints(new TemplateConstraintInfo("test", "bad-params"));
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new LongRunningConstraintFactory("test", 1500)) });
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new LongRunningConstraintFactory("test", 1500)) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new fo");
+            ParseResult parseResult = myCommand.Parse($" new fo");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateNameCompletions(args.ShortName, templateGroups, settings).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateNameCompletions(args.ShortName, templateGroups, settings).Select(l => l.Label);
 
             Assert.Empty(result);
         }
@@ -504,32 +504,32 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CanIgnoreTemplatesInGroupWithConstraints()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "group")
                 .WithConstraints(new TemplateConstraintInfo("test", "yes"))
                 .WithParameter("a");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "group")
                 .WithConstraints(new TemplateConstraintInfo("test", "no"))
-                .WithParameter("b"); 
+                .WithParameter("b");
 
-            var template3 = new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "group")
+            MockTemplateInfo template3 = new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "group")
              .WithConstraints(new TemplateConstraintInfo("test", "bad-params"))
              .WithParameter("c");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo ");
+            ParseResult parseResult = myCommand.Parse($" new foo ");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Contains("--a", result);
             Assert.DoesNotContain("--b", result);
@@ -539,32 +539,32 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void IncludesTemplatesInGroupWithLongEvaluatedConstraints()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "group")
                 .WithConstraints(new TemplateConstraintInfo("test", "yes"))
                 .WithParameter("a");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "group")
                 .WithConstraints(new TemplateConstraintInfo("test", "no"))
                 .WithParameter("b");
 
-            var template3 = new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "group")
+            MockTemplateInfo template3 = new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "group")
              .WithConstraints(new TemplateConstraintInfo("test", "bad-params"))
              .WithParameter("c");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new LongRunningConstraintFactory("test", 1500)) });
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new LongRunningConstraintFactory("test", 1500)) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo ");
+            ParseResult parseResult = myCommand.Parse($" new foo ");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
 
             Assert.Contains("--a", result);
             Assert.Contains("--b", result);
@@ -574,31 +574,31 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void WillNotEvaluateConstraints_WhenAtLeastOneTemplateInGroupDoesNotHaveConstraints()
         {
-            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "group")
+            MockTemplateInfo template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "group")
                 .WithParameter("a");
 
-            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "group")
+            MockTemplateInfo template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "group")
                 .WithConstraints(new TemplateConstraintInfo("test", "no"))
                 .WithParameter("b");
 
-            var template3 = new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "group")
+            MockTemplateInfo template3 = new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "group")
              .WithConstraints(new TemplateConstraintInfo("test", "bad-params"))
              .WithParameter("c");
 
-            var templateGroups = TemplateGroup.FromTemplateList(
+            IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new LongRunningConstraintFactory("test", 3000)) });
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new LongRunningConstraintFactory("test", 3000)) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new fo");
+            ParseResult parseResult = myCommand.Parse($" new fo");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
             var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
             Assert.NotNull(completionContext);
 
-            var result = InstantiateCommand.GetTemplateNameCompletions(args.ShortName, templateGroups, settings).Select(l => l.Label);
+            IEnumerable<string> result = InstantiateCommand.GetTemplateNameCompletions(args.ShortName, templateGroups, settings).Select(l => l.Label);
 
             Assert.Equal(new[] { "foo" }, result);
         }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TemplateCommandTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TemplateCommandTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public Task CannotCreateCommandForInvalidParameter()
         {
-            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            MockTemplateInfo template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
                 .WithParameters("have:colon", "n1", "n2");
 
             var paramSymbolInfo = new Dictionary<string, string>()
@@ -34,19 +34,19 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 { "n2", paramSymbolInfo }
             };
 
-            var hostDataLoader = A.Fake<IHostSpecificDataLoader>();
+            IHostSpecificDataLoader hostDataLoader = A.Fake<IHostSpecificDataLoader>();
             A.CallTo(() => hostDataLoader.ReadHostSpecificTemplateData(template)).Returns(new HostSpecificTemplateData(symbolInfo));
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, hostDataLoader))
                 .Single();
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
             TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse($" new foo");
+            ParseResult parseResult = myCommand.Parse($" new foo");
             InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
 
             try
@@ -69,7 +69,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public async Task Constraints_WhenTheTemplateIsAllowed()
         {
-            var template = new MockTemplateInfo(shortName: "test", identity: "testId1").WithConstraints(new TemplateConstraintInfo("test", "yes"));
+            MockTemplateInfo template = new MockTemplateInfo(shortName: "test", identity: "testId1").WithConstraints(new TemplateConstraintInfo("test", "yes"));
 
             ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
@@ -82,7 +82,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public async Task Constraints_WhenTheTemplateIsRestricted()
         {
-            var template = new MockTemplateInfo(shortName: "test").WithConstraints(new TemplateConstraintInfo("test", "no"));
+            MockTemplateInfo template = new MockTemplateInfo(shortName: "test").WithConstraints(new TemplateConstraintInfo("test", "no"));
 
             ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
@@ -95,7 +95,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public async Task Constraints_WhenTheConstraintCannotBeEvaluated()
         {
-            var template = new MockTemplateInfo(shortName: "test").WithConstraints(new TemplateConstraintInfo("test", "bad-arg"));
+            MockTemplateInfo template = new MockTemplateInfo(shortName: "test").WithConstraints(new TemplateConstraintInfo("test", "bad-arg"));
             ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/UninstallTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/UninstallTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.TestHelper;
 
@@ -16,11 +15,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("uninstall")]
         public void Uninstall_NoArguments(string commandName)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new {commandName}");
-            UninstallCommandArgs args = new UninstallCommandArgs((BaseUninstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new {commandName}");
+            UninstallCommandArgs args = new((BaseUninstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Empty(parseResult.Errors);
             Assert.Empty(args.TemplatePackages);
@@ -32,11 +31,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("uninstall")]
         public void Uninstall_WithArgument(string commandName)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new {commandName} source");
-            UninstallCommandArgs args = new UninstallCommandArgs((BaseUninstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new {commandName} source");
+            UninstallCommandArgs args = new((BaseUninstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Empty(parseResult.Errors);
             Assert.Single(args.TemplatePackages);
@@ -49,11 +48,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new uninstall source1 source2")]
         public void Uninstall_WithMultipleArgument(string command)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
-            UninstallCommandArgs args = new UninstallCommandArgs((BaseUninstallCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(command);
+            UninstallCommandArgs args = new((BaseUninstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Empty(parseResult.Errors);
             Assert.Equal(2, args.TemplatePackages.Count);
@@ -70,17 +69,17 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new source1 --uninstall source", "'source1'")]
         public void Uninstall_CanReturnParseError(string command, string expectedInvalidTokens)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
-            var errorMessages = parseResult.Errors.Select(error => error.Message);
+            ParseResult parseResult = myCommand.Parse(command);
+            IEnumerable<string> errorMessages = parseResult.Errors.Select(error => error.Message);
 
-            var expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
+            string[] expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
 
             Assert.NotEmpty(parseResult.Errors);
             Assert.Equal(expectedInvalidTokenSets.Length, parseResult.Errors.Count);
-            foreach (var tokenSet in expectedInvalidTokenSets)
+            foreach (string tokenSet in expectedInvalidTokenSets)
             {
                 Assert.True(errorMessages.Contains($"Unrecognized command or argument(s): {tokenSet}.") || errorMessages.Contains($"Unrecognized command or argument {tokenSet}."));
             }
@@ -89,14 +88,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CommandExampleCanShowParentCommandsBeyondNew()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            Command rootCommand = new Command("dotnet")
+            Command rootCommand = new("dotnet")
             {
                 myCommand
             };
 
-            var parseResult = rootCommand.Parse("dotnet new uninstall source");
+            ParseResult parseResult = rootCommand.Parse("dotnet new uninstall source");
             Assert.Equal("dotnet new uninstall my-source", Example.For<NewCommand>(parseResult).WithSubcommand<UninstallCommand>().WithArgument(UninstallCommand.NameArgument, "my-source"));
         }
     }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/UpdateTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/UpdateTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.TestHelper;
 
@@ -15,11 +14,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("--nuget-source")]
         public void Update_CanParseAddSourceOption(string optionName)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new update {optionName} my-custom-source");
-            UpdateCommandArgs args = new UpdateCommandArgs((UpdateCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new update {optionName} my-custom-source");
+            UpdateCommandArgs args = new((UpdateCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Single(args.AdditionalSources);
             Assert.Contains("my-custom-source", args.AdditionalSources);
@@ -31,10 +30,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("update")]
         public void Update_Error_WhenArguments(string commandName)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new {commandName} source");
+            ParseResult parseResult = myCommand.Parse($"new {commandName} source");
 
             Assert.True(parseResult.Errors.Any());
             Assert.Contains(parseResult.Errors, error => error.Message.Contains("Unrecognized command or argument 'source'"));
@@ -45,10 +44,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new update --check-only --add-source my-custom-source1 --add-source my-custom-source2")]
         public void Update_CanParseAddSourceOption_MultipleEntries(string testCase)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse(testCase);
-            UpdateCommandArgs args = new UpdateCommandArgs((UpdateCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(testCase);
+            UpdateCommandArgs args = new((UpdateCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Equal(2, args.AdditionalSources?.Count);
             Assert.Contains("my-custom-source1", args.AdditionalSources);
@@ -58,11 +57,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Update_CanParseInteractiveOption()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new update --interactive");
-            UpdateCommandArgs args = new UpdateCommandArgs((UpdateCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new update --interactive");
+            UpdateCommandArgs args = new((UpdateCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.True(args.Interactive);
 
@@ -77,11 +76,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("--dry-run")]
         public void Update_CanParseCheckOnlyOption(string optionAlias)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new update {optionAlias}");
-            UpdateCommandArgs args = new UpdateCommandArgs((UpdateCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new update {optionAlias}");
+            UpdateCommandArgs args = new((UpdateCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.True(args.CheckOnly);
 
@@ -94,11 +93,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void Update_Legacy_CanParseCheckOnlyOption()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse($"new --update-check");
-            UpdateCommandArgs args = new UpdateCommandArgs((LegacyUpdateCheckCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse($"new --update-check");
+            UpdateCommandArgs args = new((LegacyUpdateCheckCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.True(args.CheckOnly);
 
@@ -114,11 +113,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new --nuget-source my-custom-source --update-apply")]
         public void Update_Legacy_CanParseAddSourceOption(string testCase)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(testCase);
-            UpdateCommandArgs args = new UpdateCommandArgs((BaseUpdateCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(testCase);
+            UpdateCommandArgs args = new((BaseUpdateCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Single(args.AdditionalSources);
             Assert.Contains("my-custom-source", args.AdditionalSources);
@@ -129,11 +128,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new --interactive --update-apply source")]
         public void Update_Legacy_CanParseInteractiveOption(string testCase)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(testCase);
-            UpdateCommandArgs args = new UpdateCommandArgs((BaseUpdateCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(testCase);
+            UpdateCommandArgs args = new((BaseUpdateCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.True(args.Interactive);
         }
@@ -144,10 +143,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new --add-source my-custom-source1 --update-apply --add-source my-custom-source2")]
         public void Update_Legacy_CanParseAddSourceOption_MultipleEntries(string testCase)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            var parseResult = myCommand.Parse(testCase);
-            UpdateCommandArgs args = new UpdateCommandArgs((BaseUpdateCommand)parseResult.CommandResult.Command, parseResult);
+            ParseResult parseResult = myCommand.Parse(testCase);
+            UpdateCommandArgs args = new((BaseUpdateCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Equal(2, args.AdditionalSources?.Count);
             Assert.Contains("my-custom-source1", args.AdditionalSources);
@@ -164,17 +163,17 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [InlineData("new source1 --update-apply source", "'source1'|'source'")]
         public void Update_CanReturnParseError(string command, string expectedInvalidTokens)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse(command);
-            var errorMessages = parseResult.Errors.Select(error => error.Message);
+            ParseResult parseResult = myCommand.Parse(command);
+            IEnumerable<string> errorMessages = parseResult.Errors.Select(error => error.Message);
 
-            var expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
+            string[] expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
 
             Assert.NotEmpty(parseResult.Errors);
             Assert.Equal(expectedInvalidTokenSets.Length, parseResult.Errors.Count);
-            foreach (var tokenSet in expectedInvalidTokenSets)
+            foreach (string tokenSet in expectedInvalidTokenSets)
             {
                 Assert.True(errorMessages.Contains($"Unrecognized command or argument(s): {tokenSet}.") || errorMessages.Contains($"Unrecognized command or argument {tokenSet}."));
             }
@@ -183,14 +182,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         [Fact]
         public void CommandExampleCanShowParentCommandsBeyondNew()
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
-            Command rootCommand = new Command("dotnet")
+            Command rootCommand = new("dotnet")
             {
                 myCommand
             };
 
-            var parseResult = rootCommand.Parse("dotnet new update");
+            ParseResult parseResult = rootCommand.Parse("dotnet new update");
             Assert.Equal("dotnet new update", Example.For<NewCommand>(parseResult).WithSubcommand<UpdateCommand>());
         }
     }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateResolverTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateResolverTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 new MockTemplateInfo("console2", name: "Long name for Console App #2", identity: "Console.App2")
             };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list console2"),
                 defaultLanguage: null,
@@ -40,11 +40,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_ExactMatchOnShortNameMatchesCorrectly))]
         public async Task TestGetTemplateResolutionResult_ExactMatchOnShortNameMatchesCorrectly()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App"));
-            templatesToSearch.Add(new MockTemplateInfo("console2", name: "Long name for Console App #2", identity: "Console.App2"));
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App"),
+                new MockTemplateInfo("console2", name: "Long name for Console App #2", identity: "Console.App2")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list console"),
                 defaultLanguage: null,
@@ -60,12 +62,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_UnambiguousGroupIsFound))]
         public async Task TestGetTemplateResolutionResult_UnambiguousGroupIsFound()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L3", groupIdentity: "Console.App.Test").WithTag("language", "L3"));
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"),
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"),
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L3", groupIdentity: "Console.App.Test").WithTag("language", "L3")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list console"),
                 defaultLanguage: null,
@@ -81,14 +85,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MultipleGroupsAreFound))]
         public async Task TestGetTemplateResolutionResult_MultipleGroupsAreFound()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L3", groupIdentity: "Console.App.Test").WithTag("language", "L3"));
-            templatesToSearch.Add(new MockTemplateInfo("classlib", name: "Long name for Class Library App", identity: "Class.Library.L1", groupIdentity: "Class.Library.Test").WithTag("language", "L1"));
-            templatesToSearch.Add(new MockTemplateInfo("classlib", name: "Long name for Class Library App", identity: "Class.Library.L2", groupIdentity: "Class.Library.Test").WithTag("language", "L2"));
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"),
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"),
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L3", groupIdentity: "Console.App.Test").WithTag("language", "L3"),
+                new MockTemplateInfo("classlib", name: "Long name for Class Library App", identity: "Class.Library.L1", groupIdentity: "Class.Library.Test").WithTag("language", "L1"),
+                new MockTemplateInfo("classlib", name: "Long name for Class Library App", identity: "Class.Library.L2", groupIdentity: "Class.Library.Test").WithTag("language", "L2")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list c"),
                 defaultLanguage: null,
@@ -103,11 +109,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_DefaultLanguageDisambiguates))]
         public async Task TestGetTemplateResolutionResult_DefaultLanguageDisambiguates()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"),
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list console"),
                 defaultLanguage: null,
@@ -124,11 +132,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_InputLanguageIsPreferredOverDefault))]
         public async Task TestGetTemplateResolutionResult_InputLanguageIsPreferredOverDefault()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
-            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"),
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list console --language L2"),
                 defaultLanguage: null,
@@ -143,14 +153,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_PartialMatch_HasLanguageMismatch))]
         public async Task TestGetTemplateResolutionResult_PartialMatch_HasLanguageMismatch()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
-              new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
                   .WithTag("language", "L1")
                   .WithTag("type", "project")
-                  .WithBaselineInfo("app", "standard"));
+                  .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list console --language L2"),
                 defaultLanguage: null,
@@ -169,14 +180,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_PartialMatch_HasContextMismatch))]
         public async Task TestGetTemplateResolutionResult_PartialMatch_HasContextMismatch()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
-                   new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
                        .WithTag("language", "L1")
                        .WithTag("type", "project")
-                       .WithBaselineInfo("app", "standard"));
+                       .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list console --type item"),
                 defaultLanguage: null,
@@ -195,14 +207,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_PartialMatch_HasBaselineMismatch))]
         public async Task TestGetTemplateResolutionResult_PartialMatch_HasBaselineMismatch()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
-                   new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
                        .WithTag("language", "L1")
                        .WithTag("type", "project")
-                       .WithBaselineInfo("app", "standard"));
+                       .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list console --baseline core"),
                 defaultLanguage: null,
@@ -221,14 +234,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_PartialMatch_HasMultipleMismatches))]
         public async Task TestGetTemplateResolutionResult_PartialMatch_HasMultipleMismatches()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
-                   new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
                        .WithTag("language", "L1")
                        .WithTag("type", "project")
-                       .WithBaselineInfo("app", "standard"));
+                       .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                 GetListCommandArgsFor("new list console --language L2 --type item --baseline core"),
                 defaultLanguage: null,
@@ -247,14 +261,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_NoMatch))]
         public async Task TestGetTemplateResolutionResult_NoMatch()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
-                   new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
                        .WithTag("language", "L1")
                        .WithTag("type", "project")
-                       .WithBaselineInfo("app", "standard"));
+                       .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      GetListCommandArgsFor("new list zzzzz --language L1 --type project --baseline app"),
                      defaultLanguage: null,
@@ -274,15 +289,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MatchByTags))]
         public async Task TestGetTemplateResolutionResult_MatchByTags()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
+            List<ITemplateInfo> templatesToSearch = new()
+            {
                 new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test1")
                     .WithTag("language", "L1")
                     .WithTag("type", "project")
                     .WithClassifications("Common", "Test")
-                    .WithBaselineInfo("app", "standard"));
+                    .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      GetListCommandArgsFor("new list --tag Common"),
                      defaultLanguage: null,
@@ -300,21 +316,21 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MatchByTagsIgnoredOnNameMatch))]
         public async Task TestGetTemplateResolutionResult_MatchByTagsIgnoredOnNameMatch()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
+            List<ITemplateInfo> templatesToSearch = new()
+            {
                 new MockTemplateInfo("console1", name: "Long name for Console App Test", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
                     .WithTag("language", "L1")
                     .WithTag("type", "project")
                     .WithClassifications("Common", "Test")
-                    .WithBaselineInfo("app", "standard"));
-            templatesToSearch.Add(
-              new MockTemplateInfo("console2", name: "Long name for Console App", identity: "Console.App.T2", groupIdentity: "Console.App.Test2")
+                    .WithBaselineInfo("app", "standard"),
+                new MockTemplateInfo("console2", name: "Long name for Console App", identity: "Console.App.T2", groupIdentity: "Console.App.Test2")
                   .WithTag("language", "L1")
                   .WithTag("type", "project")
                   .WithClassifications("Common", "Test")
-                  .WithBaselineInfo("app", "standard"));
+                  .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      GetListCommandArgsFor("new list Test"),
                      defaultLanguage: null,
@@ -333,21 +349,21 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MatchByTagsIgnoredOnShortNameMatch))]
         public async Task TestGetTemplateResolutionResult_MatchByTagsIgnoredOnShortNameMatch()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
-              new MockTemplateInfo("console", name: "Long name for Console App Test", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App Test", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
                   .WithTag("language", "L1")
                   .WithTag("type", "project")
                   .WithClassifications("Common", "Test", "Console")
-                  .WithBaselineInfo("app", "standard"));
-            templatesToSearch.Add(
-              new MockTemplateInfo("cons", name: "Long name for Cons App", identity: "Console.App.T2", groupIdentity: "Console.App.Test2")
+                  .WithBaselineInfo("app", "standard"),
+                new MockTemplateInfo("cons", name: "Long name for Cons App", identity: "Console.App.T2", groupIdentity: "Console.App.Test2")
                   .WithTag("language", "L1")
                   .WithTag("type", "project")
                   .WithClassifications("Common", "Test", "Console")
-                  .WithBaselineInfo("app", "standard"));
+                  .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      GetListCommandArgsFor("new list Console"),
                      defaultLanguage: null,
@@ -366,15 +382,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MatchByTagsAndMismatchByOtherFilter))]
         public async Task TestGetTemplateResolutionResult_MatchByTagsAndMismatchByOtherFilter()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
-               new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
                    .WithTag("language", "L1")
                    .WithTag("type", "project")
                    .WithClassifications("Common", "Test")
-                   .WithBaselineInfo("app", "standard"));
+                   .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      GetListCommandArgsFor("new list --language L2 --type item --tag Common"),
                      defaultLanguage: null,
@@ -399,16 +416,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [InlineData("input", "İnput", false)]
         public async Task TestGetTemplateResolutionResult_AuthorMatch(string templateAuthor, string commandAuthor, bool matchExpected)
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-
-            templatesToSearch.Add(
-               new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test", author: templateAuthor)
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test", author: templateAuthor)
                    .WithTag("language", "L1")
                    .WithTag("type", "project")
                    .WithClassifications("Common", "Test")
-                   .WithBaselineInfo("app", "standard"));
+                   .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      GetListCommandArgsFor($"new list console --author {commandAuthor}"),
                      defaultLanguage: null,
@@ -451,16 +468,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             const string separator = "||";
             string[] templateTagsArray = templateTags.Split(separator);
 
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-
-            templatesToSearch.Add(
-               new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test", author: "TemplateAuthor")
+            List<ITemplateInfo> templatesToSearch = new()
+            {
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test", author: "TemplateAuthor")
                    .WithTag("language", "L1")
                    .WithTag("type", "project")
                    .WithClassifications(templateTagsArray)
-                   .WithBaselineInfo("app", "standard"));
+                   .WithBaselineInfo("app", "standard")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      GetListCommandArgsFor($"new list console --tag {commandTag}"),
                      defaultLanguage: null,
@@ -492,12 +509,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_TemplateWithoutTypeShouldNotBeMatchedForContextFilter))]
         public async Task TestGetTemplateResolutionResult_TemplateWithoutTypeShouldNotBeMatchedForContextFilter()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
+            List<ITemplateInfo> templatesToSearch = new()
+            {
                 new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
-                    .WithClassifications("Common", "Test"));
+                    .WithClassifications("Common", "Test")
+            };
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader());
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader());
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      GetListCommandArgsFor("new list console --type item"),
                      defaultLanguage: null,
@@ -516,23 +534,23 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact]
         public async Task TestGetTemplateResolutionResult_ConstraintsMismatch()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
+            List<ITemplateInfo> templatesToSearch = new()
+            {
                 new MockTemplateInfo("console", identity: "Console.App.T1")
-                    .WithConstraints(new TemplateConstraintInfo("test", "no")));
-            templatesToSearch.Add(
-             new MockTemplateInfo("console2", identity: "Console.App.T2")
-                 .WithConstraints(new TemplateConstraintInfo("test", "bad-param")));
+                    .WithConstraints(new TemplateConstraintInfo("test", "no")),
+                new MockTemplateInfo("console2", identity: "Console.App.T2")
+                 .WithConstraints(new TemplateConstraintInfo("test", "bad-param"))
+            };
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new list");
+            ParseResult parseResult = myCommand.Parse("new list");
             var args = new ListCommandArgs((ListCommand)parseResult.CommandResult.Command, parseResult);
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader(), new TemplateConstraintManager(settings));
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader(), new TemplateConstraintManager(settings));
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      args,
                      defaultLanguage: null,
@@ -547,23 +565,23 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact]
         public async Task TestGetTemplateResolutionResult_IgnoreConstraintsMismatch()
         {
-            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(
+            List<ITemplateInfo> templatesToSearch = new()
+            {
                 new MockTemplateInfo("console", identity: "Console.App.T1")
-                    .WithConstraints(new TemplateConstraintInfo("test", "no")));
-            templatesToSearch.Add(
-             new MockTemplateInfo("console2", identity: "Console.App.T2")
-                 .WithConstraints(new TemplateConstraintInfo("test", "bad-param")));
+                    .WithConstraints(new TemplateConstraintInfo("test", "no")),
+                new MockTemplateInfo("console2", identity: "Console.App.T2")
+                 .WithConstraints(new TemplateConstraintInfo("test", "bad-param"))
+            };
 
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
             IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
 
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var parseResult = myCommand.Parse("new list --ignore-constraints");
+            ParseResult parseResult = myCommand.Parse("new list --ignore-constraints");
             var args = new ListCommandArgs((ListCommand)parseResult.CommandResult.Command, parseResult);
 
-            ListTemplateResolver resolver = new ListTemplateResolver(templatesToSearch, new MockHostSpecificDataLoader(), new TemplateConstraintManager(settings));
+            ListTemplateResolver resolver = new(templatesToSearch, new MockHostSpecificDataLoader(), new TemplateConstraintManager(settings));
             TemplateResolutionResult matchResult = await resolver.ResolveTemplatesAsync(
                      args,
                      defaultLanguage: null,
@@ -577,10 +595,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
         private static ListCommandArgs GetListCommandArgsFor(string commandInput)
         {
-            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            RootCommand rootCommand = new();
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            rootCommand.Add(myCommand);
 
-            var parseResult = myCommand.Parse(commandInput);
+            ParseResult parseResult = rootCommand.Parse(commandInput);
             return new ListCommandArgs((ListCommand)parseResult.CommandResult.Command, parseResult);
         }
     }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCoordinatorTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCoordinatorTests.cs
@@ -4,9 +4,11 @@
 using System.CommandLine;
 using FakeItEasy;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.Cli.TemplateSearch;
 using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
+using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Mocks;
 using Microsoft.TemplateEngine.TestHelper;
@@ -17,22 +19,15 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests
 {
-    public class TemplateSearchCoordinatorTests : BaseTest, IClassFixture<EnvironmentSettingsHelper>
+    public class TemplateSearchCoordinatorTests : BaseTest
     {
-        private EnvironmentSettingsHelper _environmentSettingsHelper;
-       
-        public TemplateSearchCoordinatorTests(EnvironmentSettingsHelper environmentSettingsHelper)
-        {
-            _environmentSettingsHelper = environmentSettingsHelper;
-        }
+        private static readonly ITemplatePackageInfo s_packOneInfo = new MockTemplatePackageInfo("PackOne", "1.0.0");
 
-        private static readonly ITemplatePackageInfo _packOneInfo = new MockTemplatePackageInfo("PackOne", "1.0.0");
+        private static readonly ITemplatePackageInfo s_packTwoInfo = new MockTemplatePackageInfo("PackTwo", "1.6.0");
 
-        private static readonly ITemplatePackageInfo _packTwoInfo = new MockTemplatePackageInfo("PackTwo", "1.6.0");
+        private static readonly ITemplatePackageInfo s_packThreeInfo = new MockTemplatePackageInfo("PackThree", "2.1");
 
-        private static readonly ITemplatePackageInfo _packThreeInfo = new MockTemplatePackageInfo("PackThree", "2.1");
-
-        private static readonly ITemplateInfo _fooOneTemplate =
+        private static readonly ITemplateInfo s_fooOneTemplate =
             new MockTemplateInfo("foo1", name: "MockFooTemplateOne", identity: "Mock.Foo.1", groupIdentity: "Mock.Foo", author: "TestAuthor")
                 .WithClassifications("CSharp", "Library")
                 .WithDescription("Mock Foo template one")
@@ -40,20 +35,20 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 .WithTag("language", "C#")
                 .WithTag("type", "project");
 
-        private static readonly ITemplateInfo _fooTwoTemplate =
+        private static readonly ITemplateInfo s_fooTwoTemplate =
             new MockTemplateInfo("foo2", name: "MockFooTemplateTwo", identity: "Mock.Foo.2", groupIdentity: "Mock.Foo")
                 .WithClassifications("CSharp", "Console")
                 .WithDescription("Mock Foo template two")
                 .WithChoiceParameter("Framework", "netcoreapp2.0", "netcoreapp2.1", "netcoreapp3.1")
                 .WithTag("language", "C#");
 
-        private static readonly ITemplateInfo _barCSharpTemplate =
+        private static readonly ITemplateInfo s_barCSharpTemplate =
             new MockTemplateInfo("barC", name: "MockBarCsharpTemplate", identity: "Mock.Bar.1.Csharp", groupIdentity: "Mock.Bar")
                 .WithClassifications("CSharp")
                 .WithDescription("Mock Bar CSharp template")
                 .WithTag("language", "C#");
 
-        private static readonly ITemplateInfo _barFSharpTemplate =
+        private static readonly ITemplateInfo s_barFSharpTemplate =
             new MockTemplateInfo("barF", name: "MockBarFSharpTemplate", identity: "Mock.Bar.1.FSharp", groupIdentity: "Mock.Bar")
                 .WithClassifications("FSharp")
                 .WithDescription("Mock Bar FSharp template")
@@ -66,36 +61,38 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string v1FileLocation = SetupDiscoveryMetadata(cacheLocation, false);
             string v2FileLocation = SetupTemplateCache(cacheLocation, false);
 
-            var environment = A.Fake<IEnvironment>();
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(
-                virtualize: true,
-                environment: environment,
-                additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search foo");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            ParseResult parseResult = myCommand.Parse($"new search foo");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
 
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
-            foreach (var location in new[] { v1FileLocation, v2FileLocation })
+            foreach (string? location in new[] { v1FileLocation, v2FileLocation })
             {
                 A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(location);
-                var searchResults = await searchCoordinator.SearchAsync(
+                IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                     factory.GetPackFilter(args),
                     CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                     default).ConfigureAwait(false);
 
                 Assert.Equal(1, searchResults.Count);
                 Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-                var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+                SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
                 Assert.Equal(2, nugetSearchResults.SearchHits.Count);
-                Assert.Single(nugetSearchResults.SearchHits, pack => pack.PackageInfo.Name.Equals(_packOneInfo.Name)).MatchedTemplates.Where(t => string.Equals(t.Name, _fooOneTemplate.Name));
-                Assert.Single(nugetSearchResults.SearchHits, pack => pack.PackageInfo.Name.Equals(_packTwoInfo.Name)).MatchedTemplates.Where(t => string.Equals(t.Name, _fooTwoTemplate.Name));
+                (ITemplatePackageInfo _, IReadOnlyList<ITemplateInfo> packOneMatchedTemplates) = Assert.Single(nugetSearchResults.SearchHits, pack => pack.PackageInfo.Name.Equals(s_packOneInfo.Name));
+                (ITemplatePackageInfo _, IReadOnlyList<ITemplateInfo> packTwoMatchedTemplates) = Assert.Single(nugetSearchResults.SearchHits, pack => pack.PackageInfo.Name.Equals(s_packTwoInfo.Name));
+                Assert.Single(packOneMatchedTemplates, t => string.Equals(t.Name, s_fooOneTemplate.Name));
+                Assert.Single(packTwoMatchedTemplates, t => string.Equals(t.Name, s_fooTwoTemplate.Name));
             }
         }
 
@@ -111,35 +108,37 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string v1FileLocation = SetupDiscoveryMetadata(cacheLocation, true);
             string v2FileLocation = SetupTemplateCache(cacheLocation, true);
 
-            var environment = A.Fake<IEnvironment>();
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(
-                virtualize: true,
-                environment: environment,
-                additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search foo --framework netcoreapp2.0");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            ParseResult parseResult = myCommand.Parse($"new search foo --framework netcoreapp2.0");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
 
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
-            foreach (var location in new[] { v1FileLocation, v2FileLocation })
+            foreach (string? location in new[] { v1FileLocation, v2FileLocation })
             {
                 A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(location);
-                var searchResults = await searchCoordinator.SearchAsync(
+                IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                     factory.GetPackFilter(args),
                     CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                     default).ConfigureAwait(false);
 
                 Assert.Equal(1, searchResults.Count);
                 Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-                var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+                SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
                 Assert.Equal(1, nugetSearchResults.SearchHits.Count);
-                Assert.Single(nugetSearchResults.SearchHits, pack => pack.PackageInfo.Name.Equals(_packTwoInfo.Name)).MatchedTemplates.Where(t => string.Equals(t.Name, _fooTwoTemplate.Name));
+
+                (ITemplatePackageInfo _, IReadOnlyList<ITemplateInfo> packTwoMatchedTemplates) = Assert.Single(nugetSearchResults.SearchHits, pack => pack.PackageInfo.Name.Equals(s_packTwoInfo.Name));
+                Assert.Single(packTwoMatchedTemplates, t => string.Equals(t.Name, s_fooTwoTemplate.Name));
             }
         }
 
@@ -153,33 +152,33 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string v1FileLocation = SetupDiscoveryMetadata(cacheLocation, true);
             string v2FileLocation = SetupTemplateCache(cacheLocation, true);
 
-            var environment = A.Fake<IEnvironment>();
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(
-                virtualize: true,
-                environment: environment,
-                additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search foo --tfm netcoreapp2.0");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            ParseResult parseResult = myCommand.Parse($"new search foo --tfm netcoreapp2.0");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
 
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
-            foreach (var location in new[] { v1FileLocation, v2FileLocation })
+            foreach (string? location in new[] { v1FileLocation, v2FileLocation })
             {
                 A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(location);
-                var searchResults = await searchCoordinator.SearchAsync(
+                IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                     factory.GetPackFilter(args),
                     CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                     default).ConfigureAwait(false);
 
                 Assert.Equal(1, searchResults.Count);
                 Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-                var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+                SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
                 Assert.Equal(0, nugetSearchResults.SearchHits.Count);
             }
         }
@@ -192,37 +191,37 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string v1FileLocation = SetupDiscoveryMetadata(cacheLocation, false);
             string v2FileLocation = SetupTemplateCache(cacheLocation, false);
 
-            var environment = A.Fake<IEnvironment>();
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(
-                virtualize: true,
-                environment: environment,
-                additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search bar --language F#");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            ParseResult parseResult = myCommand.Parse($"new search bar --language F#");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
 
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
-            foreach (var location in new[] { v1FileLocation, v2FileLocation })
+            foreach (string? location in new[] { v1FileLocation, v2FileLocation })
             {
                 A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(location);
-                var searchResults = await searchCoordinator.SearchAsync(
+                IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                     factory.GetPackFilter(args),
                     CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                     default).ConfigureAwait(false);
 
                 Assert.Equal(1, searchResults.Count);
                 Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-                var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+                SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
                 Assert.Equal(1, nugetSearchResults.SearchHits.Count);
-                Assert.Equal(1, nugetSearchResults.SearchHits.First().MatchedTemplates.Count);
-                Assert.Equal(_packThreeInfo.Name, nugetSearchResults.SearchHits.First().PackageInfo.Name);
-                Assert.Equal(_barFSharpTemplate.Name, nugetSearchResults.SearchHits.First().MatchedTemplates.First().Name);
+                Assert.Equal(1, nugetSearchResults.SearchHits[0].MatchedTemplates.Count);
+                Assert.Equal(s_packThreeInfo.Name, nugetSearchResults.SearchHits[0].PackageInfo.Name);
+                Assert.Equal(s_barFSharpTemplate.Name, nugetSearchResults.SearchHits[0].MatchedTemplates[0].Name);
             }
         }
 
@@ -236,33 +235,33 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string v1FileLocation = SetupDiscoveryMetadata(cacheLocation, false);
             string v2FileLocation = SetupTemplateCache(cacheLocation, false);
 
-            var environment = A.Fake<IEnvironment>();
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(
-                virtualize: true,
-                environment: environment,
-                additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search {commandTemplate} --author {commandAuthor}");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            ParseResult parseResult = myCommand.Parse($"new search {commandTemplate} --author {commandAuthor}");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
 
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
-            foreach (var location in new[] { v1FileLocation, v2FileLocation })
+            foreach (string? location in new[] { v1FileLocation, v2FileLocation })
             {
                 A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(location);
-                var searchResults = await searchCoordinator.SearchAsync(
+                IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                     factory.GetPackFilter(args),
                     CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                     default).ConfigureAwait(false);
 
                 Assert.Equal(1, searchResults.Count);
                 Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-                var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+                SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
                 Assert.Equal(matchCount, nugetSearchResults.SearchHits.Count);
             }
         }
@@ -277,33 +276,34 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string v1FileLocation = SetupDiscoveryMetadata(cacheLocation, false);
             string v2FileLocation = SetupTemplateCache(cacheLocation, false);
 
-            var environment = A.Fake<IEnvironment>();
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(
-                virtualize: true,
-                environment: environment,
-                additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search {commandTemplate} --type {commandType}");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            ParseResult parseResult = myCommand.Parse($"new search {commandTemplate} --type {commandType}");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
+
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
-            foreach (var location in new[] { v1FileLocation, v2FileLocation })
+            foreach (string? location in new[] { v1FileLocation, v2FileLocation })
             {
                 A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(location);
-                var searchResults = await searchCoordinator.SearchAsync(
+                IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                     factory.GetPackFilter(args),
                     CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                     default).ConfigureAwait(false);
 
                 Assert.Equal(1, searchResults.Count);
                 Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-                var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+                SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
                 Assert.Equal(matchCount, nugetSearchResults.SearchHits.Count);
             }
         }
@@ -319,37 +319,38 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string v1FileLocation = SetupDiscoveryMetadata(cacheLocation, false);
             string v2FileLocation = SetupTemplateCache(cacheLocation, false);
 
-            var environment = A.Fake<IEnvironment>();
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(
-                virtualize: true,
-                environment: environment,
-                additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search {commandTemplate} --package {commandPackage}");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
 
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            ParseResult parseResult = myCommand.Parse($"new search {commandTemplate} --package {commandPackage}");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
+
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
-            foreach (var location in new[] { v1FileLocation, v2FileLocation })
+            foreach (string? location in new[] { v1FileLocation, v2FileLocation })
             {
                 A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(location);
-                var searchResults = await searchCoordinator.SearchAsync(
+                IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                     factory.GetPackFilter(args),
                     CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                     default).ConfigureAwait(false);
 
                 Assert.Equal(1, searchResults.Count);
                 Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-                var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+                SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
                 Assert.Equal(packMatchCount, nugetSearchResults.SearchHits.Count);
                 if (packMatchCount != 0)
                 {
-                    Assert.Equal(templateMatchCount, nugetSearchResults.SearchHits.Single(res => res.PackageInfo.Name == _packThreeInfo.Name).MatchedTemplates.Count);
+                    Assert.Equal(templateMatchCount, nugetSearchResults.SearchHits.Single(res => res.PackageInfo.Name == s_packThreeInfo.Name).MatchedTemplates.Count);
                 }
             }
         }
@@ -366,33 +367,33 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string v1FileLocation = SetupDiscoveryMetadata(cacheLocation, false);
             string v2FileLocation = SetupTemplateCache(cacheLocation, false);
 
-            var environment = A.Fake<IEnvironment>();
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(
-                virtualize: true,
-                environment: environment,
-                additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search {commandTemplate} --tag {commandTag}");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            ParseResult parseResult = myCommand.Parse($"new search {commandTemplate} --tag {commandTag}");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
 
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
-            foreach (var location in new[] { v1FileLocation, v2FileLocation })
+            foreach (string? location in new[] { v1FileLocation, v2FileLocation })
             {
                 A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(location);
-                var searchResults = await searchCoordinator.SearchAsync(
+                IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                     factory.GetPackFilter(args),
                     CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                     default).ConfigureAwait(false);
 
                 Assert.Equal(1, searchResults.Count);
                 Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-                var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+                SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
                 Assert.Equal(packMatchCount, nugetSearchResults.SearchHits.Count);
                 if (packMatchCount != 0)
                 {
@@ -408,33 +409,33 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string v1FileLocation = SetupDiscoveryMetadata(cacheLocation, false);
             string v2FileLocation = SetupTemplateCache(cacheLocation, false);
 
-            var environment = A.Fake<IEnvironment>();
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(
-                virtualize: true,
-                environment: environment,
-                additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages));
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
+
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search bar --language VB");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            ParseResult parseResult = myCommand.Parse($"new search bar --language VB");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
 
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
-            foreach (var location in new[] { v1FileLocation, v2FileLocation })
+            foreach (string? location in new[] { v1FileLocation, v2FileLocation })
             {
                 A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(location);
-                var searchResults = await searchCoordinator.SearchAsync(
+                IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                     factory.GetPackFilter(args),
                     CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                     default).ConfigureAwait(false);
 
                 Assert.Equal(1, searchResults.Count);
                 Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-                var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+                SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
                 Assert.Equal(0, nugetSearchResults.SearchHits.Count);
             }
         }
@@ -447,30 +448,31 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             string cacheLocation = TestUtils.CreateTemporaryFolder();
             string v2FileLocation = SetupInvalidTemplateCache(cacheLocation);
 
-            var environment = A.Fake<IEnvironment>();
+            List<(Type, IIdentifiedComponent)> builtIns = BuiltInTemplatePackagesProviderFactory.GetComponents(RepoTemplatePackages);
+            builtIns.Add((typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory()));
 
-            var engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true, environment: environment);
+            ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost(additionalComponents: builtIns);
+            IEnvironment environment = A.Fake<IEnvironment>();
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true, environment: environment);
             var templatePackageManager = new TemplatePackageManager(engineEnvironmentSettings);
 
-            engineEnvironmentSettings.Components.AddComponent(typeof(ITemplateSearchProviderFactory), new NuGetMetadataSearchProviderFactory());
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host);
+            ParseResult parseResult = myCommand.Parse($"new search --unknown");
+            SearchCommandArgs args = new((SearchCommand)parseResult.CommandResult.Command, parseResult);
 
-            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => engineEnvironmentSettings.Host);
-            var parseResult = myCommand.Parse($"new search --unknown");
-            SearchCommandArgs args = new SearchCommandArgs((SearchCommand)parseResult.CommandResult.Command, parseResult);
-
-            var templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
+            IReadOnlyList<IManagedTemplatePackage> templatePackages = await templatePackageManager.GetManagedTemplatePackagesAsync(false, default).ConfigureAwait(false);
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(engineEnvironmentSettings);
-            CliSearchFiltersFactory factory = new CliSearchFiltersFactory(templatePackages);
+            CliSearchFiltersFactory factory = new(templatePackages);
 
             A.CallTo(() => environment.GetEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE")).Returns(v2FileLocation);
-            var searchResults = await searchCoordinator.SearchAsync(
+            IReadOnlyList<SearchResult> searchResults = await searchCoordinator.SearchAsync(
                 factory.GetPackFilter(args),
                 CliSearchFiltersFactory.GetMatchingTemplatesFilter(args),
                 default).ConfigureAwait(false);
 
             Assert.Equal(1, searchResults.Count);
             Assert.Single(searchResults, result => result.Provider.Factory.DisplayName == "NuGet.org");
-            var nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
+            SearchResult nugetSearchResults = searchResults.Single(result => result.Provider.Factory.DisplayName == "NuGet.org");
             Assert.Equal(0, nugetSearchResults.SearchHits.Count);
         }
 
@@ -496,39 +498,40 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         {
             const string version = "1.0.0.0";
 
-            List<ITemplateInfo> templateCache = new List<ITemplateInfo>();
-
-            templateCache.Add(_fooOneTemplate);
-            templateCache.Add(_fooTwoTemplate);
-            templateCache.Add(_barCSharpTemplate);
-            templateCache.Add(_barFSharpTemplate);
-
-            Dictionary<string, PackToTemplateEntry> packToTemplateMap = new Dictionary<string, PackToTemplateEntry>();
-
-            List<TemplateIdentificationEntry> packOneTemplateInfo = new List<TemplateIdentificationEntry>()
+            List<ITemplateInfo> templateCache = new()
             {
-                new TemplateIdentificationEntry(_fooOneTemplate.Identity, _fooOneTemplate.GroupIdentity)
+                s_fooOneTemplate,
+                s_fooTwoTemplate,
+                s_barCSharpTemplate,
+                s_barFSharpTemplate
             };
-            packToTemplateMap[_packOneInfo.Name] = new PackToTemplateEntry(_packOneInfo.Version ?? "", packOneTemplateInfo);
 
-            List<TemplateIdentificationEntry> packTwoTemplateInfo = new List<TemplateIdentificationEntry>()
+            Dictionary<string, PackToTemplateEntry> packToTemplateMap = new();
+
+            List<TemplateIdentificationEntry> packOneTemplateInfo = new()
             {
-                new TemplateIdentificationEntry(_fooTwoTemplate.Identity, _fooTwoTemplate.GroupIdentity)
+                new TemplateIdentificationEntry(s_fooOneTemplate.Identity, s_fooOneTemplate.GroupIdentity)
             };
-            packToTemplateMap[_packTwoInfo.Name] = new PackToTemplateEntry(_packTwoInfo.Version ?? "", packTwoTemplateInfo);
+            packToTemplateMap[s_packOneInfo.Name] = new PackToTemplateEntry(s_packOneInfo.Version ?? "", packOneTemplateInfo);
 
-            List<TemplateIdentificationEntry> packThreeTemplateInfo = new List<TemplateIdentificationEntry>()
+            List<TemplateIdentificationEntry> packTwoTemplateInfo = new()
             {
-                new TemplateIdentificationEntry(_barCSharpTemplate.Identity, _barCSharpTemplate.GroupIdentity),
-                new TemplateIdentificationEntry(_barFSharpTemplate.Identity, _barFSharpTemplate.GroupIdentity)
+                new TemplateIdentificationEntry(s_fooTwoTemplate.Identity, s_fooTwoTemplate.GroupIdentity)
             };
-            packToTemplateMap[_packThreeInfo.Name] = new PackToTemplateEntry(_packThreeInfo.Version ?? "", packThreeTemplateInfo);
+            packToTemplateMap[s_packTwoInfo.Name] = new PackToTemplateEntry(s_packTwoInfo.Version ?? "", packTwoTemplateInfo);
 
-            Dictionary<string, object> additionalData = new Dictionary<string, object>();
+            List<TemplateIdentificationEntry> packThreeTemplateInfo = new()
+            {
+                new TemplateIdentificationEntry(s_barCSharpTemplate.Identity, s_barCSharpTemplate.GroupIdentity),
+                new TemplateIdentificationEntry(s_barFSharpTemplate.Identity, s_barFSharpTemplate.GroupIdentity)
+            };
+            packToTemplateMap[s_packThreeInfo.Name] = new PackToTemplateEntry(s_packThreeInfo.Version ?? "", packThreeTemplateInfo);
+
+            Dictionary<string, object> additionalData = new();
 
             if (includehostData)
             {
-                Dictionary<string, string> frameworkParamSymbolInfo = new Dictionary<string, string>()
+                Dictionary<string, string> frameworkParamSymbolInfo = new()
                 {
                     { "longName", "framework" },
                     { "shortName", "f" }
@@ -541,16 +544,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                     }
                 );
 
-                Dictionary<string, HostSpecificTemplateData> cliHostData = new Dictionary<string, HostSpecificTemplateData>()
+                Dictionary<string, HostSpecificTemplateData> cliHostData = new()
                 {
-                    { _fooOneTemplate.Identity, fooTemplateHostData },
-                    { _fooTwoTemplate.Identity, fooTemplateHostData }
+                    { s_fooOneTemplate.Identity, fooTemplateHostData },
+                    { s_fooTwoTemplate.Identity, fooTemplateHostData }
                 };
 
                 additionalData[CliHostSearchCacheData.DataName] = cliHostData;
             }
 
-            TemplateDiscoveryMetadata discoveryMetadata = new TemplateDiscoveryMetadata(version, templateCache, packToTemplateMap, additionalData);
+            TemplateDiscoveryMetadata discoveryMetadata = new(version, templateCache, packToTemplateMap, additionalData);
             string targetPath = Path.Combine(fileLocation, "searchCacheV1.json");
             File.WriteAllText(targetPath, discoveryMetadata.ToJObject().ToString());
             return Path.Combine(fileLocation, "searchCacheV1.json");
@@ -559,7 +562,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
         private static string SetupTemplateCache(string fileLocation, bool includehostData = false)
         {
-            Dictionary<string, string> frameworkParamSymbolInfo = new Dictionary<string, string>()
+            Dictionary<string, string> frameworkParamSymbolInfo = new()
                 {
                     { "longName", "framework" },
                     { "shortName", "f" }
@@ -572,25 +575,26 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 }
             );
 
-            Dictionary<string, object> additionalData = new Dictionary<string, object>()
+            Dictionary<string, object> additionalData = new()
             {
                 { CliHostSearchCacheData.DataName, fooTemplateHostData }
             };
-            List<ITemplateInfo> templateCache = new List<ITemplateInfo>();
+            List<ITemplateInfo> templateCache = new()
+            {
+                s_fooOneTemplate,
+                s_fooTwoTemplate,
+                s_barCSharpTemplate,
+                s_barFSharpTemplate
+            };
 
-            templateCache.Add(_fooOneTemplate);
-            templateCache.Add(_fooTwoTemplate);
-            templateCache.Add(_barCSharpTemplate);
-            templateCache.Add(_barFSharpTemplate);
+            var fooOneTemplateData = new TemplateSearchData(s_fooOneTemplate, includehostData ? additionalData : null);
+            var fooTwoTemplateData = new TemplateSearchData(s_fooTwoTemplate, includehostData ? additionalData : null);
+            var barCSharpTemplateData = new TemplateSearchData(s_barCSharpTemplate, null);
+            var barFSharpTemplateData = new TemplateSearchData(s_barFSharpTemplate, null);
 
-            var fooOneTemplateData = new TemplateSearchData(_fooOneTemplate, includehostData ? additionalData : null);
-            var fooTwoTemplateData = new TemplateSearchData(_fooTwoTemplate, includehostData ? additionalData : null);
-            var barCSharpTemplateData = new TemplateSearchData(_barCSharpTemplate, null);
-            var barFSharpTemplateData = new TemplateSearchData(_barFSharpTemplate, null);
-
-            var packOne = new TemplatePackageSearchData(_packOneInfo, new[] { fooOneTemplateData });
-            var packTwo = new TemplatePackageSearchData(_packTwoInfo, new[] { fooTwoTemplateData });
-            var packThree = new TemplatePackageSearchData(_packThreeInfo, new[] { barCSharpTemplateData, barFSharpTemplateData });
+            var packOne = new TemplatePackageSearchData(s_packOneInfo, new[] { fooOneTemplateData });
+            var packTwo = new TemplatePackageSearchData(s_packTwoInfo, new[] { fooTwoTemplateData });
+            var packThree = new TemplatePackageSearchData(s_packThreeInfo, new[] { barCSharpTemplateData, barFSharpTemplateData });
 
             var cache = new TemplateSearchCache(new[] { packOne, packTwo, packThree });
 

--- a/src/Tests/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
+++ b/src/Tests/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Cli;
+using Microsoft.TemplateEngine.Cli.Commands;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.EndToEndTestHarness
@@ -20,32 +21,37 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
         private const string HostIdentifier = "endtoendtestharness";
         private const string HostVersion = "v1.0.0";
         private const string CommandName = "test-test";
-        private static readonly Dictionary<string, Func<IPhysicalFileSystem, JObject, string, bool>> VerificationLookup = new Dictionary<string, Func<IPhysicalFileSystem, JObject, string, bool>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, Func<IPhysicalFileSystem, JObject, string, bool>> s_verificationLookup = new(StringComparer.OrdinalIgnoreCase);
 
         private static int Main(string[] args)
         {
-            VerificationLookup["dir_exists"] = CheckDirectoryExists;
-            VerificationLookup["file_exists"] = CheckFileExists;
-            VerificationLookup["dir_does_not_exist"] = CheckDirectoryDoesNotExist;
-            VerificationLookup["file_does_not_exist"] = CheckFileDoesNotExist;
-            VerificationLookup["file_contains"] = CheckFileContains;
-            VerificationLookup["file_does_not_contain"] = CheckFileDoesNotContain;
+            s_verificationLookup["dir_exists"] = CheckDirectoryExists;
+            s_verificationLookup["file_exists"] = CheckFileExists;
+            s_verificationLookup["dir_does_not_exist"] = CheckDirectoryDoesNotExist;
+            s_verificationLookup["file_does_not_exist"] = CheckFileDoesNotExist;
+            s_verificationLookup["file_contains"] = CheckFileContains;
+            s_verificationLookup["file_does_not_contain"] = CheckFileDoesNotContain;
 
             int batteryCount = int.Parse(args[0], CultureInfo.InvariantCulture);
             string outputPath = args[batteryCount + 1];
 
-            List<string> passThroughArgs = new List<string>();
+            List<string> passThroughArgs = new();
             passThroughArgs.AddRange(args.Skip(3 + batteryCount));
             passThroughArgs.Add("--debug:ephemeral-hive");
 
             string testAssetsRoot = args[batteryCount + 2];
+            CliTemplateEngineHost host = null;
 
-            ITemplateEngineHost host = CreateHost(testAssetsRoot);
-            host.VirtualizeDirectory(outputPath);
+            Command newCommand = NewCommandFactory.Create(
+       CommandName,
+               (ParseResult parseResult) =>
+               {
+                   FileInfo outputPath = parseResult.GetValueForOption(SharedOptions.OutputOption);
+                   host = CreateHost(testAssetsRoot, outputPath?.FullName);
+                   return host;
+               });
 
-            var command = NewCommandFactory.Create(CommandName, _ => host);
-
-            int result = ParserFactory.CreateParser(command).Parse(passThroughArgs.ToArray()).Invoke();
+            int result = ParserFactory.CreateParser(newCommand).Parse(passThroughArgs.ToArray()).Invoke();
 
             bool verificationsPassed = false;
 
@@ -70,7 +76,7 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
             Console.Error.WriteLine("Output Files:");
             foreach (string fileName in host.FileSystem.EnumerateFiles(outputPath, "*", SearchOption.AllDirectories))
             {
-                Console.Error.WriteLine(fileName.Substring(outputPath.Length));
+                Console.Error.WriteLine(fileName.AsSpan(outputPath.Length));
             }
 
             return result != 0 ? result : batteryCount == 0 ? 0 : verificationsPassed ? 0 : 1;
@@ -85,7 +91,7 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
                 return true;
             }
 
-            Console.Error.WriteLine($"Expected {path} to not contain {config["text"].ToString()} but it did");
+            Console.Error.WriteLine($"Expected {path} to not contain {config["text"]} but it did");
             return false;
         }
 
@@ -161,10 +167,10 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
         private static bool RunVerifications(JArray verifications, IPhysicalFileSystem fs, string outputPath)
         {
             bool success = true;
-            foreach (JObject verification in verifications)
+            foreach (JObject verification in verifications.Cast<JObject>())
             {
                 string kind = verification["kind"].ToString();
-                if (!VerificationLookup.TryGetValue(kind, out Func<IPhysicalFileSystem, JObject, string, bool> func))
+                if (!s_verificationLookup.TryGetValue(kind, out Func<IPhysicalFileSystem, JObject, string, bool> func))
                 {
                     Console.Error.WriteLine($"Unable to find a verification handler for {kind}");
                     return false;
@@ -175,7 +181,7 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
             return success;
         }
 
-        private static ITemplateEngineHost CreateHost(string testAssetsRoot)
+        private static CliTemplateEngineHost CreateHost(string testAssetsRoot, string outputPath)
         {
             var preferences = new Dictionary<string, string>
             {
@@ -199,7 +205,16 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
             builtIns.AddRange(Cli.Components.AllComponents);
             builtIns.Add((typeof(ITemplatePackageProviderFactory), new BuiltInTemplatePackagesProviderFactory(testAssetsRoot)));
 
-            return new Edge.DefaultTemplateEngineHost(HostIdentifier, HostVersion, preferences, builtIns, new[] { "dotnetcli" });
+            var host = new CliTemplateEngineHost(
+                HostIdentifier,
+                HostVersion,
+                preferences,
+                builtIns,
+                new[] { "dotnetcli" },
+                outputPath);
+
+            host.VirtualizeDirectory(outputPath);
+            return host;
         }
 
         /// <summary>
@@ -210,14 +225,14 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
         /// </remarks>
         private static string GetCLIVersion()
         {
-            ProcessStartInfo processInfo = new ProcessStartInfo("dotnet", "--version")
+            ProcessStartInfo processInfo = new("dotnet", "--version")
             {
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true
             };
-            StringBuilder version = new StringBuilder();
+            StringBuilder version = new();
             Process p = Process.Start(processInfo);
             if (p != null)
             {

--- a/src/Tests/dotnet-new.Tests/Approvals/AllWebProjectsWork.CanShowHelp_Mvc.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/AllWebProjectsWork.CanShowHelp_Mvc.verified.txt
@@ -12,6 +12,7 @@ Options:
   --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                 Forces content to be generated even if it would change existing files.
   --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
   -lang, --language <C#>  Specifies the template language to instantiate.
   --type <project>        Specifies the template type to instantiate.
 

--- a/src/Tests/dotnet-new.Tests/Approvals/AllWebProjectsWork.CanShowHelp_WebAPI.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/AllWebProjectsWork.CanShowHelp_WebAPI.verified.txt
@@ -11,6 +11,7 @@ Options:
   --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                 Forces content to be generated even if it would change existing files.
   --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
   -lang, --language <C#>  Specifies the template language to instantiate.
   --type <project>        Specifies the template type to instantiate.
 

--- a/src/Tests/dotnet-new.Tests/Approvals/AllWebProjectsWork.CanShowHelp_Webapp_common.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/AllWebProjectsWork.CanShowHelp_Webapp_common.verified.txt
@@ -13,6 +13,7 @@ Options:
   --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                 Forces content to be generated even if it would change existing files.
   --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
   -lang, --language <C#>  Specifies the template language to instantiate.
   --type <project>        Specifies the template type to instantiate.
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Linux.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Linux.verified.txt
@@ -29,9 +29,17 @@ webapp
 webconfig
 worker
 xunit
+--dry-run
+--force
 --help
+--name
+--no-update-check
+--output
+--project
 -?
 -h
+-n
+-o
 /?
 /h
 install

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.OSX.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.OSX.verified.txt
@@ -29,9 +29,17 @@ webapp
 webconfig
 worker
 xunit
+--dry-run
+--force
 --help
+--name
+--no-update-check
+--output
+--project
 -?
 -h
+-n
+-o
 /?
 /h
 install

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Windows.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Windows.verified.txt
@@ -36,9 +36,17 @@ wpfcustomcontrollib
 wpflib
 wpfusercontrollib
 xunit
+--dry-run
+--force
 --help
+--name
+--no-update-check
+--output
+--project
 -?
 -h
+-n
+-o
 /?
 /h
 install

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowAllowScriptsOption.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowAllowScriptsOption.verified.txt
@@ -10,6 +10,7 @@ Options:
   --dry-run                        Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                          Forces content to be generated even if it would change existing files.
   --no-update-check                Disables checking for the template package updates when instantiating a template.
+  --project <project>              The project that should be used for context evaluation.
   --allow-scripts <No|Prompt|Yes>  Specifies if post action scripts should run. [default: Prompt]
 
 Template options:

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnChoice.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnChoice.verified.txt
@@ -11,6 +11,7 @@ Options:
   --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                 Forces content to be generated even if it would change existing files.
   --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
   -lang, --language <C#>  Specifies the template language to instantiate.
   --type <project>        Specifies the template type to instantiate.
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnLanguage.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnLanguage.verified.txt
@@ -11,6 +11,7 @@ Options:
   --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                 Forces content to be generated even if it would change existing files.
   --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
   -lang, --language <F#>  Specifies the template language to instantiate.
   --type <project>        Specifies the template type to instantiate.
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnNonChoiceParam.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnNonChoiceParam.verified.txt
@@ -11,6 +11,7 @@ Options:
   --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                 Forces content to be generated even if it would change existing files.
   --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
   -lang, --language <C#>  Specifies the template language to instantiate.
   --type <project>        Specifies the template type to instantiate.
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MultipleValueChoice.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MultipleValueChoice.verified.txt
@@ -10,6 +10,7 @@ Options:
   --dry-run              Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                Forces content to be generated even if it would change existing files.
   --no-update-check      Disables checking for the template package updates when instantiating a template.
+  --project <project>    The project that should be used for context evaluation.
 
 Template options:
   -P, --Platform <android|iOS|MacOS|nix|Windows|WindowsPhone>  The target framework for the project.

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_classlib.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_classlib.verified.txt
@@ -11,6 +11,7 @@ Options:
   --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                 Forces content to be generated even if it would change existing files.
   --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
   -lang, --language <C#>  Specifies the template language to instantiate.
   --type <project>        Specifies the template type to instantiate.
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_console.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_console.verified.txt
@@ -11,6 +11,7 @@ Options:
   --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                 Forces content to be generated even if it would change existing files.
   --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
   -lang, --language <C#>  Specifies the template language to instantiate.
   --type <project>        Specifies the template type to instantiate.
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_globaljson.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_globaljson.verified.txt
@@ -11,6 +11,7 @@ Options:
   --dry-run              Displays a summary of what would happen if the given command line were run if it would result in a template creation.
   --force                Forces content to be generated even if it would change existing files.
   --no-update-check      Disables checking for the template package updates when instantiating a template.
+  --project <project>    The project that should be used for context evaluation.
   --type <item>          Specifies the template type to instantiate.
 
 Template options:

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelp_List_common.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelp_List_common.verified.txt
@@ -13,6 +13,8 @@ Options:
   --type <type>                          Filters templates based on available types. Predefined values are "project" and "item".
   --tag <tag>                            Filters the templates based on the tag.
   --ignore-constraints                   Disables checking if the template meets the constraints to be run.
+  -o, --output <output>                  Location to place the generated output.
+  --project <project>                    The project that should be used for context evaluation.
   --columns-all                          Display all columns in the output.
   --columns <author|language|tags|type>  Specifies the columns to display in the output.
   -?, -h, --help                         Show command line help.

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelp_common.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelp.CanShowHelp_common.verified.txt
@@ -10,7 +10,13 @@ Arguments:
   <template-args>        Template specific options to use.
 
 Options:
-  -?, -h, --help  Show command line help.
+  -o, --output <output>  Location to place the generated output.
+  -n, --name <name>      The name for the output being created. If no name is specified, the name of the output directory is used.
+  --dry-run              Displays a summary of what would happen if the given command line were run if it would result in a template creation.
+  --force                Forces content to be generated even if it would change existing files.
+  --no-update-check      Disables checking for the template package updates when instantiating a template.
+  --project <project>    The project that should be used for context evaluation.
+  -?, -h, --help         Show command line help.
 
 Commands:
   install <package>       Installs a template package.


### PR DESCRIPTION
fixes https://github.com/dotnet/templating/issues/4117
fixes pass-through output location of https://github.com/dotnet/templating/issues/3829

1. made refactoring to create correct `CliTemplateEngineHost` directly from `dotnet` to avoid reparsing.
`CliTemplateEngineHost` requires `output`, which is now pre-parsed. 

2. Moved the following options to `new` \ `new create` level
- `--name`
- `--output`
- `--force`
- `--dry-run`
- `--no-update-check`
- `--project` (new)

This allows usage of  `dotnet new --output my-folder console`.

3. Added missed validation in `InstantiateCommand` that allowed to put options and arguments before `create`.


4. Refactoring in unit tests
