### PR TITLE
[release/6.0.1xx] Use the portable rid for --use-current-runtime (backports #21748)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -62,7 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseCurrentRuntimeIdentifier)' == 'true'">
-    <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(NETCoreSdkPortableRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PlatformTarget)' == ''">


### PR DESCRIPTION
Backports https://github.com/dotnet/sdk/pull/21748 to 6.0.1xx

Per @tmds 
```
Fixes https://github.com/dotnet/sdk/issues/14296.
```

# Customer impact
`--use-current-runtime` is broken when building a non-portable SDK, outputting a non-portable RID when we should be outputting the portable RID. Multiple fixes were implemented along the way. This, with https://github.com/dotnet/installer/pull/14816, should finally fix this issue.

# Testing
* unit tests in ci
* source-build build within Alpine environment passes

# Risk
Low, as it has been backported to other 6.0.xxx feature sets.