### PR TITLE
Fix Property Parsing in Publish

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace Microsoft.DotNet.Cli.Utils;
 
-public class MSBuildPropertyParser {
+public static class MSBuildPropertyParser {
     public static IEnumerable<(string key, string value)> ParseProperties(string input) {
         var currentPos = 0;
         StringBuilder currentKey = new StringBuilder();

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace Microsoft.DotNet.Cli.Utils;
 
-public static class MSBuildPropertyParser {
+public class MSBuildPropertyParser {
     public static IEnumerable<(string key, string value)> ParseProperties(string input) {
         var currentPos = 0;
         StringBuilder currentKey = new StringBuilder();

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Cli
             )
         {
             ProjectInstance project = null;
-            var globalProperties = GetGlobalPropertiesFromUserArgs(userPropertyArgs);
+            var globalProperties = GetGlobalPropertiesFromUserArgs(parseResult);
 
             if (parseResult.HasOption(configOption) || globalProperties.ContainsKey(MSBuildPropertyNames.CONFIGURATION))
                 yield break;
@@ -186,17 +186,14 @@ namespace Microsoft.DotNet.Cli
         }
 
         /// <returns>A case-insensitive dictionary of any properties passed from the user and their values.</returns>
-        private Dictionary<string, string> GetGlobalPropertiesFromUserArgs(IEnumerable<string> userPropertyArgs)
+        private Dictionary<string, string> GetGlobalPropertiesFromUserArgs(ParseResult parseResult)
         {
             Dictionary<string, string> globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            var forwardingFunction = (CommonOptions.PropertiesOption as ForwardedOption<string[]>).GetForwardingFunction();
-            IEnumerable<string> globalPropEnumerable = forwardingFunction(CommonOptions.PropertiesOption.Parse(String.Join(";", userPropertyArgs)));
+            string[] globalPropEnumerable = parseResult.GetValueForOption(CommonOptions.PropertiesOption);
 
-            foreach (var propertyString in globalPropEnumerable)
+            foreach (var keyEqVal in globalPropEnumerable)
             {
-                // The parser puts keys into the format --property:Key=Value no matter the user input, so we can expect that pattern and extract the key.
-                string keyEqVal = propertyString.Split("--property:").Last();
                 string[] keyValuePair = keyEqVal.Split("=");
                 globalProperties[keyValuePair.First()] = keyValuePair.Last();
             }

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -194,7 +194,7 @@ namespace Microsoft.DotNet.Cli
             foreach (var keyEqVal in globalPropEnumerable)
             {
                 string[] keyValuePair = keyEqVal.Split("=");
-                globalProperties[keyValuePair.First()] = keyValuePair.Last();
+                globalProperties[keyValuePair[0]] = keyValuePair[1];
             }
             return globalProperties;
         }

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -34,8 +34,7 @@ namespace Microsoft.DotNet.Cli
             ParseResult parseResult,
             string defaultedConfigurationProperty,
             IEnumerable<string> slnOrProjectArgs,
-            Option<string> configOption,
-            IEnumerable<string> userPropertyArgs
+            Option<string> configOption
             )
         {
             ProjectInstance project = null;

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -193,7 +193,7 @@ namespace Microsoft.DotNet.Cli
 
             foreach (var keyEqVal in globalPropEnumerable)
             {
-                string[] keyValuePair = keyEqVal.Split("=");
+                string[] keyValuePair = keyEqVal.Split("=", 2);
                 globalProperties[keyValuePair[0]] = keyValuePair[1];
             }
             return globalProperties;

--- a/src/Cli/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Tools.Pack
             msbuildArgs.AddRange(parseResult.OptionValuesToBeForwarded(PackCommandParser.GetCommand()));
             ReleasePropertyProjectLocator projectLocator = new ReleasePropertyProjectLocator(Environment.GetEnvironmentVariable(EnvironmentVariableNames.ENABLE_PACK_RELEASE_FOR_SOLUTIONS) != null);
             msbuildArgs.AddRange(projectLocator.GetCustomDefaultConfigurationValueIfSpecified(parseResult, MSBuildPropertyNames.PACK_RELEASE,
-                slnOrProjectArgs, PackCommandParser.ConfigurationOption, msbuildArgs) ?? Array.Empty<string>());
+                slnOrProjectArgs, PackCommandParser.ConfigurationOption) ?? Array.Empty<string>());
             msbuildArgs.AddRange(slnOrProjectArgs ?? Array.Empty<string>());
 
             bool noRestore = parseResult.HasOption(PackCommandParser.NoRestoreOption) || parseResult.HasOption(PackCommandParser.NoBuildOption);

--- a/src/Cli/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/Program.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Tools.Publish
             msbuildArgs.AddRange(parseResult.OptionValuesToBeForwarded(PublishCommandParser.GetCommand()));
             ReleasePropertyProjectLocator projectLocator = new ReleasePropertyProjectLocator(Environment.GetEnvironmentVariable(EnvironmentVariableNames.ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS) != null);
             msbuildArgs.AddRange(projectLocator.GetCustomDefaultConfigurationValueIfSpecified(parseResult, MSBuildPropertyNames.PUBLISH_RELEASE,
-                slnOrProjectArgs, PublishCommandParser.ConfigurationOption, msbuildArgs) ?? Array.Empty<string>());
+                slnOrProjectArgs, PublishCommandParser.ConfigurationOption) ?? Array.Empty<string>());
             msbuildArgs.AddRange(slnOrProjectArgs ?? Array.Empty<string>());
 
             bool noRestore = parseResult.HasOption(PublishCommandParser.NoRestoreOption)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -691,7 +691,7 @@ public static class Program
         public void PublishRelease_does_not_override_Configuration_property_across_formats(string configOpt)
         {
             var helloWorldAsset = _testAssetsManager
-               .CopyTestAsset("HelloWorld", "PublishReleaseHelloWorldCsProjConfigPropOverride")
+               .CopyTestAsset("HelloWorld", $"PublishReleaseHelloWorldCsProjConfigPropOverride{configOpt}")
                .WithSource()
                .WithTargetFramework(ToolsetInfo.CurrentTargetFramework)
                .WithProjectChanges(project =>
@@ -760,7 +760,7 @@ public static class Program
             var rid = EnvironmentInfo.GetCompatibleRid(tfm);
 
             var helloWorldAsset = _testAssetsManager
-                .CopyTestAsset("HelloWorld", "PublishReleaseHelloWorldCsProjPublishProfile")
+                .CopyTestAsset("HelloWorld", $"PublishReleaseHelloWorldCsProjPublishProfile{config}")
                 .WithSource()
                 .WithTargetFramework(ToolsetInfo.CurrentTargetFramework)
                 .WithProjectChanges(project =>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -579,7 +579,7 @@ public static class Program
             var publishCommand = new DotnetPublishCommand(Log, helloWorldAsset.TestRoot);
 
             publishCommand
-            .Execute("-f net7.0")
+            .Execute("-f", "net7.0")
             .Should()
             .Pass().And.NotHaveStdErr();
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -563,6 +563,29 @@ public static class Program
                 .HaveStdOutContaining("NETSDK1190");
         }
 
+        [Theory]
+        [InlineData("-f net7.0")]
+        [InlineData("/p:TargetFramework=net7.0")]
+        public void It_publishes_correctly_with_different_property_formats_despite_PublishRelease_code(string paramsToPublish)
+        {
+            var helloWorldAsset = _testAssetsManager
+               .CopyTestAsset("HelloWorld", $"PublishesWithProperyFormats{paramsToPublish}")
+               .WithSource()
+               .WithTargetFramework(ToolsetInfo.CurrentTargetFramework);
+
+            new BuildCommand(helloWorldAsset)
+           .Execute()
+           .Should()
+           .Pass();
+
+            var publishCommand = new DotnetPublishCommand(Log, helloWorldAsset.TestRoot);
+
+            publishCommand
+            .Execute(paramsToPublish.Split(" "))
+            .Should()
+            .Pass();
+        }
+
         [Fact]
         public void It_publishes_on_release_if_PublishRelease_property_set_in_csproj()
         {

--- a/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -102,6 +102,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
         [Theory]
         [InlineData("publish", "-property", "Configuration=Debug")]
         [InlineData("publish", "-p", "Configuration=Debug")]
+        [InlineData("publish", "--property", "Configuration=Debug")]
         public void ItParsesSpacedPropertiesInPublishReleaseEvaluationPhase(string command, string propertyKey, string propertyVal)
         {
             var testInstance = _testAssetsManager.CopyTestAsset("TestAppSimple")

--- a/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -100,6 +100,23 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
         }
 
         [Theory]
+        [InlineData("publish", "-property", "Configuration=Debug")]
+        [InlineData("publish", "-p", "Configuration=Debug")]
+        public void ItParsesSpacedPropertiesInPublishReleaseEvaluationPhase(string command, string propertyKey, string propertyVal)
+        {
+            var testInstance = _testAssetsManager.CopyTestAsset("TestAppSimple")
+                .WithSource()
+                .Restore(Log);
+
+            var rootDir = testInstance.Path;
+
+            new DotnetCommand(Log)
+                .WithWorkingDirectory(rootDir)
+                .Execute(command, propertyKey, propertyVal)
+                .Should().Pass().And.NotHaveStdErr();
+        }
+
+        [Theory]
         [InlineData(null)]
         [InlineData("--sc")]
         [InlineData("--self-contained")]


### PR DESCRIPTION
Resolves https://github.com/dotnet/sdk/issues/28022
Backport: 
https://github.com/dotnet/sdk/pull/28061 **(please approve this too!)**

Post-Moderm:

I intercepted the `MSBuildPropertyParser` code stack too many interface layers in, so for some edge cases, properties passed via `/p` and `-p` were not fully parsed as it wasn't running through the `Options` Forwarding code. The ones I had tested did get parsed but for example in the above case they weren't fully parsed. Also removes an erroneous comment from the code that was old and slipped in. 

Risk:
Medium

Reason To Accept: 
Fixes a bug which will cause erroneous errors inside of `dotnet publish`. The PublishRelease code will do an MSBuild evaluation with faulty properties which could have any number of side effects, but in general it would be unrelated to what actually gets published. Still, this is high impact and should be merged in. 

Testing: [OK]
`dotnet publish -p:PublishRelease=true -property Configuration=Debug`
`dotnet publish -p:PublishRelease=true -p    Configuration=Debug`
Also 
`dotnet publish -f net7.0`
Also
`dotnet publish` with `PublishRelease` inside of a `.csproj` 