### PR TITLE
[release/7.0.1xx] Add missing EnableRuleAttributesMustMatch task property

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -40,7 +40,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       NoWarn="$(NoWarn)"
       EnableRuleAttributesMustMatch="$(ApiCompatEnableRuleAttributesMustMatch)"
       ExcludeAttributesFiles="@(ApiCompatExcludeAttributesFile)"
-      EnableRuleCannotChangeParameterName="@(ApiCompatEnableRuleCannotChangeParameterName)"
+      EnableRuleCannotChangeParameterName="$(ApiCompatEnableRuleCannotChangeParameterName)"
       RunApiCompat="$(RunApiCompat)"
       EnableStrictModeForCompatibleTfms="$([MSBuild]::ValueOrDefault('$(EnableStrictModeForCompatibleTfms)', 'true'))"
       EnableStrictModeForCompatibleFrameworksInPackage="$(EnableStrictModeForCompatibleFrameworksInPackage)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -38,6 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       PackageTargetPath="@(_PackageTargetPath)"
       RuntimeGraph="$(RuntimeIdentifierGraphPath)"
       NoWarn="$(NoWarn)"
+      EnableRuleAttributesMustMatch="$(ApiCompatEnableRuleAttributesMustMatch)"
       ExcludeAttributesFiles="@(ApiCompatExcludeAttributesFile)"
       EnableRuleCannotChangeParameterName="@(ApiCompatEnableRuleCannotChangeParameterName)"
       RunApiCompat="$(RunApiCompat)"


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/28336 & https://github.com/dotnet/sdk/pull/28344

## Customer Impact
Customers who use [APICompat's PackageValidation feature](https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview) can't enable the optional `AttributesMustMatch` rule (in the msbuild frontend) that validates that attributes are compatible between the contract and the implementation. The property/parameter is already exposed in the task but the targets file never passed the msbuild property `ApiCompatEnableRuleAttributesMustMatch` into the task.

## Testing
I verified that the property is now passed into the `ValidatePackage` task correctly and filed https://github.com/dotnet/sdk/issues/28337 for adding CI protection.

## Risk
Low. This is an opt-in rule and customers need to explicitly set the msbuild property to true.