### PR TITLE
[release/7.0.2xx] Make mapping infrastructure unit testable, Ignore effectively sealed members and types and add tests

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/AssemblySetMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/AssemblySetMapper.cs
@@ -10,13 +10,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// <summary>
     /// Object that represents a mapping between two lists of <see cref="IAssemblySymbol"/>.
     /// </summary>
-    public class AssemblySetMapper : ElementMapper<IEnumerable<ElementContainer<IAssemblySymbol>>>
+    public class AssemblySetMapper : ElementMapper<IEnumerable<ElementContainer<IAssemblySymbol>>>, IAssemblySetMapper
     {
-        private Dictionary<IAssemblySymbol, AssemblyMapper>? _assemblies;
+        private Dictionary<IAssemblySymbol, IAssemblyMapper>? _assemblies;
 
-        /// <summary>
-        /// The number of assemblies mapped.
-        /// </summary>
+        /// <inheritdoc />
         public int AssemblyCount => _assemblies != null ? _assemblies.Count : 0;
 
         /// <summary>
@@ -25,18 +23,16 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// <param name="settings">The settings used to diff the elements in the mapper.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
         public AssemblySetMapper(IRuleRunner ruleRunner,
-            MapperSettings settings = default,
-            int rightSetSize = 1)
+            MapperSettings settings,
+            int rightSetSize)
             : base(ruleRunner, settings, rightSetSize) { }
 
