### PR TITLE
Reduce official builds for servicing branches

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,13 +1,15 @@
 trigger:
   batch: true
-  branches:
-    include:
-    - main
-    - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    branches:
+      include:
+      - main
       - release/*
-    - internal/release/3.*
-    - internal/release/5.*
-    - internal/release/6.*
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    branches:
+      include:
+      - main
+      - internal/release/*
 
 variables:
   - name: teamName

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,15 +1,18 @@
-trigger:
-  batch: true
-  ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    branches:
-      include:
-      - main
-      - release/*
-  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    branches:
-      include:
-      - main
-      - internal/release/*
+${{ if eq(variables['System.TeamProject'], 'public') }}:
+  branches:
+    trigger:
+    batch: true
+    include:
+    - main
+    - release/*
+
+${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  branches:
+    trigger:
+    batch: true
+    include:
+    - main
+    - internal/release/*
 
 variables:
   - name: teamName

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,7 +2,6 @@ trigger:
   batch: true
   branches:
     include:
-    - master
     - main
     - ${{ if eq(variables['System.TeamProject'], 'public') }}:
       - release/*

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -4,7 +4,8 @@ trigger:
     include:
     - master
     - main
-    - release/*
+    - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      - release/*
     - internal/release/3.*
     - internal/release/5.*
     - internal/release/6.*


### PR DESCRIPTION
This should not be merged forward into main and release/7.0.2xx. This is intended to reduce the number of builds on branches that don't ship.