### PR TITLE
Pass in reference assemblies to ApiCompat

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.ValidateAssemblies.NonCrossTargeting.targets
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.ValidateAssemblies.NonCrossTargeting.targets
@@ -13,7 +13,7 @@
           DependsOnTargets="PrepareInputsForApiCompatValidateAssemblies;ApiCompatValidateAssembliesCore" />
 
   <Target Name="PrepareInputsForApiCompatValidateAssemblies"
-          DependsOnTargets="CoreCompile;GetApiCompatContractAssembly;GetReferencePathForApiCompatValidateAssemblies">
+          DependsOnTargets="CoreCompile;GetApiCompatContractAssembly;GetReferencesForApiCompatValidateAssemblies">
     <ItemGroup>
       <ApiCompatLeftAssemblies Include="$(ApiCompatContractAssembly)" />
       <ApiCompatRightAssemblies Include="@(IntermediateAssembly)" />
@@ -37,10 +37,10 @@
   </Target>
 
   <!-- Retrieve the implementation and contract references. -->
-  <Target Name="GetReferencePathForApiCompatValidateAssemblies"
-          DependsOnTargets="ResolveReferences">
+  <Target Name="GetReferencesForApiCompatValidateAssemblies"
+          DependsOnTargets="FindReferenceAssembliesForReferences">
     <ItemGroup>
-      <ApiCompatAssemblyReferences Include="@(ReferencePath)" />
+      <ApiCompatAssemblyReferences Include="@(ReferencePathWithRefAssemblies)" />
       <!-- Use the implementation's references if contract references aren't supplied. -->
       <ApiCompatContractAssemblyReferences Include="@(ApiCompatAssemblyReferences)"
                                            Condition="'$(ApiCompatUseImplementationReferencesForContract)' != 'false'" />
@@ -50,7 +50,7 @@
   <!-- Annotate the TargetPath item to make the ApiCompatContractAssembly property accessible in the the cross-targeting build. -->
   <Target Name="ApiCompatAnnotateTargetPathWithTargetPlatformMoniker"
           Condition="'$(ApiCompatValidateAssemblies)' == 'true'"
-          DependsOnTargets="GetApiCompatContractAssembly;GetReferencePathForApiCompatValidateAssemblies"
+          DependsOnTargets="GetApiCompatContractAssembly;GetReferencesForApiCompatValidateAssemblies"
           AfterTargets="GetTargetPathWithTargetPlatformMoniker">
     <ItemGroup>
       <TargetPathWithTargetPlatformMoniker ApiCompatContractAssembly="$(ApiCompatContractAssembly)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -53,11 +53,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Touch Files="$(ApiCompatValidatePackageSemaphoreFile)" AlwaysCreate="true" />
   </Target>
 
-  <Target Name="_GetReferencePathForPackageValidation"
-          DependsOnTargets="ResolveReferences"
-          Returns="@(_ReferencePathWithTargetFramework)">
+  <Target Name="GetReferencesForApiCompatValidatePackage"
+          DependsOnTargets="FindReferenceAssembliesForReferences"
+          Returns="@(ApiCompatAssemblyReferencesWithTargetFramework)">
     <ItemGroup>
-      <_ReferencePathWithTargetFramework Include="$(TargetFramework)" ReferencePath="@(ReferencePath, ',')" />
+      <ApiCompatAssemblyReferencesWithTargetFramework Include="$(TargetFramework)"
+                                                      ReferencePath="@(ReferencePathWithRefAssemblies, ',')" />
     </ItemGroup>
   </Target>
 
@@ -66,7 +67,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_GetTargetFrameworksOutput"
           Condition="'$(RunPackageValidationWithoutReferences)' != 'true'">
     <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="_GetReferencePathForPackageValidation"
+             Targets="GetReferencesForApiCompatValidatePackage"
              Properties="TargetFramework=%(_TargetFrameworks.Identity);
                          BuildProjectReferences=false">
       <Output ItemName="PackageValidationReferencePath" TaskParameter="TargetOutputs" />


### PR DESCRIPTION
This change fixes APICompat's targets which incorrectly were feeding in the ReferencePath item which contains implementation assemblies. Instead use the ReferencePathWithRefAssemblies item which contains the actual reference assemblies. This is the same input that the compiler receives.

As an example, System.Threading.ThreadPool's implementation assembly was building against ref/System.Private.CoreLib.dll but APICompat received the src/System.Private.CoreLib.dll assembly.

<img width="695" alt="image" src="https://user-images.githubusercontent.com/7412651/187425321-d9ba85bf-4805-4efc-902b-4b3029348626.png">