### PR TITLE
changed list command example

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IAssemblySymbolLoader.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IAssemblySymbolLoader.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET472_OR_GREATER
-#nullable enable
-#endif
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Collections.Generic;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             //we need to process errors only for templates that match on language, type or baseline
             IEnumerable<TemplateResult> templatesToAnalyze = templates.Where(template => template.IsTemplateMatch);
 
-            List<InvalidTemplateOptionResult> invalidOptionsList = new List<InvalidTemplateOptionResult>();
+            List<InvalidTemplateOptionResult> invalidOptionsList = new();
 
             //collect the options with invalid names (unmatched tokens)
             IEnumerable<InvalidTemplateOptionResult> unmatchedOptions = templatesToAnalyze.SelectMany(
@@ -61,7 +61,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         internal static List<TemplateResult> CollectTemplateMatchInfo(InstantiateCommandArgs args, IEngineEnvironmentSettings environmentSettings, TemplatePackageManager templatePackageManager, TemplateGroup templateGroup)
         {
-            List<TemplateResult> matchInfos = new List<TemplateResult>();
+            List<TemplateResult> matchInfos = new();
             foreach (CliTemplateInfo template in templateGroup.Templates)
             {
                 if (ReparseForTemplate(args, environmentSettings, templatePackageManager, templateGroup, template)
@@ -91,7 +91,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 templates = templates.Where(template => template.IsTemplateMatch);
             }
 
-            StringBuilder invalidParamsErrorText = new StringBuilder(LocalizableStrings.InvalidCommandOptions);
+            StringBuilder invalidParamsErrorText = new(LocalizableStrings.InvalidCommandOptions);
             foreach (InvalidTemplateOptionResult invalidParam in invalidParameterList)
             {
                 invalidParamsErrorText.AppendLine();
@@ -143,7 +143,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             }
             else
             {
-                var tokens = args.ParseResult.Tokens.Select(t => $"'{t.Value}'");
+                IEnumerable<string> tokens = args.ParseResult.Tokens.Select(t => $"'{t.Value}'");
                 reporter.WriteLine(string.Format(LocalizableStrings.Generic_Info_NoMatchingTemplates, string.Join(" ", tokens)).Bold().Red());
             }
             reporter.WriteLine();
@@ -168,7 +168,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Option<string> typeOption = SharedOptionsFactory.CreateTypeOption();
             Option<string> baselineOption = SharedOptionsFactory.CreateBaselineOption();
 
-            Command reparseCommand = new Command("reparse-only")
+            Command reparseCommand = new("reparse-only")
             {
                 languageOption,
                 typeOption,
@@ -181,11 +181,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             ParseResult result = ParserFactory.CreateParser(reparseCommand).Parse(args.RemainingArguments ?? Array.Empty<string>());
             string baseInputParameters = $"'{args.ShortName}'";
-            foreach (var option in new[] { languageOption, typeOption, baselineOption })
+            foreach (Option<string> option in new[] { languageOption, typeOption, baselineOption })
             {
                 if (result.FindResultFor(option) is { } optionResult && optionResult.Token is { } token)
                 {
-                    baseInputParameters = baseInputParameters + $", {token.Value}='{optionResult.GetValueOrDefault<string>()}'";
+                    baseInputParameters += $", {token.Value}='{optionResult.GetValueOrDefault<string>()}'";
                 }
             }
 
@@ -204,10 +204,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 }
             }
 
-            Reporter.Error.WriteLine();
-
-            WriteListCommandExample(args, Reporter.Error);
-            WriteSearchCommandExample(args, Reporter.Error);
             Reporter.Error.WriteLine();
         }
     }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
@@ -206,19 +206,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             Reporter.Error.WriteLine();
 
-            Reporter.Error.WriteLine(LocalizableStrings.Generic_CommandHints_List);
-
-            Reporter.Error.WriteCommand(
-                 Example
-                     .For<NewCommand>(args.ParseResult)
-                     .WithSubcommand<ListCommand>());
-
-            Reporter.Error.WriteLine(LocalizableStrings.Generic_CommandHints_Search);
-            Reporter.Error.WriteCommand(
-                  Example
-                      .For<NewCommand>(args.ParseResult)
-                      .WithSubcommand<SearchCommand>()
-                      .WithArgument(SearchCommand.NameArgument, args.ShortName ?? string.Empty));
+            WriteListCommandExample(args, Reporter.Error);
+            WriteSearchCommandExample(args, Reporter.Error);
             Reporter.Error.WriteLine();
         }
     }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
