### PR TITLE
Switch the resolver to target net7 as we expect VSMac to move forward…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     
     <!-- VS for Mac may run on a lower version of .NET than the SDK is targeting, but needs to load the resolvers.  So the resolvers and dependencies
          may target a lower version of .NET -->
-    <ResolverTargetFramework>net6.0</ResolverTargetFramework>
+    <ResolverTargetFramework>net7.0</ResolverTargetFramework>
     <!-- Source build does not need to worry about running on VS for Mac -->
     <ResolverTargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">$(SdkTargetFramework)</ResolverTargetFramework>
 


### PR DESCRIPTION
… in a future release.