### PR TITLE
removed `v` prefix from `dotnetcli` host version

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.Cli
             };
             return new CliTemplateEngineHost(
                 HostIdentifier,
-                "v" + Product.Version,
+                Product.Version,
                 preferences,
                 builtIns,
                 outputPath: outputPath?.FullName,

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstallTests.CanShowWarning_WhenConstraintTemplateIsInstalled.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstallTests.CanShowWarning_WhenConstraintTemplateIsInstalled.verified.txt
@@ -8,4 +8,4 @@ Constraints - Restricted Template  Constraints.RestrictedTemplate            Tes
 
 The following templates might not work because their constraints are not met:
 Constraints - Restricted Template (Constraints.RestrictedTemplate)
-   Template engine host: Running template on dotnetcli (version: v%VERSION%) is not supported, supported hosts is/are: do-not-exist((1.0.0, )).
+   Template engine host: Running template on dotnetcli (version: %VERSION%) is not supported, supported hosts is/are: do-not-exist((1.0.0, )).

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.Constraints_CanIgnoreConstraints_WhenForceIsSpecified.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.Constraints_CanIgnoreConstraints_WhenForceIsSpecified.verified.txt
@@ -1,6 +1,6 @@
 ﻿The template "Constraints - Restricted Template" was created successfully.
 
 Warning: the following constraints for the template 'Constraints - Restricted Template' are not met:
-   Template engine host: Running template on dotnetcli (version: v%VERSION%) is not supported, supported hosts is/are: do-not-exist((1.0.0, )).
+   Template engine host: Running template on dotnetcli (version: %VERSION%) is not supported, supported hosts is/are: do-not-exist((1.0.0, )).
 
 The template might not be usable.

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.Constraints_Error_IfTemplateIsRestricted.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.Constraints_Error_IfTemplateIsRestricted.verified.txt
@@ -1,5 +1,5 @@
 ﻿Failed to instatiate template 'Constraints - Restricted Template', the following constraints are not met:
-   Template engine host: Running template on dotnetcli (version: v%VERSION%) is not supported, supported hosts is/are: do-not-exist((1.0.0, )).
+   Template engine host: Running template on dotnetcli (version: %VERSION%) is not supported, supported hosts is/are: do-not-exist((1.0.0, )).
 
 To run the template anyway, use '--force' option:
    dotnet new Constraints.RestrictedTemplate --debug:custom-hive %SETTINGS DIRECTORY% --force

--- a/src/Tests/dotnet-new.Tests/BaseIntegrationTest.cs
+++ b/src/Tests/dotnet-new.Tests/BaseIntegrationTest.cs
@@ -3,7 +3,6 @@
 //
 
 using System.Runtime.CompilerServices;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -46,11 +45,6 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         /// Gets a path to the template packages maintained in the repo (/template_feed).
         /// </summary>
         public static string RepoTemplatePackages { get; } = VerifyExists(Path.Combine(CodeBaseRoot, "template_feed"));
-
-        /// <summary>
-        /// Gets a version of dotnet executing tests.
-        /// </summary>
-        public static string Version { get; } = $"v{Product.Version}";
 
 #if DEBUG
         /// <summary>

--- a/src/Tests/dotnet-new.Tests/DotnetNewDebugOptionsTests.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewDebugOptionsTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         public void CanShowBasicInfoWithDebugReinit()
         {
             string home = CreateTemporaryFolder(folderName: "Home");
-            string cacheFilePath = Path.Combine(home, "dotnetcli", Version, "templatecache.json");
+            string cacheFilePath = Path.Combine(home, "dotnetcli", Product.Version, "templatecache.json");
 
             CommandResult commandResult = new DotnetNewCommand(_log)
                 .WithCustomHive(home)
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         public void CanShowBasicInfoWithDebugRebuildCache()
         {
             string home = CreateTemporaryFolder(folderName: "Home");
-            string cacheFilePath = Path.Combine(home, "dotnetcli", Version, "templatecache.json");
+            string cacheFilePath = Path.Combine(home, "dotnetcli", Product.Version, "templatecache.json");
 
             CommandResult commandResult = new DotnetNewCommand(_log)
                 .WithCustomHive(home)
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             Assert.Equal(2, createdCacheEntries.Length);
             Assert.Contains(Path.Combine(home, "packages"), createdCacheEntries);
-            Assert.True(File.Exists(Path.Combine(home, "dotnetcli", Version, "templatecache.json")));
+            Assert.True(File.Exists(Path.Combine(home, "dotnetcli", Product.Version, "templatecache.json")));
         }
 
         [Fact]

--- a/src/Tests/dotnet-new.Tests/DotnetNewInstallTests.Approval.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewInstallTests.Approval.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .AddScrubber(output =>
                 {
                     output.ScrubAndReplace(testTemplateLocation, "%TEMPLATE FOLDER%");
-                    output.ScrubByRegex("dotnetcli \\(version: v[A-Za-z0-9.-]+\\)", "dotnetcli (version: v%VERSION%)");
+                    output.ScrubByRegex("dotnetcli \\(version: [A-Za-z0-9.-]+\\)", "dotnetcli (version: %VERSION%)");
                 });
         }
 

--- a/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.Approval.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.Approval.cs
@@ -550,7 +550,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .AddScrubber(output =>
                 {
                     output.ScrubByRegex("\\-\\-debug\\:custom\\-hive [A-Za-z0-9\\-\\.\\\\\\/\\{\\}\\:_]+", "--debug:custom-hive %SETTINGS DIRECTORY%");
-                    output.ScrubByRegex("dotnetcli \\(version: v[A-Za-z0-9.-]+\\)", "dotnetcli (version: v%VERSION%)");
+                    output.ScrubByRegex("dotnetcli \\(version: [A-Za-z0-9.-]+\\)", "dotnetcli (version: %VERSION%)");
                 });
         }
 
@@ -571,7 +571,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             return Verify(commandResult.StdOut)
                 .AddScrubber(output =>
                 {
-                    output.ScrubByRegex("dotnetcli \\(version: v[A-Za-z0-9.-]+\\)", "dotnetcli (version: v%VERSION%)");
+                    output.ScrubByRegex("dotnetcli \\(version: [A-Za-z0-9.-]+\\)", "dotnetcli (version: %VERSION%)");
                 });
         }
 


### PR DESCRIPTION
`dotnetcli` host appends `v` to version, this disallow to use version ranges in host constraint.