### PR TITLE
[release/7.0.1xx] backport APICompat changes for GA

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
@@ -26,6 +26,8 @@ namespace Microsoft.DotNet.ApiCompatibility
         public const string CannotAddAttribute = "CP0016";
         public const string CannotChangeParameterName = "CP0017";
         public const string CannotAddSealedToInterfaceMember = "CP0018";
+        public const string CannotReduceVisibility = "CP0019";
+        public const string CannotExpandVisibility = "CP0020";
 
         // Assembly loading ids
         public const string AssemblyNotFound = "CP1001";

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
@@ -240,4 +240,10 @@
   <data name="CannotAddSealedToInterfaceMember" xml:space="preserve">
     <value>Cannot add sealed keyword to default interface member '{0}'.</value>
   </data>
+  <data name="CannotExpandVisibility" xml:space="preserve">
+    <value>Visibility of '{0}' expanded from '{1}' to '{2}'.</value>
+  </data>
+  <data name="CannotReduceVisibility" xml:space="preserve">
+    <value>Visibility of '{0}' reduced from '{1}' to '{2}'.</value>
+  </data>
 </root>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -88,6 +88,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 return;
             }
 
+            if (!_settings.StrictMode && dt == DifferenceType.Added)
+            {
+                return;
+            }
+
             CompatDifference difference = dt switch
             {
                 DifferenceType.Changed => new CompatDifference(

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -200,10 +200,17 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
                     for (int i = 0; i < rightGroup.Attributes.Count; i++)
                     {
-                        if (!rightGroup.Seen[i])
+                        if (!rightGroup.Seen[i] && _settings.StrictMode)
                         {
                             // Attribute arguments exist on right but not left.
-                            // Issue "changed" diagnostic.
+                            // Left
+                            //   [Foo("a")]
+                            //   void F()
+                            // Right
+                            //   [Foo("a")]
+                            //   [Foo("b")]
+                            //   void F()
+                            // Issue "changed" diagnostic when in strict mode.
                             AddDifference(differences, DifferenceType.Changed, leftMetadata, rightMetadata, containing, itemRef, rightGroup.Attributes[i]);
                         }
                     }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddOrRemoveVirtualKeyword.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddOrRemoveVirtualKeyword.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Microsoft.DotNet.ApiCompatibility.Extensions;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
@@ -50,6 +51,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
             if (left.IsVirtual)
             {
+                // Removing the virtual keyword from a member in a sealed type won't be a breaking change.
+                if (leftContainingType.IsEffectivelySealed(_settings.IncludeInternalSymbols))
+                {
+                    return;
+                }
+
                 // If left is virtual and right is not, then emit a diagnostic
                 // specifying that the virtual modifier cannot be removed.
                 if (!right.IsVirtual)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime;
 using Microsoft.CodeAnalysis;
@@ -24,6 +25,40 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             context.RegisterOnTypeSymbolAction(RunOnTypeSymbol);
         }
 
+        private static Accessibility NormalizeInternals(Accessibility a) => a switch
+        {
+            Accessibility.ProtectedOrInternal => Accessibility.Protected,
+            Accessibility.ProtectedAndInternal or Accessibility.Internal => Accessibility.Private,
+            _ => a,
+        };
+
+        private int CompareAccessibility(Accessibility a, Accessibility b)
+        {
+            if (!_settings.IncludeInternalSymbols)
+            {
+                a = NormalizeInternals(a);
+                b = NormalizeInternals(b);
+            }
+
+            if (a == b)
+            {
+                return 0;
+            }
+
+            return (a, b) switch
+            {
+                (Accessibility.Public, _) => 1,
+                (_, Accessibility.Public) => -1,
+                (Accessibility.ProtectedOrInternal, _) => 1,
+                (_, Accessibility.ProtectedOrInternal) => -1,
+                (Accessibility.Protected or Accessibility.Internal, _) => 1,
+                (_, Accessibility.Protected or Accessibility.Internal) => -1,
+                (Accessibility.ProtectedAndInternal, _) => 1,
+                (_, Accessibility.ProtectedAndInternal) => -1,
+                _ => throw new NotImplementedException(),
+            };
+        }
+
         private void RunOnSymbol(
             ISymbol? left,
             ISymbol? right,
@@ -39,8 +74,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
             Accessibility leftAccess = left.DeclaredAccessibility;
             Accessibility rightAccess = right.DeclaredAccessibility;
+            int accessComparison = CompareAccessibility(leftAccess, rightAccess);
 
-            if (leftAccess > rightAccess)
+            if (accessComparison > 0)
             {
                 differences.Add(new CompatDifference(leftMetadata,
                     rightMetadata,
@@ -49,7 +85,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     DifferenceType.Changed,
                     left));
             }
-            else if (_settings.StrictMode && rightAccess > leftAccess)
+            else if (_settings.StrictMode && accessComparison < 0)
             {
                 differences.Add(new CompatDifference(leftMetadata,
                     rightMetadata,

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Runtime;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Microsoft.DotNet.ApiCompatibility.Extensions;
+
+namespace Microsoft.DotNet.ApiCompatibility.Rules
+{
+    /// <summary>
+    /// This class implements a rule to check that the visibility of symbols is not reduced.
+    /// In strict mode, it also checks that the visibility isn't expanded.
+    /// </summary>
+    public class CannotChangeVisibility : IRule
+    {
+        private readonly RuleSettings _settings;
+
+        public CannotChangeVisibility(RuleSettings settings, IRuleRegistrationContext context)
+        {
+            _settings = settings;
+            context.RegisterOnMemberSymbolAction(RunOnMemberSymbol);
+            context.RegisterOnTypeSymbolAction(RunOnTypeSymbol);
+        }
+
+        private void RunOnSymbol(
+            ISymbol? left,
+            ISymbol? right,
+            MetadataInformation leftMetadata,
+            MetadataInformation rightMetadata,
+            IList<CompatDifference> differences)
+        {
+            // The MemberMustExist rule handles missing symbols and therefore this rule only runs when left and right is not null.
+            if (left is null || right is null)
+            {
+                return;
+            }
+
+            Accessibility leftAccess = left.DeclaredAccessibility;
+            Accessibility rightAccess = right.DeclaredAccessibility;
+
+            if (leftAccess > rightAccess)
+            {
+                differences.Add(new CompatDifference(leftMetadata,
+                    rightMetadata,
+                    DiagnosticIds.CannotReduceVisibility,
+                    string.Format(Resources.CannotReduceVisibility, left, leftAccess, rightAccess),
+                    DifferenceType.Changed,
+                    left));
+            }
+            else if (_settings.StrictMode && rightAccess > leftAccess)
+            {
+                differences.Add(new CompatDifference(leftMetadata,
+                    rightMetadata,
+                    DiagnosticIds.CannotExpandVisibility,
+                    string.Format(Resources.CannotExpandVisibility, right, leftAccess, rightAccess),
+                    DifferenceType.Changed,
+                    right));
+            }
+        }
+
+        private void RunOnTypeSymbol(
+            ITypeSymbol? left,
+            ITypeSymbol? right,
+            MetadataInformation leftMetadata,
+            MetadataInformation rightMetadata,
+            IList<CompatDifference> differences) => RunOnSymbol(left, right, leftMetadata, rightMetadata, differences);
+
+        private void RunOnMemberSymbol(
+            ISymbol? left,
+            ISymbol? right,
+            ITypeSymbol leftContainingType,
+            ITypeSymbol rightContainingType,
+            MetadataInformation leftMetadata,
+            MetadataInformation rightMetadata,
+            IList<CompatDifference> differences) => RunOnSymbol(left, right, leftMetadata, rightMetadata, differences);
+    }
+}

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleFactory.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleFactory.cs
@@ -39,7 +39,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 new CannotRemoveBaseTypeOrInterface(settings, context),
                 new CannotSealType(settings, context),
                 new EnumsMustMatch(settings, context),
-                new MembersMustExist(settings, context)
+                new MembersMustExist(settings, context),
+                new CannotChangeVisibility(settings, context)
             };
 
             if (_enableRuleAttributesMustMatch)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Název parametru u člena {0} se změnil z {1} na {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">Atribut {0} nelze odebrat z {1}.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Der Parametername des Members "{0}" wurde von "{1}" in "{2}" geändert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">Das Attribut "{0}" kann nicht aus "{1}" entfernt werden.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
@@ -87,6 +87,16 @@
         <target state="translated">El nombre de parámetro del miembro '{0}' cambió de '{1}' a '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">No se puede quitar el atributo '{0}' de '{1}'.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Le nom du paramètre sur le membre « {0} » est passé de « {1} » à « {2} ».</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">Impossible de supprimer l’attribut « {0} » de « {1} ».</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Il nome del parametro nel membro '{0}' è stato modificato da '{1}' a '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">Non è possibile rimuovere l'attributo '{0}' da '{1}'.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
@@ -87,6 +87,16 @@
         <target state="translated">メンバー '{0}' のパラメーター名が '{1}' から '{2}' に変更されました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">属性 '{0}' を '{1}' から削除できません。</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
@@ -87,6 +87,16 @@
         <target state="translated">멤버 '{0}'의 매개 변수 이름이 '{1}'에서 '{2}'(으)로 변경되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">'{1}'에서 특성 '{0}'을(를) 제거할 수 없습니다.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Nazwa parametru elementu członkowskiego „{0}” została zmieniona z „{1}” na „{2}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">Nie można usunąć atrybutu „{0}” z elementu „{1}”.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Nome do parâmetro no membro '{0}' alterado de '{1}' para '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">Não é possível remover o atributo '{0}' de '{1}'.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Имя параметра на члене "{0}" изменено с "{1}" на "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">Не удается удалить атрибут "{0}" из "{1}".</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
@@ -87,6 +87,16 @@
         <target state="translated">'{0}' üyesinin parametre adı '{1}' iken '{2}' olarak değiştirildi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">'{0}' özniteliği '{1}' sınıfından kaldırılamıyor.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
@@ -87,6 +87,16 @@
         <target state="translated">成员 "{0}" 上的参数名称已从 "{1}" 更改为 "{2}"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">无法从 "{1}" 中删除属性 "{0}"。</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
@@ -87,6 +87,16 @@
         <target state="translated">成員 '{0}' 上的參數名稱從 '{1}' 變更為 '{2}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotExpandVisibility">
+        <source>Visibility of '{0}' expanded from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' expanded from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CannotReduceVisibility">
+        <source>Visibility of '{0}' reduced from '{1}' to '{2}'.</source>
+        <target state="new">Visibility of '{0}' reduced from '{1}' to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotRemoveAttribute">
         <source>Cannot remove attribute '{0}' from '{1}'.</source>
         <target state="translated">無法從 '{1}' 移除屬性 '{0}'。</target>

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -182,9 +182,7 @@ namespace CompatTests
   public class First {}
 }
 ",
-new CompatDifference[] {
-    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "T:CompatTests.First:[T:System.SerializableAttribute]")
-}
+new CompatDifference[] {}
             },
             // Attributes with array and type arguments
             {
@@ -316,7 +314,6 @@ namespace CompatTests
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.F:[T:CompatTests.FooAttribute]"),
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.F:[T:CompatTests.BarAttribute]"),
-    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "M:CompatTests.First.F:[T:CompatTests.BazAttribute]")
 }
             },
             // Attributes on property
@@ -376,7 +373,6 @@ namespace CompatTests
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "P:CompatTests.First.F:[T:CompatTests.FooAttribute]"),
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "P:CompatTests.First.F:[T:CompatTests.BarAttribute]"),
-    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "P:CompatTests.First.F:[T:CompatTests.BazAttribute]")
 }
             },
             // Attributes on event
