### PR TITLE
Don't read from suppression file it doesn't exist.

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressionEngine.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressionEngine.cs
@@ -48,6 +48,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         /// </summary>
         /// <param name="supressionFile">The path to the file to be written.</param>
         /// <returns>Whether it wrote the file.</returns>
-        bool WriteSuppressionsToFile(string supressionFile);
+        bool WriteSuppressionsToFile(string suppressionFile);
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
 
         private HashSet<Suppression> ParseSuppressionFile(string? suppressionFile)
         {
-            if (string.IsNullOrEmpty(suppressionFile?.Trim()))
+            if (string.IsNullOrWhiteSpace(suppressionFile))
             {
                 return new HashSet<Suppression>();
             }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
 
             try
             {
-                using Stream reader = GetReadableStream(suppressionFile);
+                using Stream reader = GetReadableStream(suppressionFile!);
                 if (_serializer.Deserialize(reader) is Suppression[] deserializedSuppressions)
                 {
                     return new HashSet<Suppression>(deserializedSuppressions);


### PR DESCRIPTION
Don't read from the passed in suppression file if errors will be baselined and the file doesn't exist. I.e. when invoking the CLI and passing in `--generate-suppression-file` and `suppression-file ...` path, if the file doesn't exist this would result in a FileNotFoundException instead of not reading from it.