### PR TITLE
Removing line that redirects jobs to helix staging environment

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -120,7 +120,6 @@ jobs:
                 -test
                 -projects $(Build.SourcesDirectory)\src\Tests\UnitTests.proj
                 /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\TestInHelix.binlog
-                /p:HelixBaseUri="https://helix.int-dot.net/"
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run Tests in Helix


### PR DESCRIPTION
PR https://github.com/dotnet/sdk/pull/28032 temporarily had a change that redirected jobs to helix staging environment but then we wanted to roll it back, but we only partially rolled it back which is now causing the staging environment's capacity to be exceeded.

cc: @MattGal @marcpopMSFT 