### PR TITLE
Allow Implicit RID Opt Out + Don't Infer RID for non EXE Type Projects

### DIFF
--- a/src/Assets/TestProjects/AppWithLibrarySDKStyleThatPublishesSingleFile/Program.cs
+++ b/src/Assets/TestProjects/AppWithLibrarySDKStyleThatPublishesSingleFile/Program.cs
@@ -1,0 +1,8 @@
+namespace newc;
+
+static class Program
+{
+    static void Main()
+    {
+    }    
+}

--- a/src/Assets/TestProjects/AppWithLibrarySDKStyleThatPublishesSingleFile/lib/Class1.cs
+++ b/src/Assets/TestProjects/AppWithLibrarySDKStyleThatPublishesSingleFile/lib/Class1.cs
@@ -1,0 +1,5 @@
+﻿namespace lib;
+public class Class1
+{
+
+}

--- a/src/Assets/TestProjects/AppWithLibrarySDKStyleThatPublishesSingleFile/lib/lib.csproj
+++ b/src/Assets/TestProjects/AppWithLibrarySDKStyleThatPublishesSingleFile/lib/lib.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishSingleFile>true</PublishSingleFile>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/AppWithLibrarySDKStyleThatPublishesSingleFile/newc.csproj
+++ b/src/Assets/TestProjects/AppWithLibrarySDKStyleThatPublishesSingleFile/newc.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishSingleFile>true</PublishSingleFile>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <ProjectReference Include="lib\lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -72,8 +72,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                     '$(PublishReadyToRun)' == 'true' or
                     '$(PublishSingleFile)' == 'true' or
                     '$(PublishAot)' == 'true'
-                  )">
-      true</UseCurrentRuntimeIdentifier>
+                  )">true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseCurrentRuntimeIdentifier)' == 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -65,7 +65,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                  (
                  '$(RuntimeIdentifier)' == '' and
                  '$(RuntimeIdentifiers)' == '' and
