### PR TITLE
[APICompat] Don't filter package assets and handle placeholder files

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
@@ -6,7 +6,6 @@ using NuGet.Client;
 using NuGet.ContentModel;
 using NuGet.Frameworks;
 using NuGet.Packaging;
-using NuGet.Packaging.Core;
 using NuGet.RuntimeModel;
 
 namespace Microsoft.DotNet.PackageValidation
@@ -136,7 +135,7 @@ namespace Microsoft.DotNet.PackageValidation
             NuspecReader nuspecReader = packageReader.NuspecReader;
             string packageId = nuspecReader.GetId();
             string version = nuspecReader.GetVersion().ToString();
-            IEnumerable<string> packageAssets = packageReader.GetFiles().Where(t => t.EndsWith(".dll")).ToArray();
+            IEnumerable<string> packageAssets = packageReader.GetFiles().ToArray();
 
             return new Package(packagePath!, packageId, version, packageAssets, packageAssemblyReferences);
         }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/PackageExtensions.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/PackageExtensions.cs
@@ -1,12 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using NuGet.ContentModel;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.PackageValidation
 {
     internal static class PackageExtensions
     {
+        private const string PlaceholderFile = "_._";
+
+        public static bool IsPlaceholderFile(this ContentItem contentItem) =>
+            Path.GetFileName(contentItem.Path) == PlaceholderFile;
+
+        public static bool IsPlaceholderFile(this IReadOnlyList<ContentItem> contentItems) =>
+            contentItems.Count == 1 && contentItems[0].IsPlaceholderFile();
+
         public static bool SupportsRuntimeIdentifier(this NuGetFramework tfm, string rid) =>
             tfm.Framework != ".NETFramework" || rid.StartsWith("win", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Resources.resx
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -149,5 +149,8 @@
   </data>
   <data name="BaselineTargetFrameworkIgnoredButPresentInCurrentPackage" xml:space="preserve">
     <value>Target framework '{0}' in the baseline package is ignored but exists in the current package.</value>
+  </data>
+  <data name="SkipApiCompatForPlaceholderFiles" xml:space="preserve">
+    <value>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</value>
   </data>
 </root>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/BaselinePackageValidator.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/BaselinePackageValidator.cs
@@ -43,12 +43,20 @@ namespace Microsoft.DotNet.PackageValidation.Validators
                 {
                     // Search for compatible compile time assets in the latest package.
                     IReadOnlyList<ContentItem>? latestCompileAssets = options.Package.FindBestCompileAssetForFramework(baselineTargetFramework);
-                    if (latestCompileAssets == null)
+                    // Emit an error if
+                    // - No latest compile time asset is available or
+                    // - The latest compile time asset is a placeholder but the baseline compile time asset isn't.
+                    if (latestCompileAssets == null ||
+                        (latestCompileAssets.IsPlaceholderFile() && !baselineCompileAssets.IsPlaceholderFile()))
                     {
                         log.LogError(new Suppression(DiagnosticIds.TargetFrameworkDropped) { Target = baselineTargetFramework.ToString() },
                             DiagnosticIds.TargetFrameworkDropped,
                             string.Format(Resources.MissingTargetFramework,
                                 baselineTargetFramework));
+                    }
+                    else if (baselineCompileAssets.IsPlaceholderFile() && !latestCompileAssets.IsPlaceholderFile())
+                    {
+                        // Ignore the newly added compile time asset in the latest package.
                     }
                     else if (options.EnqueueApiCompatWorkItems)
                     {
@@ -67,12 +75,20 @@ namespace Microsoft.DotNet.PackageValidation.Validators
                 {
                     // Search for compatible runtime assets in the latest package.
                     IReadOnlyList<ContentItem>? latestRuntimeAssets = options.Package.FindBestRuntimeAssetForFramework(baselineTargetFramework);
-                    if (latestRuntimeAssets == null)
+                    // Emit an error if
+                    // - No latest runtime asset is available or
+                    // - The latest runtime asset is a placeholder but the baseline runtime asset isn't.
+                    if (latestRuntimeAssets == null ||
+                        (latestRuntimeAssets.IsPlaceholderFile() && !baselineRuntimeAssets.IsPlaceholderFile()))
                     {
                         log.LogError(new Suppression(DiagnosticIds.TargetFrameworkDropped) { Target = baselineTargetFramework.ToString() },
                             DiagnosticIds.TargetFrameworkDropped,
                             string.Format(Resources.MissingTargetFramework,
                                 baselineTargetFramework));
+                    }
+                    else if (baselineRuntimeAssets.IsPlaceholderFile() && !latestRuntimeAssets.IsPlaceholderFile())
+                    {
+                        // Ignore the newly added run time asset in the latest package.
                     }
                     else if (options.EnqueueApiCompatWorkItems)
                     {
@@ -95,8 +111,13 @@ namespace Microsoft.DotNet.PackageValidation.Validators
 
                     foreach (IGrouping<string, ContentItem> baselineRuntimeSpecificAssetsRidGroup in baselineRuntimeSpecificAssetsRidGroupedPerRid)
                     {
+                        IReadOnlyList<ContentItem> baselineRuntimeSpecificAssetsForRid = baselineRuntimeSpecificAssetsRidGroup.ToArray();
                         IReadOnlyList<ContentItem>? latestRuntimeSpecificAssets = options.Package.FindBestRuntimeAssetForFrameworkAndRuntime(baselineTargetFramework, baselineRuntimeSpecificAssetsRidGroup.Key);
-                        if (latestRuntimeSpecificAssets == null)
+                        // Emit an error if
+                        // - No latest runtime specific asset is available or
+                        // - The latest runtime specific asset is a placeholder but the baseline runtime specific asset isn't.
+                        if (latestRuntimeSpecificAssets == null ||
+                            (latestRuntimeSpecificAssets.IsPlaceholderFile() && !baselineRuntimeSpecificAssetsForRid.IsPlaceholderFile()))
                         {
                             log.LogError(new Suppression(DiagnosticIds.TargetFrameworkAndRidPairDropped) { Target = baselineTargetFramework.ToString() + "-" + baselineRuntimeSpecificAssetsRidGroup.Key },
                                 DiagnosticIds.TargetFrameworkAndRidPairDropped,
@@ -104,10 +125,14 @@ namespace Microsoft.DotNet.PackageValidation.Validators
                                     baselineTargetFramework,
                                     baselineRuntimeSpecificAssetsRidGroup.Key));
                         }
+                        else if (baselineRuntimeSpecificAssetsForRid.IsPlaceholderFile() && !latestRuntimeSpecificAssets.IsPlaceholderFile())
+                        {
+                            // Ignore the newly added runtime specific asset in the latest package.
+                        }
                         else if (options.EnqueueApiCompatWorkItems)
                         {
                             apiCompatRunner.QueueApiCompatFromContentItem(log,
-                                baselineRuntimeSpecificAssetsRidGroup.ToArray(),
+                                baselineRuntimeSpecificAssetsForRid,
                                 latestRuntimeSpecificAssets,
                                 apiCompatOptions,
                                 options.BaselinePackage,

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Balíček {0} se nenašel. Zadejte prosím platnou cestu k balíčku.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Das Paket "{0}" wurde nicht gefunden. Geben Sie einen gültigen Paketpfad an.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">No se encontró el paquete "{0}". Indique una ruta de acceso de paquete válida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Package « {0} » introuvable. Indiquez un chemin d’accès de package valide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Pacchetto '{0}' non trovato. Specificare un percorso valido per il pacchetto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">パッケージ '{0}' が見つかりません。有効なパッケージ パスを指定してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">패키지 '{0}'을(를) 찾을 수 없습니다. 유효한 패키지 경로를 제공하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Nie znaleziono pakietu "{0}". Podaj prawidłową ścieżkę pakietu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Pacote '{0}' não encontrado. Forneça um caminho de pacote válido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Пакет "{0}" не найден. Укажите допустимый путь к пакету.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">“{0}“ paketi bulunamadı. Lütfen daha geçerli bir paket yolu sağlayın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">未找到包“{0}”。请提供有效的包路径。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">找不到套件 '{0}'。請提供有效的套件路徑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipApiCompatForPlaceholderFiles">
+        <source>Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</source>
+        <target state="new">Skipping api compatiblity check for target framework {0} as the package assets are placeholder files.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/18165

Instead of manually filtering package assets, let NuGet calculate the runtime and compile time assets and handle placeholder files which are returned by NuGet.

TODO:
- [ ] Add tests for packages with placeholder files.