### PR TITLE
Increase cache assets file format version to 11 in 7.0.1xx

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -304,7 +304,7 @@ namespace Microsoft.NET.Build.Tasks
         ////////////////////////////////////////////////////////////////////////////////////////////////////
 
         private const int CacheFormatSignature = ('P' << 0) | ('K' << 8) | ('G' << 16) | ('A' << 24);
-        private const int CacheFormatVersion = 10;
+        private const int CacheFormatVersion = 11;
         private static readonly Encoding TextEncoding = Encoding.UTF8;
         private const int SettingsHashLength = 256 / 8;
         private HashAlgorithm CreateSettingsHash() => SHA256.Create();


### PR DESCRIPTION
## Description

The cache assets file was modified in https://github.com/dotnet/sdk/pull/27580 to store two new values `DebugSymbolsFiles` and `ReferenceDocumentationFiles` and hence the format version should be increased.

Original Issue: https://github.com/dotnet/sdk/issues/1458

## Customer Impact

The cache assets file format changed and this can cause builds to fail with weird errors difficult to debug.

## Regression?

- [x] Yes
- [ ] No

Builds can fail

## Risk

- [] High
- [X] Medium
- [] Low

Medium risk. Even though this can affect all builds, doing a restore fixes this.

## Verification

- [x] Manual (required)
- [x] Automated