### PR TITLE
[release/7.0.1xx] Reference net7.0 version of msbuild for source-build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -112,7 +112,7 @@
           so target one that matches the version in minimumMSBuildVersion.
 
           This avoids the need to juggle references to packages that have been updated in newer MSBuild. -->
-    <MicrosoftBuildPackageVersion Condition="exists('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion')">$([System.IO.File]::ReadAllText('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion').Trim())</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion Condition="exists('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion') and '$(DotNetBuildFromSource)' != 'true'">$([System.IO.File]::ReadAllText('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion').Trim())</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>17.5.0-preview-22507-04</MicrosoftBuildLocalizationPackageVersion>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -21,8 +21,12 @@
   </ItemGroup>
 
   <Target Name="VerifyMSBuildDependency" BeforeTargets="ResolveAssemblyReferences" Condition="'$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETCoreApp'">
+    <!-- We explicitly reference an older version of MSBuild here to support VS
+    for Mac and other VS scenarios. During source-build, we only have access to
+    the latest version, which targets net7.0. -->
     <PropertyGroup>
       <MSBuildPathInPackage>$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net6.0\MSBuild.dll</MSBuildPathInPackage>
+      <MSBuildPathInPackage Condition="'$(DotNetBuildFromSource)' == 'true'">$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net7.0\MSBuild.dll</MSBuildPathInPackage>
     </PropertyGroup>
     <Error Condition="!Exists('$(MSBuildPathInPackage)')" Text="Something moved around in Microsoft.Build.Runtime, adjust code here accordingly." />
     <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3048

Backport of this source-build patch: https://github.com/dotnet/installer/blob/860067bade6be3fbda19a3162abde99286c82df1/src/SourceBuild/tarball/patches/sdk/0002-Look-for-msbuild-net7.0-artifacts.patch

We changed msbuild to [target net7.0](https://github.com/dotnet/msbuild/pull/7790) but we still need to use an older version ([17.3.0 in this case](https://github.com/dotnet/sdk/blob/39b57e7c15ec09a0c230dade5f014d17be960b42/src/Layout/redist/minimumMSBuildVersion#L1)) in the Microsoft-built SDK for VS and VS for Mac compatibility. This means we need a couple of source-build conditions for this change. The change to `MicrosoftBuildPackageVersion` only affects the repo's source-build CI leg and not the source-build tarball build.