### PR TITLE
Gate warnings for localization asset locales on TFM >= 7

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -4,7 +4,6 @@
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -159,7 +158,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var task = InitializeTask(out _);
             task.ProjectAssetsFile = projectAssetsJsonPath;
             task.TargetFramework = tfm;
-            var writer = new CacheWriter(task);
+            var writer = new CacheWriter(task, new MockPackageResolver());
             writer.WriteToMemoryStream();
             var engine = task.BuildEngine as MockBuildEngine;
 
@@ -167,7 +166,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
 
             var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1188");
-            invalidContextWarnings.Should().HaveCount(!shouldHaveWarnings ? 1 : 0);
+            invalidContextMessages.Should().HaveCount(!shouldHaveWarnings ? 1 : 0);
 
         }
 
@@ -177,12 +176,12 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         public void It_warns_on_incorrectly_cased_culture_codes_of_resources(string tfm, bool shouldHaveWarnings)
         {
             string projectAssetsJsonPath = Path.GetTempFileName();
-            var assetsContent = AssetsFileWithInvalidLocale(tfm, "ru-RU");
+            var assetsContent = AssetsFileWithInvalidLocale(tfm, "ru-ru");
             File.WriteAllText(projectAssetsJsonPath, assetsContent);
             var task = InitializeTask(out _);
             task.ProjectAssetsFile = projectAssetsJsonPath;
             task.TargetFramework = tfm;
-            var writer = new CacheWriter(task);
+            var writer = new CacheWriter(task, new MockPackageResolver());
             writer.WriteToMemoryStream();
             var engine = task.BuildEngine as MockBuildEngine;
 
@@ -190,7 +189,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
 
             var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1187");
-            invalidContextWarnings.Should().HaveCount(!shouldHaveWarnings ? 1 : 0);
+            invalidContextMessages.Should().HaveCount(!shouldHaveWarnings ? 1 : 0);
         }
 
         private ResolvePackageAssets InitializeTask(out IEnumerable<PropertyInfo> inputProperties)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -117,15 +117,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             new CacheWriter(task); // Should not error
         }
 
