### PR TITLE
Improvements to dotnet tool search help text

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-tool/search/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/LocalizableStrings.resx
@@ -124,7 +124,7 @@
     <value>Commands</value>
   </data>
   <data name="SearchTermArgumentName" xml:space="preserve">
-    <value>Search Term</value>
+    <value>SEARCH_TERM</value>
   </data>
   <data name="SearchTermDescription" xml:space="preserve">
     <value>Search term from package id or package description. Require at least one character.</value>
@@ -148,7 +148,7 @@
     <value>The number of results to return, for pagination.</value>
   </data>
   <data name="PrereleaseDescription" xml:space="preserve">
-    <value>determining whether to include pre-release packages.</value>
+    <value>Include pre-release packages.</value>
   </data>
   <data name="NoResult" xml:space="preserve">
     <value>Could not find any results.</value>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.cs.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">Určuje, jestli se mají zahrnout balíčky předběžných verzí.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">Určuje, jestli se mají zahrnout balíčky předběžných verzí.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">Hledaný výraz</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">Hledaný výraz</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.de.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">Es wird ermittelt, ob Vorabversionspakete eingeschlossen werden sollen.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">Es wird ermittelt, ob Vorabversionspakete eingeschlossen werden sollen.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">Suchbegriff</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">Suchbegriff</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.es.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">que determina si se deben incluir los paquetes de versión preliminar.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">que determina si se deben incluir los paquetes de versión preliminar.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">Término de búsqueda</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">Término de búsqueda</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.fr.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">détermination de l'inclusion ou non des packages en préversion.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">détermination de l'inclusion ou non des packages en préversion.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">Terme recherché</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">Terme recherché</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.it.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">verrà determinato se includere i pacchetti di versioni non definitive.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">verrà determinato se includere i pacchetti di versioni non definitive.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">Termine di ricerca</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">Termine di ricerca</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ja.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">プレリリース パッケージを含めるかどうかを決定します。</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">プレリリース パッケージを含めるかどうかを決定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">検索語句</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">検索語句</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ko.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">시험판 패키지를 포함할지 여부를 결정합니다.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">시험판 패키지를 포함할지 여부를 결정합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">검색어</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">검색어</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pl.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">określanie, czy uwzględniać pakiety wersji wstępnej.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">określanie, czy uwzględniać pakiety wersji wstępnej.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">Wyszukaj termin</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">Wyszukaj termin</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pt-BR.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">determinando se os pacotes de pré-lançamento devem ser incluídos.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">determinando se os pacotes de pré-lançamento devem ser incluídos.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">Termo de Pesquisa</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">Termo de Pesquisa</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ru.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">определение того, следует ли включать пакеты предварительного выпуска.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">определение того, следует ли включать пакеты предварительного выпуска.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">Условие поиска</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">Условие поиска</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.tr.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">yayın öncesi paketlerin eklenip eklenmeyeceğini belirleme.</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">yayın öncesi paketlerin eklenip eklenmeyeceğini belirleme.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">Arama Terimi</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">Arama Terimi</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hans.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">正在确定是否包括预发行包。</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">正在确定是否包括预发行包。</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">搜索词</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">搜索词</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hant.xlf
@@ -58,13 +58,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="PrereleaseDescription">
-        <source>determining whether to include pre-release packages.</source>
-        <target state="translated">正在判斷是否要包含發行前版本套件。</target>
+        <source>Include pre-release packages.</source>
+        <target state="needs-review-translation">正在判斷是否要包含發行前版本套件。</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermArgumentName">
-        <source>Search Term</source>
-        <target state="translated">搜尋字詞</target>
+        <source>SEARCH_TERM</source>
+        <target state="needs-review-translation">搜尋字詞</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchTermDescription">


### PR DESCRIPTION
### Fixes #27831 
Currently, help text of `dotnet tool search` does not match the convention.
- Argument should be in all caps with underscore
#### Original Text
```
Description:
  Search dotnet tools in nuget.org

Usage:
  dotnet tool search <Search Term> [options]

Arguments:
  <Search Term>  Search term from package id or package description. Require at least one character.

Options:
  --detail        Show detail result of the query.
  --skip <Skip>   The number of results to skip, for pagination.
  --take <Take>   The number of results to return, for pagination.
  --prerelease    determining whether to include pre-release packages.
  -?, -h, --help  Show command line help.
```
### Fix
```diff
Description:
  Search dotnet tools in nuget.org

Usage:
- dotnet tool search <Search Term> [options]
+ dotnet tool search <SEARCH_TERM> [options]

Arguments:
- <Search Term>  Search term from package id or package description. Require at least one character.
+ <SEARCH_TERM>  Search term from package id or package description. Require at least one character.

Options:
  --detail        Show detail result of the query.
  --skip <Skip>   The number of results to skip, for pagination.
  --take <Take>   The number of results to return, for pagination.
- --prerelease    determining whether to include pre-release packages.
+ --prerelease    Include pre-release packages.
  -?, -h, --help  Show command line help.
```