### PR TITLE
Support calling unique launch profiles with a case-insensitive nature & Improve errors around launch profiles

### DIFF
--- a/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/My Project/launchSettings.json
+++ b/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/My Project/launchSettings.json
@@ -1,8 +1,10 @@
 {
   "profiles": {
     "first": {
-      }
-    },
+      "commandName": "Project"
+      },
     "FIRST": {
+      "commandName": "Project"
       }
+  }
 }

--- a/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/My Project/launchSettings.json
+++ b/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/My Project/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "first": {
+      }
+    },
+    "FIRST": {
+      }
+}

--- a/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/Program.vb
+++ b/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/Program.vb
@@ -1,0 +1,9 @@
+' Copyright (c) .NET Foundation and contributors. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Imports System
+
+Public Module Program
+    Public Sub Main(args As String())
+    End Sub
+End Module

--- a/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/VbAppWithLaunchSettings.vbproj
+++ b/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/VbAppWithLaunchSettings.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <RuntimeIdentifiers>$(LatestRuntimeIdentifiers)</RuntimeIdentifiers>
+  </PropertyGroup>
+</Project>

--- a/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/VbAppWithLaunchSettings.vbproj
+++ b/src/Assets/TestProjects/AppWithDuplicateLaunchProfiles/VbAppWithLaunchSettings.vbproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifiers>$(LatestRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
@@ -60,8 +60,8 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 
                             if (caseInsensitiveProfileMatches.Count() > 1)
                             {
-                                return new LaunchSettingsApplyResult(false, string.Format(LocalizableStrings.DuplicateCaseInsensitiveLaunchProfileNames,
-                                    String.Join(",", caseInsensitiveProfileMatches.ToArray())));
+                                throw new GracefulException(LocalizableStrings.DuplicateCaseInsensitiveLaunchProfileNames,
+                                    String.Join(",", caseInsensitiveProfileMatches.ToArray()));
                             }
                             else if (!caseInsensitiveProfileMatches.Any())
                             {

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
@@ -54,7 +54,8 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                     {
                         IEnumerable<JsonProperty> caseInsensitiveProfileMatches = profilesObject
                             .EnumerateObject() // p.Name shouldn't fail, as profileObject enumerables here are only created from an existing JsonObject
-                            .Where(p => string.Compare(p.Name, profileName, StringComparison.OrdinalIgnoreCase) == 0);
+                            .Where(p => string.Equals(p.Name, profileName, StringComparison.OrdinalIgnoreCase))
+                            .ToList();
 
                         if (caseInsensitiveProfileMatches.Count() > 1)
                         {

--- a/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
@@ -173,7 +173,7 @@ The current {1} is '{2}'.</value>
     <value>Arguments passed to the application that is being run.</value>
   </data>
   <data name="RunCommandExceptionCouldNotLocateALaunchSettingsFile" xml:space="preserve">
-    <value>The specified launch profile could not be located.</value>
+    <value>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</value>
   </data>
   <data name="RunCommandExceptionCouldNotApplyLaunchSettings" xml:space="preserve">
     <value>The launch profile "{0}" could not be applied.
@@ -186,7 +186,7 @@ The current {1} is '{2}'.</value>
     <value>Using launch settings from {0}...</value>
   </data>
   <data name="LaunchProfileIsNotAJsonObject" xml:space="preserve">
-    <value>A profile with the specified name could not be found or is not a valid JSON object.</value>
+    <value>A profile with the specified name is not a valid JSON object.</value>
   </data>
   <data name="LaunchProfileHandlerCannotBeLocated" xml:space="preserve">
     <value>The launch profile type '{0}' is not supported.</value>
@@ -225,5 +225,11 @@ The current {1} is '{2}'.</value>
   </data>
   <data name="OnlyOneProjectAllowed" xml:space="preserve">
     <value>Only one project can be specified at a time using the `-p` option.</value>
+  </data>
+  <data name="DuplicateCaseInsensitiveLaunchProfileNames" xml:space="preserve">
+    <value>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</value>
+  </data>
+  <data name="LaunchProfileDoesNotExist" xml:space="preserve">
+    <value>A launch profile with the name '{0}' doesn't exist.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
@@ -186,7 +186,7 @@ The current {1} is '{2}'.</value>
     <value>Using launch settings from {0}...</value>
   </data>
   <data name="LaunchProfileIsNotAJsonObject" xml:space="preserve">
-    <value>A profile with the specified name is not a valid JSON object.</value>
+    <value>A profile with the specified name isn't a valid JSON object.</value>
   </data>
   <data name="LaunchProfileHandlerCannotBeLocated" xml:space="preserve">
     <value>The launch profile type '{0}' is not supported.</value>
@@ -227,7 +227,7 @@ The current {1} is '{2}'.</value>
     <value>Only one project can be specified at a time using the `-p` option.</value>
   </data>
   <data name="DuplicateCaseInsensitiveLaunchProfileNames" xml:space="preserve">
-    <value>There are several launch profiles with case-sensitive names, which is not permitted:
+    <value>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
@@ -227,7 +227,9 @@ The current {1} is '{2}'.</value>
     <value>Only one project can be specified at a time using the `-p` option.</value>
   </data>
   <data name="DuplicateCaseInsensitiveLaunchProfileNames" xml:space="preserve">
-    <value>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</value>
+    <value>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</value>
   </data>
   <data name="LaunchProfileDoesNotExist" xml:space="preserve">
     <value>A launch profile with the name '{0}' doesn't exist.</value>

--- a/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
@@ -173,7 +173,7 @@ The current {1} is '{2}'.</value>
     <value>Arguments passed to the application that is being run.</value>
   </data>
   <data name="RunCommandExceptionCouldNotLocateALaunchSettingsFile" xml:space="preserve">
-    <value>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</value>
+    <value>The specified launch profile '{0}' could not be located.</value>
   </data>
   <data name="RunCommandExceptionCouldNotApplyLaunchSettings" xml:space="preserve">
     <value>The launch profile "{0}" could not be applied.

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.Tools.Run
             }
             else if (!string.IsNullOrEmpty(LaunchProfile))
             {
-                throw new GracefulException(LocalizableStrings.RunCommandExceptionCouldNotLocateALaunchSettingsFile, launchSettingsPath);
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunCommandExceptionCouldNotLocateALaunchSettingsFile, launchSettingsPath).Bold().Red());
             }
 
             return true;

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.Tools.Run
             }
             else if (!string.IsNullOrEmpty(LaunchProfile))
             {
-                Reporter.Error.WriteLine(LocalizableStrings.RunCommandExceptionCouldNotLocateALaunchSettingsFile.Bold().Red());
+                throw new GracefulException(LocalizableStrings.RunCommandExceptionCouldNotLocateALaunchSettingsFile, launchSettingsPath);
             }
 
             return true;

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Hodnotu vlastnosti {0} nejde převést na řetězec.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">Pomocí možnosti -p lze v jednu chvíli zadat pouze jeden projekt.</target>
@@ -101,8 +111,8 @@ Aktuální {1} je {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">Zadaný profil spuštění se nenašel.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ Aktuální {1} je {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">Profil se zadaným názvem se nenašel nebo nepředstavuje platný objekt JSON.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">Profil se zadaným názvem se nenašel nebo nepředstavuje platný objekt JSON.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -79,8 +79,10 @@ Make the profile names distinct.</target>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
 Your project targets multiple frameworks. Specify which framework to run using '{0}'.</source>
-        <target state="translated">Projekt nelze spustit.
-Cílem projektu je více architektur. Pomocí parametru {0} určete, která architektura se má spustit.</target>
+        <target state="needs-review-translation">
+                    Projekt nelze spustit.
+                    Cílem projektu je více architektur. Pomocí parametru {0} určete, která architektura se má spustit.
+                </target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
@@ -88,10 +90,12 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
 Ensure you have a runnable project type and ensure '{0}' supports this project.
 A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
 The current {1} is '{2}'.</source>
-        <target state="translated">Projekt se nedá spustit.
-Ověřte prosím, že máte spustitelný typ projektu, a zajistěte, aby tento projekt podporoval {0}.
-Cílem spustitelného projektu by mělo být TFM (například net5.0) a jeho OutputType by měl být Exe.
-Aktuální {1} je {2}.</target>
+        <target state="needs-review-translation">
+                    Projekt se nedá spustit.
+                    Ověřte prosím, že máte spustitelný typ projektu, a zajistěte, aby tento projekt podporoval {0}.
+                    Cílem spustitelného projektu by mělo být TFM (například net5.0) a jeho OutputType by měl být Exe.
+                    Aktuální {1} je {2}.
+                </target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionNoProjects">
@@ -122,8 +126,10 @@ Aktuální {1} je {2}.</target>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
         <source>The launch profile "{0}" could not be applied.
 {1}</source>
-        <target state="translated">Profil spuštění {0} se nedá použít.
-{1}</target>
+        <target state="needs-review-translation">
+                    Profil spuštění {0} se nedá použít.
+                    {1}
+                </target>
         <note />
       </trans-unit>
       <trans-unit id="DefaultLaunchProfileDisplayName">
@@ -142,7 +148,7 @@ Aktuální {1} je {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">Profil se zadaným názvem se nenašel nebo nepředstavuje platný objekt JSON.</target>
         <note />
       </trans-unit>
@@ -159,8 +165,10 @@ Aktuální {1} je {2}.</target>
       <trans-unit id="UnexpectedExceptionProcessingLaunchSettings">
         <source>An unexpected exception occurred while processing launch settings:
 {0}</source>
-        <target state="translated">Při zpracování nastavení spuštění došlo k neočekávané výjimce:
-{0}</target>
+        <target state="needs-review-translation">
+                    Při zpracování nastavení spuštění došlo k neočekávané výjimce:
+                    {0}
+                </target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfilesCollectionIsNotAJsonObject">
@@ -171,8 +179,10 @@ Aktuální {1} je {2}.</target>
       <trans-unit id="DeserializationExceptionMessage">
         <source>An error was encountered when reading launchSettings.json.
 {0}</source>
-        <target state="translated">Při načítání launchSettings.json došlo k chybě.
-{0}</target>
+        <target state="needs-review-translation">
+                    Při načítání launchSettings.json došlo k chybě.
+                    {0}
+                </target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiecFileIsNotAValidProject">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
@@ -119,8 +119,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ Ein ausführbares Projekt muss ein ausführbares TFM (z. B. net5.0) und den Outp
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">Ein Profil mit dem angegebenen Namen wurde nicht gefunden oder ist kein gültiges JSON-Objekt.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Der Wert der Eigenschaft "{0}" konnte nicht in eine Zeichenfolge konvertiert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">Mithilfe der Option „-p“ kann jeweils nur ein Projekt angegeben werden.</target>
@@ -101,8 +111,8 @@ Ein ausführbares Projekt muss ein ausführbares TFM (z. B. net5.0) und den Outp
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">Das angegebene Startprofil wurde nicht gefunden.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ Ein ausführbares Projekt muss ein ausführbares TFM (z. B. net5.0) und den Outp
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">Ein Profil mit dem angegebenen Namen wurde nicht gefunden oder ist kein gültiges JSON-Objekt.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">Ein Profil mit dem angegebenen Namen wurde nicht gefunden oder ist kein gültiges JSON-Objekt.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
@@ -115,8 +115,8 @@ Ein ausführbares Projekt muss ein ausführbares TFM (z. B. net5.0) und den Outp
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ El valor actual de {1} es "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">No se ha encontrado ningún perfil con el nombre especificado o el que se ha encontrado no es un objeto JSON válido.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
@@ -115,8 +115,8 @@ El valor actual de {1} es "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
@@ -32,6 +32,16 @@
         <target state="translated">No se pudo convertir el valor de la propiedad "{0}" en una cadena.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">Solo se puede especificar un proyecto a la vez mediante la opción '-p'.</target>
@@ -101,8 +111,8 @@ El valor actual de {1} es "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">No se ha podido encontrar el perfil de inicio especificado.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ El valor actual de {1} es "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">No se ha encontrado ningún perfil con el nombre especificado o el que se ha encontrado no es un objeto JSON válido.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">No se ha encontrado ningún perfil con el nombre especificado o el que se ha encontrado no es un objeto JSON válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Impossible de convertir la valeur de la propriété '{0}' en chaîne.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">Vous ne pouvez spécifier qu’un seul projet à la fois à l’aide de l’option-p.</target>
@@ -101,8 +111,8 @@ Le {1} actuel est '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">Le profil de lancement spécifié est introuvable.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ Le {1} actuel est '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">Un profil avec le nom spécifié est introuvable ou n'est pas un objet JSON valide.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">Un profil avec le nom spécifié est introuvable ou n'est pas un objet JSON valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ Le {1} actuel est '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">Un profil avec le nom spécifié est introuvable ou n'est pas un objet JSON valide.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
@@ -115,8 +115,8 @@ Le {1} actuel est '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ Il valore corrente di {1} è '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">Non è stato possibile trovare alcun profilo con il nome specificato oppure il profilo non è un oggetto JSON valido.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
@@ -115,8 +115,8 @@ Il valore corrente di {1} è '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Non è stato possibile convertire il valore della proprietà '{0}' in una stringa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">È possibile specificare un solo progetto alla volta utilizzando l'opzione '-p'.</target>
@@ -101,8 +111,8 @@ Il valore corrente di {1} è '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">Il profilo di avvio specificato non è stato trovato.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ Il valore corrente di {1} è '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">Non è stato possibile trovare alcun profilo con il nome specificato oppure il profilo non è un oggetto JSON valido.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">Non è stato possibile trovare alcun profilo con il nome specificato oppure il profilo non è un oggetto JSON valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
@@ -32,6 +32,16 @@
         <target state="translated">プロパティ '{0}' の値を文字列に変換できませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">`-p` オプションで指定できるプロジェクトは、一度に 1 つだけです。</target>
@@ -101,8 +111,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">指定された起動プロファイルが見つかりませんでした。</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">指定された名前のプロファイルは見つからないか、有効な JSON オブジェクトではありません。</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">指定された名前のプロファイルは見つからないか、有効な JSON オブジェクトではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">指定された名前のプロファイルは見つからないか、有効な JSON オブジェクトではありません。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
@@ -115,8 +115,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
@@ -115,8 +115,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">지정된 이름을 가진 프로필을 찾을 수 없거나 유효한 JSON 개체가 아닙니다.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
@@ -32,6 +32,16 @@
         <target state="translated">'{0}' 속성 값을 문자열로 변환할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">'-p' 옵션을 사용하여 한 번에 하나의 프로젝트만 지정할 수 있습니다.</target>
@@ -101,8 +111,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">지정한 시작 프로필을 찾을 수 없습니다.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">지정된 이름을 가진 프로필을 찾을 수 없거나 유효한 JSON 개체가 아닙니다.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">지정된 이름을 가진 프로필을 찾을 수 없거나 유효한 JSON 개체가 아닙니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
@@ -115,8 +115,8 @@ Bieżący element {1}: „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Nie można przekonwertować wartości właściwości „{0}” na ciąg.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">Jednocześnie można określić tylko jeden projekt przy użyciu opcji „-p”.</target>
@@ -101,8 +111,8 @@ Bieżący element {1}: „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">Nie można odnaleźć określonego profilu uruchamiania.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ Bieżący element {1}: „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">Nie można znaleźć profilu o określonej nazwie lub nie jest to prawidłowy obiekt JSON.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">Nie można znaleźć profilu o określonej nazwie lub nie jest to prawidłowy obiekt JSON.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ Bieżący element {1}: „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">Nie można znaleźć profilu o określonej nazwie lub nie jest to prawidłowy obiekt JSON.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Não foi possível converter o valor da propriedade '{0}' em uma cadeia de caracteres.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">Somente um projeto pode ser especificado por vez usando a opção '-p'.</target>
@@ -101,8 +111,8 @@ O {1} atual é '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">O perfil de inicialização especificado não pôde ser localizado.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ O {1} atual é '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">Um perfil com o nome especificado não pôde ser encontrado ou não é um objeto JSON válido.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">Um perfil com o nome especificado não pôde ser encontrado ou não é um objeto JSON válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -115,8 +115,8 @@ O {1} atual é '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ O {1} atual é '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">Um perfil com o nome especificado não pôde ser encontrado ou não é um objeto JSON válido.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
@@ -115,8 +115,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Не удалось преобразовать значение свойства "{0}" в строку.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">С помощью параметра "-p" можно указать только один проект за раз.</target>
@@ -101,8 +111,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">Не удалось найти указанный профиль запуска.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">Не удается найти профиль с указанным именем, или он не является допустимым объектом JSON.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">Не удается найти профиль с указанным именем, или он не является допустимым объектом JSON.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">Не удается найти профиль с указанным именем, или он не является допустимым объектом JSON.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ Geçerli {1}: '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">Belirtilen isme sahip profil bulunamadı veya geçerli bir JSON nesnesi değil.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">'{0}' özelliğinin değeri dizeye dönüştürülemedi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">`-p` seçeneği kullanılarak tek seferde yalnızca bir proje belirtilebilir.</target>
@@ -101,8 +111,8 @@ Geçerli {1}: '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">Belirtilen başlatma profili bulunamadı.</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ Geçerli {1}: '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">Belirtilen isme sahip profil bulunamadı veya geçerli bir JSON nesnesi değil.</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">Belirtilen isme sahip profil bulunamadı veya geçerli bir JSON nesnesi değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
@@ -115,8 +115,8 @@ Geçerli {1}: '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">找不到具有指定名称的配置文件或该配置文件不是有效的 JSON 对象。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -115,8 +115,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -32,6 +32,16 @@
         <target state="translated">无法将属性“{0}”的值转换为字符串。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">使用“-p”选项一次只能指定一个项目。</target>
@@ -101,8 +111,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">找不到指定的启动配置文件。</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">找不到具有指定名称的配置文件或该配置文件不是有效的 JSON 对象。</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">找不到具有指定名称的配置文件或该配置文件不是有效的 JSON 对象。</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,10 +33,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+        <source>There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+        <target state="new">There are several launch profiles with case-sensitive names, which isn't permitted:
 {0}
 Make the profile names distinct.</target>
         <note />
@@ -142,7 +142,7 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name is not a valid JSON object.</source>
+        <source>A profile with the specified name isn't a valid JSON object.</source>
         <target state="needs-review-translation">找不到具有指定名稱的設定檔，或不是有效的 JSON 物件。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,8 +33,12 @@
         <note />
       </trans-unit>
       <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
-        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
-        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <source>There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted:
+{0}
+Make the profile names distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileDoesNotExist">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -115,8 +115,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
-        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
+        <source>The specified launch profile '{0}' could not be located.</source>
+        <target state="new">The specified launch profile '{0}' could not be located.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -32,6 +32,16 @@
         <target state="translated">無法將屬性 '{0}' 的值轉換為字串。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateCaseInsensitiveLaunchProfileNames">
+        <source>There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</source>
+        <target state="new">There are several launch profiles with case-sensitive names, which is not permitted: '{0}'. Make the profile names distinct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LaunchProfileDoesNotExist">
+        <source>A launch profile with the name '{0}' doesn't exist.</source>
+        <target state="new">A launch profile with the name '{0}' doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyOneProjectAllowed">
         <source>Only one project can be specified at a time using the `-p` option.</source>
         <target state="translated">使用 `-p` 選項時，一次只能指定一個專案。</target>
@@ -101,8 +111,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotLocateALaunchSettingsFile">
-        <source>The specified launch profile could not be located.</source>
-        <target state="translated">找不到指定的啟動設定檔。</target>
+        <source>The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</source>
+        <target state="new">The specified launch profile '{0}' could not be located. Is it of the form ./Properties/launchSettings.json?</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionCouldNotApplyLaunchSettings">
@@ -128,8 +138,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileIsNotAJsonObject">
-        <source>A profile with the specified name could not be found or is not a valid JSON object.</source>
-        <target state="translated">找不到具有指定名稱的設定檔，或不是有效的 JSON 物件。</target>
+        <source>A profile with the specified name is not a valid JSON object.</source>
+        <target state="needs-review-translation">找不到具有指定名稱的設定檔，或不是有效的 JSON 物件。</target>
         <note />
       </trans-unit>
       <trans-unit id="LaunchProfileHandlerCannotBeLocated">

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsVbProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsVbProj.cs
@@ -48,18 +48,18 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         {
             var testAppName = "AppWithDuplicateLaunchProfiles";
             var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+                .WithSource();
 
             var runResult = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testInstance.Path)
                 .Execute("--launch-profile", "first");
 
-            string[] expectedErrorWords = LocalizableStrings.DuplicateCaseInsensitiveLaunchProfileNames.Replace("\'{0}\'", "").Split(" ");
+            string expectedError = String.Format(LocalizableStrings.DuplicateCaseInsensitiveLaunchProfileNames, "\tfirst,\r\n\tFIRST");
             runResult
                 .Should()
-                .Fail();
-
-            expectedErrorWords.ForEach(word => runResult.Should().HaveStdErrContaining(word));
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError);
         }
 
         [Fact]

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsVbProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsVbProj.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using FluentAssertions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -54,7 +56,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .WithWorkingDirectory(testInstance.Path)
                 .Execute("--launch-profile", "first");
 
