### PR TITLE
Add an official builder assembly attribute

### DIFF
--- a/src/Common/CompileOptions.cs
+++ b/src/Common/CompileOptions.cs
@@ -3,7 +3,7 @@
 using System.Reflection;
 
 #if MICROSOFT_ENABLE_TELEMETRY
-      [assembly: AssemblyMetadata("OfficialBuilder", "Microsoft")]
+      [assembly: AssemblyMetadata("TelemetryOptOutDefault", Microsoft.DotNet.Cli.CompileOptions.TelemetryOptOutDefaultString)]
 #endif
 
 namespace Microsoft.DotNet.Cli
@@ -15,6 +15,12 @@ namespace Microsoft.DotNet.Cli
         false;
 #else
         true;
+#endif
+        public const string TelemetryOptOutDefaultString =
+#if MICROSOFT_ENABLE_TELEMETRY
+        "False";
+#else
+        "True";
 #endif
     }
 }

--- a/src/Common/CompileOptions.cs
+++ b/src/Common/CompileOptions.cs
@@ -1,5 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Reflection;
+
+#if MICROSOFT_ENABLE_TELEMETRY
+      [assembly: AssemblyMetadata("OfficialBuilder", "Microsoft")]
+#endif
 
 namespace Microsoft.DotNet.Cli
 {


### PR DESCRIPTION
This setting was inverted in RC1 and we still haven't figured out why. Adding an attribute we can check for in the installer repo codeflow. If somehow this ends up different than the actual telemetry setting, it'll be a sign of a massive compiler failure so assume this is enough.