### PR TITLE
[release/7.0.1xx]Disable publishing artifacts at build task of template engine job to fix the failure of uploading artifacts in CI

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -370,7 +370,6 @@ jobs:
       - ${{ if contains(parameters.agentOs, 'Windows_NT') }}:
         - script: eng\CIBuild.cmd
                     -configuration $(_BuildConfig)
-                    $(_PublishArgs)
                     $(_SignArgs)
                     $(_OfficialBuildIdArgs)
                     /p:Test=false
@@ -412,8 +411,11 @@ jobs:
           displayName: Run dotnet new Integration Tests
 
       - ${{ if not(contains(parameters.agentOs, 'Windows_NT')) }}:
-        - script: eng/common/cibuild.sh
+        - script: eng/common/build.sh
                     --configuration $(_BuildConfig)
+                    --restore
+                    --build
+                    --ci
                     $(_SignArgs)
                     $(_OfficialBuildIdArgs)
                     $(_InternalRuntimeDownloadArgs)


### PR DESCRIPTION
**Problem**
CI failed uploading artifacts at build task.

**Root Cause**
Build task of template engine job duplicate publishes artifacts.

**Fix**
Disable publishing artifacts at build of template engine job. Template Engine tests don't need it.