### PR TITLE
MSBuild on .NET 7: Downgrade compile-time references (#28079)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -42,13 +42,13 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>b23dc07bd7363fcd986a17230c2734bc656e71a7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.4.0-preview-22466-03">
+    <Dependency Name="Microsoft.Build" Version="17.4.0-preview-22469-04">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>48ab5664b8734afdf4aedba5f72a0663435eef16</Sha>
+      <Sha>cc3db358d34ad4cd1ec0c67e17582d7ca2a15040</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.4.0-preview-22466-03">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.4.0-preview-22469-04">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>48ab5664b8734afdf4aedba5f72a0663435eef16</Sha>
+      <Sha>cc3db358d34ad4cd1ec0c67e17582d7ca2a15040</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.5-beta.22470.2">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -105,15 +105,16 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.4.0-preview-22466-03</MicrosoftBuildPackageVersion>
-    <!-- .NET Framework-targeted tasks will need to run in an MSBuild that is older than the very latest,
+    <MicrosoftBuildPackageVersion>17.4.0-preview-22469-04</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildCurrentPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildCurrentPackageVersion>
+    <!-- Some tasks and the resolver will need to run in an MSBuild that is older than the very latest,
           so target one that matches the version in minimumMSBuildVersion.
 
           This avoids the need to juggle references to packages that have been updated in newer MSBuild. -->
-    <MicrosoftBuildPackageVersion Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETFramework' and exists('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion')">$([System.IO.File]::ReadAllText('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion').Trim())</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion Condition="exists('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion')">$([System.IO.File]::ReadAllText('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion').Trim())</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.4.0-preview-22466-03</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.4.0-preview-22469-04</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/src/Layout/tool_msbuild/tool_msbuild.csproj
+++ b/src/Layout/tool_msbuild/tool_msbuild.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimePackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildCurrentPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Localization" Version="$(MicrosoftBuildLocalizationPackageVersion)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
   </ItemGroup>


### PR DESCRIPTION
* Update dependencies from https://github.com/dotnet/msbuild build 20220919.4

Microsoft.Build , Microsoft.Build.Localization
 From Version 17.4.0-preview-22466-03 -> To Version 17.4.0-preview-22469-04

* Pin MSBuild references to a lower version

Always referencing the latest MSBuild means that some things like the
SDK resolver would be forced to target MSBuild's latest runtime, and
that would break compat with uses. For instance, VSMac is currently on
.NET 6.0 and can't run a net7.0 resolver.

We do, however, want to always _ship_ the latest MSBuild.

Co-authored-by: dotnet-maestro[bot] <dotnet-maestro[bot]@users.noreply.github.com>