### PR TITLE
Fix --use-current-runtime on Alpine

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -72,7 +72,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                    '$(PublishAot)' == 'true'
                    )
                  )">
-    <RuntimeIdentifier>$(NETCoreSdkPortableRuntimeIdentifier)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('linux-musl'))">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkPortableRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PlatformTarget)' == ''">


### PR DESCRIPTION
See https://github.com/dotnet/sdk/pull/22373#discussion_r985007320.