### PR TITLE
[dotnet tool] Add ability to check if a tool is installed

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-tool/list/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/LocalizableStrings.resx
@@ -154,4 +154,10 @@
   <data name="ListToolCommandInvalidGlobalAndLocalAndToolPath" xml:space="preserve">
     <value>The local option(--local), the global option (--global), the tool path option (--tool-path), can only have one at a time. Specify only one of the options: {0}.</value>
   </data>
+  <data name="PackageIdArgumentDescription" xml:space="preserve">
+    <value>The NuGet Package Id of the tool to list</value>
+  </data>
+  <data name="PackageIdArgumentName" xml:space="preserve">
+    <value>PACKAGE_ID</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/ToolListCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/ToolListCommandParser.cs
@@ -13,6 +13,12 @@ namespace Microsoft.DotNet.Cli
 {
     internal static class ToolListCommandParser
     {
+        public static readonly Argument<string> PackageIdArgument = new Argument<string>(LocalizableStrings.PackageIdArgumentName)
+        {
+            Description = LocalizableStrings.PackageIdArgumentDescription,
+            Arity = ArgumentArity.ZeroOrOne,
+        };
+
         public static readonly Option<bool> GlobalOption = ToolAppliedOption.GlobalOption;
 
         public static readonly Option<bool> LocalOption = ToolAppliedOption.LocalOption;
@@ -30,6 +36,7 @@ namespace Microsoft.DotNet.Cli
         {
             var command = new Command("list", LocalizableStrings.CommandDescription);
 
+            command.AddArgument(PackageIdArgument);
             command.AddOption(GlobalOption.WithHelpDescription(command, LocalizableStrings.GlobalOptionDescription));
             command.AddOption(LocalOption.WithHelpDescription(command, LocalizableStrings.LocalOptionDescription));
             command.AddOption(ToolPathOption.WithHelpDescription(command, LocalizableStrings.ToolPathOptionDescription));

--- a/src/Cli/dotnet/commands/dotnet-tool/list/ToolListLocalCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/ToolListLocalCommand.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolManifest;
+using Microsoft.DotNet.ToolPackage;
 using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Tools.Tool.List
@@ -33,6 +34,12 @@ namespace Microsoft.DotNet.Tools.Tool.List
         public override int Execute()
         {
             var table = new PrintableTable<(ToolManifestPackage toolManifestPackage, FilePath SourceManifest)>();
+            var packageIdArgument = _parseResult.GetValueForArgument(ToolListCommandParser.PackageIdArgument);
+            PackageId? packageId = null;
+            if (!string.IsNullOrWhiteSpace(packageIdArgument))
+            {
+                packageId = new PackageId(packageIdArgument);
+            }
 
             table.AddColumn(
                 LocalizableStrings.PackageIdColumn,
@@ -47,8 +54,22 @@ namespace Microsoft.DotNet.Tools.Tool.List
                 LocalizableStrings.ManifestFileColumn,
                 p => p.SourceManifest.Value);
 
-            table.PrintRows(_toolManifestInspector.Inspect(), l => _reporter.WriteLine(l));
+            var packageEnumerable = _toolManifestInspector.Inspect().Where(
+                 (t) => PackageIdMatches(t.toolManifestPackage, packageId)
+             );
+            table.PrintRows(packageEnumerable, l => _reporter.WriteLine(l));
+
+            if (packageId.HasValue && !packageEnumerable.Any())
+            {
+                // return 1 if target package was not found
+                return 1;
+            }
             return 0;
+        }
+
+        private bool PackageIdMatches(ToolManifestPackage package, PackageId? packageId)
+        {
+            return !packageId.HasValue || package.PackageId.Equals(packageId);
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.cs.xlf
@@ -27,6 +27,16 @@
         <target state="translated">Manifest</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Verze</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.de.xlf
@@ -27,6 +27,16 @@
         <target state="translated">Manifest</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Version</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.es.xlf
@@ -27,6 +27,16 @@
         <target state="translated">Manifiesto</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Versión</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.fr.xlf
@@ -27,6 +27,16 @@
         <target state="translated">Manifeste</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Version</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.it.xlf
@@ -27,6 +27,16 @@
         <target state="translated">Manifesto</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Versione</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ja.xlf
@@ -27,6 +27,16 @@
         <target state="translated">マニフェスト</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">バージョン</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ko.xlf
@@ -27,6 +27,16 @@
         <target state="translated">매니페스트</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">버전</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pl.xlf
@@ -27,6 +27,16 @@
         <target state="translated">Manifest</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Wersja</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pt-BR.xlf
@@ -27,6 +27,16 @@
         <target state="translated">Manifesto</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Versão</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ru.xlf
@@ -27,6 +27,16 @@
         <target state="translated">Манифест</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Версия</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.tr.xlf
@@ -27,6 +27,16 @@
         <target state="translated">Bildirim</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Sürüm</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hans.xlf
@@ -27,6 +27,16 @@
         <target state="translated">清单</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">版本</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hant.xlf
@@ -27,6 +27,16 @@
         <target state="translated">資訊清單</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>The NuGet Package Id of the tool to list</source>
+        <target state="new">The NuGet Package Id of the tool to list</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">版本</target>

--- a/src/Tests/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
@@ -241,6 +241,66 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             return package.Object;
         }
 
+        [Fact]
+        public void GivenPackageIdArgItPrintsThatPackage()
+        {
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
+            store
+                .Setup(s => s.EnumeratePackages())
+                .Returns(new[] {
+                     CreateMockToolPackage(
+                        "test.tool",
+                        "1.3.5-preview",
+                        new[] {
+                            new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
+                        }
+                    ),
+                    CreateMockToolPackage(
+                        "another.tool",
+                        "2.7.3",
+                        new[] {
+                            new RestoredCommand(new ToolCommandName("bar"), "dotnet", new FilePath("tool"))
+                        }
+                    ),
+                    CreateMockToolPackage(
+                        "some.tool",
+                        "1.0.0",
+                        new[] {
+                            new RestoredCommand(new ToolCommandName("fancy-foo"), "dotnet", new FilePath("tool"))
+                        }
+                    )
+                });
+
+            var command = CreateCommand(store.Object, "test.tool -g");
+
+            command.Execute().Should().Be(0);
+
+            _reporter.Lines.Should().Equal(EnumerateExpectedTableLines(store.Object, new PackageId("test.tool")));
+        }
+
+        [Fact]
+        public void GivenNotInstalledPackageItPrintsEmpty()
+        {
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
+            store
+                .Setup(s => s.EnumeratePackages())
+                .Returns(new[] {
+                    CreateMockToolPackage(
+                        "test.tool",
+                        "1.3.5-preview",
+                        new[] {
+                            new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
+                        }
+                    )
+                });
+
+            var command = CreateCommand(store.Object, "not-installed-package -g");
+
+            command.Execute().Should().Be(1);
+
+            _reporter.Lines.Should().Equal(EnumerateExpectedTableLines(store.Object, new PackageId("not-installed-package")));
+        }
+
         private IToolPackage CreateMockBrokenPackage(string id, string version)
         {
             var package = new Mock<IToolPackage>(MockBehavior.Strict);
@@ -273,14 +333,16 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             }
         }
 
-        private IEnumerable<string> EnumerateExpectedTableLines(IToolPackageStoreQuery store)
+        private IEnumerable<string> EnumerateExpectedTableLines(IToolPackageStoreQuery store, PackageId? targetPackageId = null)
         {
             static string GetCommandsString(IToolPackage package)
             {
                 return string.Join(ToolListGlobalOrToolPathCommand.CommandDelimiter, package.Commands.Select(c => c.Name));
             }
 
-            var packages = store.EnumeratePackages().Where(PackageHasCommands).OrderBy(package => package.Id);
+            var packages = store.EnumeratePackages().Where(
+                (p) => PackageHasCommands(p) && ToolListGlobalOrToolPathCommand.PackageIdMatches(p, targetPackageId)
+                ).OrderBy(package => package.Id);
             var columnDelimiter = PrintableTable<IToolPackageStoreQuery>.ColumnDelimiter;
 
             int packageIdColumnWidth = LocalizableStrings.PackageIdColumn.Length;


### PR DESCRIPTION
Addresses #23549 
Added an optional `PACKAGE_ID` argument to `dotnet tool list` to allow checking if a specific tool was installed
If argument supplied, command returns `1` if no tool with that package id was found, return `0` otherwise.

## Usage
`dotnet tool list [<PACKAGE_ID>] [options]`
### Examples
```
PS C:\Users\Jacky\Documents\workspace\sdk> dotnet tool list -g
Package Id                             Version         Commands
-------------------------------------------------------------------------
dotnet-reportgenerator-globaltool      5.0.4           reportgenerator
microsoft.dotnet-interactive           1.0.345202      dotnet-interactive

PS C:\Users\Jacky\Documents\workspace\sdk> dotnet tool list -g dotnet-reportgenerator-globaltool
Package Id                             Version      Commands
-------------------------------------------------------------------
dotnet-reportgenerator-globaltool      5.0.4        reportgenerator

PS C:\Users\Jacky\Documents\workspace\sdk> dotnet tool list -g some.other
Package Id      Version      Commands
-------------------------------------
```

```
PS C:\Users\Jacky\Documents\workspace\exp> dotnet tool list
Package Id      Version                 Commands         Manifest
-------------------------------------------------------------------------------------------------------------------------
dotnet-ef       7.0.0-rc.1.22426.7      dotnet-ef        C:\Users\Jacky\Documents\workspace\exp\.config\dotnet-tools.json
cake.tool       2.2.0                   dotnet-cake      C:\Users\Jacky\Documents\workspace\exp\.config\dotnet-tools.json

PS C:\Users\Jacky\Documents\workspace\exp> dotnet tool list dotnet-ef
Package Id      Version                 Commands       Manifest
-----------------------------------------------------------------------------------------------------------------------
dotnet-ef       7.0.0-rc.1.22426.7      dotnet-ef      C:\Users\Jacky\Documents\workspace\exp\.config\dotnet-tools.json

PS C:\Users\Jacky\Documents\workspace\exp> dotnet tool list something.else
Package Id      Version      Commands      Manifest
---------------------------------------------------
```

## Changes
* Added `PackageIdArgument` argument to `ToolListCommandParser`
* Added additional filtering logic to `ToolListGlobalOrToolPathCommand` and `ToolListLocalCommand` in order to only display the tool matches the supplied package id
* Added testcases in `ToolListLocalCommandTests` and `ToolListGlobalOrToolPathCommandTests` to ensure command works as expected when `PACKAGE_ID` is supplied