### PR TITLE
[Blazor] Eliminate duplicate inputs to ComputeBlazorBuildAssets

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -160,7 +160,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <ComputeBlazorBuildAssets
-      Candidates="@(ReferenceCopyLocalPaths);@(WasmNativeAsset)"
+      Candidates="@(ReferenceCopyLocalPaths->Distinct());@(WasmNativeAsset)"
       ProjectAssembly="@(IntermediateAssembly)"
       ProjectDebugSymbols="@(_DebugSymbolsIntermediatePath)"
       SatelliteAssemblies="@(ReferenceSatellitePaths)"


### PR DESCRIPTION
There should be no duplicates in ReferenceCopyLocalPaths, but when a bug
causes it to be, it creates issues for Blazor. This change makes our
pipeline more resilient against these issues by removing the duplicates
and giving the build a chance to succeed in spite of bugs that introduce
duplicate items.

Addresses https://github.com/dotnet/aspnetcore/issues/39606

See the details [here](https://github.com/dotnet/aspnetcore/issues/39606#issuecomment-966414221) this is not a bug in our code, we are just making the pipeline more resilient against it.