-        [Fact]
-        public void It_warns_on_invalid_culture_codes_of_resources()
-        {
-            string projectAssetsJsonPath = Path.GetTempFileName();
-            var assetsContent = @"
+        private static string AssetsFileWithInvalidLocale(string tfm, string locale) => @"
 {
   `version`: 3,
   `targets`: {
-    `net7.0`: {
+    `{tfm}`: {
       `JavaScriptEngineSwitcher.Core/3.3.0`: {
         `type`: `package`,
         `compile`: {
@@ -136,59 +132,65 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         },
         `resource`: {
           `lib/netstandard2.0/ru-ru/JavaScriptEngineSwitcher.Core.resources.dll`: {
-            `locale`: `what is this even`
+            `locale`: `{locale}`
           }
         }
       }
     }
+  },
+  `project`: {
+    `version`: `1.0.0`,
+    `frameworks`: {
+      `{tfm}`: {
+        `targetAlias`: `{tfm}`
+      }
+    }
   }
-}".Replace("`", "\"");
-            File.WriteAllText(projectAssetsJsonPath, assetsContent);
-            var task = InitializeTask(out _);
-            task.ProjectAssetsFile = projectAssetsJsonPath;
-            task.TargetFramework = "net7.0";
-            var writer = new CacheWriter(task);
-            writer.WriteToCacheFile();
-            var messages = (task.BuildEngine as MockBuildEngine).Warnings;
-            var invalidContextMessages = messages.Where(msg => msg.Code == "NETSDK1188");
-            invalidContextMessages.Should().HaveCount(1);
-        }
-        
-        [Fact]
-        public void It_warns_on_incorrectly_cased_culture_codes_of_resources()
+}".Replace("`", "\"").Replace("{tfm}", tfm).Replace("{locale}", locale);
+
+        [InlineData("net7.0", true)]
+        [InlineData("net6.0", false)]
+        [Theory]
+        public void It_warns_on_invalid_culture_codes_of_resources(string tfm, bool shouldHaveWarnings)
         {
             string projectAssetsJsonPath = Path.GetTempFileName();
-            var assetsContent = @"
-{
-  `version`: 3,
-  `targets`: {
-    `net7.0`: {
-      `JavaScriptEngineSwitcher.Core/3.3.0`: {
-        `type`: `package`,
-        `compile`: {
-          `lib/netstandard2.0/JavaScriptEngineSwitcher.Core.dll`: {}
-        },
-        `runtime`: {
-          `lib/netstandard2.0/JavaScriptEngineSwitcher.Core.dll`: {}
-        },
-        `resource`: {
-          `lib/netstandard2.0/ru-ru/JavaScriptEngineSwitcher.Core.resources.dll`: {
-            `locale`: `ru-ru`
-          }
-        }
-      }
-    }
-  }
-}".Replace("`", "\"");
+            var assetsContent = AssetsFileWithInvalidLocale(tfm, "what is this even");
             File.WriteAllText(projectAssetsJsonPath, assetsContent);
             var task = InitializeTask(out _);
             task.ProjectAssetsFile = projectAssetsJsonPath;
-            task.TargetFramework = "net7.0";
+            task.TargetFramework = tfm;
             var writer = new CacheWriter(task);
-            writer.WriteToCacheFile();
-            var messages = (task.BuildEngine as MockBuildEngine).Warnings;
-            var invalidContextMessages = messages.Where(msg => msg.Code == "NETSDK1187");
-            invalidContextMessages.Should().HaveCount(1);
+            writer.WriteToMemoryStream();
+            var engine = task.BuildEngine as MockBuildEngine;
+
+            var invalidContextWarnings = engine.Warnings.Where(msg => msg.Code == "NETSDK1188");
+            invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
+
+            var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1188");
+            invalidContextWarnings.Should().HaveCount(!shouldHaveWarnings ? 1 : 0);
+
+        }
+
+        [InlineData("net7.0", true)]
+        [InlineData("net6.0", false)]
+        [Theory]
+        public void It_warns_on_incorrectly_cased_culture_codes_of_resources(string tfm, bool shouldHaveWarnings)
+        {
+            string projectAssetsJsonPath = Path.GetTempFileName();
+            var assetsContent = AssetsFileWithInvalidLocale(tfm, "ru-RU");
+            File.WriteAllText(projectAssetsJsonPath, assetsContent);
+            var task = InitializeTask(out _);
+            task.ProjectAssetsFile = projectAssetsJsonPath;
+            task.TargetFramework = tfm;
+            var writer = new CacheWriter(task);
+            writer.WriteToMemoryStream();
+            var engine = task.BuildEngine as MockBuildEngine;
+
+            var invalidContextWarnings = engine.Warnings.Where(msg => msg.Code == "NETSDK1187");
+            invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
+
+            var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1187");
+            invalidContextWarnings.Should().HaveCount(!shouldHaveWarnings ? 1 : 0);
         }
 
         private ResolvePackageAssets InitializeTask(out IEnumerable<PropertyInfo> inputProperties)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -166,7 +166,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
 
             var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1188");
-            invalidContextMessages.Should().HaveCount(!shouldHaveWarnings ? 1 : 0);
+            invalidContextMessages.Should().HaveCount(shouldHaveWarnings ? 0 : 1);
 
         }
 
@@ -189,7 +189,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
 
             var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1187");
-            invalidContextMessages.Should().HaveCount(!shouldHaveWarnings ? 1 : 0);
+            invalidContextMessages.Should().HaveCount(shouldHaveWarnings ? 0 : 1);
         }
 
         private ResolvePackageAssets InitializeTask(out IEnumerable<PropertyInfo> inputProperties)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockPackageResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockPackageResolver.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using NuGet.ProjectModel;
 using NuGet.Versioning;
 using System.IO;
 
@@ -24,5 +25,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             packageRoot = _root;
             return Path.Combine(_root, packageId, version.ToNormalizedString(), "path");
         }
+
+        public string ResolvePackageAssetPath(LockFileTargetLibrary package, string relativePath) => Path.Combine(GetPackageDirectory(package.Name, package.Version), relativePath);
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/IPackageResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/IPackageResolver.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using NuGet.ProjectModel;
 using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks
@@ -9,5 +10,6 @@ namespace Microsoft.NET.Build.Tasks
     {
         string GetPackageDirectory(string packageId, NuGetVersion version);
         string GetPackageDirectory(string packageId, NuGetVersion version, out string packageRoot);
+        string ResolvePackageAssetPath(LockFileTargetLibrary package, string relativePath);
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1429,9 +1429,10 @@ namespace Microsoft.NET.Build.Tasks
                                 if (tfm.Version.Major >= 7)
                                 {
                                     _task.Log.LogWarning(Strings.PackageContainsIncorrectlyCasedLocale, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale);
-                                } else
+                                }
+                                else
                                 {
-                                    _task.Log.LogMessage(Strings.PackageContainsIncorrectlyCasedLocale, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale)
+                                    _task.Log.LogMessage(Strings.PackageContainsIncorrectlyCasedLocale, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale);
                                 }
                             }
                             locale = normalizedLocale;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1425,14 +1425,29 @@ namespace Microsoft.NET.Build.Tasks
                             var normalizedLocale = System.Globalization.CultureInfo.GetCultureInfo(locale).Name;
                             if (normalizedLocale != locale)
                             {
-                                _task.Log.LogWarning(Strings.PackageContainsIncorrectlyCasedLocale, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale);
+                                var tfm = _lockFile.GetTargetAndThrowIfNotFound(_targetFramework, null).TargetFramework;
+                                if (tfm.Version.Major >= 7)
+                                {
+                                    _task.Log.LogWarning(Strings.PackageContainsIncorrectlyCasedLocale, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale);
+                                } else
+                                {
+                                    _task.Log.LogMessage(Strings.PackageContainsIncorrectlyCasedLocale, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale)
+                                }
                             }
                             locale = normalizedLocale;
                         }
                         catch (System.Globalization.CultureNotFoundException cnf)
                         {
-                            _task.Log.LogWarning(Strings.PackageContainsUnknownLocale, package.Name, package.Version.ToNormalizedString(), cnf.InvalidCultureName);
-                            // We could potentially strip this unknown locales at this point, but we do not.
+                            var tfm = _lockFile.GetTargetAndThrowIfNotFound(_targetFramework, null).TargetFramework;
+                            if (tfm.Version.Major >= 7)
+                            {
+                                _task.Log.LogWarning(Strings.PackageContainsUnknownLocale, package.Name, package.Version.ToNormalizedString(), cnf.InvalidCultureName);
+                            } else
+                            {
+                                _task.Log.LogMessage(Strings.PackageContainsUnknownLocale, package.Name, package.Version.ToNormalizedString(), cnf.InvalidCultureName);
+                            }
+
+                            // We could potentially strip this unknown locale at this point, but we do not.
                             // Locale data can change over time (it's typically an OS database that's kept updated),
                             // and the data on the system running the build may not be the same data as
                             // the system executing the built code. So we should be permissive for this case.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -677,6 +677,10 @@ namespace Microsoft.NET.Build.Tasks
 
             private const char RelatedPropertySeparator = ';';
 
+            /// <summary>
+            /// This constructor should only be used for testing - IPackgeResolver carries a lot of
+            /// state so using mocks really help with testing this component.
+            /// </summary>
             public CacheWriter(ResolvePackageAssets task, IPackageResolver resolver) : this(task)
             {
                 _packageResolver = resolver;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -657,8 +657,8 @@ namespace Microsoft.NET.Build.Tasks
             private ResolvePackageAssets _task;
             private BinaryWriter _writer;
             private LockFile _lockFile;
-            private NuGetPackageResolver _packageResolver;
             private LockFileTarget _compileTimeTarget;
+            private IPackageResolver _packageResolver;
             private LockFileTarget _runtimeTarget;
             private Dictionary<string, int> _stringTable;
             private List<string> _metadataStrings;
@@ -676,6 +676,11 @@ namespace Microsoft.NET.Build.Tasks
             private const string NetCorePlatformLibrary = "Microsoft.NETCore.App";
 
             private const char RelatedPropertySeparator = ';';
+
+            public CacheWriter(ResolvePackageAssets task, IPackageResolver resolver) : this(task)
+            {
+                _packageResolver = resolver;
+            }
 
             public CacheWriter(ResolvePackageAssets task)
             {


### PR DESCRIPTION
## Description
In https://github.com/dotnet/sdk/pull/26729 we introduced a new warning to .NET 7 SDKs around inconsistent locale casing for resources found in NuGet packages, but we did not gate that warning on a TFM change. This means that users that work on case-insensitive file systems are very likely to start hitting the new warning on an SDK update, instead of a TFM update. We want to not do that so that we encourage folks to update SDKs as soon as they come out. We have had reports of a couple of internal customers 

## Regression

**No**, instead we want to change the default. I suppose you could call it a user-experience regression?

## Risk

**Low**, this uses existing patterns to check an already-available piece of data.

## Testing

- [x] manual testing
- [x] automated tests to cover the matrix of TFM versions and error codes we added
