### PR TITLE
Read PackageDefinitions and PackageDependencies from the cache assets file instead of ResolvePackageDependencies

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
@@ -21,9 +21,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         [Theory]
         [MemberData(nameof(ItemCounts))]
-        public void ItRaisesLockFileToMSBuildItems(string projectName, int[] counts, bool emitLegacyAssetsFileItems)
+        public void ItRaisesLockFileToMSBuildItems(string projectName, int[] counts)
         {
-            var task = GetExecutedTaskFromPrefix(projectName, out _, emitLegacyAssetsFileItems);
+            var task = GetExecutedTaskFromPrefix(projectName, out _);
 
             task.PackageDefinitions .Count().Should().Be(counts[0]);
             task.FileDefinitions    .Count().Should().Be(counts[1]);
@@ -40,34 +40,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 {
                     new object[] {
                         "dotnet.new",
-                        new int[] { 110, 2536, 1, 846, 73 },
-                        true
-                    },
-                    new object[] {
-                        "dotnet.new",
-                        new int[] { 110, 0, 0, 846, 0 },
-                        false
+                        new int[] { 110, 2536, 1, 845, 75 },
                     },
                     new object[] {
                         "simple.dependencies",
-                        new int[] { 113, 2613, 1, 878, 94 },
-                        true
-                    },
-                    new object[] {
-                        "simple.dependencies",
-                        new int[] { 113, 0, 0, 878, 0 },
-                        false
+                        new int[] { 113, 2613, 1, 877, 96 },
                     },
                 };
             }
-        }
-
-        [Fact]
-        public void ItOmitsLegacyItemsByDefault()
-        {
-            var task = new ResolvePackageDependencies();
-
-            task.EmitLegacyAssetsFileItems.Should().Be(false);
         }
 
         [Theory]
@@ -584,8 +564,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 ProjectAssetsFile = lockFile.Path,
                 ProjectPath = null,
-                ProjectLanguage = projectLanguage, // set language
-                EmitLegacyAssetsFileItems = true
+                ProjectLanguage = projectLanguage // set language
             };
             task.Execute().Should().BeTrue();
 
@@ -669,8 +648,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 ProjectAssetsFile = lockFile.Path,
                 ProjectPath = null,
-                ProjectLanguage = projectLanguage, // set language
-                EmitLegacyAssetsFileItems = true
+                ProjectLanguage = projectLanguage // set language
             };
             task.Execute().Should().BeTrue();
 
@@ -839,19 +817,19 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             GetExecutedTaskFromContents(lockFileContent, out _); // Task should not fail on matching framework names
         }
 
-        private static ResolvePackageDependencies GetExecutedTaskFromPrefix(string lockFilePrefix, out LockFile lockFile, bool emitLegacyAssetsFileItems = true, string target = null)
+        private static ResolvePackageDependencies GetExecutedTaskFromPrefix(string lockFilePrefix, out LockFile lockFile, string target = null)
         {
             lockFile = TestLockFiles.GetLockFile(lockFilePrefix);
-            return GetExecutedTask(lockFile, emitLegacyAssetsFileItems, target);
+            return GetExecutedTask(lockFile, target);
         }
 
-        private static ResolvePackageDependencies GetExecutedTaskFromContents(string lockFileContents, out LockFile lockFile, bool emitLegacyAssetsFileItems = true, string target = null)
+        private static ResolvePackageDependencies GetExecutedTaskFromContents(string lockFileContents, out LockFile lockFile, string target = null)
         {
             lockFile = TestLockFiles.CreateLockFile(lockFileContents);
-            return GetExecutedTask(lockFile, emitLegacyAssetsFileItems, target);
+            return GetExecutedTask(lockFile, target);
         }
 
