### PR TITLE
Limit libstdc++ woraround to TFM <= net7.0

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1160,7 +1160,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Temporary workaround for https://github.com/dotnet/runtime/issues/75468. Delete once the issue is fixed. -->
   <PropertyGroup>
-    <LinkStandardCPlusPlusLibrary Condition="'$(OS)' != 'Windows_NT' and '$(LinkStandardCPlusPlusLibrary)' == ''">true</LinkStandardCPlusPlusLibrary>
+    <LinkStandardCPlusPlusLibrary Condition="$([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '7.0')) and '$(OS)' != 'Windows_NT' and '$(LinkStandardCPlusPlusLibrary)' == ''">true</LinkStandardCPlusPlusLibrary>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1160,7 +1160,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Temporary workaround for https://github.com/dotnet/runtime/issues/75468. Delete once the issue is fixed. -->
   <PropertyGroup>
-    <LinkStandardCPlusPlusLibrary Condition="$([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '7.0')) and '$(OS)' != 'Windows_NT' and '$(LinkStandardCPlusPlusLibrary)' == ''">true</LinkStandardCPlusPlusLibrary>
+    <LinkStandardCPlusPlusLibrary Condition="$([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '7.0')) and '$(OS)' != 'Windows_NT' and '$(LinkStandardCPlusPlusLibrary)' == ''">true</LinkStandardCPlusPlusLibrary>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />


### PR DESCRIPTION
With (today's) latest daily build of installer `8.0.100-alpha.1.22521.5`, publishing `net8.0` project with `LinkStandardCPlusPlusLibrary=false` works fine; only projects targeting `net7.0` (or lower) framework give the error because we are using 8.0 targets and 7.0 binaries. 