### PR TITLE
[release/7.0.1xx] Provide package description for APICompat packages

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -11,6 +11,7 @@
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <Nullable>enable</Nullable>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
+    <PackageDescription>MSBuild tasks and targets to perform api compatibility checks on assemblies and packages.</PackageDescription>
   </PropertyGroup>
 
   <!-- SDK's task infrastructure -->

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
@@ -10,6 +10,7 @@
     <StrongNameKeyId>Open</StrongNameKeyId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>apicompat</ToolCommandName>
+    <PackageDescription>Tool to perform api compatibility checks on assemblies and packages.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/28102 to release/7.0.1xx

## Customer Impact
Customers who search for the APICompat packages on frontends (website, VS) will notice that these packages are missing a description, and in the worst-case wonder if these are legit packages. By providing a description, the intent of the package is made clear.

## Testing
I verified that the produced package's metadata now contains a package description.

## Risk
Low. The compile assemblies aren't impacted by this change. Only the metadata in the NuGet nuspec is impacted.