### PR TITLE
Expand existing EOL warning to target 5.0

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
@@ -20,7 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     receive servicing updates and security fixes.
   -->
   <ItemGroup>
-    <_EolNetCoreTargetFrameworkVersions Include="1.0;1.1;2.0;2.1;2.2;3.0" />
+    <_EolNetCoreTargetFrameworkVersions Include="1.0;1.1;2.0;2.1;2.2;3.0;5.0" />
   </ItemGroup>
 
   <Target Name="_CheckForEolTargetFrameworks" AfterTargets="_CheckForUnsupportedNETCoreVersion"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetEolFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetEolFrameworks.cs
@@ -23,6 +23,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp1.0")]
         [InlineData("netcoreapp3.0")]
         [InlineData("netcoreapp2.1")]
+        [InlineData("net5.0")]
         public void It_warns_that_framework_is_out_of_support(string targetFrameworks)
         {
             var testProject = new TestProject()


### PR DESCRIPTION
## Description

The 5.0 runtime went out of support in May. At the time, we discussed when to add the warning message to customer builds when targeting 5.0.  We decided it made sense to align that with the next major release so we're planning on doing this for the November releases: https://github.com/dotnet/sdk/pull/27943

## Customer Impact
Customer will get a build warning for any project that targets 5.0.

## Regression

No

## Risk 
Low. Customers can add CheckEolTargetFramework=false to avoid this warning.

## Testing 
Automated