@@ -440,7 +436,6 @@ namespace CompatTests
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "E:CompatTests.First.F:[T:CompatTests.FooAttribute]"),
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "E:CompatTests.First.F:[T:CompatTests.BarAttribute]"),
-    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "E:CompatTests.First.F:[T:CompatTests.BazAttribute]")
 }
             },
             // Attributes on constructor
@@ -500,7 +495,6 @@ namespace CompatTests
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.#ctor:[T:CompatTests.FooAttribute]"),
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.#ctor:[T:CompatTests.BarAttribute]"),
-    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "M:CompatTests.First.#ctor:[T:CompatTests.BazAttribute]")
 }
             },
             // Attributes on return type
@@ -560,7 +554,6 @@ namespace CompatTests
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.F->int:[T:CompatTests.FooAttribute]"),
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.F->int:[T:CompatTests.BarAttribute]"),
-    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "M:CompatTests.First.F->int:[T:CompatTests.BazAttribute]")
 }
             },
             // Attributes on method parameter
@@ -615,7 +608,6 @@ namespace CompatTests
 ",
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.F(System.Int32,System.String)$0:[T:CompatTests.BarAttribute]"),
-    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "M:CompatTests.First.F(System.Int32,System.String)$0:[T:CompatTests.BazAttribute]"),
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.F(System.Int32,System.String)$1:[T:CompatTests.FooAttribute]"),
 
 }
