### PR TITLE
[release/7.0.1xx] Disable msbuild server by default

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils
     internal class MSBuildForwardingAppWithoutLogging
     {
         private static readonly bool AlwaysExecuteMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_RUN_MSBUILD_OUTOFPROC");
-        private static readonly bool UseMSBuildServer = !Env.GetEnvironmentVariableAsBool("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER");
+        private static readonly bool UseMSBuildServer = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILD_SERVER", false);
 
         private const string MSBuildExeName = "MSBuild.dll";
 


### PR DESCRIPTION
### Summary
This PR makes MSBuild server an opt-in feature for 7.0 SDK, instead of opt-out. Given the recent failures in the dotnet/runtime repo when using this feature (https://github.com/dotnet/runtime/issues/75391), we would like to have more time to fix the bugs and dogfood before it becomes an opt-out feature.

### Customer Impact

Revert to 6.0-and-previous behavior, avoiding new instability (but not getting new perf improvements).

- This fix would remove instability of `dotnet build` introduced by the opt-out MSBuild Server feature.
- Customers would still have an option to use the feature.

### Regression?

Yes--server failed in some new cases.

### Testing

Unit tests.

### Risk

Low risk. 

### Description of the fix
We ignore DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER opt-out env. variable and use an opt-in DOTNET_CLI_USE_MSBUILD_SERVER env variable instead to control the MSBuild Server feature in SDK CLI.