### PR TITLE
Implement publish-self-contained

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -23,14 +23,14 @@ namespace Microsoft.DotNet.Cli
                 IsHidden = true
             }.ForwardAsProperty()
             .AllowSingleArgPerToken();
-            
+
         public static Option<VerbosityOptions> VerbosityOption =
             new ForwardedOption<VerbosityOptions>(
                 new string[] { "-v", "--verbosity" },
                 description: CommonLocalizableStrings.VerbosityOptionDescription)
-                {
-                    ArgumentHelpName = CommonLocalizableStrings.LevelArgumentName
-                }.ForwardAsSingle(o => $"-verbosity:{o}");
+            {
+                ArgumentHelpName = CommonLocalizableStrings.LevelArgumentName
+            }.ForwardAsSingle(o => $"-verbosity:{o}");
 
         public static Option<VerbosityOptions> HiddenVerbosityOption =
             new ForwardedOption<VerbosityOptions>(
@@ -47,15 +47,15 @@ namespace Microsoft.DotNet.Cli
                 description)
             {
                 ArgumentHelpName = CommonLocalizableStrings.FrameworkArgumentName
-                    
+
             }.ForwardAsSingle(o => $"-property:TargetFramework={o}")
             .AddCompletions(Complete.TargetFrameworksFromProjectFile);
 
         private static string RuntimeArgName = CommonLocalizableStrings.RuntimeIdentifierArgumentName;
         private static Func<string, IEnumerable<string>> RuntimeArgFunc = o => new string[] { $"-property:RuntimeIdentifier={o}", "-property:_CommandLineDefinedRuntimeIdentifier=true" };
         private static CompletionDelegate RuntimeCompletions = Complete.RunTimesFromProjectFile;
-        
-        public static Option<string> RuntimeOption = 
+
+        public static Option<string> RuntimeOption =
             new ForwardedOption<string>(
                 new string[] { "-r", "--runtime" })
             {
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.Cli
                 "--no-self-contained",
                 CommonLocalizableStrings.FrameworkDependentOptionDescription)
             // Flip the argument so that if this option is specified we get selfcontained=false
-            .SetForwardingFunction((arg, p) => ForwardSelfContainedOptions(!arg, p)); 
+            .SetForwardingFunction((arg, p) => ForwardSelfContainedOptions(!arg, p));
 
         public static readonly Option<string> TestPlatformOption = new Option<string>("--Platform");
 
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.Cli
                 // ResolveOsOptionToRuntimeIdentifier handles resolving the RID when both arch and os are specified
                 return Array.Empty<string>();
             }
-            
+
             var selfContainedSpecified = parseResult.HasOption(SelfContainedOption) || parseResult.HasOption(NoSelfContainedOption);
             return ResolveRidShorthandOptions(null, arg, selfContainedSpecified);
         }
@@ -231,7 +231,7 @@ namespace Microsoft.DotNet.Cli
 
             var dotnetRootPath = Path.GetDirectoryName(Environment.ProcessPath);
             // When running under test the path does not always contain "dotnet".
-			// The sdk folder is /d/ when run on helix because of space issues
+            // The sdk folder is /d/ when run on helix because of space issues
             dotnetRootPath = Path.GetFileName(dotnetRootPath).Contains("dotnet") || Path.GetFileName(dotnetRootPath).Contains("x64") || Path.GetFileName(dotnetRootPath).Equals("d") ? dotnetRootPath : Path.Combine(dotnetRootPath, "dotnet");
             return dotnetRootPath;
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ForceCommandLineSelfContainedToBeLocal.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ForceCommandLineSelfContainedToBeLocal.targets
@@ -1,0 +1,6 @@
+﻿<Project TreatAsLocalProperty="SelfContained">
+  <PropertyGroup>
+    <SelfContained Condition=" '$(_IsPublishing)' == 'true' and '$(PublishSelfContained)' != '' and '$(PublishSelfContained)' != 'true'">false</SelfContained>
+    <SelfContained Condition=" '$(_IsPublishing)' == 'true' and '$(PublishSelfContained)' == 'true'">true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -69,7 +69,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                    '$(SelfContained)' == 'true' or
                    '$(PublishReadyToRun)' == 'true' or
                    '$(PublishSingleFile)' == 'true' or
-                   '$(PublishAot)' == 'true'
+                   '$(PublishAot)' == 'true' or
+                   '$(PublishSelfContained)' == 'true'
                    )
                  )">
     <RuntimeIdentifier>$(NETCoreSdkPortableRuntimeIdentifier)</RuntimeIdentifier>
@@ -165,6 +166,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="SelfContained"/>
+
+    <NETSdkError Condition="'$(PublishSelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
+                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
+                 FormatArguments="PublishSelfContained"/>
 
     <NETSdkError Condition="'$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -22,7 +22,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
