### PR TITLE
Support multiple suppression files

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
@@ -13,8 +13,15 @@ namespace Microsoft.DotNet.ApiCompat
         /// </summary>
         public static void GenerateSuppressionFile(ISuppressionEngine suppressionEngine,
             ICompatibilityLogger log,
+            string[]? suppressionFiles,
             string? suppressionOutputFile)
         {
+            // When a single suppression (input) file is passed in but no suppression output file, use the single input file.
+            if (suppressionOutputFile == null && suppressionFiles?.Length == 1)
+            {
+                suppressionOutputFile = suppressionFiles[0];
+            }
+
             if (suppressionOutputFile == null)
             {
                 throw new ArgumentException(CommonResources.SuppressionsFileNotSpecified, nameof(suppressionOutputFile));

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
@@ -13,16 +13,16 @@ namespace Microsoft.DotNet.ApiCompat
         /// </summary>
         public static void GenerateSuppressionFile(ISuppressionEngine suppressionEngine,
             ICompatibilityLogger log,
-            string? suppressionFile)
+            string? suppressionOutputFile)
         {
-            if (suppressionFile == null)
+            if (suppressionOutputFile == null)
             {
-                throw new ArgumentException(CommonResources.SuppressionsFileNotSpecified, nameof(suppressionFile));
+                throw new ArgumentException(CommonResources.SuppressionsFileNotSpecified, nameof(suppressionOutputFile));
             }
 
-            if (suppressionEngine.WriteSuppressionsToFile(suppressionFile))
+            if (suppressionEngine.WriteSuppressionsToFile(suppressionOutputFile))
             {
-                log.LogMessage(MessageImportance.High, CommonResources.WroteSuppressions, suppressionFile);
+                log.LogMessage(MessageImportance.High, CommonResources.WroteSuppressions, suppressionOutputFile);
             }
         }
     }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
@@ -15,7 +15,8 @@ namespace Microsoft.DotNet.ApiCompat
     {
         public static void Run(Func<ISuppressionEngine, ICompatibilityLogger> logFactory,
             bool generateSuppressionFile,
-            string? suppressionFile,
+            string[]? suppressionFiles,
+            string? suppressionOutputFile,
             string? noWarn,
             bool enableRuleAttributesMustMatch,
             string[]? excludeAttributesFiles,
@@ -29,12 +30,9 @@ namespace Microsoft.DotNet.ApiCompat
             (string CaptureGroupPattern, string ReplacementString)[]? leftAssembliesTransformationPatterns,
             (string CaptureGroupPattern, string ReplacementString)[]? rightAssembliesTransformationPatterns)
         {
-            // Configure the suppression engine. Ignore the passed in suppression file if it should be generated and doesn't yet exist.
-            string? suppressionFileForEngine = generateSuppressionFile && !File.Exists(suppressionFile) ? null : suppressionFile;
-
             // Initialize the service provider
             ApiCompatServiceProvider serviceProvider = new(logFactory,
-                () => new SuppressionEngine(suppressionFileForEngine, noWarn, generateSuppressionFile),
+                () => new SuppressionEngine(suppressionFiles, noWarn, generateSuppressionFile),
                 (log) => new RuleFactory(log,
                     enableRuleAttributesMustMatch,
                     excludeAttributesFiles,
@@ -91,7 +89,7 @@ namespace Microsoft.DotNet.ApiCompat
             {
                 SuppressionFileHelper.GenerateSuppressionFile(serviceProvider.SuppressionEngine,
                     serviceProvider.CompatibilityLogger,
-                    suppressionFile);
+                    suppressionOutputFile);
             }
         }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
@@ -89,6 +89,7 @@ namespace Microsoft.DotNet.ApiCompat
             {
                 SuppressionFileHelper.GenerateSuppressionFile(serviceProvider.SuppressionEngine,
                     serviceProvider.CompatibilityLogger,
+                    suppressionFiles,
                     suppressionOutputFile);
             }
         }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
@@ -80,6 +80,7 @@ namespace Microsoft.DotNet.ApiCompat
             {
                 SuppressionFileHelper.GenerateSuppressionFile(serviceProvider.SuppressionEngine,
                     serviceProvider.CompatibilityLogger,
+                    suppressionFiles,
                     suppressionOutputFile);
             }
         }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using Microsoft.DotNet.ApiCompatibility.Logging;
 using Microsoft.DotNet.ApiCompatibility.Rules;
 using Microsoft.DotNet.PackageValidation;
