### PR TITLE
[release/7.0.1xx] Fix msbuild evaluation of ApiCompat task pkg

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.Task.targets
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.Task.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DotNetApiCompatTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.ApiCompat.Task.dll</DotNetApiCompatTaskAssembly>
     <DotNetApiCompatTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and Exists('$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.ApiCompat.Task.dll')">$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.ApiCompat.Task.dll</DotNetApiCompatTaskAssembly>
-    <DotNetApiCompatTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and $(DotNetApiCompatTaskAssembly)' == ''">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.ApiCompat.Task.dll</DotNetApiCompatTaskAssembly>
+    <DotNetApiCompatTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(DotNetApiCompatTaskAssembly)' == ''">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.ApiCompat.Task.dll</DotNetApiCompatTaskAssembly>
     <UseApiCompatPackage>true</UseApiCompatPackage>
     <!-- TODO: Remove when the consumers of this package upgraded to a newer SDK with this change. -->
     <UseCompatibilityPackage>true</UseCompatibilityPackage>


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/commit/0a1f5cdffe8f9e4badc6a4c9da22644b74bc9b18.

## Customer Impact
Customers who reference the `Microsoft.DotNet.ApiCopmat.Task` package to make use of the very latest APICompat features (which aren't yet available in the SDK) will notice an msbuild evaluation error that will effectively break their build. Fixing the broken msbuild condition which recently regressed as part of https://github.com/dotnet/sdk/commit/e99f2b75d33bb0cc1bb9f019f447896e2077d58c. 

## Testing
I verified that adding a reference to the `Microsoft.DotNet.ApiCompat.Task` nuget package doesn't result in an msbuild evaluation error anymore and that the component works as intended. Filed https://github.com/dotnet/sdk/issues/28300 for adding CI protection.

## Risk
Very low. The msbuild evaluation is unblocked and the condition still works as expected.