-                 '$(_IsExecutable)' == 'true' and
+                 '$(_IsExecutable)' == 'true' and '$(IsTestProject)' != 'true' and
+                 '$(IsRidAgnostic)' != 'true' and
                  '$(DisableImplicitRuntimeIdentifier)' != 'true' and
                    (
                    '$(SelfContained)' == 'true' or

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -65,6 +65,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                  (
                  '$(RuntimeIdentifier)' == '' and
                  '$(RuntimeIdentifiers)' == '' and
+                 '$(OutputType)' == 'Exe' and
                    (
                    '$(SelfContained)' == 'true' or
                    '$(PublishReadyToRun)' == 'true' or

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -66,7 +66,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                  '$(RuntimeIdentifier)' == '' and
                  '$(RuntimeIdentifiers)' == '' and
                  '$(_IsExecutable)' == 'true' and '$(IsTestProject)' != 'true' and
-                 '$(IsRidAgnostic)' != 'true') and
+                 '$(IsRidAgnostic)' != 'true' and
                   (
                     '$(SelfContained)' == 'true' or
                     '$(PublishReadyToRun)' == 'true' or

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -65,7 +65,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                  (
                  '$(RuntimeIdentifier)' == '' and
                  '$(RuntimeIdentifiers)' == '' and
-                 '$(OutputType)' == 'Exe' and
+                 '$(_IsExecutable)' == 'true' and
+                 '$(DisableImplicitRuntimeIdentifier)' == '' and
                    (
                    '$(SelfContained)' == 'true' or
                    '$(PublishReadyToRun)' == 'true' or

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -61,20 +61,22 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeIdentifier Condition="'$(PlatformTarget)' == 'x86' or '$(PlatformTarget)' == ''">win7-x86</RuntimeIdentifier>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(UseCurrentRuntimeIdentifier)' == 'true' or
-                 (
+  <PropertyGroup Condition="'$(UseCurrentRuntimeIdentifier)' == ''">
+    <UseCurrentRuntimeIdentifier Condition="
                  '$(RuntimeIdentifier)' == '' and
                  '$(RuntimeIdentifiers)' == '' and
                  '$(_IsExecutable)' == 'true' and '$(IsTestProject)' != 'true' and
-                 '$(IsRidAgnostic)' != 'true' and
-                 '$(DisableImplicitRuntimeIdentifier)' != 'true' and
-                   (
-                   '$(SelfContained)' == 'true' or
-                   '$(PublishReadyToRun)' == 'true' or
-                   '$(PublishSingleFile)' == 'true' or
-                   '$(PublishAot)' == 'true'
-                   )
-                 )">
+                 '$(IsRidAgnostic)' != 'true') and
+                  (
+                    '$(SelfContained)' == 'true' or
+                    '$(PublishReadyToRun)' == 'true' or
+                    '$(PublishSingleFile)' == 'true' or
+                    '$(PublishAot)' == 'true'
+                  )">
+      true</UseCurrentRuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseCurrentRuntimeIdentifier)' == 'true'">
     <RuntimeIdentifier>$(NETCoreSdkPortableRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -66,7 +66,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                  '$(RuntimeIdentifier)' == '' and
                  '$(RuntimeIdentifiers)' == '' and
                  '$(_IsExecutable)' == 'true' and
-                 '$(DisableImplicitRuntimeIdentifier)' == '' and
+                 '$(DisableImplicitRuntimeIdentifier)' != 'true' and
                    (
                    '$(SelfContained)' == 'true' or
                    '$(PublishReadyToRun)' == 'true' or

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileLibrary.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileLibrary.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using FluentAssertions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -30,6 +31,12 @@ namespace Microsoft.NET.Publish.Tests
             publishCommand.Execute()
                     .Should()
                     .Pass();
+
+            // It would be better if we could somehow check the library binlog or something for a RID instead.
+            var exeFolder = publishCommand.GetOutputDirectory(targetFramework: targetFramework);
+            // Parent: RID, then TFM, then Debug, then bin, then the test folder
+            var ridlessLibraryDllPath = Path.Combine(exeFolder.Parent.Parent.Parent.Parent.FullName, "lib", "bin", "Debug", targetFramework, "lib.dll");
+            Assert.True(File.Exists(ridlessLibraryDllPath));
         }
 
     }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileLibrary.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileLibrary.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishASingleFileLibrary : SdkTest
+    {
+        public GivenThatWeWantToPublishASingleFileLibrary(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        // Tests regression on https://github.com/dotnet/sdk/pull/28484
+        public void ItPublishesSuccessfullyWithRIDAndPublishSingleFileLibrary()
+        {
+            var testAsset = _testAssetsManager
+                     .CopyTestAsset("AppWithLibrarySDKStyleThatPublishesSingleFile")
+                     .WithSource();
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute()
+                    .Should()
+                    .Pass();
+        }
+
+    }
+
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileLibrary.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileLibrary.cs
@@ -16,12 +16,14 @@ namespace Microsoft.NET.Publish.Tests
         {
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         // Tests regression on https://github.com/dotnet/sdk/pull/28484
         public void ItPublishesSuccessfullyWithRIDAndPublishSingleFileLibrary()
         {
+            var targetFramework = ToolsetInfo.CurrentTargetFramework;
             var testAsset = _testAssetsManager
                      .CopyTestAsset("AppWithLibrarySDKStyleThatPublishesSingleFile")
+                     .WithTargetFramework(targetFramework)
                      .WithSource();
 
             var publishCommand = new PublishCommand(testAsset);

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -194,6 +194,30 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Fact]
+        public void ImplicitRuntimeIdentifierOptOutCorrecltyOptsOut()
+        {
+            var targetFramework = ToolsetInfo.CurrentTargetFramework;
+            var runtimeIdentifier = EnvironmentInfo.GetCompatibleRid(targetFramework);
+            var testProject = new TestProject()
+            {
+                IsExe = true,
+                TargetFrameworks = targetFramework
+            };
+            testProject.AdditionalProperties["SelfContained"] = "true";
+            testProject.AdditionalProperties["DisableImplicitRuntimeIdentifier"] = "true";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1191");
+        }
+
+        [Fact]
         public void DuplicateRuntimeIdentifiers()
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -204,7 +204,7 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = targetFramework
             };
             testProject.AdditionalProperties["SelfContained"] = "true";
-            testProject.AdditionalProperties["UseCurrentRuntime"] = "false";
+            testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "false";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -204,7 +204,7 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = targetFramework
             };
             testProject.AdditionalProperties["SelfContained"] = "true";
-            testProject.AdditionalProperties["DisableImplicitRuntimeIdentifier"] = "true";
+            testProject.AdditionalProperties["UseCurrentRuntime"] = "false";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 


### PR DESCRIPTION
# Description
- Allows `UseCurrentRuntimeIdentifier` property to opt out of this feature (Implicit RIDS) in case someone doesn't want it
- Resolves issue where you do the following:

Create a .NET Core project (e,g, Winforms APP)
In same solution, add a Class Library and set it as a project reference to the main project (created in step1)
Navigate to ClickOnce publish wizard, and set all as default
Navigate to Configurations wizard and set it to Framework-Dependent, SingleFile, x86
<img width="571" alt="image" src="https://user-images.githubusercontent.com/12663534/196774500-fe142f01-8329-44f7-af9c-ad7e0dd8cd69.png">

Publish and see failure. **Only fails in VS. Also, if you set the properties anywhere besides VS, it won't fail.**

Before:
![Screenshot_47](https://user-images.githubusercontent.com/23152278/196548531-1e95a81a-9fce-42ce-8946-ed2b9c04ee35.png)

After:
![Screenshot_48](https://user-images.githubusercontent.com/23152278/196548639-8cfa1cbe-a7ee-43fb-966f-6daf88d9d741.png)


Why?

1) PublishSingleFile (PSF) is not supposed to work if you don't set a RID, but it works if you set a RID in the top-level project but then don't flow the RID to the project references. 

2) AppendsRuntimeIdentifierToOutputPath is set to true even with there is no rid in a library if the top level project had a rid, so the library is ridless but tries to append it's nonexistent rid to the output path which used to be OK

3) We tried to infer a RID because PSF generally requires a RID to exist but the check for the RID doesn't run in PrepareForPublish for Non-Exe projects. 

4) When VS Injects their own publishing properties in the publishing wizard the pathing gets mixed up.

So, we can solve this by only doing that inference for Exe OutputTypes since PSF doesn't require a RID in subprojects. Rainer confirmed with me that it fixed this scenario. We need to take it to tactics now most likely.

cc @rainersigwald @dsplaisted 

# Customer Impact

Will allow customers to correctly publish libraries in the VS Publishing wizard but also keep the feature of not having to specify a RID when building or publishing selfcontained and friends.

# Regression

This is a new feature so not a regression.

# Risk

Low because it only lowers the scope of a newer feature and allows opting out of that feature instead of doing it everytime. 
But there is a chance it might break something else we haven't thought of. So far, we didn't find anything else.

# Testing

See the above Before and after screenshot. 
