### PR TITLE
Upgrade the verbosity of error headers

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
                         if (logHeader)
                         {
                             logHeader = false;
-                            _log.LogMessage(MessageImportance.Normal,
+                            _log.LogMessage(MessageImportance.High,
                                 Resources.ApiCompatibilityHeader,
                                 difference.Left.AssemblyId,
                                 difference.Right.AssemblyId,


### PR DESCRIPTION
Making sure that error headers are logged in the msbuild frontend by upgrading the message importance to high (which is the same verbosity as the actual errors are logged). Noticed that in https://dev.azure.com/dnceng-public/public/_build/results?buildId=73287&view=logs&j=ff0f4165-94fa-565b-d5ea-6d06d02692b1&t=f1a24c14-2fbe-549c-aa5a-2486434dc4a8&l=5195.