### PR TITLE
[dotnet-new] Add inRoot option for AddProjectsToSolutionPostAction

### DIFF
--- a/TemplateEngine.slnf
+++ b/TemplateEngine.slnf
@@ -19,6 +19,7 @@
       "src\\Tests\\Microsoft.TemplateEngine.Cli.UnitTests\\Microsoft.TemplateEngine.Cli.UnitTests.csproj",
       "src\\Tests\\Microsoft.TemplateEngine.EndToEndTestHarness\\Microsoft.TemplateEngine.EndToEndTestHarness.csproj",
       "src\\Tests\\dotnet-new.Tests\\dotnet-new.IntegrationTests.csproj",
+      "src\\Tests\\dotnet.Tests\\dotnet.Tests.csproj",
       "template_feed\\Microsoft.DotNet.Common.ItemTemplates\\Microsoft.DotNet.Common.ItemTemplates.csproj",
       "template_feed\\Microsoft.DotNet.Common.ProjectTemplates.7.0\\Microsoft.DotNet.Common.ProjectTemplates.7.0.csproj"
     ]

--- a/src/Assets/TestPackages/dotnet-new/Microsoft.TemplateEngine.TestTemplates.csproj
+++ b/src/Assets/TestPackages/dotnet-new/Microsoft.TemplateEngine.TestTemplates.csproj
@@ -22,6 +22,9 @@
     <None Include="nupkg_templates\**" CopyToOutputDirectory="Always" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="test_templates\PostActions\AddProjectToSolution\BasicInSolutionRoot\.template.config\template.json" />
+    <None Remove="test_templates\PostActions\AddProjectToSolution\BasicInSolutionRoot\Basic.csproj" />
+    <None Remove="test_templates\PostActions\AddProjectToSolution\BasicInSolutionRoot\Program.cs" />
     <None Remove="test_templates\TemplateWithConditionalParameters\.template.config\template.json" />
     <None Remove="test_templates\TemplateWithConditionalParameters\Test.cs" />
   </ItemGroup>

--- a/src/Assets/TestPackages/dotnet-new/Microsoft.TemplateEngine.TestTemplates.csproj
+++ b/src/Assets/TestPackages/dotnet-new/Microsoft.TemplateEngine.TestTemplates.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageType>Template</PackageType>
@@ -20,12 +20,5 @@
 
     <Content Include="nupkg_templates\**" />
     <None Include="nupkg_templates\**" CopyToOutputDirectory="Always" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="test_templates\PostActions\AddProjectToSolution\BasicInSolutionRoot\.template.config\template.json" />
-    <None Remove="test_templates\PostActions\AddProjectToSolution\BasicInSolutionRoot\Basic.csproj" />
-    <None Remove="test_templates\PostActions\AddProjectToSolution\BasicInSolutionRoot\Program.cs" />
-    <None Remove="test_templates\TemplateWithConditionalParameters\.template.config\template.json" />
-    <None Remove="test_templates\TemplateWithConditionalParameters\Test.cs" />
   </ItemGroup>
 </Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/AddProjectToSolution/BasicInSolutionRoot/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/AddProjectToSolution/BasicInSolutionRoot/.template.config/template.json
@@ -1,0 +1,27 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.PostActions.AddProjectToSolution.BasicInSolutionRoot",
+    "generatorVersions": "[1.0.0.0-*)",
+    "groupIdentity": "TestAssets.PostActions.AddProjectToSolution.BasicInSolutionRoot",
+    "precedence": "100",
+    "identity": "TestAssets.PostActions.AddProjectToSolution.BasicInSolutionRoot",
+    "shortName": "TestAssets.PostActions.AddProjectToSolution.BasicInSolutionRoot",
+    "sourceName": "Basic",
+    "primaryOutputs": [
+        {
+            "path": "Basic.csproj"
+        }
+    ],
+    "postActions": [
+        {
+            "description": "Add projects to solution",
+            "manualInstructions": [ { "text": "Add generated project to solution manually." } ],
+            "args": {
+                "inRoot": true
+            },
+            "actionId": "D396686C-DE0E-4DE6-906D-291CD29FC5DE",
+            "continueOnError": true
+        }
+    ]
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/AddProjectToSolution/BasicInSolutionRoot/Basic.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/AddProjectToSolution/BasicInSolutionRoot/Basic.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/AddProjectToSolution/BasicInSolutionRoot/Program.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/AddProjectToSolution/BasicInSolutionRoot/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Basic
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+            string result = JsonConvert.SerializeObject(new { a = "test" });
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-new/DotnetCommandCallbacks.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/DotnetCommandCallbacks.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Tools.New
             return RestoreCommand.Run(new string[] { pathToRestore }) == 0;
         }
 
