### PR TITLE
[release/7.0.1xx] Skip failing test PublishClickOnceWithPublishProfile

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Publish.Tests
         {
         }
 
-        [FullMSBuildOnlyTheory]
+        [FullMSBuildOnlyTheory(Skip = "https://github.com/dotnet/sdk/issues/27766")]
         [InlineData(false)]
         [InlineData(true)]
         public void PublishClickOnceWithPublishProfile(bool? publishSingleFile)


### PR DESCRIPTION
Tracked by https://github.com/dotnet/sdk/issues/27766