### PR TITLE
apicompat: treat IntPtr as nint and UIntPtr as nuint

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Extensions/SymbolExtensions.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Extensions/SymbolExtensions.cs
@@ -29,7 +29,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Extensions
             return format.WithParameterOptions(format.ParameterOptions & ~SymbolDisplayParameterOptions.IncludeParamsRefOut);
         }
 
-        internal static string ToComparisonDisplayString(this ISymbol symbol) => symbol.ToDisplayString(Format);//.Replace("System.IntPtr", "nint");
+        internal static string ToComparisonDisplayString(this ISymbol symbol) =>
+            symbol.ToDisplayString(Format)
+                  .Replace("System.IntPtr", "nint") // Treat IntPtr and nint as the same
+                  .Replace("System.UIntPtr", "nuint"); // Treat UIntPtr and nuint as the same
 
         internal static IEnumerable<ITypeSymbol> GetAllBaseTypes(this ITypeSymbol type)
         {

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Extensions/SymbolExtensions.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Extensions/SymbolExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Extensions
             return format.WithParameterOptions(format.ParameterOptions & ~SymbolDisplayParameterOptions.IncludeParamsRefOut);
         }
 
-        internal static string ToComparisonDisplayString(this ISymbol symbol) => symbol.ToDisplayString(Format);
+        internal static string ToComparisonDisplayString(this ISymbol symbol) => symbol.ToDisplayString(Format);//.Replace("System.IntPtr", "nint");
 
         internal static IEnumerable<ITypeSymbol> GetAllBaseTypes(this ITypeSymbol type)
         {

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
@@ -466,5 +466,41 @@ namespace CompatTests
             };
             Assert.Equal(expected, differences);
         }
+
+        [Fact]
+        public void NumericPtrFlaggedOnlyBeforeNet7()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  using System;
+
+  public class First
+  {
+    public void F(IntPtr p) {}
+  }
+}
+";
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public void F(nint p) {}
+  }
+}
+";
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new(s_ruleFactory);
+
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
+
+            CompatDifference[] expected =
+            {
+            };
+            // ReferenceID on .NET 7 for left member is "M:CompatTests.First.F(System.IntPtr)"
+            Assert.Equal(expected, differences);
+        }
     }
 }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
@@ -468,7 +468,7 @@ namespace CompatTests
         }
 
         [Fact]
-        public void NumericPtrFlaggedOnlyBeforeNet7()
+        public void NumericPtrNotFlagged()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -478,6 +478,7 @@ namespace CompatTests
   public class First
   {
     public void F(IntPtr p) {}
+    public void G(UIntPtr p) {}
   }
 }
 ";
@@ -487,6 +488,7 @@ namespace CompatTests
   public class First
   {
     public void F(nint p) {}
+    public void G(nuint p) {}
   }
 }
 ";
@@ -496,11 +498,7 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            CompatDifference[] expected =
-            {
-            };
-            // ReferenceID on .NET 7 for left member is "M:CompatTests.First.F(System.IntPtr)"
-            Assert.Equal(expected, differences);
+            Assert.Empty(differences);
         }
     }
 }


### PR DESCRIPTION
Previously, ApiCompat would consider `IntPtr` and `nint` (as well as `UIntPtr` and `nuint`) as different types, emitting diagnostics where there shouldn't have been. This change updates the display string used by the SymbolComparer to replace all instances of `IntPtr` with `nint` and `UIntPtr` with `nuint`.

Fixes #25566