### PR TITLE
revert perma-escaping of semicolons and support semicolon-delimited unquoted property values

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
@@ -65,6 +65,21 @@ public static class MSBuildPropertyParser {
             while(TryConsume(out char? c) && c != ';') {
                 currentValue.Append(c);
             }
+            // we're either at the end or 
+            if (AtEnd()) return;
+            // we're just past a semicolon
+            // if semicolon, we need to check if there are any other = in the string (signifying property pairs)
+            if (input.IndexOf('=', currentPos) != -1) {
+                // there are more = in the string, so eject and let a new key/value pair be parsed
+                return;
+            } else {
+                currentValue.Append(';');
+                // there are no more = in the string, so consume the remainder of the string
+                while(TryConsume(out char? c))
+                {
+                    currentValue.Append(c);
+                }
+            }
         }
 
         void ParseValue() {

--- a/src/Cli/dotnet/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/OptionForwardingExtensions.cs
@@ -22,8 +22,7 @@ namespace Microsoft.DotNet.Cli
             .SetForwardingFunction((optionVals) =>
                 optionVals
                     .SelectMany(Microsoft.DotNet.Cli.Utils.MSBuildPropertyParser.ParseProperties)
-                    // must escape semicolon-delimited property values when forwarding them to MSBuild
-                    .Select(keyValue => $"{option.Aliases.FirstOrDefault()}:{keyValue.key}={keyValue.value.Replace(";", "%3B")}")
+                    .Select(keyValue => $"{option.Aliases.FirstOrDefault()}:{keyValue.key}={keyValue.value}")
                 );
 
         public static Option<T> ForwardAsMany<T>(this ForwardedOption<T> option, Func<T, IEnumerable<string>> format) => option.SetForwardingFunction(format);

--- a/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
@@ -48,10 +48,11 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
         [Theory]
         [InlineData(new string[] { "-p:teamcity_buildConfName=\"Build, Test and Publish\"" }, new string[] { "--property:teamcity_buildConfName=\"Build, Test and Publish\"" })]
         [InlineData(new string[] { "-p:prop1=true", "-p:prop2=false" }, new string[] { "--property:prop1=true", "--property:prop2=false" })]
-        [InlineData(new string[] { "-p:prop1=\".;/opt/usr\"" }, new string[] { "--property:prop1=\".%3B/opt/usr\"" })]
-        [InlineData(new string[] { "-p:prop1=true;prop2=false;prop3=\"wut\";prop4=\"1;2;3\"" }, new string[]{ "--property:prop1=true", "--property:prop2=false", "--property:prop3=\"wut\"", "--property:prop4=\"1%3B2%3B3\""})]
-        [InlineData(new string[] { "-p:prop4=\"1;2;3\"" }, new string[]{ "--property:prop4=\"1%3B2%3B3\""})]
-        [InlineData(new string[] { "-p:prop4=\"1 ;2 ;3 \"" }, new string[]{ "--property:prop4=\"1 %3B2 %3B3 \""})]
+        [InlineData(new string[] { "-p:prop1=\".;/opt/usr\"" }, new string[] { "--property:prop1=\".;/opt/usr\"" })]
+        [InlineData(new string[] { "-p:prop1=true;prop2=false;prop3=\"wut\";prop4=\"1;2;3\"" }, new string[]{ "--property:prop1=true", "--property:prop2=false", "--property:prop3=\"wut\"", "--property:prop4=\"1;2;3\""})]
+        [InlineData(new string[] { "-p:prop4=\"1;2;3\"" }, new string[]{ "--property:prop4=\"1;2;3\""})]
+        [InlineData(new string[] { "-p:prop4=\"1 ;2 ;3 \"" }, new string[]{ "--property:prop4=\"1 ;2 ;3 \""})]
+        [InlineData(new string[] { "-p:RuntimeIdentifiers=linux-x64;linux-arm64" }, new string[]{ "--property:RuntimeIdentifiers=linux-x64;linux-arm64"})]
         public void Can_pass_msbuild_properties_safely(string[] tokens, string[] forwardedTokens) {
             var forwardingFunction = (CommonOptions.PropertiesOption as ForwardedOption<string[]>).GetForwardingFunction();
             var result = CommonOptions.PropertiesOption.Parse(tokens);


### PR DESCRIPTION
## Description

In earlier SDKs we added explicit support for the MSBuild `-property` option to the CLI's parser, in order to include it in help output and smooth over a couple rough edges in the option syntax in MSBuild. In addition, adding this option allowed internal SDK code to start parsing and inspecting the keys and values of user-supplied Properties, something we started taking advantage of in several changes for .NET 7.  However, the parser for these keys and values did not support unquoted values that contained semicolons, as is the case in situations like `-p RuntimeIdentifiers=linux-x64;macos-arm64`. We should support this, as MSBuild does support this.

In addition, we unified the escaping of semicolon-delimited values for all properties, resulting in a property like `-p RuntimeIdentifiers="linux-x64;osx-arm64"` being forwarded to MSBuild as `-property:RuntimeIdentifiers="linux-x64%3Bosx-arm64"`. As a result, the users' intent (a list of RIDs) was not honored. This change was made after looking at the other uses of semicolon-escaping in the CLI codebase, but it was improper to generalize it to all user inputs. The rules that we should follow for semicolon escaping have been codified as a result:

* only when users are using CLI arguments that aren't MSBuild properties (like -r for example being translated to the RuntimeIdentifier property)
* only when that properties' value might reasonably contain a semicolon (like a URL for example)
* never for properties that users directly pass

This change removes the automatic semicolon escaping, as well as adding support for semicolon-delimited property values.

Closes https://github.com/dotnet/sdk/issues/28131.

If approved, we'll want to ensure quick flow + merge to 7.0.100 for sure, potentially 7.0.100-rc2 as well depending on time remaining.

## Customer impact

Customers could not specify property lists via the CLI, and some forms of values could not be forwarded at all untouched by the CLI parser. Often this surfaces in runtime identifiers, or assembly search paths. Customers could workaround this in some cases by setting the value in an environment variable, since those are automatically used by MSBuild if the name of the variable matches the MSBuild property name, but this is an awkward workaround at best.

## Regression

**Yes**, this mangling didn't occur in prior SDK version bands.

## Risk

**Low**, we have even more automated parser test coverage over these scenarios now

## Testing

Previous test cases showing the semicolon-escaping were updated to [check for non-escaping](https://github.com/dotnet/sdk/pull/27859/files#diff-85eac01427aa22388012f83cfb6d6807e0fe66d83faac150565057ed38e5aca1R51-R54), and new cases were added to cover the list-of-values scenarios for both [quoted](https://github.com/dotnet/sdk/pull/27859/files#diff-85eac01427aa22388012f83cfb6d6807e0fe66d83faac150565057ed38e5aca1R53) and [unquoted](https://github.com/dotnet/sdk/pull/27859/files#diff-85eac01427aa22388012f83cfb6d6807e0fe66d83faac150565057ed38e5aca1R55) property values.