-        private static ResolvePackageDependencies GetExecutedTask(LockFile lockFile, bool emitLegacyAssetsFileItems, string target)
+        private static ResolvePackageDependencies GetExecutedTask(LockFile lockFile, string target)
         {
             var resolver = new MockPackageResolver(_packageRoot);
 
@@ -860,7 +838,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 ProjectAssetsFile = lockFile.Path,
                 ProjectPath = _projectPath,
                 ProjectLanguage = null,
-                EmitLegacyAssetsFileItems = emitLegacyAssetsFileItems,
                 TargetFramework = target
             };
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -327,7 +327,7 @@ namespace Microsoft.NET.Build.Tasks
         ////////////////////////////////////////////////////////////////////////////////////////////////////
 
         private const int CacheFormatSignature = ('P' << 0) | ('K' << 8) | ('G' << 16) | ('A' << 24);
-        private const int CacheFormatVersion = 10;
+        private const int CacheFormatVersion = 12;
         private static readonly Encoding TextEncoding = Encoding.UTF8;
         private const int SettingsHashLength = 256 / 8;
         private HashAlgorithm CreateSettingsHash() => SHA256.Create();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -759,20 +759,20 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     _projectFileDependencies = _lockFile.GetProjectFileDependencySet(frameworkAlias);
                 }
-            }
 
-            private Dictionary<string, string> CreateTargetNameToAlisMap() => _lockFile.Targets.ToDictionary(t => t.Name, t =>
-            {
-                var alias = _lockFile.GetLockFileTargetAlias(t);
-                if (string.IsNullOrEmpty(t.RuntimeIdentifier))
+                Dictionary<string, string> CreateTargetNameToAlisMap() => _lockFile.Targets.ToDictionary(t => t.Name, t =>
                 {
-                    return alias;
-                }
-                else
-                {
-                    return alias + "/" + t.RuntimeIdentifier;
-                }
-            });
+                    var alias = _lockFile.GetLockFileTargetAlias(t);
+                    if (string.IsNullOrEmpty(t.RuntimeIdentifier))
+                    {
+                        return alias;
+                    }
+                    else
+                    {
+                        return alias + "/" + t.RuntimeIdentifier;
+                    }
+                });
+            }
 
             public void WriteToCacheFile()
             {
@@ -1495,7 +1495,7 @@ namespace Microsoft.NET.Build.Tasks
                                         return alias ?? tg;
                                     }).Contains(target));
 
-                    if (!messages.Any())
+                    if (messages.Count() == 0)
                     {
                         return string.Empty;
                     }
@@ -1537,10 +1537,9 @@ namespace Microsoft.NET.Build.Tasks
 
                     foreach (var package in target.Libraries)
                     {
-                        string packageId = $"{package.Name}/{package.Version.ToNormalizedString()}";
-
                         if (_projectFileDependencies.Contains(package.Name))
                         {
+                            string packageId = GetPackageId(package);
                             WriteItem(packageId);
                             WriteMetadata(MetadataKeys.ParentTarget, frameworkAlias); // Foreign Key
                             WriteMetadata(MetadataKeys.ParentPackage, string.Empty); // Foreign Key
@@ -1557,7 +1556,7 @@ namespace Microsoft.NET.Build.Tasks
                     Dictionary<string, string> resolvedPackageVersions,
                     HashSet<string> transitiveProjectRefs)
                 {
-                    string packageId = $"{package.Name}/{package.Version.ToNormalizedString()}";
+                    string packageId = GetPackageId(package);
                     string frameworkAlias = _targetNameToAliasMap[targetName];
                     foreach (var deps in package.Dependencies)
                     {
@@ -1578,6 +1577,8 @@ namespace Microsoft.NET.Build.Tasks
                         }
                     }
                 }
