### PR TITLE
Do not eagerly discover CWD during parser construction

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -94,9 +94,13 @@ namespace Microsoft.DotNet.Cli
                 ArgumentHelpName = CommonLocalizableStrings.VersionSuffixArgumentName
             }.ForwardAsSingle(o => $"-property:VersionSuffix={o}");
 
-        public static Argument<T> DefaultToCurrentDirectory<T>(this Argument<T> arg)
+        public static Lazy<string> NormalizedCurrentDirectory = new Lazy<string>(() => PathUtility.EnsureTrailingSlash(Directory.GetCurrentDirectory()));
+
+        public static Argument<string> DefaultToCurrentDirectory(this Argument<string> arg)
         {
-            arg.SetDefaultValue(PathUtility.EnsureTrailingSlash(Directory.GetCurrentDirectory()));
+            // we set this lazily so that we don't pay the overhead of determining the
+            // CWD multiple times, one for each Argument that uses this.
+            arg.SetDefaultValueFactory(() => NormalizedCurrentDirectory.Value);
             return arg;
         }
 


### PR DESCRIPTION
As reported [here](https://twitter.com/ChetHusk/status/1587436608210337793), some string arguments set their default value to the current directory. The way this is currently configured looks up and sets this value at parser-construction time as opposed to command-invocation time, which has a few side effects that we should change:

* this work is done for every parse, instead of deferring to just parses that invoke the Command that uses the Argument configured in this way
* this work can potentially fail, giving unexpected errors to the user - in the linked thread @khalidabuhakmeh was running a workload command, but the stack trace came from the add command
