### PR TITLE
Add the Microsoft* package and see if it's small enough to be downloaded.

### DIFF
--- a/src/Tests/UnitTests.proj
+++ b/src/Tests/UnitTests.proj
@@ -139,6 +139,12 @@
         <Destination>d/.nuget</Destination>
         <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestPackages.Runtime.zip</Uri>
       </HelixCorrelationPayload>
+
+      <HelixCorrelationPayload Include="SDKTestPackages.Microsoft.zip">
+        <PayloadDirectory>$(TestDotnetRoot)</PayloadDirectory>
+        <Destination>d/.nuget</Destination>
+        <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestPackages.Microsoft.zip</Uri>
+      </HelixCorrelationPayload>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
We hit a size limit last time but this is slightly smaller so maybe it'll work. we're still seeing a lot of timeouts so it's worth a shot.