### PR TITLE
Revert "do not emit diagnostic when attribute argument is internal type"

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -48,32 +48,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             }
         }
 
-        private bool IsInternalArgument(TypedConstant argument) => (argument.Kind == TypedConstantKind.Type
-            && argument.Value is INamedTypeSymbol typ
-            && !typ.IsVisibleOutsideOfAssembly(_settings.IncludeInternalSymbols));
-
-        private bool HasInternalArguments(AttributeData attr)
-        {
-            foreach (TypedConstant argument in attr.ConstructorArguments)
-            {
-                if (IsInternalArgument(argument))
-                {
-                    return true;
-                }
-            }
-
-            foreach (KeyValuePair<string, TypedConstant> kv in attr.NamedArguments)
-            {
-                TypedConstant argument = kv.Value;
-                if (IsInternalArgument(argument))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         private void AddDifference(IList<CompatDifference> differences, DifferenceType dt, MetadataInformation leftMetadata, MetadataInformation rightMetadata, ISymbol containing, string itemRef, AttributeData attr)
         {
             string? docId = attr.AttributeClass?.GetDocumentationCommentId();
@@ -175,9 +149,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         for (int j = 0; j < rightGroup.Attributes.Count; j++)
                         {
                             AttributeData rightAttribute = rightGroup.Attributes[j];
-                            if (AttributeEquals(leftAttribute, rightAttribute)
-                                || HasInternalArguments(leftAttribute) // If attribute argument is an internal type, ignore.
-                                || HasInternalArguments(rightAttribute))
+                            if (AttributeEquals(leftAttribute, rightAttribute))
                             {
                                 rightGroup.Seen[j] = true;
                                 seen = true;

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -219,42 +219,6 @@ namespace CompatTests
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
 }
-            },
-            // Attributes with internal type arguments
-            {
-                @"
-namespace CompatTests
-{
-  using System;
-
-  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
-  public class FooAttribute : Attribute {
-    public FooAttribute(Type type) {}
-    public Type A;
-  }
-
-  internal class Bar {}
-
-  [Foo(typeof(Bar), A = typeof(int))]
-  public class First {}
-}
-",
-                @"
-namespace CompatTests
-{
-  using System;
-
-  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
-  public class FooAttribute : Attribute {
-    public FooAttribute(Type type) {}
-    public Type A;
-  }
-
-  [Foo(typeof(int), A = typeof(int))]
-  public class First {}
-}
-",
-new CompatDifference[] {}
             }
         };
 

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -219,6 +219,47 @@ namespace CompatTests
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
 }
+            },
+            // Attributes on internal type arguments
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+  using CompatTestsSecondNamespace;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(Type type) {}
+  }
+
+  [Foo(typeof(Bar))]
+  public class First {}
+}
+
+namespace CompatTestsSecondNamespace {
+  internal class Bar {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(Type type) {}
+    public Type A;
+  }
+
+  internal class Bar {}
+
+  [Foo(typeof(Bar))]
+  public class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First:[T:CompatTests.FooAttribute]"),
+}
             }
         };
 


### PR DESCRIPTION
The diagnostic emitted that this PR suppressed accurately identified a mismatch in the type arguments to TypeConverterAttribute. PR https://github.com/dotnet/runtime/pull/75235 addresses that mismatch, and it's unclear if internal type arguments actually need to be excluded from the attribute rule.

Reverts dotnet/sdk#27648