### PR TITLE
Change default for MSBuild Server.

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils
     internal class MSBuildForwardingAppWithoutLogging
     {
         private static readonly bool AlwaysExecuteMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_RUN_MSBUILD_OUTOFPROC");
-        private static readonly bool UseMSBuildServer = !Env.GetEnvironmentVariableAsBool("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER");
+        private static readonly bool UseMSBuildServer = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILD_SERVER", false);
 
         private const string MSBuildExeName = "MSBuild.dll";
 


### PR DESCRIPTION
### Summary
This PR makes MSBuild server an opt-in feature for 7.0 SDK, instead of opt-out. Given the recent failures in dotnet/runtime repo when using this feature, we would like to have more time to fix the bugs and test it before it becomes an opt-out feature.

### Customer Impact
- This fix would remove instability of `dotnet build` introduced by the opt-out MSBuild Server feature.
- Customers would still have an option to use the feature.

### Regression?
This fixes a regression.

### Testing
Unit tests.

### Risk
Low risk. 

### Description of the fix
We ignore DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER opt-out env. variable and use an opt-in DOTNET_CLI_USE_MSBUILD_SERVER env variable instead to control the MSBuild Server feature in SDK CLI.