@@ -126,27 +126,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             SuggestTypoCorrections(instantiateArgs, templateGroups, reporter);
             reporter.WriteLine();
 
-            reporter.WriteLine(LocalizableStrings.Generic_CommandHints_List);
-            reporter.WriteCommand(Example.For<NewCommand>(instantiateArgs.ParseResult).WithSubcommand<ListCommand>());
-
-            reporter.WriteLine(LocalizableStrings.Generic_CommandHints_Search);
-
-            if (string.IsNullOrWhiteSpace(instantiateArgs.ShortName))
-            {
-                reporter.WriteCommand(
-                    Example
-                        .For<NewCommand>(instantiateArgs.ParseResult)
-                        .WithSubcommand<SearchCommand>()
-                        .WithArgument(SearchCommand.NameArgument));
-            }
-            else
-            {
-                reporter.WriteCommand(
-                  Example
-                      .For<NewCommand>(instantiateArgs.ParseResult)
-                      .WithSubcommand<SearchCommand>()
-                      .WithArgument(SearchCommand.NameArgument, instantiateArgs.ShortName));
-            }
+            WriteListCommandExample(instantiateArgs, reporter);
+            WriteSearchCommandExample(instantiateArgs, reporter);
             reporter.WriteLine();
         }
 
@@ -517,6 +498,40 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     }
                     reporter.WriteCommand(example);
                 }
+            }
+        }
+
+        private static void WriteListCommandExample(InstantiateCommandArgs instantiateArgs, IReporter reporter)
+        {
+            if (!string.IsNullOrWhiteSpace(instantiateArgs.ShortName))
+            {
+                reporter.WriteLine(LocalizableStrings.Generic_CommandHints_List_Template, instantiateArgs.ShortName);
+                reporter.WriteCommand(
+                  Example
+                      .For<NewCommand>(instantiateArgs.ParseResult)
+                      .WithSubcommand<ListCommand>()
+                      .WithArgument(ListCommand.NameArgument, instantiateArgs.ShortName));
+            }
+            else
+            {
+                reporter.WriteLine(LocalizableStrings.Generic_CommandHints_List);
+                reporter.WriteCommand(
+                    Example
+                        .For<NewCommand>(instantiateArgs.ParseResult)
+                        .WithSubcommand<ListCommand>());
+            }
+        }
+
+        private static void WriteSearchCommandExample(InstantiateCommandArgs instantiateArgs, IReporter reporter)
+        {
+            if (!string.IsNullOrWhiteSpace(instantiateArgs.ShortName))
+            {
+                reporter.WriteLine(LocalizableStrings.Generic_CommandHints_Search);
+                reporter.WriteCommand(
+                    Example
+                        .For<NewCommand>(instantiateArgs.ParseResult)
+                        .WithSubcommand<SearchCommand>()
+                        .WithArgument(SearchCommand.NameArgument, instantiateArgs.ShortName));
             }
         }
     }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/BaseListCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/BaseListCommand.cs
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Arity = new ArgumentArity(0, 1)
         };
 