-
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(HasRuntimeOutput)' == ''">
@@ -34,6 +33,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Set default intermediate and output paths -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultOutputPaths.targets" Condition="'$(UsingNETSdkDefaults)' == 'true'"/>
+
+  <!-- Allow targets to edit SelfContained.-->
+  <Import Project="Microsoft.NET.ForceCommandLineSelfContainedToBeLocal.targets" Condition=" '$(PublishSelfContained)' != '' "/>
 
   <!-- Before any additional SDK targets are imported, import the publish profile.
        This allows the publish profile to set properties like RuntimeIdentifier and them be

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -20,7 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <Configurations Condition=" '$(Configurations)' == '' ">Debug;Release</Configurations>
     <Platforms Condition=" '$(Platforms)' == '' ">AnyCPU</Platforms>
-    <Configuration Condition="'$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -376,6 +376,34 @@ namespace Microsoft.NET.Build.Tests
 
         [Theory]
         [InlineData("net7.0")]
+        public void It_does_not_build_SelfContained_due_to_PublishSelfContained_being_true(string targetFramework)
+        {
+            var runtimeIdentifier = EnvironmentInfo.GetCompatibleRid(targetFramework);
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", identifier: targetFramework)
+                .WithSource()
+                .WithTargetFramework(targetFramework)
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", runtimeIdentifier));
+                    propertyGroup.Add(new XElement(ns + "PublishSelfContained", "true"));
+                });
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            buildCommand
+                .Execute("-p:SelfContained=false")
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: runtimeIdentifier);
+            outputDirectory.Should().NotHaveFile("hostfxr.dll");
+        }
+
+        [Theory]
+        [InlineData("net7.0")]
         public void It_builds_a_runnable_output_with_Prefer32Bit(string targetFramework)
         {
             if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))

--- a/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools;
@@ -117,6 +119,85 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
                 .Execute()
                 .Should().Pass()
                      .And.HaveStdOutContaining("Hello World");
+        }
+
+        [Fact]
+        public void ItPublishesSelfContainedWithPublishSelfContainedTrue()
+        {
+            var testAppName = "MSBuildTestApp";
+            var rid = EnvironmentInfo.GetCompatibleRid();
+            var outputDirectory = PublishApp(testAppName, rid, "-p:PublishSelfContained=true");
+
+            var outputProgram = Path.Combine(outputDirectory.FullName, $"{testAppName}{Constants.ExeSuffix}");
+
+            outputDirectory.Should().HaveFiles(new[] {
+                "System.dll", // File that should only exist if self contained 
+            });
+
+            new RunExeCommand(Log, outputProgram)
+                .Execute()
+                .Should().Pass()
+                     .And.HaveStdOutContaining("Hello World");
+        }
+
+        [Theory]
+        [InlineData("net7.0")]
+        public void ItPublishesSelfContainedWithPublishSelfContainedProperty(string targetFramework)
+        {
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+            var testAsset = _testAssetsManager
+            .CopyTestAsset("HelloWorld", identifier: targetFramework)
+            .WithSource()
+            .WithTargetFramework(targetFramework)
+            .WithProjectChanges(project =>
+            {
+                var ns = project.Root.Name.Namespace;
+                var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                propertyGroup.Add(new XElement(ns + "PublishSelfContained", "true"));
+            });
+
+            var publishCommand = new PublishCommand(testAsset);
+            var publishResult = publishCommand.Execute($"/p:RuntimeIdentifier={rid}");
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(
+                targetFramework: targetFramework,
+                runtimeIdentifier: rid);
+            publishDirectory.Should().HaveFiles(new[] {
+                "HelloWorld.dll",
+                "System.dll"
+            });
+        }
+
+        [RequiresMSBuildVersionTheory("17.5.0.0")] // This needs _IsPublishing to be set in MSBuild to pass.
+        [InlineData("net7.0")]
+        public void PublishSelfContainedPropertyOverridesSelfContainProperty(string targetFramework)
+        {
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testAsset = _testAssetsManager
+            .CopyTestAsset("HelloWorld")
+            .WithSource()
+            .WithProjectChanges(project =>
+            {
+                var ns = project.Root.Name.Namespace;
+                var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                propertyGroup.Add(new XElement(ns + "PublishSelfContained", "true"));
+            });
+
+            var publishCommand = new PublishCommand(testAsset);
+            var publishResult = publishCommand.Execute( $"/p:RuntimeIdentifier={rid}", "/p:SelfContained=false");
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(
+                targetFramework: targetFramework,
+                runtimeIdentifier: rid);
+            publishDirectory.Should().HaveFiles(new[] {
+                "HelloWorld.dll",
+                "System.dll"  // File that should only exist if self contained 
+            });
         }
 
         [Theory]


### PR DESCRIPTION
Adds PublishSelfContained (PSC):

1. You can add 
```xml
<PublishSelfContained>true</PublishSelfContained>
```
to publish self-contained by default but not build self-contained by default. You can of course also forward the property.

2. If you do `dotnet publish --no-sc -p:PublishSelfContained=true`, `--no-sc` will win. Or if `PublishSelfContained` is in the properties.

4. Had a large group discussion about getting these things to work in MSBuild with `t:/Publish` -- it's not possible. But we are going to do work to get it to align with VS.

5. `PublishSelfContained` will also imply a RID. 