-        internal static bool AddProjectsToSolution(string solutionPath, IReadOnlyList<string> projectsToAdd, string? solutionFolder)
+        internal static bool AddProjectsToSolution(string solutionPath, IReadOnlyList<string> projectsToAdd, string? solutionFolder, bool? inRoot)
         {
             PathUtility.EnsureAllPathsExist(new[] { solutionPath }, CommonLocalizableStrings.FileNotFound, allowDirectories: false);
             PathUtility.EnsureAllPathsExist(projectsToAdd, CommonLocalizableStrings.FileNotFound, allowDirectories: false);
@@ -54,6 +54,11 @@ namespace Microsoft.DotNet.Tools.New
             if (!string.IsNullOrWhiteSpace(solutionFolder))
             {
                 commandArgs = commandArgs.Append(SlnAddParser.SolutionFolderOption.Aliases.First()).Append(solutionFolder);
+            }
+
+            if (inRoot is true)
+            {
+                commandArgs = commandArgs.Append(SlnAddParser.InRootOption.Aliases.First());
             }
             var addProjectToSolutionCommand = new AddProjectToSolutionCommand(SlnCommandParser.GetCommand().Parse(commandArgs.ToArray()));
             return addProjectToSolutionCommand.Execute() == 0;

--- a/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
@@ -164,6 +164,11 @@
     to solution file: {1}
     solution folder: {2}</value>
   </data>
+  <data name="PostAction_AddProjToSln_InRoot_Running" xml:space="preserve">
+    <value>Adding
+    project(s): {0}
+    in the root of solution file: {1}</value>
+  </data>
   <data name="PostAction_AddProjToSln_Succeeded" xml:space="preserve">
     <value>Successfully added project(s) to a solution file.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
@@ -154,6 +154,7 @@
   <data name="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified" xml:space="preserve">
     <value>Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</value>
+    <comment>do not translate: 'solutionFolder', 'inRoot'</comment>
   </data>
   <data name="PostAction_AddProjToSln_Failed" xml:space="preserve">
     <value>Failed to add project(s) to the solution: {0}</value>
@@ -167,11 +168,16 @@
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</value>
+    <comment>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</comment>
   </data>
   <data name="PostAction_AddProjToSln_InRoot_Running" xml:space="preserve">
     <value>Adding
     project(s): {0}
     in the root of solution file: {1}</value>
+    <comment>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</comment>
   </data>
   <data name="PostAction_AddProjToSln_Succeeded" xml:space="preserve">
     <value>Successfully added project(s) to a solution file.</value>

--- a/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-new/LocalizableStrings.resx
@@ -151,6 +151,10 @@
   <data name="PostAction_AddProjToSln_Error_NoSolutionFile" xml:space="preserve">
     <value>Unable to determine which solution file to add the reference to.</value>
   </data>
+  <data name="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified" xml:space="preserve">
+    <value>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</value>
+  </data>
   <data name="PostAction_AddProjToSln_Failed" xml:space="preserve">
     <value>Failed to add project(s) to the solution: {0}</value>
     <comment>{0} - the reason why operation failed, normally ends with period</comment>

--- a/src/Cli/dotnet/commands/dotnet-new/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/PostActions/DotnetSlnPostActionProcessor.cs
@@ -105,7 +105,14 @@ namespace Microsoft.DotNet.Tools.New.PostActionProcessors
             string solutionFolder = GetSolutionFolder(action);
             bool? inRoot = GetInRoot(action);
 
-            Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostAction_AddProjToSln_Running, string.Join(" ", projectFiles), nearestSlnFilesFound[0], solutionFolder));
+            if (inRoot is true)
+            {
+                Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostAction_AddProjToSln_InRoot_Running, string.Join(" ", projectFiles), nearestSlnFilesFound[0]));
+            }
+            else
+            {
+                Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostAction_AddProjToSln_Running, string.Join(" ", projectFiles), nearestSlnFilesFound[0], solutionFolder));
+            }
             return AddProjectsToSolution(nearestSlnFilesFound[0], projectFiles, solutionFolder, inRoot);
         }
 

