### PR TITLE
[release/7.0.1xx-rc2] Update dependencies from microsoft/vstest

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -105,9 +105,9 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>3ed642746f2609c6f586d096803630095b4add78</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220913-02">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.4.0-release-20220920-01">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>d94aafd04f9ebecda6d36cce3f8cc1605d88f4ed</Sha>
+      <Sha>e3ef271ba4d8ef1cda34bfa544e33c350fce622e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="7.0.100-1.22452.1">
       <Uri>https://github.com/dotnet/linker</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,7 +79,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/vstest -->
-    <MicrosoftNETTestSdkPackageVersion>17.4.0-preview-20220913-02</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>17.4.0-release-20220920-01</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
Porting to rc2 from rtm #28039

Update Microsoft.NET.Test.Sdk to remove dbghelp.

From Version 17.4.0-release-20220919-06 -> To Version 17.4.0-release-20220920-01