### PR TITLE
[release/7.0.1xx] Revert "do not emit diagnostic when attribute argument is internal type (#27648)"

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -48,32 +48,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             }
         }
 
-        private bool IsInternalArgument(TypedConstant argument) => (argument.Kind == TypedConstantKind.Type
-            && argument.Value is INamedTypeSymbol typ
-            && !typ.IsVisibleOutsideOfAssembly(_settings.IncludeInternalSymbols));
-
-        private bool HasInternalArguments(AttributeData attr)
-        {
-            foreach (TypedConstant argument in attr.ConstructorArguments)
-            {
-                if (IsInternalArgument(argument))
-                {
-                    return true;
-                }
-            }
-
-            foreach (KeyValuePair<string, TypedConstant> kv in attr.NamedArguments)
-            {
-                TypedConstant argument = kv.Value;
-                if (IsInternalArgument(argument))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         private void AddDifference(IList<CompatDifference> differences, DifferenceType dt, MetadataInformation leftMetadata, MetadataInformation rightMetadata, ISymbol containing, string itemRef, AttributeData attr)
         {
             string? docId = attr.AttributeClass?.GetDocumentationCommentId();
@@ -175,9 +149,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         for (int j = 0; j < rightGroup.Attributes.Count; j++)
                         {
                             AttributeData rightAttribute = rightGroup.Attributes[j];
-                            if (AttributeEquals(leftAttribute, rightAttribute)
-                                || HasInternalArguments(leftAttribute) // If attribute argument is an internal type, ignore.
-                                || HasInternalArguments(rightAttribute))
+                            if (AttributeEquals(leftAttribute, rightAttribute))
                             {
                                 rightGroup.Seen[j] = true;
                                 seen = true;

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -220,13 +220,31 @@ new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
 }
             },
-            // Attributes with internal type arguments
+            // Attributes on internal type arguments
             {
                 @"
 namespace CompatTests
 {
   using System;
+  using CompatTestsSecondNamespace;
 
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(Type type) {}
+  }
+
+  [Foo(typeof(Bar))]
+  public class First {}
+}
+
+namespace CompatTestsSecondNamespace {
+  internal class Bar {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(Type type) {}
@@ -235,26 +253,13 @@ namespace CompatTests
 
   internal class Bar {}
 
-  [Foo(typeof(Bar), A = typeof(int))]
+  [Foo(typeof(Bar))]
   public class First {}
 }
 ",
-                @"
-namespace CompatTests
-{
-  using System;
-
-  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
-  public class FooAttribute : Attribute {
-    public FooAttribute(Type type) {}
-    public Type A;
-  }
-
-  [Foo(typeof(int), A = typeof(int))]
-  public class First {}
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First:[T:CompatTests.FooAttribute]"),
 }
-",
-new CompatDifference[] {}
             }
         };
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/27774 to release/7.0.1xx

## Customer Impact
TL;DR: Missing functionality in a new opt-in 7.0 feature.

Customers who turn on the `AttributesMustMatch` rule expect that internal type arguments are compared between two attributes. However, without this change, those arguments are ignored when the attributes themselves are public. This would cause breaking changes for certain attribute arguments to not get flagged.

## Testing
I verified that internal type arguments are no longer ignored.

## Risk
Low. This would only affect users who turn on the `AttribtuesMustMatch` rule and have not set the `IncludeInternalSymbols` flag to `true`.