--- a/src/Cli/dotnet/commands/dotnet-new/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/PostActions/DotnetSlnPostActionProcessor.cs
@@ -105,6 +105,12 @@ namespace Microsoft.DotNet.Tools.New.PostActionProcessors
             string solutionFolder = GetSolutionFolder(action);
             bool? inRoot = GetInRoot(action);
 
+            if (!string.IsNullOrWhiteSpace(solutionFolder) && inRoot is true)
+            {
+                Reporter.Error.WriteLine(LocalizableStrings.PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified);
+                return false;
+            }
+
             if (inRoot is true)
             {
                 Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostAction_AddProjToSln_InRoot_Running, string.Join(" ", projectFiles), nearestSlnFilesFound[0]));

--- a/src/Cli/dotnet/commands/dotnet-new/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/PostActions/DotnetSlnPostActionProcessor.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Tools.New.PostActionProcessors
                 return false;
             }
 
-            string solutionFolder = GetSolutionFolder(action);
+            string? solutionFolder = GetSolutionFolder(action);
             bool? inRoot = GetInRoot(action);
 
             if (!string.IsNullOrWhiteSpace(solutionFolder) && inRoot is true)
@@ -145,13 +145,13 @@ namespace Microsoft.DotNet.Tools.New.PostActionProcessors
             }
         }
 
-        private static string GetSolutionFolder(IPostAction actionConfig)
+        private static string? GetSolutionFolder(IPostAction actionConfig)
         {
             if (actionConfig.Args != null && actionConfig.Args.TryGetValue("solutionFolder", out string? solutionFolder))
             {
                 return solutionFolder;
             }
-            return string.Empty;
+            return null;
         }
 
         private static bool? GetInRoot(IPostAction actionConfig)

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
@@ -62,6 +62,15 @@
         <target state="translated">Přidání projektu/ů do souboru řešení se nezdařilo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
@@ -42,6 +42,13 @@
         <target state="translated">Našlo se více projektů: {0}.</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">Akce Přidat odkaz na projekt do řešení není v šabloně správně nakonfigurovaná. Nedají se určit soubory projektu, které se mají přidat.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.cs.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">Přidávání
+        <target state="needs-review-translation">Přidávání
     projektu/ů: {0}
     do souboru řešení: {1}
     složka řešení: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
@@ -62,6 +62,15 @@
         <target state="translated">Projekt(e) konnten nicht zu einer Lösungsdatei hinzugefügt werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">Projekte
+        <target state="needs-review-translation">Projekte
     hinzufügen: {0}
     zur Lösungsdatei: {1}
     Lösungsordner: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.de.xlf
@@ -42,6 +42,13 @@
         <target state="translated">Mehrere Projekte gefunden: {0}.</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">Die Aktion „Projektverweis zur Projektmappe hinzufügen“ ist in der Vorlage nicht ordnungsgemäß konfiguriert. Die hinzuzufügenden Projektdateien können nicht ermittelt werden.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
@@ -62,6 +62,15 @@
         <target state="translated">No se pudieron agregar proyectos a un archivo de solución.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">Agregando
+        <target state="needs-review-translation">Agregando
     proyectos: {0}
      al archivo de solución: {1}
      carpeta de la solución: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.es.xlf
@@ -42,6 +42,13 @@
         <target state="translated">Se encontraron varios proyectos: {0}.</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">La acción de agregar una referencia de proyecto a la solución no está configurada correctamente en la plantilla. No se pueden determinar los archivos de proyecto que se van a agregar.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
@@ -62,6 +62,15 @@
         <target state="translated">Échec de l’ajout du ou des projets à un fichier solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">Ajout
