### PR TITLE
Testfix: Virtualize templating settings folder during tests

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -153,9 +153,10 @@ namespace Microsoft.NET.Build.Tests
         public void It_builds_successfully_when_targeting_net_framework()
         {
             var testDirectory = _testAssetsManager.CreateTestDirectory().Path;
-            var newCommand = new DotnetCommand(Log, "new", "wpf", "--no-restore");
-            newCommand.WorkingDirectory = testDirectory;
-            newCommand.Execute()
+            new DotnetNewCommand(Log, "wpf", "--no-restore")
+                .WithVirutalHive()
+                .WithWorkingDirectory(testDirectory)
+                .Execute()
                 .Should()
                 .Pass();
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
@@ -185,9 +185,12 @@ namespace Microsoft.NET.Build.Tests
         {
             var testDirectory = _testAssetsManager.CreateTestDirectory().Path;
 
-            var newCommand = new DotnetCommand(Log, "new", "wpf", "-lang", "vb");
-            newCommand.WorkingDirectory = testDirectory;
-            newCommand.Execute().Should().Pass();
+            new DotnetNewCommand(Log, "wpf", "-lang", "vb")
+                .WithVirutalHive()
+                .WithWorkingDirectory(testDirectory)
+                .Execute()
+                .Should()
+                .Pass();
 
             var buildCommand = new BuildCommand(Log, testDirectory);
             buildCommand.Execute().Should().Pass();

--- a/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
@@ -207,7 +207,8 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(_testProject, identifier: identifier);
 
-            new DotnetCommand(Log, "new", "sln")
+            new DotnetNewCommand(Log, "sln")
+                .WithVirutalHive()
                 .WithWorkingDirectory(testAsset.TestRoot)
                 .Execute()
                 .Should()


### PR DESCRIPTION
**Problem:** dotnet new is currently not properly supporting multiple parallel runs - due to attempts to update settings folder in home folder, without proper error handling. This can backfire in CI scenarios where multiple concurrent tests are using `dotnet new` without virtualizing it's settings ([example](https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-sdk-refs-pull-27679-merge-a5e20c75f6c74d51a4/Microsoft.NET.Build.Tests.dll.12/3/console.af8f29e0.log?helixlogtype=result)).

**Solution:** Use settings virtualization for `dotnet new` usage in integration tests