### PR TITLE
Add actionable output to templating destructive changes notification

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1271,7 +1271,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rerun the command and pass --force to accept and create..
+        ///   Looks up a localized string similar to To accept changes and proceed with creating, rerun the command and pass &apos;{0}&apos; option:.
         /// </summary>
         internal static string RerunCommandAndPassForceToCreateAnyway {
             get {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1271,7 +1271,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To accept changes and proceed with creating, rerun the command and pass &apos;{0}&apos; option:.
+        ///   Looks up a localized string similar to To create the template anyway, run the command with &apos;{0}&apos; option:.
         /// </summary>
         internal static string RerunCommandAndPassForceToCreateAnyway {
             get {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -191,7 +191,7 @@
     <value>Overwrite</value>
   </data>
   <data name="RerunCommandAndPassForceToCreateAnyway" xml:space="preserve">
-    <value>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</value>
+    <value>To create the template anyway, run the command with '{0}' option:</value>
     <comment>{0} - additional option name (--force)</comment>
   </data>
   <data name="RunHelpForInformationAboutAcceptedParameters" xml:space="preserve">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -191,7 +191,8 @@
     <value>Overwrite</value>
   </data>
   <data name="RerunCommandAndPassForceToCreateAnyway" xml:space="preserve">
-    <value>Rerun the command and pass --force to accept and create.</value>
+    <value>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</value>
+    <comment>{0} - additional option name (--force)</comment>
   </data>
   <data name="RunHelpForInformationAboutAcceptedParameters" xml:space="preserve">
     <value>For usage information, run: </value>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -273,7 +273,11 @@ namespace Microsoft.TemplateEngine.Cli
                         }
                         Reporter.Error.WriteLine();
                     }
-                    Reporter.Error.WriteLine(LocalizableStrings.RerunCommandAndPassForceToCreateAnyway.Bold().Red());
+                    Reporter.Error.WriteLine(
+                        string.Format(
+                            LocalizableStrings.RerunCommandAndPassForceToCreateAnyway, SharedOptions.ForceOption.Aliases.First()).Bold().Red()
+                        );
+                    Reporter.Error.WriteCommand(Example.FromExistingTokens(templateArgs.ParseResult).WithOption(SharedOptions.ForceOption));
                     return NewCommandStatus.CannotCreateOutputFile;
                 default:
                     return NewCommandStatus.Unexpected;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">Spusťte příkaz znovu a pro přijetí a vytvoření předejte možnost --force.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">Führen Sie den Befehl erneut aus, und übergeben Sie --force, um den Befehl zu akzeptieren und zu erstellen.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">Vuelva a ejecutar el comando y pase --force para aceptar y crear.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">Exécutez la commande et passez --force pour accepter et créer.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">Eseguire di nuovo il comando e passare--Force per accettare e creare.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">受け入れて作成するにはコマンドを再実行し、--force を渡してください。</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">명령을 다시 실행하고 --force를 전달하여 수락하고 만듭니다.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">Ponownie uruchom polecenie and pass --force, aby zaakceptować i utworzyć.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">Re-execute o comando e passe --force para aceitar e criar.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">Чтобы создать шаблон, повторно выполните команду и передайте параметр --force.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">Komutu yeniden çalıştırın ve “--force to accept and create” uyarısını geçin.</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">重新运行命令并传递 --force 以接受和创建。</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -702,8 +702,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
-        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <source>To create the template anyway, run the command with '{0}' option:</source>
+        <target state="new">To create the template anyway, run the command with '{0}' option:</target>
         <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -702,9 +702,9 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="RerunCommandAndPassForceToCreateAnyway">
-        <source>Rerun the command and pass --force to accept and create.</source>
-        <target state="translated">重新執行命令並傳遞 --強制接受並建立。</target>
-        <note />
+        <source>To accept changes and proceed with creating, rerun the command and pass '{0}' option:</source>
+        <target state="new">To accept changes and proceed with creating, rerun the command and pass '{0}' option:</target>
+        <note>{0} - additional option name (--force)</note>
       </trans-unit>
       <trans-unit id="RunHelpForInformationAboutAcceptedParameters">
         <source>For usage information, run: </source>

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotOverwriteFilesWithoutForce.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotOverwriteFilesWithoutForce.verified.txt
@@ -2,7 +2,7 @@
   Overwrite   folderA/%FILENAME%
   Overwrite   folderA/%FILENAME%
 
-To accept changes and proceed with creating, rerun the command and pass '--force' option:
+To create the template anyway, run the command with '--force' option:
    dotnet new console --name overwrite-test -o folderA --debug:custom-hive %HOME% --force
 
 For details on the exit code, refer to https://aka.ms/templating-exit-codes#73

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotOverwriteFilesWithoutForce.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CannotOverwriteFilesWithoutForce.verified.txt
@@ -2,6 +2,7 @@
   Overwrite   folderA/%FILENAME%
   Overwrite   folderA/%FILENAME%
 
-Rerun the command and pass --force to accept and create.
+To accept changes and proceed with creating, rerun the command and pass '--force' option:
+   dotnet new console --name overwrite-test -o folderA --debug:custom-hive %HOME% --force
 
 For details on the exit code, refer to https://aka.ms/templating-exit-codes#73

--- a/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.Approval.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.Approval.cs
@@ -436,6 +436,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             return Verify(commandResult.StdErr)
                 .AddScrubber(output =>
                 {
+                    output = output.Replace(_fixture.HomeDirectory, "%HOME%");
                     //unify directory separators
                     output = output.Replace("\\", "/");
                     //order of files may vary, replace filename with placeholders


### PR DESCRIPTION
## Problem

Fixes https://github.com/dotnet/templating/issues/5319
Dotnet new had nonactionable output when notifying about destructive changes

## Solution

Added immediately runnable command
Updated tests accordingly