### PR TITLE
Add missing EnableRuleAttributesMustMatch task parameter

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -38,6 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       PackageTargetPath="@(_PackageTargetPath)"
       RuntimeGraph="$(RuntimeIdentifierGraphPath)"
       NoWarn="$(NoWarn)"
+      EnableRuleAttributesMustMatch="$(ApiCompatEnableRuleAttributesMustMatch)"
       ExcludeAttributesFiles="@(ApiCompatExcludeAttributesFile)"
       EnableRuleCannotChangeParameterName="@(ApiCompatEnableRuleCannotChangeParameterName)"
       RunApiCompat="$(RunApiCompat)"


### PR DESCRIPTION
With https://github.com/dotnet/sdk/commit/78026b22587175e611eedf334760ad25bda425b4, the `EnableRuleAttributesMustMatch` switch was added but I forgot to also accept it in the `ValidatePackage` task invocation in the `ValidatePackage.targets` file.

Filed https://github.com/dotnet/sdk/issues/28337 to add integration tests for the optional rule parameters.