@@ -666,7 +658,6 @@ namespace CompatTests
 ",
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "T:CompatTests.First`2<0>:[T:CompatTests.BarAttribute]"),
-    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "T:CompatTests.First`2<0>:[T:CompatTests.BazAttribute]"),
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First`2<1>:[T:CompatTests.FooAttribute]"),
 
 }
@@ -723,6 +714,517 @@ namespace CompatTests
 ",
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.F``2<0>:[T:CompatTests.BarAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.F``2<1>:[T:CompatTests.FooAttribute]"),
+
+}
+            }
+        };
+
+        public static TheoryData<string, string, CompatDifference[]> StrictMode => new()
+        {
+            // Attribute added to type
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [Foo(""S"", A = true, B = 3)]
+  public class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+  
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [Serializable]
+  [Foo(""S"", A = true, B = 3)]
+  public class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "T:CompatTests.First:[T:System.SerializableAttribute]")
+}
+            },
+            // Attributes on method
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    [Foo(""S"", A = true, B = 3)]
+    [Bar]
+    public void F() {}
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    [Foo(""T"")]
+    [Baz]
+    public void F() {}
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.F:[T:CompatTests.FooAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.F:[T:CompatTests.BarAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "M:CompatTests.First.F:[T:CompatTests.BazAttribute]")
+}
+            },
+            // Attributes on property
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    [Foo(""S"", A = true, B = 3)]
+    [Bar]
+    public int F { get; }
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    [Foo(""T"")]
+    [Baz]
+    public int F { get; }
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "P:CompatTests.First.F:[T:CompatTests.FooAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "P:CompatTests.First.F:[T:CompatTests.BarAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "P:CompatTests.First.F:[T:CompatTests.BazAttribute]")
+}
+            },
+            // Attributes on event
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    public delegate void EventHandler(object sender, object e);
+
+    [Foo(""S"", A = true, B = 3)]
+    [Bar]
+    public event EventHandler F;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    public delegate void EventHandler(object sender, object e);
+
+    [Foo(""T"")]
+    [Baz]
+    public event EventHandler F;
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "E:CompatTests.First.F:[T:CompatTests.FooAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "E:CompatTests.First.F:[T:CompatTests.BarAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "E:CompatTests.First.F:[T:CompatTests.BazAttribute]")
+}
+            },
+            // Attributes on constructor
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    [Foo(""S"", A = true, B = 3)]
+    [Bar]
+    public First() {}
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    [Foo(""T"")]
+    [Baz]
+    public First() {}
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.#ctor:[T:CompatTests.FooAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.#ctor:[T:CompatTests.BarAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "M:CompatTests.First.#ctor:[T:CompatTests.BazAttribute]")
+}
+            },
+            // Attributes on return type
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    [return: Foo(""S"", A = true, B = 3)]
+    [return: Bar]
+    public int F() => 0;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    [return: Foo(""T"")]
+    [return: Baz]
+    public int F() => 0;
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.F->int:[T:CompatTests.FooAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.F->int:[T:CompatTests.BarAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "M:CompatTests.First.F->int:[T:CompatTests.BazAttribute]")
+}
+            },
+            // Attributes on method parameter
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    public void F([Bar] int v, [Foo(""S"", A = true, B = 0)] string s) {}
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    public void F([Baz] int v, [Foo(""T"")] string s) {}
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.F(System.Int32,System.String)$0:[T:CompatTests.BarAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "M:CompatTests.First.F(System.Int32,System.String)$0:[T:CompatTests.BazAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.F(System.Int32,System.String)$1:[T:CompatTests.FooAttribute]"),
+
+}
+            },
+            // Attributes on type parameter of class
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First<[Bar] T1, [Foo(""S"", A = true, B = 0)] T2> {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First<[Baz] T1, [Foo(""T"")] T2> {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "T:CompatTests.First`2<0>:[T:CompatTests.BarAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "T:CompatTests.First`2<0>:[T:CompatTests.BazAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First`2<1>:[T:CompatTests.FooAttribute]"),
+
+}
+            },
+            // Attributes on type parameter of method
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    public void F<[Bar] T1, [Foo(""S"", A = true, B = 0)] T2>() {}
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A = false;
+    public int B = 0;
+  }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BarAttribute : Attribute { }
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class BazAttribute : Attribute { }
+
+  public class First {
+
+    public void F<[Baz] T1, [Foo(""T"")] T2>() {}
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "M:CompatTests.First.F``2<0>:[T:CompatTests.BarAttribute]"),
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "M:CompatTests.First.F``2<0>:[T:CompatTests.BazAttribute]"),
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "M:CompatTests.First.F``2<1>:[T:CompatTests.FooAttribute]"),
 
