### PR TITLE
normalize accessibility when not including internal symbols

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
@@ -36,8 +36,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         {
             if (!_settings.IncludeInternalSymbols)
             {
-                a = CannotChangeVisibility.NormalizeInternals(a);
-                b = CannotChangeVisibility.NormalizeInternals(b);
+                a = NormalizeInternals(a);
+                b = NormalizeInternals(b);
             }
 
             if (a == b)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
@@ -25,19 +25,19 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             context.RegisterOnTypeSymbolAction(RunOnTypeSymbol);
         }
 
-        private static Accessibility normalizeInternals(Accessibility a) => a switch
+        private static Accessibility NormalizeInternals(Accessibility a) => a switch
         {
             Accessibility.ProtectedOrInternal => Accessibility.Protected,
             Accessibility.ProtectedAndInternal or Accessibility.Internal => Accessibility.Private,
             _ => a,
         };
 
-        private int compareAccessibility(Accessibility a, Accessibility b)
+        private int CompareAccessibility(Accessibility a, Accessibility b)
         {
             if (!_settings.IncludeInternalSymbols)
             {
-                a = CannotChangeVisibility.normalizeInternals(a);
-                b = CannotChangeVisibility.normalizeInternals(b);
+                a = CannotChangeVisibility.NormalizeInternals(a);
+                b = CannotChangeVisibility.NormalizeInternals(b);
             }
 
             if (a == b)
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
             Accessibility leftAccess = left.DeclaredAccessibility;
             Accessibility rightAccess = right.DeclaredAccessibility;
-            int accessComparison = compareAccessibility(leftAccess, rightAccess);
+            int accessComparison = CompareAccessibility(leftAccess, rightAccess);
 
             if (accessComparison > 0)
             {

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotChangeVisibilityTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotChangeVisibilityTests.cs
@@ -44,6 +44,50 @@ new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotReduceVisibility, string.Empty, DifferenceType.Changed, "T:CompatTests.First")
 }
             },
+            // Reducing visibility of internal type to protected
+            {
+                @"
+namespace CompatTests
+{
+  public class First {
+    internal int F = 0;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {
+    protected int F = 0;
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotReduceVisibility, string.Empty, DifferenceType.Changed, "F:CompatTests.First.F")
+}
+            },
+            // Reducing visibility of protected type to internal
+            {
+                @"
+namespace CompatTests
+{
+  public class First {
+    protected int F = 0;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {
+    internal int F = 0;
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotReduceVisibility, string.Empty, DifferenceType.Changed, "F:CompatTests.First.F")
+}
+            },
             // Expand visibility of type
             {
                 @"
@@ -298,7 +342,7 @@ new CompatDifference[] {
 
         public static TheoryData<string, string, CompatDifference[]> NoInternals => new()
         {
-            // Expand visibility of type
+            // No diagnostic on expanding visibility of type from internal to public
             {
                 @"
 namespace CompatTests
@@ -314,7 +358,7 @@ namespace CompatTests
 ",
 new CompatDifference[] {}
             },
-            // Expand visibility of member
+            // No diagnostic on expanding visibility of member from protected to protected internal
             {
                 @"
 namespace CompatTests


### PR DESCRIPTION
Previously, the comparison between `Accessibility` values returned by Roslyn relied on comparing their numerical enum values.
However, that ordering neither considered `protected` of higher accessibility than `internal`, nor did it treat `internal` members as `private`, when internal symbols are excluded.

This meant that when internal symbols were excluded, the accessibility of internal symbols would still affect the compatibility checker, and it would emit unwanted diagnostics in those circumstances.

This change defines a custom comparator for `Accessibility` values that takes these factors into account.