### PR TITLE
Bugfix: Report error on conditional params authoring errors

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -274,6 +274,12 @@ namespace Microsoft.TemplateEngine.Cli
                     }
                     Reporter.Error.WriteLine(LocalizableStrings.RerunCommandAndPassForceToCreateAnyway.Bold().Red());
                     return NewCommandStatus.CannotCreateOutputFile;
+                case CreationResultStatus.TemplateIssueDetected:
+                    if (!string.IsNullOrEmpty(instantiateResult.ErrorMessage))
+                    {
+                        Reporter.Error.WriteLine(instantiateResult.ErrorMessage.Bold().Red());
+                    }
+                    return NewCommandStatus.TemplateIssueDetected;
                 default:
                     return NewCommandStatus.Unexpected;
             }


### PR DESCRIPTION
**Problem:** Template authoring issues with conditional parameters were not clearly surfaced to user (generic internal error [return code 70](https://github.com/dotnet/templating/blob/main/docs/Exit-Codes.md#70) was returned instead)

**Solution:** Properly handle error codes returned from `TemplateCreator`

