### PR TITLE
Remove timeout, reenable ProjectReferences_Graph test

### DIFF
--- a/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
+++ b/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
@@ -310,7 +310,7 @@ $@"<ItemGroup>
             Assert.All(fileset, f => Assert.False(f.IsStaticFile, $"File {f.FilePath} should not be a static file."));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/29213")]
+        [Fact]
         public async Task ProjectReferences_Graph()
         {
             // A->B,F,W(Watch=False)
@@ -330,7 +330,7 @@ $@"<ItemGroup>
             var options = GetWatchOptions();
             var filesetFactory = new MsBuildFileSetFactory(options, _reporter, _muxerPath, projectA, output, waitOnError: false, trace: true);
 
-            var fileset = await GetFileSet(filesetFactory);
+            var fileset = await filesetFactory.CreateAsync(CancellationToken.None);
 
             Assert.NotNull(fileset);
 
@@ -363,20 +363,13 @@ $@"<ItemGroup>
         private Task<FileSet> GetFileSet(string projectPath)
         {
             DotNetWatchOptions options = GetWatchOptions();
-            return GetFileSet(new MsBuildFileSetFactory(options, _reporter, _muxerPath, projectPath, new OutputSink(), waitOnError: false, trace: false));
+            return new MsBuildFileSetFactory(options, _reporter, _muxerPath, projectPath, new OutputSink(), waitOnError: false, trace: false).CreateAsync(CancellationToken.None);
         }
 
         private static DotNetWatchOptions GetWatchOptions() => 
             new DotNetWatchOptions(false, false, false, false, false, false);
 
         private static string GetTestProjectPath(TestAsset target) => Path.Combine(GetTestProjectDirectory(target), target.TestProject.Name + ".csproj");
-
-        private async Task<FileSet> GetFileSet(MsBuildFileSetFactory filesetFactory)
-        {
-            return await filesetFactory
-                .CreateAsync(CancellationToken.None)
-                .TimeoutAfter(TimeSpan.FromSeconds(30));
-        }
 
         private static string WriteFile(TestAsset testAsset, string name, string contents = "")
         {


### PR DESCRIPTION
It's not clear why the test has been flaky. The original report https://github.com/dotnet/aspnetcore/issues/22980 showed argument exception where a parameter was null that can't possibly be null in the current version of the source. The corresponding build is not available anymore.

https://github.com/dotnet/aspnetcore/issues/29213 claims that the test sometimes times out. There is in fact an explicit timeout of 30s. The tests do perform IO (build) so is certainly possible that under heavy loads a VM might take longer than 30s to complete the test.

Resolves https://github.com/dotnet/aspnetcore/issues/29213