### PR TITLE
Added `new` to the list of commands to track the second verb

### DIFF
--- a/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 topLevelCommandName: new HashSet<string> {"publish"},
                 optionsToLog: new HashSet<Option> { PublishCommandParser.RuntimeOption }
             ),
-            new AllowListToSendVerbSecondVerbFirstArgument(new HashSet<string> {"workload", "tool"}),
+            new AllowListToSendVerbSecondVerbFirstArgument(new HashSet<string> {"workload", "tool", "new"}),
         };
 
         private static void LogVerbosityForAllTopLevelCommand(


### PR DESCRIPTION
Added `new` to the list of commands to track the second verb.

Template language is already tracked here: https://github.com/dotnet/sdk/blob/361ca8ea760d7ed69da76f0b968f3b119d5bd222/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs#L77