+
+                static string GetPackageId(LockFileTargetLibrary package) => $"{package.Name}/{package.Version.ToNormalizedString()}";
             }
 
             private void WriteResourceAssemblies()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -18,9 +18,6 @@ namespace Microsoft.NET.Build.Tasks
     /// </summary>
     public sealed class ResolvePackageDependencies : TaskBase
     {
-        /// <summary>
-        /// Only used if <see cref="EmitLegacyAssetsFileItems"/> is <see langword="true"/>.
-        /// </summary>
         private readonly Dictionary<string, string> _fileTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         private HashSet<string> _projectFileDependencies;
@@ -37,7 +34,6 @@ namespace Microsoft.NET.Build.Tasks
 
         /// <summary>
         /// All the targets in the lock file.
-        /// Only populated if <see cref="EmitLegacyAssetsFileItems"/> is <see langword="true"/>.
         /// </summary>
         [Output]
         public ITaskItem[] TargetDefinitions
@@ -56,7 +52,6 @@ namespace Microsoft.NET.Build.Tasks
 
         /// <summary>
         /// All the files in the lock file.
-        /// Only populated if <see cref="EmitLegacyAssetsFileItems"/> is <see langword="true"/>.
         /// </summary>
         [Output]
         public ITaskItem[] FileDefinitions
@@ -77,7 +72,6 @@ namespace Microsoft.NET.Build.Tasks
         /// <summary>
         /// All the dependencies between files and packages, labeled by the group containing
         /// the file (e.g. CompileTimeAssembly, RuntimeAssembly, etc.).
-        /// Only populated if <see cref="EmitLegacyAssetsFileItems"/> is <see langword="true"/>.
         /// </summary>
         [Output]
         public ITaskItem[] FileDependencies
@@ -113,12 +107,6 @@ namespace Microsoft.NET.Build.Tasks
         {
             get; set;
         }
-
-        /// <summary>
-        /// Setting this property restores pre-16.7 behaviour of populating <see cref="TargetDefinitions"/>,
-        /// <see cref="FileDefinitions"/> and <see cref="FileDependencies"/> outputs.
-        /// </summary>
-        public bool EmitLegacyAssetsFileItems { get; set; } = false;
 
         public string TargetFramework { get; set; }
 
@@ -194,11 +182,6 @@ namespace Microsoft.NET.Build.Tasks
                 item.SetMetadata(MetadataKeys.DiagnosticLevel, GetPackageDiagnosticLevel(package));
 
                 _packageDefinitions.Add(item);
-
-                if (!EmitLegacyAssetsFileItems)
-                {
-                    continue;
-                }
 
                 foreach (var file in package.Files)
                 {
@@ -276,18 +259,15 @@ namespace Microsoft.NET.Build.Tasks
         {
             foreach (var target in LockFile.Targets)
             {
-                if (EmitLegacyAssetsFileItems)
-                {
-                    TaskItem item = new TaskItem(target.Name);
-                    item.SetMetadata(MetadataKeys.RuntimeIdentifier, target.RuntimeIdentifier ?? string.Empty);
-                    item.SetMetadata(MetadataKeys.TargetFramework, TargetFramework);
-                    item.SetMetadata(MetadataKeys.TargetFrameworkMoniker, target.TargetFramework.DotNetFrameworkName);
-                    item.SetMetadata(MetadataKeys.FrameworkName, target.TargetFramework.Framework);
-                    item.SetMetadata(MetadataKeys.FrameworkVersion, target.TargetFramework.Version.ToString());
-                    item.SetMetadata(MetadataKeys.Type, "target");
+                TaskItem item = new TaskItem(target.Name);
+                item.SetMetadata(MetadataKeys.RuntimeIdentifier, target.RuntimeIdentifier ?? string.Empty);
+                item.SetMetadata(MetadataKeys.TargetFramework, TargetFramework);
+                item.SetMetadata(MetadataKeys.TargetFrameworkMoniker, target.TargetFramework.DotNetFrameworkName);
+                item.SetMetadata(MetadataKeys.FrameworkName, target.TargetFramework.Framework);
+                item.SetMetadata(MetadataKeys.FrameworkVersion, target.TargetFramework.Version.ToString());
+                item.SetMetadata(MetadataKeys.Type, "target");
 
-                    _targetDefinitions.Add(item);
-                }
+                _targetDefinitions.Add(item);
 
                 // raise each library in the target
                 GetPackageAndFileDependencies(target);
@@ -323,11 +303,8 @@ namespace Microsoft.NET.Build.Tasks
                 // get sub package dependencies
                 GetPackageDependencies(package, target.Name, resolvedPackageVersions, transitiveProjectRefs);
 
-                if (EmitLegacyAssetsFileItems)
-                {
-                    // get file dependencies on this package
-                    GetFileDependencies(package, target.Name);
-                }
+                // get file dependencies on this package
+                GetFileDependencies(package, target.Name);
             }
         }
 
@@ -375,7 +352,7 @@ namespace Microsoft.NET.Build.Tasks
                     string filePath = entry.Item1;
                     IDictionary<string, string> properties = entry.Item2;
 
-                    if (NuGetUtils.IsPlaceholderFile(filePath) || !EmitLegacyAssetsFileItems)
+                    if (NuGetUtils.IsPlaceholderFile(filePath))
                     {
                         continue;
                     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -309,6 +309,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="TransitiveProjectReferences" ItemName="_TransitiveProjectReferences" />
       <Output TaskParameter="PackageFolders" ItemName="AssetsFilePackageFolder" />
       <Output TaskParameter="PackageDependencies" ItemName="PackageDependencies" />
+      <Output TaskParameter="PackageDefinitions" ItemName="PackageDefinitions" />
     </ResolvePackageAssets>
 
     <ItemGroup Condition="'$(CopyDebugSymbolFilesFromPackages)' == 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -310,6 +310,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="PackageFolders" ItemName="AssetsFilePackageFolder" />
       <Output TaskParameter="PackageDependencies" ItemName="PackageDependencies" />
       <Output TaskParameter="PackageDefinitions" ItemName="PackageDefinitions" />
+      <Output TaskParameter="PackageDependenciesBetweenPackages" ItemName="PackageDependencies" />
     </ResolvePackageAssets>
 
     <ItemGroup Condition="'$(CopyDebugSymbolFilesFromPackages)' == 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -196,14 +196,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       ProjectPath="$(MSBuildProjectFullPath)"
       ProjectAssetsFile="$(ProjectAssetsFile)"
       ProjectLanguage="$(Language)"
-      EmitLegacyAssetsFileItems="$(EmitLegacyAssetsFileItems)"
       TargetFramework="$(TargetFramework)"
-      ContinueOnError="ErrorAndContinue">
+      ContinueOnError="ErrorAndContinue"
+      Condition="'$(EmitLegacyAssetsFileItems)' == 'true'">
 
       <Output TaskParameter="PackageDefinitions" ItemName="PackageDefinitions" />
       <Output TaskParameter="PackageDependencies" ItemName="PackageDependencies" />
-
-      <!-- These outputs only produced when EmitLegacyAssetsFileItems is true -->
       <Output TaskParameter="TargetDefinitions" ItemName="TargetDefinitions" />
       <Output TaskParameter="FileDefinitions" ItemName="FileDefinitions" />
       <Output TaskParameter="FileDependencies" ItemName="FileDependencies" />


### PR DESCRIPTION
Fixes #27738

We want to avoid reading the assets file because it is a large file, which can cause performance degradation in design-time builds for large projects when executing `ResolvePackageDependencies`.

To improve this, the assets cache file in `ResolvePackageAssets` will now keep track of  `PackageDefinitions` and `PackageDependencies`.

**The change:**
Output `PackageDefinitions` and `PackageDependencies` items from `ResolvePackageAssets`, and modified the targets so that `ResolvePackageDependencies` is only called when `EmitLegacyAssetsFileItems` is true.

All the code related to `EmitLegacyAssetsFileItems` in `ResolvePackageDependencies` was removed since there is case for when the value is false.
Unit-tests were modified to remove `EmitLegacyAssetsFileItems` in ResolvePackageDependencies.