@@ -15,7 +14,8 @@ namespace Microsoft.DotNet.ApiCompat
     {
         public static void Run(Func<ISuppressionEngine, ICompatibilityLogger> logFactory,
             bool generateSuppressionFile,
-            string? suppressionFile,
+            string[]? suppressionFiles,
+            string? suppressionOutputFile,
             string? noWarn,
             bool enableRuleAttributesMustMatch,
             string[]? excludeAttributesFiles,
@@ -30,12 +30,9 @@ namespace Microsoft.DotNet.ApiCompat
             Dictionary<string, string[]>? packageAssemblyReferences,
             Dictionary<string, string[]>? baselinePackageAssemblyReferences)
         {
-            // Configure the suppression engine. Ignore the passed in suppression file if it should be generated and doesn't yet exist.
-            string? suppressionFileForEngine = generateSuppressionFile && !File.Exists(suppressionFile) ? null : suppressionFile;
-
             // Initialize the service provider
             ApiCompatServiceProvider serviceProvider = new(logFactory,
-                () => new SuppressionEngine(suppressionFileForEngine, noWarn, generateSuppressionFile),
+                () => new SuppressionEngine(suppressionFiles, noWarn, generateSuppressionFile),
                 (log) => new RuleFactory(log,
                     enableRuleAttributesMustMatch,
                     excludeAttributesFiles,
@@ -83,7 +80,7 @@ namespace Microsoft.DotNet.ApiCompat
             {
                 SuppressionFileHelper.GenerateSuppressionFile(serviceProvider.SuppressionEngine,
                     serviceProvider.CompatibilityLogger,
-                    suppressionFile);
+                    suppressionOutputFile);
             }
         }
     }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidateAssembliesTask.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidateAssembliesTask.cs
@@ -35,14 +35,19 @@ namespace Microsoft.DotNet.ApiCompat.Task
         public string? RoslynAssembliesPath { get; set; }
 
         /// <summary>
-        /// If true, generates a compatibility suppression file that contains the api compatibility errors.
+        /// If true, generates a suppression file that contains the api compatibility errors.
         /// </summary>
-        public bool GenerateCompatibilitySuppressionFile { get; set; }
+        public bool GenerateSuppressionFile { get; set; }
 
         /// <summary>
-        /// The path to a compatibility suppression file. If provided, the suppressions are read and stored.
+        /// The path to suppression files. If provided, the suppressions are read and stored.
         /// </summary>
-        public string? CompatibilitySuppressionFilePath { get; set; }
+        public string[]? SuppressionFiles { get; set; }
+
+        /// <summary>
+        /// The path to the suppression output file that is written to, when <see cref="GenerateCompatibilitySuppressionFile"/> is true.
+        /// </summary>
+        public string? SuppressionOutputFile { get; set; }
 
         /// <summary>
         /// A NoWarn string contains the error codes that should be ignored.
@@ -116,8 +121,9 @@ namespace Microsoft.DotNet.ApiCompat.Task
         {
             Func<ISuppressionEngine, MSBuildCompatibilityLogger> logFactory = (suppressionEngine) => new(Log, suppressionEngine);
             ValidateAssemblies.Run(logFactory,
-                GenerateCompatibilitySuppressionFile,
-                CompatibilitySuppressionFilePath,
+                GenerateSuppressionFile,
+                SuppressionFiles,
+                SuppressionOutputFile,
                 NoWarn,
                 EnableRuleAttributesMustMatch,
                 ExcludeAttributesFiles,

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
@@ -80,14 +80,19 @@ namespace Microsoft.DotNet.ApiCompat.Task
         public string? BaselinePackageTargetPath { get; set; }
 
         /// <summary>
-        /// If true, generates a compatibility suppression file that contains the api compatibility errors.
+        /// If true, generates a suppression file that contains the api compatibility errors.
         /// </summary>
-        public bool GenerateCompatibilitySuppressionFile { get; set; }
+        public bool GenerateSuppressionFile { get; set; }
 
         /// <summary>
-        /// The path to a compatibility suppression file. If provided, the suppressions are read and stored.
+        /// The path to suppression files. If provided, the suppressions are read and stored.
         /// </summary>
-        public string? CompatibilitySuppressionFilePath { get; set; }
+        public string[]? SuppressionFiles { get; set; }
+
+        /// <summary>
+        /// The path to the suppression output file that is written to, when <see cref="GenerateCompatibilitySuppressionFile"/> is true.
+        /// </summary>
+        public string? SuppressionOutputFile { get; set; }
 
         /// <summary>
         /// Assembly references grouped by target framework, for the assets inside the package.
@@ -132,8 +137,9 @@ namespace Microsoft.DotNet.ApiCompat.Task
 
             Func<ISuppressionEngine, MSBuildCompatibilityLogger> logFactory = (suppressionEngine) => new(Log, suppressionEngine);
             ValidatePackage.Run(logFactory,
-                GenerateCompatibilitySuppressionFile,
-                CompatibilitySuppressionFilePath,
+                GenerateSuppressionFile,
+                SuppressionFiles,
+                SuppressionOutputFile,
                 NoWarn,
                 EnableRuleAttributesMustMatch,
                 ExcludeAttributesFiles,

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.ValidateAssemblies.Common.targets
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.ValidateAssemblies.Common.targets
@@ -8,7 +8,8 @@
   <Target Name="ApiCompatValidateAssembliesCore"
           Inputs="@(ApiCompatLeftAssemblies);
                   @(ApiCompatRightAssemblies);
-                  $(CompatibilitySuppressionFilePath)"
+                  @(ApiCompatSuppressionFile);
+                  $(ApiCompatSuppressionOutputFile)"
           Outputs="$(ApiCompatValidateAssembliesSemaphoreFile)"
           Condition="'@(ApiCompatLeftAssemblies)' != '' and '@(ApiCompatRightAssemblies)' != ''"
           DependsOnTargets="$(ApiCompatValidateAssembliesDependsOn)">
@@ -16,8 +17,9 @@
       RoslynAssembliesPath="$(RoslynAssembliesPath)"
       LeftAssemblies="@(ApiCompatLeftAssemblies)"
       RightAssemblies="@(ApiCompatRightAssemblies)"
-      GenerateCompatibilitySuppressionFile="$(GenerateCompatibilitySuppressionFile)"
-      CompatibilitySuppressionFilePath="$(CompatibilitySuppressionFilePath)"
+      GenerateSuppressionFile="$(ApiCompatGenerateSuppressionFile)"
+      SuppressionFiles="@(ApiCompatSuppressionFile)"
+      SuppressionOutputFile="$(ApiCompatSuppressionOutputFile)"
       NoWarn="$(NoWarn)"
       EnableRuleAttributesMustMatch="$(ApiCompatEnableRuleAttributesMustMatch)"
       ExcludeAttributesFiles="@(ApiCompatExcludeAttributesFile)"

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -19,13 +19,17 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             // Important: Keep parameters exposed in sync with the msbuild task frontend.
 
             // Global options
-            Option<string?> suppressionFileOption = new("--suppression-file",
-                "The path to a compatibility suppression file.")
-            {
-                ArgumentHelpName = "file"
-            };
             Option<bool> generateSuppressionFileOption = new("--generate-suppression-file",
                 "If true, generates a compatibility suppression file.");
+            Option<string[]> suppressionFilesOption = new("--suppression-file",
+                "The path to one or more suppression files to read from.")
+            {
+                AllowMultipleArgumentsPerToken= true,
+                Arity = ArgumentArity.ZeroOrMore,
+                ArgumentHelpName = "file"
+            };
+            Option<string?> suppressionOutputFileOption = new("--suppression-output-file",
+                "The path to a suppression file to write to when --generate-suppression-file is true.");
             Option<string?> noWarnOption = new("--noWarn",
                 "A NoWarn string that allows to disable specific rules.");
             Option<string?> roslynAssembliesPathOption = new("--roslyn-assemblies-path",
@@ -99,8 +103,9 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             {
                 TreatUnmatchedTokensAsErrors = true
             };
-            rootCommand.AddGlobalOption(suppressionFileOption);
             rootCommand.AddGlobalOption(generateSuppressionFileOption);
+            rootCommand.AddGlobalOption(suppressionFilesOption);
+            rootCommand.AddGlobalOption(suppressionOutputFileOption);
             rootCommand.AddGlobalOption(noWarnOption);
             rootCommand.AddGlobalOption(roslynAssembliesPathOption);
             rootCommand.AddGlobalOption(verbosityOption);
@@ -126,7 +131,8 @@ namespace Microsoft.DotNet.ApiCompat.Tool
 
                 MessageImportance verbosity = context.ParseResult.GetValueForOption(verbosityOption);
                 bool generateSuppressionFile = context.ParseResult.GetValueForOption(generateSuppressionFileOption);
-                string? suppressionFile = context.ParseResult.GetValueForOption(suppressionFileOption);
+                string[]? suppressionFiles = context.ParseResult.GetValueForOption(suppressionFilesOption);
+                string? suppressionOutputFile = context.ParseResult.GetValueForOption(suppressionOutputFileOption);
                 string? noWarn = context.ParseResult.GetValueForOption(noWarnOption);
                 bool enableRuleAttributesMustMatch = context.ParseResult.GetValueForOption(enableRuleAttributesMustMatchOption);
                 string[]? excludeAttributesFiles = context.ParseResult.GetValueForOption(excludeAttributesFilesOption);
@@ -144,7 +150,8 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 Func<ISuppressionEngine, ConsoleCompatibilityLogger> logFactory = (suppressionEngine) => new(suppressionEngine, verbosity);
                 ValidateAssemblies.Run(logFactory,
                     generateSuppressionFile,
-                    suppressionFile,
+                    suppressionFiles,
+                    suppressionOutputFile,
                     noWarn,
                     enableRuleAttributesMustMatch,
                     excludeAttributesFiles,
@@ -222,7 +229,8 @@ namespace Microsoft.DotNet.ApiCompat.Tool
 
                 MessageImportance verbosity = context.ParseResult.GetValueForOption(verbosityOption);
                 bool generateSuppressionFile = context.ParseResult.GetValueForOption(generateSuppressionFileOption);
-                string? suppressionFile = context.ParseResult.GetValueForOption(suppressionFileOption);
+                string[]? suppressionFiles = context.ParseResult.GetValueForOption(suppressionFilesOption);
+                string? suppressionOutputFile = context.ParseResult.GetValueForOption(suppressionOutputFileOption);
                 string? noWarn = context.ParseResult.GetValueForOption(noWarnOption);
                 bool enableRuleAttributesMustMatch = context.ParseResult.GetValueForOption(enableRuleAttributesMustMatchOption);
                 string[]? excludeAttributesFiles = context.ParseResult.GetValueForOption(excludeAttributesFilesOption);
@@ -241,7 +249,8 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 Func<ISuppressionEngine, ConsoleCompatibilityLogger> logFactory = (suppressionEngine) => new(suppressionEngine, verbosity);
                 ValidatePackage.Run(logFactory,
                     generateSuppressionFile,
-                    suppressionFile,
+                    suppressionFiles,
+                    suppressionOutputFile,
                     noWarn,
                     enableRuleAttributesMustMatch,
                     excludeAttributesFiles,

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressionEngine.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressionEngine.cs
@@ -48,6 +48,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         /// </summary>
         /// <param name="supressionFile">The path to the file to be written.</param>
         /// <returns>Whether it wrote the file.</returns>
-        bool WriteSuppressionsToFile(string suppressionFile);
+        bool WriteSuppressionsToFile(string suppressionOutputFile);
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -26,13 +26,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         public bool BaselineAllErrors { get; }
 
         /// <inheritdoc/>
-        public SuppressionEngine(string? suppressionFile = null,
+        public SuppressionEngine(string[]? suppressionFiles = null,
             string? noWarn = null,
             bool baselineAllErrors = false)
         {
             BaselineAllErrors = baselineAllErrors;
             _noWarn = string.IsNullOrEmpty(noWarn) ? new HashSet<string>() : new HashSet<string>(noWarn!.Split(';'));
-            _validationSuppressions = ParseSuppressionFile(suppressionFile);
+            _validationSuppressions = ParseSuppressionFiles(suppressionFiles);
         }
 
         /// <inheritdoc/>
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         }
 
         /// <inheritdoc/>
-        public bool WriteSuppressionsToFile(string suppressionFile)
+        public bool WriteSuppressionsToFile(string suppressionOutputFile)
         {
             if (_validationSuppressions.Count == 0)
                 return false;
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
                 .ThenBy(sup => sup.Target)
                 .ToArray();
 
-            using (Stream writer = GetWritableStream(suppressionFile))
+            using (Stream writer = GetWritableStream(suppressionOutputFile))
             {
                 _readerWriterLock.EnterReadLock();
                 try
@@ -161,27 +161,30 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
             // Do nothing. Used for tests.
         }
 
-        private HashSet<Suppression> ParseSuppressionFile(string? suppressionFile)
+        private HashSet<Suppression> ParseSuppressionFiles(string[]? suppressionFiles)
         {
-            if (string.IsNullOrWhiteSpace(suppressionFile))
-            {
-                return new HashSet<Suppression>();
-            }
+            HashSet<Suppression> suppressions = new();
 
-            try
+            if (suppressionFiles != null)
             {
-                using Stream reader = GetReadableStream(suppressionFile!);
-                if (_serializer.Deserialize(reader) is Suppression[] deserializedSuppressions)
+                foreach (string suppressionFile in suppressionFiles)
                 {
-                    return new HashSet<Suppression>(deserializedSuppressions);
+                    try
+                    {
+                        using Stream reader = GetReadableStream(suppressionFile);
+                        if (_serializer.Deserialize(reader) is Suppression[] deserializedSuppressions)
+                        {
+                            suppressions.UnionWith(deserializedSuppressions);
+                        }
+                    }
+                    catch (FileNotFoundException) when (BaselineAllErrors)
+                    {
+                        // Throw if the passed in suppression file doesn't exist and errors aren't baselined.
+                    }
                 }
             }
-            catch (FileNotFoundException) when (BaselineAllErrors)
-            {
-                // Throw if the passed in suppression file doesn't exist and errors aren't baselined.
-            }
 
-            return new HashSet<Suppression>();
+            return suppressions;
         }
 
         // FileAccess.Read and FileShare.Read are specified to allow multiple processes to concurrently read from the suppression file.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.Common.targets
@@ -24,9 +24,27 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RoslynAssembliesPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$([System.IO.Path]::Combine('$(RoslynAssembliesPath)', bincore))</RoslynAssembliesPath>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(CompatibilitySuppressionFilePath)' == ''">
-      <_compatibilitySuppressionFilePath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', 'CompatibilitySuppressions.xml'))</_compatibilitySuppressionFilePath>
-      <CompatibilitySuppressionFilePath Condition="Exists($(_compatibilitySuppressionFilePath)) or '$(GenerateCompatibilitySuppressionFile)' == 'true'">$(_compatibilitySuppressionFilePath)</CompatibilitySuppressionFilePath>
+    <!-- Respect legacy property and item names. -->
+    <PropertyGroup>
+      <ApiCompatGenerateSuppressionFile Condition="'$(ApiCompatGenerateSuppressionFile)' == ''">$(GenerateCompatibilitySuppressionFile)</ApiCompatGenerateSuppressionFile>
     </PropertyGroup>
+
+    <ItemGroup>
+      <ApiCompatSuppressionFile Include="$(CompatibilitySuppressionFilePath)"
+                                Condition="'@(ApiCompatSuppressionFile)' == '' and '$(CompatibilitySuppressionFilePath)' != ''" />
+    </ItemGroup>
+    <!-- END: Respect legacy property and item names. -->
+
+    <PropertyGroup>
+      <_apiCompatDefaultProjectSuppressionFile>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', 'CompatibilitySuppressions.xml'))</_apiCompatDefaultProjectSuppressionFile>
+      <!-- Pass in a default suppression output file if non is supplied, and ApiCompatGenerateSuppressionFile is true. -->
+      <ApiCompatSuppressionOutputFile Condition="'$(ApiCompatSuppressionOutputFile)' == '' and '$(ApiCompatGenerateSuppressionFile)' == 'true'">$(_apiCompatDefaultProjectSuppressionFile)</ApiCompatSuppressionOutputFile>
+    </PropertyGroup>
+
+    <!-- Pass in a default suppression file, if it exists. -->
+    <ItemGroup Condition="'@(ApiCompatSuppressionFile)' == ''">
+      <ApiCompatSuppressionFile Include="$(_apiCompatDefaultProjectSuppressionFile)"
+                                Condition="Exists($(_apiCompatDefaultProjectSuppressionFile))" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -48,7 +48,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       EnableStrictModeForCompatibleFrameworksInPackage="$(EnableStrictModeForCompatibleFrameworksInPackage)"
       EnableStrictModeForBaselineValidation="$(EnableStrictModeForBaselineValidation)"
       GenerateSuppressionFile="$(ApiCompatGenerateSuppressionFile)"
-      SuppressionFiles="@(ApiCompatSuppressionFiles)"
+      SuppressionFiles="@(ApiCompatSuppressionFile)"
       SuppressionOutputFile="$(ApiCompatSuppressionOutputFile)"
       BaselinePackageTargetPath="$(_packageValidationBaselinePath)"
       RoslynAssembliesPath="$(RoslynAssembliesPath)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -19,7 +19,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="RunPackageValidation"
           DependsOnTargets="$(RunPackageValidationDependsOn)"
           AfterTargets="Pack"
-          Inputs="@(NuGetPackInput);$(CompatibilitySuppressionFilePath)"
+          Inputs="@(NuGetPackInput);
+                  @(ApiCompatSuppressionFile);
+                  $(ApiCompatSuppressionOutputFile)"
           Outputs="$(ApiCompatValidatePackageSemaphoreFile)"
           Condition="'$(EnablePackageValidation)' == 'true' and '$(IsPackable)' == 'true'">
     <PropertyGroup>
@@ -45,8 +47,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       EnableStrictModeForCompatibleTfms="$([MSBuild]::ValueOrDefault('$(EnableStrictModeForCompatibleTfms)', 'true'))"
       EnableStrictModeForCompatibleFrameworksInPackage="$(EnableStrictModeForCompatibleFrameworksInPackage)"
       EnableStrictModeForBaselineValidation="$(EnableStrictModeForBaselineValidation)"
-      GenerateCompatibilitySuppressionFile="$(GenerateCompatibilitySuppressionFile)"
-      CompatibilitySuppressionFilePath="$(CompatibilitySuppressionFilePath)"
+      GenerateSuppressionFile="$(ApiCompatGenerateSuppressionFile)"
+      SuppressionFiles="@(ApiCompatSuppressionFiles)"
+      SuppressionOutputFile="$(ApiCompatSuppressionOutputFile)"
       BaselinePackageTargetPath="$(_packageValidationBaselinePath)"
       RoslynAssembliesPath="$(RoslynAssembliesPath)"
       PackageAssemblyReferences="@(PackageValidationReferencePath)" />

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 using Xunit;
 
@@ -51,14 +52,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
         [Fact]
         public void SuppressionEngineThrowsIfFileDoesNotExist()
         {
-            Assert.Throws<FileNotFoundException>(() => new SuppressionEngine("AFileThatDoesNotExist.xml"));
-        }
-
-        [Fact]
-        public void SuppressionEngineDoesNotThrowOnEmptyFile()
-        {
-            SuppressionEngine _ = new(suppressionFile: string.Empty);
-            _ = new SuppressionEngine(suppressionFile: "      ");
+            Assert.Throws<FileNotFoundException>(() => new SuppressionEngine(new string[] { "AFileThatDoesNotExist.xml" }));
         }
 
         [Fact]
@@ -177,19 +171,18 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
 
         public int GetSuppressionCount() => _validationSuppressions.Count;
 
-        protected override Stream GetReadableStream(string baselineFile)
+        protected override Stream GetReadableStream(string suppressionFile)
         {
             // Not Disposing stream since it will be disposed by caller.
             _stream = new MemoryStream();
             return _stream;
         }
 
-        protected override Stream GetWritableStream(string validationSuppressionFile) => new MemoryStream();
+        protected override Stream GetWritableStream(string suppressionFile) => new MemoryStream();
 
         protected override void AfterWrittingSuppressionsCallback(Stream stream)
         {
-            if (_callback != null)
-                _callback();
+            _callback?.Invoke();
         }
     }
 
@@ -198,7 +191,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
         private MemoryStream _stream;
         private StreamWriter _writer;
         // On .NET Framework the xsd element is written before the xsi element, where-as on modern .NET, it's the other way around.
-        private readonly static string s_suppressionsHeader = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework") ?
+        private static readonly string s_suppressionsHeader = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework") ?
             @"<Suppressions xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">" :
             @"<Suppressions xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">";
         public readonly string suppressionsFile = @$"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -317,8 +310,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
         private readonly MemoryStream _outputStream = new();
         private readonly Action<Stream> _callback;
 
-        public TestSuppressionEngine(string suppressionsFile, string noWarn, Action<Stream> callback)
-            : base(suppressionsFile, noWarn)
+        public TestSuppressionEngine(string[] suppressionsFiles, string noWarn, Action<Stream> callback)
+            : base(suppressionsFiles, noWarn)
         {
             if (callback == null)
             {
@@ -328,11 +321,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
         }
 
         public static TestSuppressionEngine CreateTestSuppressionEngine(Action<Stream> callback = null, string noWarn = "")
-            => new("NonExistentFile.xml", noWarn, callback);
+            => new(new string[] { "NonExistentFile.xml" }, noWarn, callback);
 
         public int GetSuppressionCount() => _validationSuppressions.Count;
 
-        protected override Stream GetReadableStream(string baselineFile)
+        protected override Stream GetReadableStream(string suppressionFile)
         {
             // Not Disposing stream since it will be disposed by caller.
             _stream = new MemoryStream();
@@ -343,7 +336,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             return _stream;
         }
 
-        protected override Stream GetWritableStream(string validationSuppressionFile) => _outputStream;
+        protected override Stream GetWritableStream(string suppressionFile) => _outputStream;
 
         protected override void AfterWrittingSuppressionsCallback(Stream stream) => _callback(stream);
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/26746

Changes the frontends to allow multiple suppression files and writing to an output suppression path while retaining the existing msbuild properties and items to not break existing customers.