### PR TITLE
Include ijwhost in DesignerRuntimeImplementationProjectOutputGroupOutput

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -139,6 +139,13 @@ Copyright (c) .NET Foundation. All rights reserved.
         Include="@(_DesignerShadowCopy->'%(FullPath)')"
         TargetPath="%(_DesignerShadowCopy.DestinationSubDirectory)%(_DesignerShadowCopy.Filename)%(_DesignerShadowCopy.Extension)"
         />
+
+      <!-- Include ijwhost.dll for projects that use it -->
+      <DesignerRuntimeImplementationProjectOutputGroupOutput
+        Include="$(IjwHostSourcePath)"
+        TargetPath="$(_DotNetIjwHostLibraryName)"
+        Condition="'$(IjwHostSourcePath)' != '' and '$(UseIJWHost)' == 'true'"
+        />
       </ItemGroup>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -22,6 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(DesignerRuntimeImplementationProjectOutputGroupDependsOn);
       _GenerateDesignerDepsFile;
       _GenerateDesignerRuntimeConfigFile;
+      GetCopyToOutputDirectoryItems;
       _GatherDesignerShadowCopyFiles;
     </DesignerRuntimeImplementationProjectOutputGroupDependsOn>
 
@@ -142,11 +143,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <!-- Include ijwhost.dll for projects that use it -->
       <DesignerRuntimeImplementationProjectOutputGroupOutput
-        Include="$(IjwHostSourcePath)"
-        TargetPath="$(_DotNetIjwHostLibraryName)"
-        Condition="'$(IjwHostSourcePath)' != '' and '$(UseIJWHost)' == 'true'"
+        Include="@(AllItemsFullPathWithTargetPath->WithMetadataValue('Filename', '$(_DotNetIjwHostLibraryNameWithoutExtension)')->WithMetadataValue('Extension', '$(_IjwHostLibraryExtension)'))"
         />
-      </ItemGroup>
+    </ItemGroup>
   </Target>
 
 </Project>


### PR DESCRIPTION
`ijwhost` is required for C++/CLI assemblies. If a project that has a designer (like WinForms) references a C++/CLI assembly, it needs to be told about `ijwhost`.

It looks like there is no automated testing support for C++/CLI projects right now due to https://github.com/dotnet/sdk/issues/11008. I just manually ran `msbuild /t:DesignerRuntimeImplementationProjectOutputGroup` on a C++/CLI project and checked that ijwhost was in the target outputs.