### PR TITLE
Fix ApiCompatEnableRuleCannotChangeParameterName prop

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -40,7 +40,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       NoWarn="$(NoWarn)"
       EnableRuleAttributesMustMatch="$(ApiCompatEnableRuleAttributesMustMatch)"
       ExcludeAttributesFiles="@(ApiCompatExcludeAttributesFile)"
-      EnableRuleCannotChangeParameterName="@(ApiCompatEnableRuleCannotChangeParameterName)"
+      EnableRuleCannotChangeParameterName="$(ApiCompatEnableRuleCannotChangeParameterName)"
       RunApiCompat="$(RunApiCompat)"
       EnableStrictModeForCompatibleTfms="$([MSBuild]::ValueOrDefault('$(EnableStrictModeForCompatibleTfms)', 'true'))"
       EnableStrictModeForCompatibleFrameworksInPackage="$(EnableStrictModeForCompatibleFrameworksInPackage)"


### PR DESCRIPTION
This should be an msbuild property, not an item.
Adding the fix to the .NET 7 backport PR: https://github.com/dotnet/sdk/pull/28338.

Was incorrectly implemented in https://github.com/dotnet/sdk/commit/d78f4b42fd8f8ef4516455435f8e62316020571c