### PR TITLE
Fix single assembly mode when invoking ApiComparer

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunnerWorkItem.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunnerWorkItem.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
         /// <summary>
         /// The metadata information of the left assemblies to compare with the rights.
         /// </summary>
-        public readonly IReadOnlyList<MetadataInformation> Lefts;
+        public readonly IReadOnlyList<MetadataInformation> Left;
 
         /// <summary>
         /// The api compat options to configure the comparison checks.
@@ -26,29 +26,46 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
         /// <summary>
         /// The metadata information of the right assemblies that are compared against the lefts.
         /// </summary>
-        public HashSet<MetadataInformation> Rights { get; }
+        public IList<IReadOnlyList<MetadataInformation>> Right { get; }
 
         /// <summary>
-        /// Initializes an api compat work item.
+        /// Creates a workitem with a single left set, options and multiple right sets.
         /// </summary>
-        public ApiCompatRunnerWorkItem(IReadOnlyList<MetadataInformation> lefts,
+        public ApiCompatRunnerWorkItem(IReadOnlyList<MetadataInformation> left,
             ApiCompatRunnerOptions options,
-            IEnumerable<MetadataInformation> rights)
+            List<IReadOnlyList<MetadataInformation>> right)
         {
-            Lefts = lefts;
+            Left = left;
             Options = options;
-            Rights = new HashSet<MetadataInformation>(rights);
+            Right = right;
         }
 
+        /// <summary>
+        /// Creates a workitem with a single left set, options and a single right set.
+        /// </summary>
+        public ApiCompatRunnerWorkItem(IReadOnlyList<MetadataInformation> left,
+            ApiCompatRunnerOptions options,
+            IReadOnlyList<MetadataInformation> right)
+        {
+            Left = left;
+            Options = options;
+            Right = new List<IReadOnlyList<MetadataInformation>>(new IReadOnlyList<MetadataInformation>[] { right });
+        }
+
+        /// <summary>
+        /// Creates a workitem with a single left, options and a single right.
+        /// </summary>
         public ApiCompatRunnerWorkItem(MetadataInformation left,
             ApiCompatRunnerOptions options,
-            params MetadataInformation[] rights)
-            : this(new MetadataInformation[] { left }, options, rights)
+            MetadataInformation right)
+            : this(new MetadataInformation[] { left },
+                  options,
+                  new MetadataInformation[] { right })
         {
         }
 
         /// <inheritdoc />
-        public bool Equals(ApiCompatRunnerWorkItem other) => other.Lefts.SequenceEqual(Lefts) && other.Options.Equals(Options);
+        public bool Equals(ApiCompatRunnerWorkItem other) => other.Left.SequenceEqual(Left) && other.Options.Equals(Options);
 
         /// <inheritdoc />
         public override bool Equals(object? obj) => obj is ApiCompatRunnerWorkItem item && Equals(item);
@@ -59,7 +76,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
             unchecked
             {
                 int hash = 19 + Options.GetHashCode();
-                foreach (MetadataInformation left in Lefts)
+                foreach (MetadataInformation left in Left)
                 {
                     hash = hash * 31 + left.GetHashCode();
                 }
@@ -74,6 +91,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
         public static bool operator !=(ApiCompatRunnerWorkItem workItem1, ApiCompatRunnerWorkItem workItem2) => !(workItem1 == workItem2);
 
         /// <inheritdoc />
-        public override string ToString() => $"{Lefts.Select(l => l.AssemblyId).Aggregate((l1, l2) => l1 + ", " + l2)}: {Options}";
+        public override string ToString() => $"{Left.Select(l => l.AssemblyId).Aggregate((l1, l2) => l1 + ", " + l2)}: {Options}";
     }
 }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
@@ -64,10 +64,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             MetadataInformation right1 = new("A.dll", @"lib\netstandard2.0\A.dll");
             MetadataInformation right2 = new("A.dll", @"lib\net462\A.dll");
 
-            apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right1, right2));
+            apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right1));
+            apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right2));
 
             Assert.Single(apiCompatRunner.WorkItems);
-            Assert.Equal(2, apiCompatRunner.WorkItems.First().Rights.Count);
+            Assert.Equal(2, apiCompatRunner.WorkItems.First().Right.Count);
         }
 
         [Fact]
@@ -78,10 +79,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             MetadataInformation left = new("A.dll", @"lib\netstandard2.0\A.dll");
             MetadataInformation right = new("A.dll", @"lib\net462\A.dll");
 
-            apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right, right));
+            apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right));
+            apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right));
 
             Assert.Single(apiCompatRunner.WorkItems);
-            Assert.Single(apiCompatRunner.WorkItems.First().Rights);
+            Assert.Single(apiCompatRunner.WorkItems.First().Right);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatWorkItemTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatWorkItemTests.cs
@@ -19,9 +19,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
 
             ApiCompatRunnerWorkItem workItem = new(left, apiCompatOptions, right);
 
+            Assert.Equal(new MetadataInformation[] { left }, workItem.Left);
             Assert.Equal(apiCompatOptions, workItem.Options);
-            Assert.Equal(new MetadataInformation[] { left }, workItem.Lefts);
-            Assert.Equal(new MetadataInformation[] { right }, workItem.Rights);
+            Assert.Single(workItem.Right);
+            Assert.Equal(new MetadataInformation[] { right }, workItem.Right[0]);
         }
 
         [Fact]


### PR DESCRIPTION
Use the correct overload when invoking ApiComparer to compare left and right assemblies, and assembly sets with each other. 

Also fix the underlying ApiCompatRunnerWorkItem type to allow multiple right assembly sets for a given left assembly set and rename the left and right property to follow the naming convention in ApiComparer.
Update a few tests because of the data structure change in the ApiCompatRunnerWorkItem type.

In addition to that, fixing ApiComparer not returning compat differences for assemblies that aren't passed in (i.e. when a type forward for a left reference can't be resolved). Previously the result was joined with the passed in left/right which would exclude anything that isn't part of left/right. I'm now instead doing a manual left outer join.