### PR TITLE
Backport of https://github.com/dotnet/sdk/pull/27510

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -101,9 +101,9 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>b396ad8b56c089ec3fa189f1013530d237a0e8c2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220813-01">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220826-03">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>ef0aa102e9c7d5cf55af06c2747d11e07d12b69a</Sha>
+      <Sha>18229112629d81c6004490b2e03367c07896f2b3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="7.0.100-1.22423.4">
       <Uri>https://github.com/dotnet/linker</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,7 +79,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/vstest -->
-    <MicrosoftNETTestSdkPackageVersion>17.4.0-preview-20220813-01</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>17.4.0-preview-20220826-03</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/27510

Update dependencies from https://github.com/microsoft/vstest build 20220826-03 (#27510)

[main] Update dependencies from microsoft/vstest

## Description

This change is needed for fixing https://github.com/dotnet/source-build/issues/2970

The change in vstest flows to source-build, that is built in `dotnet/installer` through `dotnet/sdk`.