### PR TITLE
Return workload manifests in defined, controllable order

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using Microsoft.DotNet.Cli;
@@ -17,7 +18,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         private readonly string [] _manifestDirectories;
         private static HashSet<string> _outdatedManifestIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "microsoft.net.workload.android", "microsoft.net.workload.blazorwebassembly", "microsoft.net.workload.ios",
             "microsoft.net.workload.maccatalyst", "microsoft.net.workload.macos", "microsoft.net.workload.tvos" };
-        private readonly HashSet<string>? _knownManifestIds;
+        private readonly Dictionary<string, int>? _knownManifestIdsAndOrder;
 
         public SdkDirectoryWorkloadManifestProvider(string sdkRootPath, string sdkVersion, string? userProfileDir)
             : this(sdkRootPath, sdkVersion, Environment.GetEnvironmentVariable, userProfileDir)
@@ -44,7 +45,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             var knownManifestIdsFilePath = Path.Combine(_sdkRootPath, "sdk", sdkVersion, "IncludedWorkloadManifests.txt");
             if (File.Exists(knownManifestIdsFilePath))
             {
-                _knownManifestIds = File.ReadAllLines(knownManifestIdsFilePath).Where(l => !string.IsNullOrEmpty(l)).ToHashSet();
+                _knownManifestIdsAndOrder = new Dictionary<string, int>();
+                int lineNumber = 0;
+                foreach (var manifestId in File.ReadAllLines(knownManifestIdsFilePath).Where(l => !string.IsNullOrEmpty(l)))
+                {
+                    _knownManifestIdsAndOrder[manifestId] = lineNumber++;
+                }
             }
 
             string? userManifestsDir = userProfileDir is null ? null : Path.Combine(userProfileDir, "sdk-manifests", _sdkVersionBand.ToString());
@@ -126,9 +132,9 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 }
             }
 
-            if (_knownManifestIds != null && _knownManifestIds.Any(id => !manifestIdsToDirectories.ContainsKey(id)))
+            if (_knownManifestIdsAndOrder != null && _knownManifestIdsAndOrder.Keys.Any(id => !manifestIdsToDirectories.ContainsKey(id)))
             {
-                var missingManifestIds = _knownManifestIds.Where(id => !manifestIdsToDirectories.ContainsKey(id));
+                var missingManifestIds = _knownManifestIdsAndOrder.Keys.Where(id => !manifestIdsToDirectories.ContainsKey(id));
                 foreach (var missingManifestId in missingManifestIds)
                 {
                     var manifestDir = FallbackForMissingManifest(missingManifestId);
@@ -139,7 +145,21 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 }
             }
 
-            return manifestIdsToDirectories.Values;
+            //  Return manifests in a stable order.  Manifests in the IncludedWorkloadManifests.txt file will be first, and in the same order they appear in that file.
+            //  Then the rest of the manifests (if any) will be returned in (ordinal case-insensitive) alphabetical order.
+            return manifestIdsToDirectories
+                .OrderBy(kvp =>
+                {
+                    if (_knownManifestIdsAndOrder != null &&
+                        _knownManifestIdsAndOrder.TryGetValue(kvp.Key, out var order))
+                    {
+                        return order;
+                    }
+                    return int.MaxValue;
+                })
+                .ThenBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(kvp => kvp.Value)
+                .ToList();
         }
 
         private string FallbackForMissingManifest(string manifestId)

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -343,6 +343,43 @@ namespace ManifestReaderTests
                 .BeEquivalentTo("6.0.100-preview.4/iOS", "6.0.100/Android");
         }
 
+        [Fact]
+        public void ItReturnsManifestsInOrderFromIncludedWorkloadManifestsFile()
+        {
+            var testDirectory = _testAssetsManager.CreateTestDirectory().Path;
+            var fakeDotnetRootDirectory = Path.Combine(testDirectory, "dotnet");
+
+            //  microsoft.net.workload.mono.toolchain.net6, microsoft.net.workload.mono.toolchain.net7, microsoft.net.workload.emscripten.net6, microsoft.net.workload.emscripten.net7
+
+            var currentSdkVersion = "7.0.100";
+            var fallbackWorkloadBand = "7.0.100-rc.2";
+
+            CreateMockManifest(fakeDotnetRootDirectory, currentSdkVersion, "NotInIncudedWorkloadsFile");
+            CreateMockManifest(fakeDotnetRootDirectory, currentSdkVersion, "Microsoft.Net.Workload.Mono.Toolchain.net6");
+            CreateMockManifest(fakeDotnetRootDirectory, fallbackWorkloadBand, "Microsoft.Net.Workload.Mono.Toolchain.net7");
+            CreateMockManifest(fakeDotnetRootDirectory, fallbackWorkloadBand, "Microsoft.Net.Workload.Emscripten.net6");
+            CreateMockManifest(fakeDotnetRootDirectory, currentSdkVersion, "Microsoft.Net.Workload.Emscripten.net7");
+
+            var knownWorkloadsFilePath = Path.Combine(fakeDotnetRootDirectory, "sdk", currentSdkVersion, "IncludedWorkloadManifests.txt");
+            Directory.CreateDirectory(Path.GetDirectoryName(knownWorkloadsFilePath)!);
+            File.WriteAllText(knownWorkloadsFilePath, @"
+Microsoft.Net.Workload.Mono.Toolchain.net6
+Microsoft.Net.Workload.Mono.Toolchain.net7
+Microsoft.Net.Workload.Emscripten.net6
+Microsoft.Net.Workload.Emscripten.net7"
+                .Trim());
+
+            var sdkDirectoryWorkloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: fakeDotnetRootDirectory, sdkVersion: currentSdkVersion, userProfileDir: null);
+
+            GetManifestContents(sdkDirectoryWorkloadManifestProvider)
+                .Should()
+                .Equal($"{currentSdkVersion}/Microsoft.Net.Workload.Mono.Toolchain.net6",
+                       $"{fallbackWorkloadBand}/Microsoft.Net.Workload.Mono.Toolchain.net7",
+                       $"{fallbackWorkloadBand}/Microsoft.Net.Workload.Emscripten.net6",
+                       $"{currentSdkVersion}/Microsoft.Net.Workload.Emscripten.net7",
+                       $"{currentSdkVersion}/NotInIncudedWorkloadsFile");
+        }
+
         private void CreateMockManifest(string rootDir, string version, string manifestId)
         {
             var manifestDirectory = Path.Combine(rootDir, "sdk-manifests", version);


### PR DESCRIPTION
# Description

The WASM workload stopped working when we switched to stable branding.  This is because the order in which we imported workload manifest targets was not guaranteed and ended up changing when the branding changed, but the WASM workload manifest targets did depend on the order they were imported.

To fix this, we will return workload manifests in a stable order.  Manifests in the IncludedWorkloadManifests.txt file will be first, and in the same order they appear in that file.  Then the rest of the manifests (if any) will be returned in (ordinal case-insensitive) alphabetical order.

Fixes #22358
Fixes #28607

Alternatively, we could have changed the WASM workload manifest targets to be resilient to being imported in an arbitrary order.  That would have been a lot more risky: The change itself would be more complex, it would be harder to test, and the time to flow the change through the build graph would be longer.

# Customer Impact

Without this change (or another more risky change to the WASM workload manifest targets), the WASM workload won't work in stable versioned .NET SDKs.

# Regression

Yes, this worked in earlier prereleases, but dropping the prerelease specifier from the version triggered this regression.

# Risk

Low

# Testing

Added unit test.  Planning to validate E2E scenario with WASM manually.