### PR TITLE
Fix checking for updated workload packs in advertising manifests

### DIFF
--- a/src/Assets/TestProjects/SampleManifest/MockListSampleUpdated.json
+++ b/src/Assets/TestProjects/SampleManifest/MockListSampleUpdated.json
@@ -5,7 +5,7 @@
             "description": "mock-workload-1",
             "kind": "dev",
             "packs": [
-                "Test.Pack.A",
+                "Test.Pack.A.Renamed",
                 "Test.Pack.B",
                 "Test.Pack.C"
             ]
@@ -20,17 +20,17 @@
         "mock-workload-3": {
             "description": "mock-workload-3",
             "packs": [
-                "Test.Pack.A"
+                "Test.Pack.A.Renamed"
             ]
         }
     },
     "packs": {
-        "Test.Pack.A": {
+        "Test.Pack.A.Renamed": {
             "version": "2.0.0",
             "kind": "sdk"
         },
         "Test.Pack.B": {
-            "version": "2.0.0",
+            "version": "3.0.0",
             "kind": "framework"
         },
         "Test.Pack.C": {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -563,8 +563,9 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
                 var existingWorkload = _workloads[workloadId];
                 var existingPacks = GetPacksInWorkload(existingWorkload.workload, existingWorkload.manifest).Select(p => p.packId).ToHashSet();
-                var updatedWorkload = advertisingManifestResolver._workloads[workloadId].workload;
-                var updatedPacks = advertisingManifestResolver.GetPacksInWorkload(existingWorkload.workload, existingWorkload.manifest).Select(p => p.packId);
+
+                var updatedWorkload = advertisingManifestResolver._workloads[workloadId];
+                var updatedPacks = advertisingManifestResolver.GetPacksInWorkload(updatedWorkload.workload, updatedWorkload.manifest).Select(p => p.packId);
 
                 if (!existingPacks.SetEquals(updatedPacks) || existingPacks.Any(p => PackHasChanged(_packs[p].pack, advertisingManifestResolver._packs[p].pack)))
                 {


### PR DESCRIPTION
## Description

Fixes issue where after updating from Preview 7, workload install commands would fail with a KeyNotFoundException.

Fixes #28217

## Regression

Yes - this is a behavior regression from previous previews.  The code didn't regress recently, rather we renamed workload packs in RC1 which exposed a preexisting bug in the code.

## Risk

**Low**

## Testing

- [x] manual testing
- [x] updated automated tests cases to cover scenario where workload pack was renamed
