### PR TITLE
apicompat: sort suppressions

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Xml;
 using System.Xml.Serialization;

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
@@ -140,12 +140,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
 
             Assert.Equal(new Suppression("CP0001")
             {
-                Target = "T:A.B",
-                Left = "ref/netstandard2.0/tempValidation.dll",
-                Right = "lib/net6.0/tempValidation.dll"
+                Target = "T:A",
+                Left = "lib/netstandard1.3/tempValidation.dll",
+                Right = "lib/netstandard1.3/tempValidation.dll"
             }, deserializedSuppressions[0]);
 
-            Assert.Equal(newSuppression, deserializedSuppressions[9]);
+            Assert.Equal(newSuppression, deserializedSuppressions[4]);
         }
 
         [Fact]
@@ -207,36 +207,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
 {s_suppressionsHeader}
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:A.B</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:tempValidation.Class1.Bar(System.Int32)</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:tempValidation.Class1.SomeOtherGenericMethod``1(``0)</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:tempValidation.Class1.SomeNewBreakingChange</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:tempValidation.SomeGenericType`1</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:A</Target>
     <Left>lib/netstandard1.3/tempValidation.dll</Left>
     <Right>lib/netstandard1.3/tempValidation.dll</Right>
@@ -249,13 +219,43 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
-    <DiagnosticId>PKV004</DiagnosticId>
-    <Target>.NETFramework,Version=v4.8</Target>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:A.B</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:tempValidation.SomeGenericType`1</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:tempValidation.Class1.Bar(System.Int32)</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:tempValidation.Class1.SomeNewBreakingChange</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:tempValidation.Class1.SomeOtherGenericMethod``1(``0)</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP123</DiagnosticId>
     <Target>T:myValidation.Class1</Target>
     <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>PKV004</DiagnosticId>
+    <Target>.NETFramework,Version=v4.8</Target>
   </Suppression>
 </Suppressions>";
 
@@ -263,36 +263,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
 {s_suppressionsHeader}
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:A.B</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:tempValidation.Class1.Bar(System.Int32)</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:tempValidation.Class1.SomeOtherGenericMethod``1(``0)</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:tempValidation.Class1.SomeNewBreakingChange</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:tempValidation.SomeGenericType`1</Target>
-    <Left>ref/netstandard2.0/tempValidation.dll</Left>
-    <Right>lib/net6.0/tempValidation.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:A</Target>
     <Left>lib/netstandard1.3/tempValidation.dll</Left>
     <Right>lib/netstandard1.3/tempValidation.dll</Right>
@@ -305,13 +275,43 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
-    <DiagnosticId>PKV004</DiagnosticId>
-    <Target>.NETFramework,Version=v4.8</Target>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:A.B</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:tempValidation.SomeGenericType`1</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:tempValidation.Class1.Bar(System.Int32)</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:tempValidation.Class1.SomeNewBreakingChange</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:tempValidation.Class1.SomeOtherGenericMethod``1(``0)</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP123</DiagnosticId>
     <Target>T:myValidation.Class1</Target>
     <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>PKV004</DiagnosticId>
+    <Target>.NETFramework,Version=v4.8</Target>
   </Suppression>
 </Suppressions>";
 

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Xml.Serialization;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
 
 namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests


### PR DESCRIPTION
Sort suppressions before writing them to disk.
1. DiagnosticId by id number (PKV < CP)
2. Left (null < non-null)
3. Right (null < non-null)
4. Target (null < non-null)