-        internal Argument<string> NameArgument { get; } = new("template-name")
+        internal static Argument<string> NameArgument { get; } = new("template-name")
         {
             Description = SymbolStrings.Command_List_Argument_Name,
             Arity = new ArgumentArity(0, 1)

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/LegacyListCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/LegacyListCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         private void ValidateParentCommandArguments(CommandResult commandResult)
         {
-            var nameArgumentResult = commandResult.Children.FirstOrDefault(symbol => symbol.Symbol == this.NameArgument);
+            var nameArgumentResult = commandResult.Children.FirstOrDefault(symbol => symbol.Symbol == ListCommand.NameArgument);
             if (nameArgumentResult == null)
             {
                 return;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/ListCommandArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/ListCommandArgs.cs
@@ -10,7 +10,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
     {
         internal ListCommandArgs(BaseListCommand command, ParseResult parseResult) : base(command, parseResult)
         {
-            string? nameCriteria = parseResult.GetValueForArgument(command.NameArgument);
+            string? nameCriteria = parseResult.GetValueForArgument(ListCommand.NameArgument);
             if (!string.IsNullOrWhiteSpace(nameCriteria))
             {
                 ListNameCriteria = nameCriteria;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -767,6 +767,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to To list installed templates similar to &apos;{0}&apos;, run:.
+        /// </summary>
+        internal static string Generic_CommandHints_List_Template {
+            get {
+                return ResourceManager.GetString("Generic_CommandHints_List_Template", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To search for the templates on NuGet.org, run:.
         /// </summary>
         internal static string Generic_CommandHints_Search {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -385,8 +385,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="InvalidParameterTemplateHint" xml:space="preserve">
     <value>For more information, run:</value>
   </data>
-  <data name="Generic_CommandHints_List" xml:space="preserve">
-    <value>To list installed templates, run:</value>
+  <data name="Generic_CommandHints_List_Template" xml:space="preserve">
+    <value>To list installed templates similar to '{0}', run:</value>
   </data>
   <data name="ColumnNameAuthor" xml:space="preserve">
     <value>Author</value>
@@ -802,5 +802,8 @@ The header is followed by the list of parameters and their errors (might be seve
   <data name="Commands_TemplateShortNameCommandConflict_Info" xml:space="preserve">
     <value>To instantiate the template with short name '{0}', run:</value>
     <comment>Followed by command example from new line.</comment>
+  </data>
+  <data name="Generic_CommandHints_List" xml:space="preserve">
+    <value>To list installed templates, run:</value>
   </data>
 </root>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Pokud chcete vypsat nainstalované šablony, spusťte:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">Pokud chcete hledat šablony na NuGet.org, spusťte:</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Um installierte Vorlagen aufzulisten, führen Sie folgende Aktion aus:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">Um nach den Vorlagen unter NuGet.org zu suchen, führen Sie folgende Aktion aus:</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Para mostrar la lista de plantillas instaladas, ejecute:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">Para buscar las plantillas en NuGet.org, ejecute:</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Pour répertorier les modèles installés, exécutez :</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">Pour rechercher les modèles sur NuGet.org, exécutez :</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Per elencare i modelli installati, eseguire:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">Per cercare i modelli in NuGet.org, eseguire:</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">インストールされているテンプレートを一覧表示するには、次を実行してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">NuGet.org のテンプレートを検索するには、次を実行してください。</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">설치된 템플릿을 나열하려면 다음을 실행하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">NuGet.org에서 템플릿을 검색하려면 다음을 실행하세요.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Aby wyświetlić listę zainstalowanych szablonów, uruchom:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">Aby wyszukać szablonów na stronie NuGet.org, uruchom:</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Para listar os modelos instalados, execute:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">Para pesquisar os modelos no NuGet.org, execute:</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Чтобы перечислить установленные шаблоны, выполните следующую команду:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">Чтобы найти шаблоны на NuGet.org, выполните следующую команду:</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Yüklü şablonları listelemek için şunu çalıştırın:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">NuGet.org sitesinde şablon aramak için şunu çalıştırın:</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">若要列出已安装的模板，请运行:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">要在 NuGet.org 上搜索模板，请运行:</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -413,6 +413,11 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">若要列出已安裝的範本，請執行:</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_CommandHints_List_Template">
+        <source>To list installed templates similar to '{0}', run:</source>
+        <target state="new">To list installed templates similar to '{0}', run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_CommandHints_Search">
         <source>To search for the templates on NuGet.org, run:</source>
         <target state="translated">若要在範本上搜尋 NuGet.org，請執行:</target>

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CannotShowHelpForTemplate_FullNameMatch.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CannotShowHelpForTemplate_FullNameMatch.verified.txt
@@ -1,6 +1,6 @@
 ﻿No templates or subcommands found matching: 'Console App'.
 
-To list installed templates, run:
-   dotnet new list
+To list installed templates similar to 'Console App', run:
+   dotnet new list 'Console App'
 To search for the templates on NuGet.org, run:
    dotnet new search 'Console App'

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CannotShowHelpForTemplate_PartialNameMatch.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CannotShowHelpForTemplate_PartialNameMatch.verified.txt
@@ -4,7 +4,7 @@ Did you mean one of the following templates?
 Did you mean one of the following subcommands?
    dotnet new list -h
 
-To list installed templates, run:
-   dotnet new list
+To list installed templates similar to 'class', run:
+   dotnet new list class
 To search for the templates on NuGet.org, run:
    dotnet new search class

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanSuggestTypoCorrection_Command.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanSuggestTypoCorrection_Command.verified.txt
@@ -2,8 +2,8 @@
 Did you mean one of the following subcommands?
    dotnet new uninstall
 
-To list installed templates, run:
-   dotnet new list
+To list installed templates similar to 'uninstal', run:
+   dotnet new list uninstal
 To search for the templates on NuGet.org, run:
    dotnet new search uninstal
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanSuggestTypoCorrection_Template.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanSuggestTypoCorrection_Template.verified.txt
@@ -2,8 +2,8 @@
 Did you mean one of the following templates?
    dotnet new console
 
-To list installed templates, run:
-   dotnet new list
+To list installed templates similar to 'cnsle', run:
+   dotnet new list cnsle
 To search for the templates on NuGet.org, run:
    dotnet new search cnsle
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplateWithUnknownLanguage.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplateWithUnknownLanguage.verified.txt
@@ -1,8 +1,8 @@
 ﻿No templates found matching: 'console', --language='D#'.
 Allowed values for '--language' option are: 'C#', 'F#', 'VB'.
 
-To list installed templates, run:
-   dotnet new list
+To list installed templates similar to 'console', run:
+   dotnet new list console
 To search for the templates on NuGet.org, run:
    dotnet new search console
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplateWithUnknownLanguage.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplateWithUnknownLanguage.verified.txt
@@ -1,10 +1,5 @@
 ﻿No templates found matching: 'console', --language='D#'.
 Allowed values for '--language' option are: 'C#', 'F#', 'VB'.
 
-To list installed templates similar to 'console', run:
-   dotnet new list console
-To search for the templates on NuGet.org, run:
-   dotnet new search console
-
 
 For details on the exit code, refer to https://aka.ms/templating-exit-codes#103

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplateWithUnknownType.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplateWithUnknownType.verified.txt
@@ -1,8 +1,8 @@
 ﻿No templates found matching: 'console', --type='item'.
 Allowed values for '--type' option are: 'project'.
 
-To list installed templates, run:
-   dotnet new list
+To list installed templates similar to 'console', run:
+   dotnet new list console
 To search for the templates on NuGet.org, run:
    dotnet new search console
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplateWithUnknownType.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplateWithUnknownType.verified.txt
@@ -1,10 +1,5 @@
 ﻿No templates found matching: 'console', --type='item'.
 Allowed values for '--type' option are: 'project'.
 
-To list installed templates similar to 'console', run:
-   dotnet new list console
-To search for the templates on NuGet.org, run:
-   dotnet new search console
-
 
 For details on the exit code, refer to https://aka.ms/templating-exit-codes#103

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WhenFullNameIsUsed.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateTemplate_WhenFullNameIsUsed.verified.txt
@@ -1,7 +1,7 @@
 ﻿No templates or subcommands found matching: 'Console App'.
 
-To list installed templates, run:
-   dotnet new list
+To list installed templates similar to 'Console App', run:
+   dotnet new list 'Console App'
 To search for the templates on NuGet.org, run:
    dotnet new search 'Console App'
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateUnknownTemplate.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotInstantiateUnknownTemplate.verified.txt
@@ -1,7 +1,7 @@
 ﻿No templates or subcommands found matching: 'unknownapp'.
 
-To list installed templates, run:
-   dotnet new list
+To list installed templates similar to 'unknownapp', run:
+   dotnet new list unknownapp
 To search for the templates on NuGet.org, run:
    dotnet new search unknownapp
 


### PR DESCRIPTION
changed `list` command example on unknown template:
```
To list installed templates, run:
   dotnet new list
```
to
```
To list installed templates similar to 'class', run:
   dotnet new list class
```