### PR TITLE
ResolveReadyToRunCompilers: map non-portable rids when targetOS is determined.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -143,7 +143,15 @@ namespace Microsoft.NET.Build.Tasks
 
             bool version5 = crossgen2PackVersion.Major < 6;
             bool isSupportedTarget = ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture);
-            string targetOS = _targetPlatform switch
+
+            var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
+            string portablePlatform = NuGetUtils.GetBestMatchingRid(
+                    runtimeGraph,
+                    _targetPlatform,
+                    new[] { "linux", "linux-musl", "osx", "win" },
+                    out _);
+
+            string targetOS = portablePlatform switch
             {
                 "linux" => "linux",
                 "linux-musl" => "linux",

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -144,28 +144,13 @@ namespace Microsoft.NET.Build.Tasks
             bool version5 = crossgen2PackVersion.Major < 6;
             bool isSupportedTarget = ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture);
 
-            var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
-            string portablePlatform = NuGetUtils.GetBestMatchingRid(
-                    runtimeGraph,
-                    _targetPlatform,
-                    new[] { "linux", "linux-musl", "osx", "win" },
-                    out _);
-
-            string targetOS = portablePlatform switch
-            {
-                "linux" => "linux",
-                "linux-musl" => "linux",
-                "osx" => "osx",
-                "win" => "windows",
-                _ => null
-            };
-
             // In .NET 5 Crossgen2 supported only the following host->target compilation scenarios:
             //      win-x64 -> win-x64
             //      linux-x64 -> linux-x64
             //      linux-musl-x64 -> linux-musl-x64
+            string targetOS = null;
             isSupportedTarget = isSupportedTarget &&
-                targetOS != null &&
+                GetCrossgen2TargetOS(out targetOS) &&
                 (!version5 || _targetRuntimeIdentifier == _hostRuntimeIdentifier) &&
                 GetCrossgen2ComponentsPaths(version5);
 
@@ -194,6 +179,48 @@ namespace Microsoft.NET.Build.Tasks
 
             _crossgen2IsVersion5 = version5;
             return true;
+        }
+
+        private bool GetCrossgen2TargetOS(out string targetOS)
+        {
+            targetOS = null;
+
+            // Determine targetOS based on target rid.
+            // Use the runtime graph to support non-portable target rids.
+            var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
+            string portablePlatform = NuGetUtils.GetBestMatchingRid(
+                    runtimeGraph,
+                    _targetPlatform,
+                    new[] { "linux", "linux-musl", "osx", "win" },
+                    out _);
+
+            // For source-build, allow the bootstrap SDK rid to be unknown to the runtime repo graph.
+            if (portablePlatform == null && _targetRuntimeIdentifier == _hostRuntimeIdentifier)
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    portablePlatform = "linux";
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    portablePlatform = "win";
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    portablePlatform = "osx";
+                }
+            }
+
+            targetOS = portablePlatform switch
+            {
+                "linux" => "linux",
+                "linux-musl" => "linux",
+                "osx" => "osx",
+                "win" => "windows",
+                _ => null
+            };
+
+            return targetOS != null;
         }
 
         private ITaskItem GetNETCoreAppRuntimePack()


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/28312.

cc @AntonLapounov @ViktorHofer ptal.