@@ -742,6 +1244,23 @@ new CompatDifference[] {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
+
+            IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(StrictMode))]
+        public void EnsureStrictModeReported(string leftSyntax, string rightSyntax, CompatDifference[] expected)
+        {
+            using TempDirectory root = new();
+            string filePath = Path.Combine(root.DirPath, "exclusions.txt");
+            File.Create(filePath).Dispose();
+            TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context, new[] { filePath }));
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: true));
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -147,6 +147,46 @@ new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
 }
             },
+            // Attribute repeated with additional arguments
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+  
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [Serializable]
+  [Foo(""S"")]
+  public class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+  
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [Serializable]
+  [Foo(""S"")]
+  [Foo(""T"")]
+  public class First {}
+}
+",
+new CompatDifference[] {}
+            },
+
             // Attribute added to type
             {
                 @"
@@ -759,6 +799,47 @@ namespace CompatTests
 ",
 new CompatDifference[] {
     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "T:CompatTests.First:[T:System.SerializableAttribute]")
+}
+            },
+            // Attribute repeated with additional arguments
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+  
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [Serializable]
+  [Foo(""S"")]
+  public class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+  
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [Serializable]
+  [Foo(""S"")]
+  [Foo(""T"")]
+  public class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
 }
             },
             // Attributes on method

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddOrRemoveVirtualKeywordTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddOrRemoveVirtualKeywordTests.cs
@@ -72,6 +72,13 @@ namespace CompatTests {{
                                     (DifferenceType.Removed, "M:CompatTests.First.remove_F(CompatTests.First.EventHandler)"),
                                     (DifferenceType.Removed, "E:CompatTests.First.F")),
             };
