### PR TITLE
Cherry pick fix parsing for arguments ending with dll/exe (#28662)

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tools.Test
 
             // Fix for https://github.com/Microsoft/vstest/issues/1453
             // Run dll/exe directly using the VSTestForwardingApp
-            if (ContainsBuiltTestSources(args))
+            if (ContainsBuiltTestSources(parseResult))
             {
                 return ForwardToVSTestConsole(parseResult, args, settings, testSessionCorrelationId);
             }
@@ -227,16 +227,15 @@ namespace Microsoft.DotNet.Tools.Test
             }
         }
 
-        private static bool ContainsBuiltTestSources(string[] args)
+        private static bool ContainsBuiltTestSources(ParseResult parseResult)
         {
-            foreach (string arg in args)
+            string commandArgument = parseResult.GetValueForArgument(TestCommandParser.SlnOrProjectArgument);
+
+            if (commandArgument is not null && (commandArgument.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || commandArgument.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)))
             {
-                if (!arg.StartsWith("-") &&
-                    (arg.EndsWith("dll", StringComparison.OrdinalIgnoreCase) || arg.EndsWith("exe", StringComparison.OrdinalIgnoreCase)))
-                {
-                    return true;
-                }
+                return true;
             }
+
             return false;
         }
 

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromDll.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromDll.cs
@@ -113,5 +113,29 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             result.ExitCode.Should().Be(1);
         }
+
+        [Theory]
+        [InlineData("-e:foo=bardll")]
+        [InlineData("-e:foo=barexe")]
+        public void MissingOutputDllAndArgumentsEndWithDllOrExeShouldFailInMSBuild(string arg)
+        {
+            var testAppName = "VSTestCore";
+            var testAsset = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource()
+                .WithVersionVariables();
+
+            new BuildCommand(testAsset)
+                .Execute()
+                .Should().Pass();
+
+            var result = new DotnetTestCommand(Log)
+                .Execute(arg);
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut.Should().Contain("MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.");
+            }
+
+            result.ExitCode.Should().Be(1);
+        }
     }
 }

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -801,6 +801,27 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Directory.EnumerateFileSystemEntries(flagDirectory).Should().NotBeEmpty();
         }
 
+        [Theory]
+        [InlineData("-e:foo=bardll")]
+        [InlineData("-e:foo=barexe")]
+        public void ArgumentsEndWithDllOrExeShouldNotFail(string arg)
+        {
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp();
+
+            // Call test
+            CommandResult result = new DotnetTestCommand(Log)
+                .Execute(testProjectDirectory, arg);
+
+            // Verify
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
+                result.StdOut.Should().Contain("Failed VSTestFailTest");
+            }
+        }
+
         private string CopyAndRestoreVSTestDotNetCoreTestApp([CallerMemberName] string callingMethod = "")
         {
             // Copy VSTestCore project in output directory of project dotnet-vstest.Tests


### PR DESCRIPTION
Cherry pick fix parsing for arguments ending with dll/exe