### PR TITLE
Improve the example with specified language when language option is given with invalid option

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
@@ -152,11 +152,16 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             if (templateGroup.ShortNames.Any())
             {
                 reporter.WriteLine(LocalizableStrings.InvalidParameterTemplateHint);
-                reporter.WriteCommand(
-                    Example
-                        .For<NewCommand>(args.ParseResult)
-                        .WithArgument(NewCommand.ShortNameArgument, templateGroup.ShortNames[0])
-                        .WithHelpOption());
+                var example = Example
+                    .For<NewCommand>(args.ParseResult)
+                    .WithArgument(NewCommand.ShortNameArgument, templateGroup.ShortNames[0]);
+                var language = matchInfos.Where(mi => mi.Language != null).FirstOrDefault()?.Language;
+                if (language != null)
+                {
+                    example.WithOption(language.Option, language.GetValueOrDefault<string>()!);
+                }
+                example.WithHelpOption();
+                reporter.WriteCommand(example);
             }
 
             return invalidOptionsList.Any() ? NewCommandStatus.InvalidOption : NewCommandStatus.NotFound;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateOptionResult.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateOptionResult.cs
@@ -47,7 +47,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             return new TemplateOptionResult(
                     option,
                     optionResult.Token?.Value ?? string.Empty,
-                    optionResult.GetValueOrDefault<string>());
+                    optionResult.GetValueOrDefault()?.ToString());
         }
     }
 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateResult.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateResult.cs
@@ -3,6 +3,7 @@
 //
 
 using System.CommandLine;
+using System.CommandLine.Parsing;
 
 namespace Microsoft.TemplateEngine.Cli.Commands
 {
@@ -29,6 +30,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         internal bool IsBaselineMatch { get; private set; }
 
+        internal OptionResult? Language { get; private set; }
+
         internal CliTemplateInfo TemplateInfo => _templateCommand.Template;
 
         internal IEnumerable<TemplateOptionResult> ValidTemplateOptions => _parametersInfo.Where(i => !(i is InvalidTemplateOptionResult));
@@ -41,6 +44,12 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             result.IsLanguageMatch = templateCommand.LanguageOption == null || !parseResult.HasErrorFor(templateCommand.LanguageOption);
             result.IsTypeMatch = templateCommand.TypeOption == null || !parseResult.HasErrorFor(templateCommand.TypeOption);
             result.IsBaselineMatch = templateCommand.BaselineOption == null || !parseResult.HasErrorFor(templateCommand.BaselineOption);
+
+            if (templateCommand.LanguageOption != null && result.IsTemplateMatch)
+            {
+                result.Language = parseResult.FindResultFor(templateCommand.LanguageOption);
+            }
+
             foreach (var option in templateCommand.TemplateOptions)
             {
                 if (parseResult.HasErrorFor(option.Value.Option))

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.NoMatchHandling.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.NoMatchHandling.cs
@@ -131,6 +131,154 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                     new string?[] { "value", "langVersion", "--langVersion", null, "Required argument missing for option: '--langVersion'." }
                 }
             };
