### PR TITLE
Create workloads enumerator lazily in dotnet-new host

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
@@ -145,7 +145,10 @@ namespace Microsoft.DotNet.Cli
                 builtIns.Add((typeof(ITemplateConstraintFactory), new ProjectCapabilityConstraintFactory()));
                 builtIns.Add((typeof(MSBuildEvaluator), new MSBuildEvaluator(outputDirectory: outputPath?.FullName, projectPath: projectPath?.FullName)));
             }
-            builtIns.Add((typeof(IWorkloadsInfoProvider), new WorkloadsInfoProvider(new WorkloadInfoHelper())));
+
+            builtIns.Add((typeof(IWorkloadsInfoProvider), new WorkloadsInfoProvider(
+                    new Lazy<IWorkloadsRepositoryEnumerator>(() => new WorkloadInfoHelper())))
+            );
             builtIns.Add((typeof(ISdkInfoProvider), new SdkInfoProvider()));
 
             string? preferredLangEnvVar = Environment.GetEnvironmentVariable(PrefferedLangEnvVarName);

--- a/src/Cli/dotnet/commands/dotnet-new/WorkloadsInfoProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/WorkloadsInfoProvider.cs
@@ -16,10 +16,10 @@ namespace Microsoft.DotNet.Tools.New
 {
     internal class WorkloadsInfoProvider : IWorkloadsInfoProvider
     {
-        private readonly IWorkloadsRepositoryEnumerator _workloadsRepositoryEnumerator;
+        private readonly Lazy<IWorkloadsRepositoryEnumerator> _workloadsRepositoryEnumerator;
         public Guid Id { get; } = Guid.Parse("{F8BA5B13-7BD6-47C8-838C-66626526817B}");
 
-        public WorkloadsInfoProvider(IWorkloadsRepositoryEnumerator workloadsRepositoryEnumerator)
+        public WorkloadsInfoProvider(Lazy<IWorkloadsRepositoryEnumerator> workloadsRepositoryEnumerator)
         {
             _workloadsRepositoryEnumerator = workloadsRepositoryEnumerator;
         }
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Tools.New
         public Task<IEnumerable<WorkloadInfo>> GetInstalledWorkloadsAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult(
-                _workloadsRepositoryEnumerator.InstalledAndExtendedWorkloads.Select(w => new WorkloadInfo(w.Id, w.Description))
+                _workloadsRepositoryEnumerator.Value.InstalledAndExtendedWorkloads.Select(w => new WorkloadInfo(w.Id, w.Description))
                 );
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -946,7 +946,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             string tempDirPath = null,
             RestoreActionConfig restoreActionConfig = null)
         {
-            TimestampedFileLogger logger = new(Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{DateTime.Now:yyyyMMdd_HHmmss}.log"));
+            TimestampedFileLogger logger = new(Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:yyyyMMdd_HHmmss}.log"));
             InstallClientElevationContext elevationContext = new(logger);
 
             if (nugetPackageDownloader == null)

--- a/src/Tests/dotnet.Tests/dotnet-new/WorkloadsInfoProviderTests.cs
+++ b/src/Tests/dotnet.Tests/dotnet-new/WorkloadsInfoProviderTests.cs
@@ -14,6 +14,7 @@ using Microsoft.TemplateEngine.Abstractions.Components;
 using Xunit;
 using System.Linq;
 using System.Collections.Generic;
+using System;
 
 namespace Microsoft.DotNet.Cli.New.Tests
 {
@@ -44,7 +45,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
                 currentSdkVersion: "1.2.3",
                 workloadRecordRepo: repoMock.Object,
                 workloadResolver: resolverMock.Object);
-            IWorkloadsInfoProvider wp = new WorkloadsInfoProvider(workloadsEnumerator);
+            IWorkloadsInfoProvider wp = new WorkloadsInfoProvider(new Lazy<IWorkloadsRepositoryEnumerator>(workloadsEnumerator));
 
             // Act
             var workloads = wp.GetInstalledWorkloadsAsync(default).Result;


### PR DESCRIPTION
### Problem

`dotnet new` is creating `WorkloadInfoHelper` that transitively causes creation of 'Microsoft.NET.Workload_<timestamp>.log' log in `%temp%` folder on each execution (regardles whether workloads constraints are being used or not).
This leads to unnecessary I/O operations. Also under specific circumstances `dotnet new` can fail due to log already being created (As log names are being created only with per-second granularity: https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs#L949) :

```
Unhandled exception: System.IO.IOException: The process cannot access the file 'C:\Users\jankrivanek\AppData\Local\Temp\Microsoft.NET.Workload_20221020_134925.log' because it is being used by another process.
  at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
  at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
  at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
  at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
  at System.IO.StreamWriter.ValidateArgsAndOpenPath(String path, Boolean append, Encoding encoding, Int32 bufferSize)
  at System.IO.File.CreateText(String path)
  at Microsoft.DotNet.Installer.Windows.TimestampedFileLogger..ctor(String path, Int32 flushThreshold, String[] logPipeNames)
  at Microsoft.DotNet.Workloads.Workload.Install.NetSdkMsiInstallerClient.Create(Boolean verifySignatures, SdkFeatureBand sdkFeatureBand, IWorkloadResolver workloadResolver, INuGetPackageDownloader nugetPackageDownloader, VerbosityOptions verbosity, PackageSourceLocation packageSourceLocation, IReporter reporter, String tempDirPath, RestoreActionConfig restoreActionConfig)
  at Microsoft.DotNet.Workloads.Workload.Install.WorkloadInstallerFactory.GetWorkloadInstaller(IReporter reporter, SdkFeatureBand sdkFeatureBand, IWorkloadResolver workloadResolver, VerbosityOptions verbosity, String userProfileDir, Boolean verifySignatures, INuGetPackageDownloader nugetPackageDownloader, String dotnetDir, String tempDirPath, PackageSourceLocation packageSourceLocation, RestoreActionConfig restoreActionConfig, Boolean elevationRequired)
  at Microsoft.DotNet.Workloads.Workload.List.WorkloadInfoHelper..ctor(VerbosityOptions verbosity, String targetSdkVersion, Nullable`1 verifySignatures, IReporter reporter, IWorkloadInstallationRecordRepository workloadRecordRepo, String currentSdkVersion, String dotnetDir, String userProfileDir, IWorkloadResolver workloadResolver)
  at Microsoft.DotNet.Cli.NewCommandParser.CreateHost(Boolean disableSdkTemplates, Boolean disableProjectContext, FileInfo projectPath, FileInfo outputPath, LogLevel logLevel)
  at Microsoft.DotNet.Cli.NewCommandParser.<GetCommand>g__GetEngineHost|11_0(ParseResult parseResult)
  at Microsoft.TemplateEngine.Cli.Commands.BaseCommand.CreateEnvironmentSettings(GlobalArgs args, ParseResult parseResult)
  at Microsoft.TemplateEngine.Cli.Commands.BaseCommand`1.InvokeAsync(InvocationContext context)
  at Microsoft.TemplateEngine.Cli.Commands.BaseCommand`1.Invoke(InvocationContext context)
  at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
``` 

### Sample repro

```
> start /b dotnet new --help & start /b dotnet new --help

System.IO.IOException: The process cannot access the file (...)
```

### Solution

Create the workload provider lazily

### Additional details

`WorkloadInfoHelper` is as well used in `dotnet workload` commands - so those have the same issue - e.g.:

```
> start /b dotnet workload list & start /b dotnet workload list

Unhandled exception: System.IO.IOException: The process cannot access the file (...)
```

however those command or probably much less likely to be executed in parallel or quick sequence