### PR TITLE
Prevent `dotnet test` verbosity from being ignored

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.Tools.Test
                     msbuildArgs.Add(argument);
             }
 
-            string verbosityArg = result.ForwardedOptionValues<IReadOnlyCollection<string>>(TestCommandParser.GetCommand(), "verbosity")?.SingleOrDefault() ?? null;
+            string verbosityArg = result.ForwardedOptionValues<IReadOnlyCollection<string>>(TestCommandParser.GetCommand(), "--verbosity")?.SingleOrDefault() ?? null;
             if (verbosityArg != null)
             {
                 string[] verbosity = verbosityArg.Split(':', 2);

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -352,7 +352,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         public void ItUsesVerbosityPassedToDefineVerbosityOfConsoleLoggerOfTheTests(string verbosity, bool shouldShowPassedTests)
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("9");
+            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp($"9_{verbosity}");
 
             // Call test
             CommandResult result = new DotnetTestCommand(Log)

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -343,8 +343,13 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(1);
         }
 
-        [Fact]
-        public void ItUsesVerbosityPassedToDefineVerbosityOfConsoleLoggerOfTheTests()
+        [Theory]
+        [InlineData("q", false)]
+        [InlineData("m", false)]
+        [InlineData("n", true)]
+        [InlineData("d", true)]
+        [InlineData("diag", true)]
+        public void ItUsesVerbosityPassedToDefineVerbosityOfConsoleLoggerOfTheTests(string verbosity, bool shouldShowPassedTests)
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
             var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("9");
@@ -352,16 +357,27 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Call test
             CommandResult result = new DotnetTestCommand(Log)
                                         .WithWorkingDirectory(testProjectDirectory)
-                                        .Execute("-v", "q");
+                                        .Execute("-v", verbosity);
 
             // Verify
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total:     2");
-                result.StdOut.Should().Contain("Passed:     1");
-                result.StdOut.Should().Contain("Failed:     1");
-                result.StdOut.Should().NotContain("Passed TestNamespace.VSTestTests.VSTestPassTest");
-                result.StdOut.Should().NotContain("Failed TestNamespace.VSTestTests.VSTestFailTest");
+                if (shouldShowPassedTests)
+                {
+                    result.StdOut.Should().Contain("Total tests: 2");
+                    result.StdOut.Should().Contain("Passed: 1");
+                    result.StdOut.Should().Contain("Failed: 1");
+
+                    result.StdOut.Should().Contain("Passed VSTestPassTest");
+                }
+                else
+                {
+                    result.StdOut.Should().Contain("Total:     2");
+                    result.StdOut.Should().Contain("Passed:     1");
+                    result.StdOut.Should().Contain("Failed:     1");
+
+                    result.StdOut.Should().NotContain("Passed VSTestPassTest");
+                }
             }
 
             result.ExitCode.Should().Be(1);
@@ -603,7 +619,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(0);
         }
 
-        [PlatformSpecificFact(TestPlatforms.Linux, Skip="https://github.com/dotnet/sdk/issues/22865")]
+        [PlatformSpecificFact(TestPlatforms.Linux, Skip = "https://github.com/dotnet/sdk/issues/22865")]
         public void ItShouldShowWarningMessageOnCollectCodeCoverageThatProfilerWasNotInitialized()
         {
             var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("13");
@@ -618,7 +634,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Verify test results
             if (!TestContext.IsLocalized())
             {
-               result.StdOut.Should().Contain("No code coverage data available. Code coverage is currently supported only on Windows, Linux x64 and macOS x64.");
+                result.StdOut.Should().Contain("No code coverage data available. Code coverage is currently supported only on Windows, Linux x64 and macOS x64.");
                 result.StdOut.Should().Contain("Total:     1");
                 result.StdOut.Should().Contain("Passed:     1");
                 result.StdOut.Should().NotContain("Failed!");


### PR DESCRIPTION
One of the two aliases of `Command` instance (obtained from static class `TestCommandParser`, not a runtime instance of a command) needs to be passed to `ForwardedOptionValues`.

Debug visualization after the fix (note `alias` value):
![New Picture (2)](https://user-images.githubusercontent.com/11148519/191203879-29b6231d-240a-4037-a39e-892b2566127c.png)

The existing test `ItUsesVerbosityPassedToDefineVerbosityOfConsoleLoggerOfTheTests` was using only `quiet` mode and was testing for the wrong strings anyway  (`TestNamespace.VSTestTests.VSTestPassTest` and `TestNamespace.VSTestTests.VSTestFailTest`, when only tests names are shown nowadays in case of verbosity >= `normal`), hence the regression.


This fixes #16122.

