### PR TITLE
Fix br compression size regression in Blazor WASM

### DIFF
--- a/src/BlazorWasmSdk/Tool/Program.cs
+++ b/src/BlazorWasmSdk/Tool/Program.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tool
 
             var compressionLevelOption = new Option<CompressionLevel>(
                 "-c",
-                getDefaultValue: () => CompressionLevel.Optimal,
+                getDefaultValue: () => CompressionLevel.SmallestSize,
                 description: "System.IO.Compression.CompressionLevel for the Brotli compression algorithm.");
             var sourcesOption = new Option<List<string>>(
                 "-s",


### PR DESCRIPTION
Reacting to https://github.com/dotnet/runtime/pull/72266, which changed CompressionLevel.Optimal to no longer mean "smallest size", but instead a balance between compression speed and output size. In Blazor WASM publishing, we really want smallest size - it is preferred to spend more time during publish in order for less bytes to be downloaded and cached in the browser.

The fix is to change the default compression level to SmallestSize in the brotli tool used by WASM publish.

Here are my numbers I captured locally from doing `dotnet publish -c Release` with a `dotnet new blazorwasm` app.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/eerhardt/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/eerhardt/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

</head>

<body link="#0563C1" vlink="#954F72">



  | all .br file size | BroltiCompress Task Time
-- | -- | --
preview.7.22375.6 | 2.58 MB | 6.2s
rc.1.22431.11 | 3.29 MB | 231ms
dotnet/sdk/release/7.0.1xx | 3.28 MB | 209ms
dotnet/sdk/thisFix | 2.64 MB | 7.6s



</body>

</html>


This fixes this regression seen on our size perf chart:

![image](https://user-images.githubusercontent.com/8291187/188220483-da0b1096-14ff-48cf-b1b3-9243177ba569.png)