+        <target state="needs-review-translation">Ajout
     du ou des projets :{0}
     au fichier de solution{1}
     Dossier de solution :{2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.fr.xlf
@@ -42,6 +42,13 @@
         <target state="translated">Plusieurs projets trouvés : {0}</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">L’ajout d’une référence de projet à l’action de solution n’est pas configuré correctement dans le modèle. Impossible de déterminer les fichiers de projet à ajouter.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
@@ -62,6 +62,15 @@
         <target state="translated">Non è stato possibile aggiungere il/i progetto/i a un file di soluzione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">Aggiunta di
+        <target state="needs-review-translation">Aggiunta di
     progetti: {0}
     al file della soluzione: {1}
     cartella della soluzione: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.it.xlf
@@ -42,6 +42,13 @@
         <target state="translated">Sono stati trovati più progetti: {0}.</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">L'aggiunta del riferimento al progetto all'azione della soluzione non è configurata correttamente nel modello. Non è possibile determinare i file di progetto da aggiungere.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
@@ -62,6 +62,15 @@
         <target state="translated">プロジェクトをソリューション ファイルに追加できませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">
+        <target state="needs-review-translation">
  プロジェクトの追加 対象: {0}
  対応するソリューション ファイル: {1}
  ソリューション フォルダー: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ja.xlf
@@ -42,6 +42,13 @@
         <target state="translated">複数のプロジェクトが見つかりました: {0}。</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">ソリューションへのプロジェクト参照追加のアクションがテンプレートで正しく構成されていません。追加するプロジェクトファイルを特定できません。</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
@@ -62,6 +62,15 @@
         <target state="translated">솔루션 파일에 프로젝트를 추가하지 못했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">
+        <target state="needs-review-translation">
     프로젝트 추가 {0}
     대상 솔루션 파일: {1}
     솔루션 폴더: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ko.xlf
@@ -42,6 +42,13 @@
         <target state="translated">여러 프로젝트를 찾았습니다: {0}.</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">솔루션 작업에 프로젝트 참조 추가가 템플릿에서 올바르게 구성되지 않았습니다. 추가할 프로젝트 파일을 확인할 수 없습니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
@@ -62,6 +62,15 @@
         <target state="translated">Nie można dodać projektów do pliku rozwiązania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
@@ -42,6 +42,13 @@
         <target state="translated">Znaleziono wiele projektów: {0}.</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">Dodawanie odwołania projektu do akcji rozwiązania nie jest poprawnie skonfigurowane w szablonie. Nie można określić plików projektu do dodania.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pl.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">Dodawanie
+        <target state="needs-review-translation">Dodawanie
     projektu (-ów): {0}
     do pliku rozwiązania: {1}
     folder rozwiązania: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
@@ -62,6 +62,15 @@
         <target state="translated">Falha ao adicionar projeto(s) a um arquivo de solução.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
@@ -42,6 +42,13 @@
         <target state="translated">Vários projetos encontrados: {0}.</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">A adição de referência de projeto à ação de solução não está configurada corretamente no modelo. Não é possível determinar os arquivos de projeto a serem adicionados.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.pt-BR.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">Adicionando
+        <target state="needs-review-translation">Adicionando
     projeto(s): {0}
     ao arquivo de solução: {1}
     pasta de solução: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
@@ -62,6 +62,15 @@
         <target state="translated">Не удалось добавить проект (ы) в файл решения.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
@@ -42,6 +42,13 @@
         <target state="translated">Найдено несколько проектов: {0}</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">Добавить ссылку на проект в решение. Действие в шаблоне настроено неправильно. Не удалось определить файлы проекта для добавления.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.ru.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">Добавление
+        <target state="needs-review-translation">Добавление
     проекта: {0}
     в файл решения: {1}
     папка решения: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
@@ -62,6 +62,15 @@
         <target state="translated">Bir çözüm dosyasına proje(ler) eklenemedi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">
+        <target state="needs-review-translation">
     projesi/projeleri: {0}
     şu çözüm dosyasına: {1}
     şu çözüm klasörüne: {2} ekleniyor</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.tr.xlf
@@ -42,6 +42,13 @@
         <target state="translated">Birden çok proje bulundu: {0}.</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">Çözüme proje başvurusu ekleme eylemi şablonda doğru şekilde yapılandırılmadı. Eklenecek proje dosyaları belirlenemiyor.</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
@@ -62,6 +62,15 @@
         <target state="translated">无法将项目添加到解决方案文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">添加
+        <target state="needs-review-translation">添加
     项目: {0}
     到解决方案文件: {1}
     解决方案文件夹: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hans.xlf
@@ -42,6 +42,13 @@
         <target state="translated">找到多个项目: {0}。</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">模板中未正确配置将项目引用添加到解决方案操作。无法确定要添加的项目文件。</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
@@ -62,6 +62,15 @@
         <target state="translated">無法將專案新增至方案檔。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_InRoot_Running">
+        <source>Adding
+    project(s): {0}
+    in the root of solution file: {1}</source>
+        <target state="new">Adding
+    project(s): {0}
+    in the root of solution file: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
@@ -42,6 +42,13 @@
         <target state="translated">找到多個專案: {0}。</target>
         <note>{0} - semi-colon separated list of path to projects found.</note>
       </trans-unit>
+      <trans-unit id="PostAction_AddProjToSln_Error_BothInRootAndSolutionFolderSpecified">
+        <source>Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
+        <target state="new">Add project reference to solution action is not configured correctly in the template.
+    The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
         <target state="translated">範本中未正確設定將專案參考新增至方案動作。無法判斷要新增的專案檔案。</target>

--- a/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-new/xlf/LocalizableStrings.zh-Hant.xlf
@@ -47,7 +47,7 @@
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</source>
         <target state="new">Add project reference to solution action is not configured correctly in the template.
     The 'solutionFolder' and 'inRoot' cannot be used together; use only one of the options.</target>
-        <note />
+        <note>do not translate: 'solutionFolder', 'inRoot'</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Error_NoProjectsToAdd">
         <source>Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add.</source>
@@ -76,18 +76,21 @@
         <target state="new">Adding
     project(s): {0}
     in the root of solution file: {1}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Running">
         <source>Adding
     project(s): {0}
     to solution file: {1}
     solution folder: {2}</source>
-        <target state="translated">正在新增
+        <target state="needs-review-translation">正在新增
     專案: {0}
     至解決方案檔案: {1}
     解決方案資料夾: {2}</target>
-        <note />
+        <note>{0} - list of file paths to projects to add,
+{1} - the path to target solution file,
+{2} - the solution folder inside solution to add the projects to.</note>
       </trans-unit>
       <trans-unit id="PostAction_AddProjToSln_Succeeded">
         <source>Successfully added project(s) to a solution file.</source>

--- a/src/Tests/dotnet.Tests/dotnet-new/DotnetSlnPostActionTests.cs
+++ b/src/Tests/dotnet.Tests/dotnet-new/DotnetSlnPostActionTests.cs
@@ -222,16 +222,50 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.Equal(slnFileFullPath, callback.Solution);
         }
 