-            string expectedError = String.Format(LocalizableStrings.DuplicateCaseInsensitiveLaunchProfileNames, "\tfirst,\r\n\tFIRST");
+            string expectedError = String.Format(LocalizableStrings.DuplicateCaseInsensitiveLaunchProfileNames, "\tfirst," + (OperatingSystem.IsWindows() ? "\r" : "") + "\n\tFIRST");
             runResult
                 .Should()
                 .Fail()


### PR DESCRIPTION
# Changes:
- Separates the error for a corrupt json file and a non-existent launch profile
- Adds a more specific error for if the launch settings WAS found but the Profile was not found 
![image](https://user-images.githubusercontent.com/23152278/200421169-2b6ce6d9-021f-422f-8acf-4fcc115bdf24.png)

![image](https://user-images.githubusercontent.com/23152278/200421585-40d4850b-1417-44fb-ac2a-1eab82b7eb0f.png)
(The last sentence is no longer there ^) 

- The new no launch profile error specifies where it tried to look for the launch profile
- If you have one launch profile like https and try to call it with HTTPS it will be OK
![image](https://user-images.githubusercontent.com/23152278/200421866-cb090ea5-e730-44d7-b90e-367accb87e7e.png)


- If you have multiple launch profiles like https and HTTPS and try to use the profile, you will get an error

![image](https://user-images.githubusercontent.com/23152278/200421004-800b26bf-97ad-4ee9-ad4d-b4306e0eb356.png)



Resolves: https://github.com/dotnet/sdk/issues/25868