### PR TITLE
Import the Container Build package from WebSDK

### DIFF
--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -73,8 +73,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Using Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <SdkContainerSupportPackageVersion>0.2.7</SdkContainerSupportPackageVersion>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(EnableSdkContainerSupport)' == 'true'">
-    <PackageReference Include="Microsoft.NET.Build.Containers" Version="0.2.7" />
+    <PackageReference Include="Microsoft.NET.Build.Containers" Version="$(SdkContainerSupportPackageVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
 </Project>

--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -73,7 +73,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Using Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DisableImplicitContainerBuild)' != 'true'">
+  <ItemGroup Condition="'$(EnableSdkContainerSupport)' == 'true'">
     <PackageReference Include="Microsoft.NET.Build.Containers" Version="0.2.7" />
   </ItemGroup>
 

--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -73,4 +73,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Using Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(DisableImplicitContainerBuild)' != 'true'">
+    <PackageReference Include="Microsoft.NET.Build.Containers" Version="0.2.7" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Stop-gap until the package reference is directly available through the SDK