+        [Fact(DisplayName = nameof(AddProjectToSolutionCanPlaceProjectInSolutionRoot))]
+        public void AddProjectToSolutionCanPlaceProjectInSolutionRoot()
+        {
+            var callback = new MockAddProjectToSolutionCallback();
+            var actionProcessor = new DotnetSlnPostActionProcessor(callback.AddProjectToSolution);
+
+            string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
+            string slnFileFullPath = Path.Combine(targetBasePath, "MyApp.sln");
+            string projFileFullPath = Path.Combine(targetBasePath, "MyApp.csproj");
+
+            _engineEnvironmentSettings.Host.FileSystem.WriteAllText(slnFileFullPath, "");
+
+            var args = new Dictionary<string, string>() {
+                { "projectFiles", "MyApp.csproj" },
+                { "inRoot", "true" }
+            };
+            var postAction = new MockPostAction { ActionId = DotnetSlnPostActionProcessor.ActionProcessorId, Args = args };
+
+            MockCreationEffects creationEffects = new MockCreationEffects()
+                .WithFileChange(new MockFileChange("./MyApp.csproj", "./MyApp.csproj", ChangeKind.Create));
+
+            actionProcessor.Process(
+                _engineEnvironmentSettings,
+                postAction,
+                creationEffects,
+                new MockCreationResult(),
+                targetBasePath);
+
+            Assert.True(callback.InRoot);
+        }
+
         private class MockAddProjectToSolutionCallback
         {
             public string? Solution { get; private set; }
 
             public IReadOnlyList<string?>? Projects { get; private set; }
 
+            public bool? InRoot { get; private set; }
+
             public bool AddProjectToSolution(string solution, IReadOnlyList<string?> projects, string? targetFolder, bool? inRoot)
             {
                 Solution = solution;
                 Projects = projects;
+                InRoot = inRoot;
 
                 return true;
             }

--- a/src/Tests/dotnet.Tests/dotnet-new/DotnetSlnPostActionTests.cs
+++ b/src/Tests/dotnet.Tests/dotnet-new/DotnetSlnPostActionTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
 
             public IReadOnlyList<string?>? Projects { get; private set; }
 
-            public bool AddProjectToSolution(string solution, IReadOnlyList<string?> projects, string? targetFolder)
+            public bool AddProjectToSolution(string solution, IReadOnlyList<string?> projects, string? targetFolder, bool? inRoot)
             {
                 Solution = solution;
                 Projects = projects;


### PR DESCRIPTION
**New PR**
For [dotnet-new issue #4178](https://github.com/dotnet/templating/issues/4178).
Adds `inRoot` argument which is passed to `dotnet sln add` as `--in-root`. 

cc @vlada-shubina 