### PR TITLE
Trim away FullFramework release leg

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -101,11 +101,6 @@ stages:
               _PublishArgs: ''
               _SignType: test
               _Test: -test
-            Build_Release:
-              _BuildConfig: Release
-              _PublishArgs: ''
-              _SignType: test
-              _Test: -test
 
     - template: /eng/build.yml
       parameters:


### PR DESCRIPTION
The failure rates for Debug vs. Release are essentially identical. Keep the Debug one (we have lots of release).