### PR TITLE
RuntimeIdentifiers Code Coverage + Implicit RuntimeIdentifiers (not just runtimeIdentifier)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -64,7 +64,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(UseCurrentRuntimeIdentifier)' == 'true' or
                  (
                  '$(RuntimeIdentifier)' == '' and
-                 '$(RuntimeIdentifiers)' == '' and
                    (
                    '$(SelfContained)' == 'true' or
                    '$(PublishReadyToRun)' == 'true' or
@@ -162,19 +161,19 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
 
     <!-- The following RID errors are asserts, and we don't expect them to ever occur. The error message is added as a safeguard.-->
-    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == ''"
+    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="SelfContained"/>
 
-    <NETSdkError Condition="'$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == ''"
+    <NETSdkError Condition="'$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="PublishReadyToRun"/>
 
-    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == ''"
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == ''"
                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                 FormatArguments="PublishSingleFile"/>
 
-    <NETSdkError Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == ''"
+    <NETSdkError Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == ''"
                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                 FormatArguments="PublishAot"/>
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -221,28 +221,19 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Fact]
-        public void It_Publishes_Successfully_With_RID_Requiring_Properties_And_RuntimeIdentifierS_but_no_RuntimeIdentifier()
+        public void PublishSuccessfullyWithRIDRequiringPropertyAndRuntimeIdentifiersNoRuntimeIdentifier()
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;
             var runtimeIdentifier = EnvironmentInfo.GetCompatibleRid(targetFramework);
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("HelloWorld")
-                .WithSource()
-                .WithProjectChanges(project =>
-                {
-                    var ns = project.Root.Name.Namespace;
-                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
-                    propertyGroup.Add(new XElement(ns + "RuntimeIdentifiers", runtimeIdentifier));
-                    propertyGroup.Add(new XElement(ns + "PublishReadyToRun", "true"));
-                });
+            var testProject = new TestProject()
+            {
+                IsExe = true,
+                TargetFrameworks = targetFramework
+            };
 
-            var buildCommand = new BuildCommand(testAsset);
-            buildCommand
-                .Execute()
-                .Should()
-                .Pass();
-
-            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: runtimeIdentifier);
+            testProject.AdditionalProperties["RuntimeIdentifiers"] = runtimeIdentifier;
+            testProject.AdditionalProperties["PublishReadyToRun"] = "true";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(testAsset);
             publishCommand


### PR DESCRIPTION
# Description

Resolves https://github.com/dotnet/sdk/issues/28048, follow up to https://github.com/dotnet/sdk/issues/27985 
We can imply a runtime identifier even if `RuntimeIdentifiers` is added and add a test to show that this feature works with not just one RID but `RuntimeIdentifiers`. The RID here is used to publish the project which will then use runtime identifiers. 

# Customer Impact

Low, this makes it so projects using RuntimeIdentifiers don't need to specify a RuntimeIdentifier, but probably they did anyways. It is a cleaner solution to the one we put out for source build a while ago, but both solutions fix the issue. We are raising this because we're making changes to this file anyways for a much more severe break, which is https://github.com/dotnet/sdk/pull/28628.

# Regression 

No.

# Risk

Somewhere between low and medium, closer to low than medium.

# Testing

We added a test to test the scenario that the previous fix... well, fixed, but we haven't run it through source-build who were the initial consumers that discovered the problem with how we handled RuntimeIdentifiers. 


