### PR TITLE
Provide package description for APICompat packages

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -11,6 +11,7 @@
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <Nullable>enable</Nullable>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
+    <PackageDescription>MSBuild tasks and targets to perform api compatibility checks on assemblies and packages.</PackageDescription>
   </PropertyGroup>
 
   <!-- SDK's task infrastructure -->

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
@@ -10,6 +10,7 @@
     <StrongNameKeyId>Open</StrongNameKeyId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>apicompat</ToolCommandName>
+    <PackageDescription>Tool to perform api compatibility checks on assemblies and packages.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Both the old nuget package and the new ones didn't provide a package description:

![image](https://user-images.githubusercontent.com/7412651/191739775-acc2bbc5-6226-4b30-b5ed-5ec83c1debe7.png)

![image](https://user-images.githubusercontent.com/7412651/191739808-35d2e851-943f-48d3-92d4-8e07347ce08a.png)