-        /// <summary>
-        /// Gets the assembly mappers built from the provided lists of <see cref="IAssemblySymbol"/>.
-        /// <returns>The list of <see cref="AssemblyMapper"/> representing the underlying assemblies.</returns>
-        public IEnumerable<AssemblyMapper> GetAssemblies()
+        /// <inheritdoc />
+        public IEnumerable<IAssemblyMapper> GetAssemblies()
         {
             if (_assemblies == null)
             {
-                _assemblies = new Dictionary<IAssemblySymbol, AssemblyMapper>(Settings.EqualityComparer);
+                _assemblies = new Dictionary<IAssemblySymbol, IAssemblyMapper>(Settings.EqualityComparer);
                 AddOrCreateMappers(Left, ElementSide.Left);
 
                 for (int i = 0; i < Right.Length; i++)
@@ -54,7 +50,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
 
                     foreach (ElementContainer<IAssemblySymbol> assemblyContainer in assemblyContainers)
                     {
-                        if (!_assemblies.TryGetValue(assemblyContainer.Element, out AssemblyMapper? mapper))
+                        if (!_assemblies.TryGetValue(assemblyContainer.Element, out IAssemblyMapper? mapper))
                         {
                             mapper = new AssemblyMapper(RuleRunner, Settings, Right.Length, this);
                             _assemblies.Add(assemblyContainer.Element, mapper);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ElementMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ElementMapper.cs
@@ -10,29 +10,23 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// <summary>
     /// Class that represents a mapping in between two objects of type <see cref="T"/>.
     /// </summary>
-    public abstract class ElementMapper<T>
+    public abstract class ElementMapper<T> : IElementMapper<T>
     {
         private IEnumerable<CompatDifference>? _differences;
 
-        /// <summary>
-        /// Property representing the Left hand side of the mapping.
-        /// </summary>
+        /// <inheritdoc />
         public T? Left { get; private set; }
 
-        /// <summary>
-        /// Property representing the Right hand side element(s) of the mapping.
-        /// </summary>
+        /// <inheritdoc />
         public T?[] Right { get; private set; }
 
-        /// <summary>
-        /// The <see cref="MapperSettings"/> used to diff <see cref="Left"/> and <see cref="Right"/>.
-        /// </summary>
+        /// <inheritdoc />
         public MapperSettings Settings { get; }
 
         /// <summary>
         /// The rule runner to perform api comparison checks.
         /// </summary>
-        protected IRuleRunner RuleRunner { get; }
+        protected readonly IRuleRunner RuleRunner;
 
         /// <summary>
         /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
@@ -40,8 +34,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// <param name="settings">The settings used to diff the elements in the mapper.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
         public ElementMapper(IRuleRunner ruleRunner,
-            MapperSettings settings = default,
-            int rightSetSize = 1)
+            MapperSettings settings,
+            int rightSetSize)
         {
             if (rightSetSize < 1)
                 throw new ArgumentOutOfRangeException(nameof(rightSetSize), Resources.ShouldBeGreaterThanZero);
@@ -51,12 +45,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
             Right = new T[rightSetSize];
         }
 
-        /// <summary>
-        /// Adds an element to the mapping given the <paramref name="side"/> and the <paramref name="setIndex"/>.
-        /// </summary>
-        /// <param name="element">The element to add to the mapping.</param>
-        /// <param name="side">Value representing the side of the mapping.</param>
-        /// <param name="setIndex">Value representing the index the element is added. Only used when adding to <see cref="ElementSide.Right"/>.</param>
+        /// <inheritdoc />
         public virtual void AddElement(T element, ElementSide side, int setIndex = 0)
         {
             if (side == ElementSide.Left)
@@ -72,12 +61,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
             }
         }
 
-        /// <summary>
-        /// Returns the element from the specified <see cref="ElementSide"/> and index.
-        /// </summary>
-        /// <param name="side">Value representing the side of the mapping.</param>
-        /// <param name="setIndex">Value representing the index the element is retrieved. Only used when adding to <see cref="ElementSide.Right"/>.</param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public T? GetElement(ElementSide side, int setIndex)
         {
             if (side == ElementSide.Left)
@@ -88,12 +72,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
             return Right[setIndex];
         }
 
-        /// <summary>
-        /// Runs the rules found by the rule driver on the element mapper and returns a list of differences.
-        /// </summary>
-        /// <returns>A list containing the list of differences for each possible combination of
-        /// (<see cref="ElementMapper{T}.Left"/>, <see cref="ElementMapper{T}.Right"/>).
-        /// One list of <see cref="CompatDifference"/> per the number of right elements that the <see cref="ElementMapper{T}"/> contains.</returns>
+        /// <inheritdoc />
         public IEnumerable<CompatDifference> GetDifferences()
         {
             return _differences ??= RuleRunner.Run(this);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/IAssemblyMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/IAssemblyMapper.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.ApiCompatibility.Abstractions
+{
+    /// <summary>
+    /// Interface that represents a mapping between multiple <see cref="IAssemblySymbol"/> objects.
+    /// This also holds a list of <see cref="INamespaceMapper"/> to represent the mapping of namespaces in between
+    /// <see cref="IElementMapper{T}.Left"/> and <see cref="IElementMapper{T}.Right"/>.
+    /// </summary>
+    public interface IAssemblyMapper : IElementMapper<ElementContainer<IAssemblySymbol>>
+    {
+        /// <summary>
+        /// The containing assembly set of this assembly. Null if the assembly is not part of a set.
+        /// </summary>
+        IAssemblySetMapper? ContainingAssemblySet { get; }
+
+        /// <summary>
+        /// Gets the assembly load errors that happened when trying to follow type forwards.
+        /// </summary>
+        IEnumerable<CompatDifference> AssemblyLoadErrors { get; }
+
+        /// <summary>
+        /// Gets the mappers for the namespaces contained in <see cref="ElementMapper{T}.Left"/> and <see cref="ElementMapper{T}.Right"/>
+        /// </summary>
+        /// <returns>The list of <see cref="NamespaceMapper"/>.</returns>
+        IEnumerable<INamespaceMapper> GetNamespaces();
+    }
+}

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/IAssemblySetMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/IAssemblySetMapper.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.ApiCompatibility.Abstractions
+{
+    /// <summary>
+    /// Interface that represents a mapping between two lists of <see cref="IAssemblySymbol"/>.
+    /// </summary>
+    public interface IAssemblySetMapper : IElementMapper<IEnumerable<ElementContainer<IAssemblySymbol>>>
+    {
+        /// <summary>
+        /// The number of assemblies mapped.
+        /// </summary>
+        int AssemblyCount { get; }
+
+        /// <summary>
+        /// Gets the assembly mappers built from the provided lists of <see cref="IAssemblySymbol"/>.
+        /// <returns>The list of <see cref="AssemblyMapper"/> representing the underlying assemblies.</returns>
+        /// </summary>
+        IEnumerable<IAssemblyMapper> GetAssemblies();
+    }
+}

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/IElementMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/IElementMapper.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.ApiCompatibility.Abstractions
+{
+    /// <summary>
+    /// Interface that represents a mapping in between two objects of type <see cref="T"/>.
+    /// </summary>
+    public interface IElementMapper<T>
+    {
+        /// <summary>
+        /// Property representing the Left hand side of the mapping.
+        /// </summary>
+        T? Left { get; }
+
+        /// <summary>
+        /// Property representing the Right hand side element(s) of the mapping.
+        /// </summary>
+        T?[] Right { get; }
+
+        /// <summary>
+        /// The <see cref="MapperSettings"/> used to diff <see cref="Left"/> and <see cref="Right"/>.
+        /// </summary>
+        MapperSettings Settings { get; }
+
+        /// <summary>
+        /// Adds an element to the mapping given the <paramref name="side"/> and the <paramref name="setIndex"/>.
+        /// </summary>
+        /// <param name="element">The element to add to the mapping.</param>
+        /// <param name="side">Value representing the side of the mapping.</param>
+        /// <param name="setIndex">Value representing the index the element is added. Only used when adding to <see cref="ElementSide.Right"/>.</param>
+        void AddElement(T element, ElementSide side, int setIndex = 0);
+
+        /// <summary>
+        /// Returns the element from the specified <see cref="ElementSide"/> and index.
+        /// </summary>
+        /// <param name="side">Value representing the side of the mapping.</param>
+        /// <param name="setIndex">Value representing the index the element is retrieved. Only used when adding to <see cref="ElementSide.Right"/>.</param>
+        T? GetElement(ElementSide side, int setIndex);
+
+        /// <summary>
+        /// Runs the rules found by the rule driver on the element mapper and returns a list of differences.
+        /// </summary>
+        /// <returns>A list containing the list of differences for each possible combination of
+        /// (<see cref="ElementMapper{T}.Left"/>, <see cref="ElementMapper{T}.Right"/>).
+        /// One list of <see cref="CompatDifference"/> per the number of right elements that the <see cref="ElementMapper{T}"/> contains.</returns>
+        IEnumerable<CompatDifference> GetDifferences();
+    }
+}

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/IMemberMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/IMemberMapper.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.ApiCompatibility.Abstractions
+{
+    /// <summary>
+    /// Interface that represents a mapping between two <see cref="ISymbol"/> objects.
+    /// </summary>
+    public interface IMemberMapper : IElementMapper<ISymbol>
+    {
+        /// <summary>
+        /// The containg type of this member.
+        /// </summary>
+        ITypeMapper ContainingType { get; }
+    }
+}

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/INamespaceMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/INamespaceMapper.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.ApiCompatibility.Abstractions
+{
+    /// <summary>
+    /// Interface that represents a mapping between two <see cref="INamespaceSymbol"/> objects.
+    /// This also holds a list of <see cref="ITypeMapper"/> to represent the mapping of types in between
+    /// <see cref="IElementMapper{T}.Left"/> and <see cref="IElementMapper{T}.Right"/>.
+    /// </summary>
+    public interface INamespaceMapper : IElementMapper<INamespaceSymbol>
+    {
+        /// <summary>
+        /// The containing assembly of this namespace.
+        /// </summary>
+        IAssemblyMapper ContainingAssembly { get; }
+
+        /// <summary>
+        /// Gets all the <see cref="TypeMapper"/> representing the types defined in the namespace including the typeforwards.
+        /// </summary>
+        /// <returns>The mapper representing the types in the namespace</returns>
+        IEnumerable<ITypeMapper> GetTypes();
+
+        /// <summary>
+        /// Adds forwarded types to the mapper to the index specified in the mapper.
+        /// </summary>
+        /// <param name="forwardedTypes">List containing the <see cref="INamedTypeSymbol"/> that represents the forwarded types.</param>
+        /// <param name="side">Side to add the forwarded types into, 0 (Left) or 1 (Right).</param>
+        /// <param name="setIndex">Value representing the index on the set of elements corresponding to the compared side.</param>
+        void AddForwardedTypes(IEnumerable<INamedTypeSymbol>? forwardedTypes, ElementSide side, int setIndex);
+    }
+}

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ITypeMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ITypeMapper.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.ApiCompatibility.Abstractions
+{
+    /// <summary>
+    /// Interface that represents a mapping between two <see cref="ITypeSymbol"/> objects.
+    /// This also holds the nested types as a list of <see cref="ITypeMapper"/> and the members defined within the type
+    /// as a list of <see cref="IMemberMapper"/>
+    /// </summary>
+    public interface ITypeMapper : IElementMapper<ITypeSymbol>
+    {
+        /// <summary>
+        /// The containg namespace of this type.
+        /// </summary>
+        INamespaceMapper ContainingNamespace { get; }
+
+        /// <summary>
+        /// The containing type of this type. Null if the type isn't nested.
+        /// </summary>
+        ITypeMapper? ContainingType { get; }
+
+        /// <summary>
+        /// Indicates whether we have a complete mapper and if the members should be diffed.
+        /// </summary>
+        bool ShouldDiffMembers { get; }
+
+        /// <summary>
+        /// Gets the nested types within the mapped types.
+        /// </summary>
+        /// <returns>The list of <see cref="TypeMapper"/> representing the nested types.</returns>
+        IEnumerable<ITypeMapper> GetNestedTypes();
+
+        /// <summary>
+        /// Gets the members defined in this type.
+        /// </summary>
+        /// <returns>The list of <see cref="MemberMapper"/> representing the members.</returns>
+        IEnumerable<IMemberMapper> GetMembers();
+    }
+}

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/MemberMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/MemberMapper.cs
@@ -9,12 +9,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     /// <summary>
     /// Object that represents a mapping between two <see cref="ISymbol"/> objects.
     /// </summary>
-    public class MemberMapper : ElementMapper<ISymbol>
+    public class MemberMapper : ElementMapper<ISymbol>, IMemberMapper
     {
-        /// <summary>
-        /// The containg type of this member.
-        /// </summary>
-        public TypeMapper ContainingType { get; }
+        /// <inheritdoc />
+        public ITypeMapper ContainingType { get; }
 
         /// <summary>
         /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
@@ -22,9 +20,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// <param name="settings">The settings used to diff the elements in the mapper.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
         public MemberMapper(IRuleRunner ruleRunner,
-            TypeMapper containingType,
-            MapperSettings settings = default,
-            int rightSetSize = 1)
+            MapperSettings settings,
+            int rightSetSize,
+            ITypeMapper containingType)
             : base(ruleRunner, settings, rightSetSize)
         {
             ContainingType = containingType;

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
@@ -50,12 +50,12 @@ namespace Microsoft.DotNet.ApiCompatibility
         public IEnumerable<CompatDifference> GetDifferences(ElementContainer<IAssemblySymbol> left,
             ElementContainer<IAssemblySymbol> right)
         {
-            var mapper = _elementMapperFactory.CreateAssemblyMapper(Settings.ToMapperSettings());
-            mapper.AddElement(left, ElementSide.Left);
-            mapper.AddElement(right, ElementSide.Right);
+            IAssemblyMapper assemblyMapper = _elementMapperFactory.CreateAssemblyMapper(Settings.ToMapperSettings(), rightCount: 1);
+            assemblyMapper.AddElement(left, ElementSide.Left);
+            assemblyMapper.AddElement(right, ElementSide.Right);
 
             IDifferenceVisitor visitor = _differenceVisitorFactory.Create();
-            visitor.Visit(mapper);
+            visitor.Visit(assemblyMapper);
 
             return visitor.CompatDifferences;
         }
@@ -64,12 +64,12 @@ namespace Microsoft.DotNet.ApiCompatibility
         public IEnumerable<CompatDifference> GetDifferences(IEnumerable<ElementContainer<IAssemblySymbol>> left,
             IEnumerable<ElementContainer<IAssemblySymbol>> right)
         {
-            var mapper = _elementMapperFactory.CreateAssemblySetMapper(Settings.ToMapperSettings());
-            mapper.AddElement(left, ElementSide.Left);
-            mapper.AddElement(right, ElementSide.Right);
+            IAssemblySetMapper assemblySetMapper = _elementMapperFactory.CreateAssemblySetMapper(Settings.ToMapperSettings(), rightCount: 1);
+            assemblySetMapper.AddElement(left, ElementSide.Left);
+            assemblySetMapper.AddElement(right, ElementSide.Right);
 
             IDifferenceVisitor visitor = _differenceVisitorFactory.Create();
-            visitor.Visit(mapper);
+            visitor.Visit(assemblySetMapper);
 
             return visitor.CompatDifferences;
         }
@@ -98,15 +98,15 @@ namespace Microsoft.DotNet.ApiCompatibility
             IReadOnlyList<ElementContainer<IAssemblySymbol>> right)
         {
             int rightCount = right.Count;
-            var mapper = _elementMapperFactory.CreateAssemblyMapper(Settings.ToMapperSettings(), rightCount);
-            mapper.AddElement(left, ElementSide.Left);
+            IAssemblyMapper assemblyMapper = _elementMapperFactory.CreateAssemblyMapper(Settings.ToMapperSettings(), rightCount);
+            assemblyMapper.AddElement(left, ElementSide.Left);
             for (int i = 0; i < rightCount; i++)
             {
-                mapper.AddElement(right[i], ElementSide.Right, i);
+                assemblyMapper.AddElement(right[i], ElementSide.Right, i);
             }
 
             IDifferenceVisitor visitor = _differenceVisitorFactory.Create();
-            visitor.Visit(mapper);
+            visitor.Visit(assemblyMapper);
 
             return SortCompatDifferencesByInputMetadata(visitor.CompatDifferences.ToLookup(c => c.Right, t => t), right);
         }
@@ -115,15 +115,15 @@ namespace Microsoft.DotNet.ApiCompatibility
         public IEnumerable<CompatDifference> GetDifferences(IEnumerable<ElementContainer<IAssemblySymbol>> left,
             IReadOnlyList<IEnumerable<ElementContainer<IAssemblySymbol>>> right)
         {
-            var mapper = _elementMapperFactory.CreateAssemblySetMapper(Settings.ToMapperSettings(), right.Count);
-            mapper.AddElement(left, ElementSide.Left);
+            IAssemblySetMapper assemblySetMapper = _elementMapperFactory.CreateAssemblySetMapper(Settings.ToMapperSettings(), right.Count);
+            assemblySetMapper.AddElement(left, ElementSide.Left);
             for (int rightIndex = 0; rightIndex < right.Count; rightIndex++)
             {
-                mapper.AddElement(right[rightIndex], ElementSide.Right, rightIndex);
+                assemblySetMapper.AddElement(right[rightIndex], ElementSide.Right, rightIndex);
             }
 
             IDifferenceVisitor visitor = _differenceVisitorFactory.Create();
-            visitor.Visit(mapper);
+            visitor.Visit(assemblySetMapper);
 
             return SortCompatDifferencesByInputMetadata(visitor.CompatDifferences.ToLookup(c => c.Left, t => t), left);
         }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
@@ -17,45 +17,45 @@ namespace Microsoft.DotNet.ApiCompatibility
         public IEnumerable<CompatDifference> CompatDifferences => _compatDifferences;
 
         /// <inheritdoc />
-        public void Visit<T>(ElementMapper<T> mapper)
+        public void Visit<T>(IElementMapper<T> mapper)
         {
-            if (mapper is AssemblySetMapper assemblySetMapper)
+            if (mapper is IAssemblySetMapper assemblySetMapper)
             {
                 Visit(assemblySetMapper);
             }
-            else if (mapper is AssemblyMapper assemblyMapper)
+            else if (mapper is IAssemblyMapper assemblyMapper)
             {
                 Visit(assemblyMapper);
             }
-            else if (mapper is NamespaceMapper nsMapper)
+            else if (mapper is INamespaceMapper nsMapper)
             {
                 Visit(nsMapper);
             }
-            else if (mapper is TypeMapper typeMapper)
+            else if (mapper is ITypeMapper typeMapper)
             {
                 Visit(typeMapper);
             }
-            else if (mapper is MemberMapper memberMapper)
+            else if (mapper is IMemberMapper memberMapper)
             {
                 Visit(memberMapper);
             }
         }
 
         /// <inheritdoc />
-        public void Visit(AssemblySetMapper mapper)
+        public void Visit(IAssemblySetMapper mapper)
         {
-            foreach (AssemblyMapper assembly in mapper.GetAssemblies())
+            foreach (IAssemblyMapper assembly in mapper.GetAssemblies())
             {
                 Visit(assembly);
             }
         }
 
         /// <inheritdoc />
-        public void Visit(AssemblyMapper assembly)
+        public void Visit(IAssemblyMapper assembly)
         {
             AddDifferences(assembly);
 
-            foreach (NamespaceMapper @namespace in assembly.GetNamespaces())
+            foreach (INamespaceMapper @namespace in assembly.GetNamespaces())
             {
                 Visit(@namespace);
             }
@@ -69,27 +69,27 @@ namespace Microsoft.DotNet.ApiCompatibility
         }
 
         /// <inheritdoc />
-        public void Visit(NamespaceMapper @namespace)
+        public void Visit(INamespaceMapper @namespace)
         {
-            foreach (TypeMapper type in @namespace.GetTypes())
+            foreach (ITypeMapper type in @namespace.GetTypes())
             {
                 Visit(type);
             }
         }
 
         /// <inheritdoc />
-        public void Visit(TypeMapper type)
+        public void Visit(ITypeMapper type)
         {
             AddDifferences(type);
 
             if (type.ShouldDiffMembers)
             {
-                foreach (TypeMapper nestedType in type.GetNestedTypes())
+                foreach (ITypeMapper nestedType in type.GetNestedTypes())
                 {
                     Visit(nestedType);
                 }
 
-                foreach (MemberMapper member in type.GetMembers())
+                foreach (IMemberMapper member in type.GetMembers())
                 {
                     Visit(member);
                 }
@@ -97,12 +97,12 @@ namespace Microsoft.DotNet.ApiCompatibility
         }
 
         /// <inheritdoc />
-        public void Visit(MemberMapper member)
+        public void Visit(IMemberMapper member)
         {
             AddDifferences(member);
         }
 
-        private void AddDifferences<T>(ElementMapper<T> mapper)
+        private void AddDifferences<T>(IElementMapper<T> mapper)
         {
             foreach (CompatDifference item in mapper.GetDifferences())
             {

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ElementMapperFactory.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ElementMapperFactory.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
 using Microsoft.DotNet.ApiCompatibility.Rules;
 
@@ -14,20 +12,20 @@ namespace Microsoft.DotNet.ApiCompatibility
     public interface IElementMapperFactory
     {
         /// <summary>
-        /// Creates an AssemblySetMapper instance with optional given mapper settings and the count of the rights that are compared.
+        /// Creates an <see cref="IAssemblySetMapper"/> instance with optional given mapper settings and the count of the rights that are compared.
         /// </summary>
         /// <param name="settings">The mapper settings.</param>
         /// <param name="rightCount">The number of rights that are compared.</param>
         /// <returns>Returns an AssemblySetMapper based on the given inputs.</returns>
-        ElementMapper<IEnumerable<ElementContainer<IAssemblySymbol>>> CreateAssemblySetMapper(MapperSettings settings = default, int rightCount = 1);
+        IAssemblySetMapper CreateAssemblySetMapper(MapperSettings settings, int rightCount);
 
         /// <summary>
-        /// Creates an AssemblyMapper instance with optional given mapper assetings and the count of the rights that are compared.
+        /// Creates an <see cref="IAssemblyMapper"/> instance with optional given mapper assetings and the count of the rights that are compared.
         /// </summary>
         /// <param name="settings">The mapper settings.</param>
         /// <param name="rightCount">The number of rights that are compared.</param>
         /// <returns>Returns an AssemblyMapper based on the given inputs.</returns>
-        ElementMapper<ElementContainer<IAssemblySymbol>> CreateAssemblyMapper(MapperSettings settings = default, int rightCount = 1);
+        IAssemblyMapper CreateAssemblyMapper(MapperSettings settings, int rightCount);
     }
 
     /// <summary>
@@ -43,11 +41,11 @@ namespace Microsoft.DotNet.ApiCompatibility
         }
 
         /// <inheritdoc />
-        public ElementMapper<IEnumerable<ElementContainer<IAssemblySymbol>>> CreateAssemblySetMapper(MapperSettings settings = default, int rightCount = 1) =>
+        public IAssemblySetMapper CreateAssemblySetMapper(MapperSettings settings, int rightCount) =>
             new AssemblySetMapper(_ruleRunner, settings, rightCount);
 
         /// <inheritdoc />
-        public ElementMapper<ElementContainer<IAssemblySymbol>> CreateAssemblyMapper(MapperSettings settings = default, int rightCount = 1) =>
+        public IAssemblyMapper CreateAssemblyMapper(MapperSettings settings, int rightCount) =>
             new AssemblyMapper(_ruleRunner, settings, rightCount);
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IDifferenceVisitor.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IDifferenceVisitor.cs
@@ -18,40 +18,40 @@ namespace Microsoft.DotNet.ApiCompatibility
         IEnumerable<CompatDifference> CompatDifferences { get; }
 
         /// <summary>
-        /// Visits the tree for the given <see cref="ElementMapper{T}"/>.
+        /// Visits the tree for the given <see cref="IElementMapper{T}"/>.
         /// </summary>
         /// <typeparam name="T">Underlying type for the objects that the mapper holds.</typeparam>
         /// <param name="mapper"><see cref="ElementMapper{T}"/> to visit.</param>
-        void Visit<T>(ElementMapper<T> mapper);
+        void Visit<T>(IElementMapper<T> mapper);
 
         /// <summary>
-        /// Visits the <see cref="AssemblySetMapper"/> and visits each <see cref="AssemblyMapper"/> in the mapper.
+        /// Visits the <see cref="IAssemblySetMapper"/> and visits each <see cref="IAssemblyMapper"/> in the mapper.
         /// </summary>
         /// <param name="mapper">The <see cref="AssemblySetMapper"/> to visit.</param>
-        void Visit(AssemblySetMapper mapper);
+        void Visit(IAssemblySetMapper mapper);
 
         /// <summary>
-        /// Visits an <see cref="AssemblyMapper"/> and adds it's differences to the <see cref="DiagnosticBag{CompatDifference}"/>.
+        /// Visits an <see cref="IAssemblyMapper"/> and adds it's differences to the <see cref="DiagnosticBag{CompatDifference}"/>.
         /// </summary>
         /// <param name="assembly">The mapper to visit.</param>
-        void Visit(AssemblyMapper assembly);
+        void Visit(IAssemblyMapper assembly);
 
         /// <summary>
-        /// Visits the <see cref="NamespaceMapper"/> and visits each <see cref="TypeMapper"/> in the mapper.
+        /// Visits the <see cref="INamespaceMapper"/> and visits each <see cref="ITypeMapper"/> in the mapper.
         /// </summary>
         /// <param name="mapper">The <see cref="NamespaceMapper"/> to visit.</param>
-        void Visit(NamespaceMapper @namespace);
+        void Visit(INamespaceMapper @namespace);
 
         /// <summary>
-        /// Visits an <see cref="TypeMapper"/> and adds it's differences to the <see cref="DiagnosticBag{CompatDifference}"/>.
+        /// Visits an <see cref="ITypeMapper"/> and adds it's differences to the <see cref="DiagnosticBag{CompatDifference}"/>.
         /// </summary>
         /// <param name="type">The mapper to visit.</param>
-        void Visit(TypeMapper type);
+        void Visit(ITypeMapper type);
 
         /// <summary>
-        /// Visits an <see cref="MemberMapper"/> and adds it's differences to the <see cref="DiagnosticBag{CompatDifference}"/>.
+        /// Visits an <see cref="IMemberMapper"/> and adds it's differences to the <see cref="DiagnosticBag{CompatDifference}"/>.
         /// </summary>
         /// <param name="member">The mapper to visit.</param>
-        void Visit(MemberMapper member);
+        void Visit(IMemberMapper member);
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/MapperSettings.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/MapperSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
@@ -28,7 +29,17 @@ namespace Microsoft.DotNet.ApiCompatibility
         public readonly bool WarnOnMissingReferences;
 
         /// <summary>
-        /// Instantiate an object with the desired comparison settings.
+        /// Instantiates default MapperSettings.
+        /// </summary>
+        public MapperSettings()
+        {
+            Filter = new SymbolAccessibilityBasedFilter(false);
+            EqualityComparer = new DefaultSymbolsEqualityComparer();
+            WarnOnMissingReferences = false;
+        }
+
+        /// <summary>
+        /// Instantiates MapperSettings with the desired comparison settings.
         /// </summary>
         /// <param name="ruleRunner">The rule runner.</param>
         /// <param name="filter">The symbol filter.</param>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -13,8 +13,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     /// </summary>
     public class RuleRunner : IRuleRunner
     {
-        private readonly IRuleContext _context;
         private readonly IRuleFactory _ruleFactory;
+        private readonly IRuleContext _context;
 
         public RuleRunner(IRuleFactory ruleFactory, IRuleContext context)
         {
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         {
             List<CompatDifference> differences = new();
 
-            int rightLength = mapper.Right.Length;            
+            int rightLength = mapper.Right.Length;
             for (int rightIndex = 0; rightIndex < rightLength; rightIndex++)
             {
                 if (mapper is AssemblyMapper am)

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Mappers/AssemblyMapperTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Mappers/AssemblyMapperTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Microsoft.DotNet.ApiCompatibility.Rules;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.ApiCompatibility.Tests.Mappers
+{
+    public class AssemblyMapperTests
+    {
+        [Fact]
+        public void AssemblyMapper_Ctor_PropertiesSet()
+        {
+            IRuleRunner ruleRunner = Mock.Of<IRuleRunner>();
+            MapperSettings mapperSettings = new();
+            int rightSetSize = 5;
+            IAssemblySetMapper assemblySetMapper = Mock.Of<IAssemblySetMapper>();
+
+            AssemblyMapper assemblyMapper = new(ruleRunner, mapperSettings, rightSetSize, assemblySetMapper);
+
+            Assert.Equal(mapperSettings, assemblyMapper.Settings);
+            Assert.Equal(rightSetSize, assemblyMapper.Right.Length);
+            Assert.Equal(assemblySetMapper, assemblyMapper.ContainingAssemblySet);
+        }
+
+        [Fact]
+        public void AssemblyMapper_GetNamespacesWithoutLeftAndRight_EmptyResult()
+        {
+            AssemblyMapper assemblyMapper = new(Mock.Of<IRuleRunner>(), new MapperSettings(), rightSetSize: 1);
+            Assert.Empty(assemblyMapper.GetNamespaces());
+        }
+
+        [Fact]
+        public void AssemblyMapper_GetNamespaces_ReturnsExpected()
+        {
+            string leftSyntax = @"
+namespace AssemblyMapperTestNamespace1
+{
+    public class A { }
+}
+namespace AssemblyMapperTestNamespace2
+{
+    public class A { }
+}
+";
+            string rightSyntax = @"
+namespace AssemblyMapperTestNamespace1
+{
+    public class A { }
+}
+namespace AssemblyMapperTestNamespace2
+{
+    public class A { }
+}
+namespace AssemblyMapperTestNamespace3
+{
+    public class A { }
+}
+";
+            ElementContainer<IAssemblySymbol> left = new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax),
+                MetadataInformation.DefaultLeft);
+            ElementContainer<IAssemblySymbol> right = new(SymbolFactory.GetAssemblyFromSyntax(rightSyntax),
+                MetadataInformation.DefaultRight);
+            AssemblyMapper assemblyMapper = new(Mock.Of<IRuleRunner>(), new MapperSettings(), rightSetSize: 1);
+            assemblyMapper.AddElement(left, ElementSide.Left);
+            assemblyMapper.AddElement(right, ElementSide.Right);
+
+            IEnumerable<INamespaceMapper> namespaceMappers = assemblyMapper.GetNamespaces();
+
+            Assert.Equal(3, namespaceMappers.Count());
+            Assert.Equal(new string?[] { "AssemblyMapperTestNamespace1", "AssemblyMapperTestNamespace2", null }, namespaceMappers.Select(n => n.Left?.Name));
+            Assert.Equal(new string[] { "AssemblyMapperTestNamespace1", "AssemblyMapperTestNamespace2", "AssemblyMapperTestNamespace3" }, namespaceMappers.SelectMany(n => n.Right).Select(r => r?.Name));
+        }
+    }
+}

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Mappers/TypeMapperTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Mappers/TypeMapperTests.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Microsoft.DotNet.ApiCompatibility.Rules;
+using Moq;
+using Xunit;
+using System.Linq;
+
+namespace Microsoft.DotNet.ApiCompatibility.Tests.Mappers
+{
+    public class TypeMapperTests
+    {
+        [Fact]
+        public void TypeMapper_Ctor_PropertiesSet()
+        {
+            IRuleRunner ruleRunner = Mock.Of<IRuleRunner>();
+            MapperSettings mapperSettings = new();
+            int rightSetSize = 5;
+            INamespaceMapper containingNamespace = Mock.Of<INamespaceMapper>();
+            ITypeMapper containingType = Mock.Of<ITypeMapper>();
+
+            TypeMapper assemblyMapper = new(ruleRunner, mapperSettings, rightSetSize, containingNamespace, containingType);
+
+            Assert.Equal(mapperSettings, assemblyMapper.Settings);
+            Assert.Equal(rightSetSize, assemblyMapper.Right.Length);
+            Assert.Equal(containingNamespace, assemblyMapper.ContainingNamespace);
+            Assert.Equal(containingType, assemblyMapper.ContainingType);
+        }
+
+        [Fact]
+        public void TypeMapper_GetNestedTypesWithoutLeftAndRight_EmptyResult()
+        {
+            TypeMapper typeMapper = new(Mock.Of<IRuleRunner>(), new MapperSettings(), rightSetSize: 1, Mock.Of<INamespaceMapper>());
+            Assert.Empty(typeMapper.GetNestedTypes());
+        }
+
+        [Fact]
+        public void TypeMapper_GetMembersWithoutLeftAndRight_EmptyResult()
+        {
+            TypeMapper typeMapper = new(Mock.Of<IRuleRunner>(), new MapperSettings(), rightSetSize: 1, Mock.Of<INamespaceMapper>());
+            Assert.Empty(typeMapper.GetMembers());
+        }
+
+        [Fact]
+        public void TypeMapper_GetNestedTypes_ReturnsExpected()
+        {
+            string leftSyntax = @"
+public class A
+{
+    protected class B { }
+    protected class C { }
+}
+";
+            string rightSyntax = @"
+public class A
+{
+    public class B { }
+    public class C { }
+    protected internal class D { }
+}
+";
+            ElementContainer<IAssemblySymbol> left = new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax),
+                MetadataInformation.DefaultLeft);
+            ElementContainer<IAssemblySymbol> right = new(SymbolFactory.GetAssemblyFromSyntax(rightSyntax),
+                MetadataInformation.DefaultRight);
+            AssemblyMapper assemblyMapper = new(Mock.Of<IRuleRunner>(), new MapperSettings(), rightSetSize: 1);
+            assemblyMapper.AddElement(left, ElementSide.Left);
+            assemblyMapper.AddElement(right, ElementSide.Right);
+
+            IEnumerable<INamespaceMapper> namespaceMappers = assemblyMapper.GetNamespaces();
+            Assert.Single(namespaceMappers);
+
+            IEnumerable<ITypeMapper> typeMappers = namespaceMappers.Single().GetTypes();
+            Assert.Single(typeMappers);
+
+            IEnumerable<ITypeMapper> nestedTypeMappers = typeMappers.Single().GetNestedTypes();
+
+            Assert.Equal(3, nestedTypeMappers.Count());
+            Assert.Equal(new string?[] { "B", "C", null }, nestedTypeMappers.Select(n => n.Left?.Name));
+            Assert.Equal(new string[] { "B", "C", "D" }, nestedTypeMappers.SelectMany(n => n.Right).Select(r => r?.Name));
+        }
+
+        [Fact]
+        public void TypeMapper_GetMembers_ReturnsExpected()
+        {
+            string leftSyntax = @"
+public class A
+{
+    public A() { }
+    public string B;
+    public string C;
+}
+";
+            string rightSyntax = @"
+public class A
+{
+    public A() { }
+    public string B;
+    public string C;
+    protected internal string D;
+}
+";
+            ElementContainer<IAssemblySymbol> left = new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax),
+                MetadataInformation.DefaultLeft);
+            ElementContainer<IAssemblySymbol> right = new(SymbolFactory.GetAssemblyFromSyntax(rightSyntax),
+                MetadataInformation.DefaultRight);
+            AssemblyMapper assemblyMapper = new(Mock.Of<IRuleRunner>(), new MapperSettings(), rightSetSize: 1);
+            assemblyMapper.AddElement(left, ElementSide.Left);
+            assemblyMapper.AddElement(right, ElementSide.Right);
+
+            IEnumerable<INamespaceMapper> namespaceMappers = assemblyMapper.GetNamespaces();
+            Assert.Single(namespaceMappers);
+
+            IEnumerable<ITypeMapper> typeMappers = namespaceMappers.Single().GetTypes();
+            Assert.Single(typeMappers);
+
+            IEnumerable<IMemberMapper> memberMappers = typeMappers.Single().GetMembers();
+
+            Assert.Equal(4, memberMappers.Count());
+            Assert.Equal(new string?[] { ".ctor", "B", "C", null }, memberMappers.Select(n => n.Left?.Name));
+            Assert.Equal(new string[] { ".ctor", "B", "C", "D" }, memberMappers.SelectMany(n => n.Right).Select(r => r?.Name));
+        }
+
+        [Fact]
+        public void TypeMapper_GetMembersAndGetNestedTypesWithOnlyEffectivelySealedMembersAndTypes_ReturnsEmpty()
+        {
+            string leftSyntax = @"
+public class A
+{
+    private A() { }
+    protected class B { }
+    protected internal class C { }
+}
+";
+            string rightSyntax = @"
+public class A
+{
+    private A() { }
+    protected class B { }
+    protected internal class C { }
+}
+";
+            ElementContainer<IAssemblySymbol> left = new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax),
+                MetadataInformation.DefaultLeft);
+            ElementContainer<IAssemblySymbol> right = new(SymbolFactory.GetAssemblyFromSyntax(rightSyntax),
+                MetadataInformation.DefaultRight);
+            AssemblyMapper assemblyMapper = new(Mock.Of<IRuleRunner>(), new MapperSettings(), rightSetSize: 1);
+            assemblyMapper.AddElement(left, ElementSide.Left);
+            assemblyMapper.AddElement(right, ElementSide.Right);
+
+            IEnumerable<INamespaceMapper> namespaceMappers = assemblyMapper.GetNamespaces();
+            Assert.Single(namespaceMappers);
+
+            IEnumerable<ITypeMapper> typeMappers = namespaceMappers.Single().GetTypes();
+            Assert.Single(typeMappers);
+
+            IEnumerable<IMemberMapper> memberMappers = typeMappers.Single().GetMembers();
+            Assert.Empty(memberMappers);
+
+            IEnumerable<ITypeMapper> nestedTypeMappers = typeMappers.Single().GetNestedTypes();
+            Assert.Empty(nestedTypeMappers);
+        }
+    }
+}


### PR DESCRIPTION
**Backport of https://github.com/dotnet/sdk/commit/0d8aea8a1cac35e67f81de240405e725410dfc8c into release/7.0.2xx**

* Make mapping infrastructure unit testable

Define interfaces for the mapping types in order for them to not depend on concrete implementations in order for them to be unit test-able.

* Ignore effectively sealed members and types

Don't map effectively sealed members and types so that individual rules don't have to special case them.

* Add unit tests for mapper types and eff sealed case

* Update SymbolExtensions.cs