+
+            yield return new object[]
+            {
+                "foo --fake",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithParameter("langVersion")
+                },
+                new string?[][]
+                {
+                    new string?[] { "name", null, "--fake", null, null }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --fake value",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithParameter("langVersion")
+                },
+                new string?[][]
+                {
+                    new string?[] { "name", null, "--fake", null, null },
+                    new string?[] { "name", null, "value", null, null }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --language F# --include",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("language", "C#").WithParameter("include", "bool"),
+                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithTag("language", "F#")
+                },
+                new string?[][]
+                {
+                    new string?[] { "name", null, "--include", null, null }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --language F# --exclude",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("language", "C#").WithParameter("include", "bool"),
+                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithTag("language", "F#")
+                },
+                new string?[][]
+                {
+                    new string?[] { "name", null, "--exclude", null, null }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --int 6 --float 3.14 --hex 0x1A2F --bool --string stringtype --choice c1 --fake",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+                    .WithParameter("int", paramType: "integer")
+                    .WithParameter("float", paramType: "float")
+                    .WithParameter("hex", paramType: "hex")
+                    .WithParameter("bool", paramType: "bool")
+                    .WithParameter("string", paramType: "string")
+                    .WithChoiceParameter("choice", "c1", "c2")
+                },
+                new string?[][]
+                {
+                    new string?[] { "name", null, "--fake", null, null }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --int 6 --float 3.14 --hex 0x1A2F --bool --string stringtype --choice c1 --fake value",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+                    .WithParameter("int", paramType: "integer")
+                    .WithParameter("float", paramType: "float")
+                    .WithParameter("hex", paramType: "hex")
+                    .WithParameter("bool", paramType: "bool")
+                    .WithParameter("string", paramType: "string")
+                    .WithChoiceParameter("choice", "c1", "c2")
+                },
+                new string?[][]
+                {
+                    new string?[] { "name", null, "--fake", null, null },
+                    new string?[] { "name", null, "value", null, null }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --language F# --int 6 --float 3.14 --hex 0x1A2F --bool --string stringtype --choice c1 --include",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("language", "C#")
+                    .WithParameter("int", paramType: "integer")
+                    .WithParameter("float", paramType: "float")
+                    .WithParameter("hex", paramType: "hex")
+                    .WithParameter("bool", paramType: "bool")
+                    .WithParameter("string", paramType: "string")
+                    .WithChoiceParameter("choice", "c1", "c2")
+                    .WithParameter("include", "bool"),
+                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithTag("language", "F#")
+                    .WithParameter("int", paramType: "integer")
+                    .WithParameter("float", paramType: "float")
+                    .WithParameter("hex", paramType: "hex")
+                    .WithParameter("bool", paramType: "bool")
+                    .WithParameter("string", paramType: "string")
+                    .WithChoiceParameter("choice", "c1", "c2")
+                },
+                new string?[][]
+                {
+                    new string?[] { "name", null, "--include", null, null }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --language F# --int 6 --float 3.14 --hex 0x1A2F --bool --string stringtype --choice c1 --exclude",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithTag("language", "C#")
+                    .WithParameter("int", paramType: "integer")
+                    .WithParameter("float", paramType: "float")
+                    .WithParameter("hex", paramType: "hex")
+                    .WithParameter("bool", paramType: "bool")
+                    .WithParameter("string", paramType: "string")
+                    .WithChoiceParameter("choice", "c1", "c2")
+                    .WithParameter("include", "bool"),
+                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithTag("language", "F#")
+                    .WithParameter("int", paramType: "integer")
+                    .WithParameter("float", paramType: "float")
+                    .WithParameter("hex", paramType: "hex")
+                    .WithParameter("bool", paramType: "bool")
+                    .WithParameter("string", paramType: "string")
+                    .WithChoiceParameter("choice", "c1", "c2")
+                },
+                new string?[][]
+                {
+                    new string?[] { "name", null, "--exclude", null, null }
+                }
+            };
         }
 
         [Theory]

--- a/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.cs
@@ -398,6 +398,21 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .And.HaveStdOutContaining("--framework");
         }
 
+        [Theory]
+        [InlineData("-lang", "F#", "--use-program-main")]
+        [InlineData("--language", "F#", "--use-program-main")]
+        [InlineData("-lang", "C#", "--no-exist")]
+        public void ExampleHasLanguageForSepecifiedLanguageWithInvalidOption(string languageOption, string language, string invalidOption)
+        {
+            CommandResult cmd = new DotnetNewCommand(Log, "console", languageOption, language, invalidOption)
+                .WithVirtualHive()
+                .Execute();
+            cmd.Should().Fail()
+                .And.HaveStdErrContaining($"'{invalidOption}' is not a valid option")
+                .And.HaveStdErrContaining("For more information, run:")
+                .And.HaveStdErrContaining($"dotnet new console --language {language} -h");
+        }
+
         [Fact]
         public void ItCanShowParseError()
         {


### PR DESCRIPTION
### Problem
- https://github.com/dotnet/templating/issues/4494
- When valid bool option and invalid option are given, the exception unable to cast is thrown .
- Cli lacks unit tests for the option with invalid names.

### Solution

- Specified language is added to the example when language option is given together with invalid option.
- Handle bool option in TemplateOptionResult for handling no template found
- Expand Cli unit tests.

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)