+            // effectively sealed containing type
+            yield return new object[] {
+                CreateType(" class", "private First() {}", " public virtual void F() {}"),
+                CreateType(" class", "private First() {}", " public void F() {}"),
+                false,
+                CreateDifferences(),
+            };
         }
 
         public static IEnumerable<object[]> AddedCases()

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotChangeVisibilityTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotChangeVisibilityTests.cs
@@ -1,0 +1,327 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Microsoft.DotNet.ApiCompatibility.Tests;
+using Xunit;
+
+namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
+{
+    public class CannotChangeVisibilityTests
+    {
+        private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new CannotChangeVisibility(settings, context));
+
+        /*
+         * Tests for:
+         * - Reduce visibility of type
+         * - Expand visibility of type
+         * - Expand visibility of member
+         * - Restricting visibility of protected member inside sealed type
+         * - Restricting visibility of protected member inside type without accessible constructor
+         * - Restricting visibility of member
+         * - Strict mode
+         */
+
+        public static TheoryData<string, string, CompatDifference[]> TestCases => new()
+        {
+            // Reduce visibility of type
+            {
+                @"
+namespace CompatTests
+{
+  public class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  internal class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotReduceVisibility, string.Empty, DifferenceType.Changed, "T:CompatTests.First")
+}
+            },
+            // Expand visibility of type
+            {
+                @"
+namespace CompatTests
+{
+  internal class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {}
+}
+",
+new CompatDifference[] {}
+            },
+            // Expand visibility of member
+            {
+                @"
+namespace CompatTests
+{
+  public class First {
+    protected int F;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {
+    public int F;
+  }
+}
+",
+new CompatDifference[] {}
+            },
+            // Reducing visibility of protected member inside sealed type.
+            // Since we don't visit private members, we don't issue a diagnostic here.
+            // We suppress the warning for declaring protected members in sealed types,
+            // since we want to check for a different diagnostic.
+            {
+                @"
+namespace CompatTests
+{
+  public sealed class First {
+
+#pragma warning disable CS0628
+    protected int F;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public sealed class First {
+
+#pragma warning disable CS0169
+    private int F;
+  }
+}
+",
+new CompatDifference[] {}
+            },
+            // Reducing visibility of protected member inside type without accessible constructor
+            // Since we don't visit private members, we don't issue a diagnostic here.
+            {
+                @"
+namespace CompatTests
+{
+  public class First {
+    private First() {}
+
+#pragma warning disable CS0628
+    protected int F;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {
+    private First() {}
+
+#pragma warning disable CS0169
+    private int F;
+  }
+}
+",
+new CompatDifference[] {}
+            },
+            // Reduce visibility of member
+            {
+                @"
+namespace CompatTests
+{
+  public class First {
+    public int F;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {
+    protected int F;
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotReduceVisibility, string.Empty, DifferenceType.Changed, "F:CompatTests.First.F")
+}
+            }
+        };
+
+        public static TheoryData<string, string, CompatDifference[]> StrictMode => new()
+        {
+            // Reduce visibility of type
+            {
+                @"
+namespace CompatTests
+{
+  public class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  internal class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotReduceVisibility, string.Empty, DifferenceType.Changed, "T:CompatTests.First")
+}
+            },
+            // Expand visibility of type
+            {
+                @"
+namespace CompatTests
+{
+  internal class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotExpandVisibility, string.Empty, DifferenceType.Changed, "T:CompatTests.First")
+}
+            },
+            // Expand visibility of member
+            {
+                @"
+namespace CompatTests
+{
+  public class First {
+    protected int F;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {
+    public int F;
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotExpandVisibility, string.Empty, DifferenceType.Changed, "F:CompatTests.First.F")
+}
+            },
+            // Reducing visibility of protected member inside sealed type
+            // Since we don't visit private members, we don't issue a diagnostic here.
+            // We suppress the warning for declaring protected members in sealed types,
+            // since we want to check for a different diagnostic.
+            {
+                @"
+namespace CompatTests
+{
+  public sealed class First {
+
+#pragma warning disable CS0628
+    protected int F;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public sealed class First {
+
+#pragma warning disable CS0169
+    private int F;
+  }
+}
+",
+new CompatDifference[] {}
+            },
+            // Reducing visibility of protected member inside type without accessible constructor
+            // Since we don't visit private members, we don't issue a diagnostic here.
+            {
+                @"
+namespace CompatTests
+{
+  public class First {
+    private First() {}
+
+#pragma warning disable CS0628
+    protected int F;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {
+    private First() {}
+
+#pragma warning disable CS0169
+    private int F;
+  }
+}
+",
+new CompatDifference[] {}
+            },
+            // Reduce visibility of member
+            {
+                @"
+namespace CompatTests
+{
+  public class First {
+    public int F;
+  }
+}
+",
+                @"
+namespace CompatTests
+{
+  public class First {
+    protected int F;
+  }
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotReduceVisibility, string.Empty, DifferenceType.Changed, "F:CompatTests.First.F")
+}
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void EnsureDiagnosticIsReported(string leftSyntax, string rightSyntax, CompatDifference[] expected)
+        {
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(includeInternalSymbols: true));
+
+            IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(StrictMode))]
+        public void EnsureDiagnosticIsReportedInStrictMode(string leftSyntax, string rightSyntax, CompatDifference[] expected)
+        {
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(
+                includeInternalSymbols: true,
+                strictMode: true));
+
+            IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
This backport consists of 5 changes:
1. c3f9e6dc9740f5de469d41c027dbe5775d1bf052: apicompat: add rule to check change in visibility
2. 5627049bf3fee6912617604588dfff600a855a4d: don't emit attribute added diagnostic in strict mode
3. a9179759a3fdefd9ccb55763bdd6afc367c425a9: don't issue diagnostic when virtual is removed from sealed type
4. ac6cd3913898e579b620b8b07c60783821686db7: apicompat: attribute changed on right must only be emitted in strict mode
5. 8f9568fa6bd20797915d35cf6acff0977e370a20: normalize accessibility when not including internal symbols

## Customer Impact
TL;DR Rules behave correctly in strict mode and when internal members are excluded.

Previously, the attribute rule was emitting strict-mode diagnostics even outside strict mode. Additionally, internal members were not being excluded from analysis even when specified. These issues caused many false positive diagnostics to be emitted. The backported changes fix this behavior by taking these modes into account.

The new visibility change rule was announced for .NET 7, and also maintains parity with the legacy APICompat tool.

## Testing
All ApiCompat rules tests pass. The runtime built with this backport branch no longer emits false positive diagnostics.

## Risk
Low-Medium. Only affects users who are consuming the opt-in attribute and virtual modifier rules. Additionally, a new rule is added, but it shouldn't affect customers who aren't comparing in strict mode.