### PR TITLE
Retarget Microsoft.Extensions.DotNetDeltaApplier to netstandard2.1

### DIFF
--- a/src/Assets/TestProjects/WatchApp60/Program.cs
+++ b/src/Assets/TestProjects/WatchApp60/Program.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Started");
+            // Process ID is insufficient because PID's may be reused.
+            Console.WriteLine($"Process identifier = {Process.GetCurrentProcess().Id}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
+            if (args.Length > 0 && args[0] == "--no-exit")
+            {
+                Thread.Sleep(Timeout.Infinite);
+            }
+            Console.WriteLine("Exiting");
+        }
+    }
+}

--- a/src/Assets/TestProjects/WatchApp60/WatchApp60.csproj
+++ b/src/Assets/TestProjects/WatchApp60/WatchApp60.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net60</TargetFramework>
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
+
+</Project>

--- a/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
@@ -4,26 +4,52 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Metadata;
 
 namespace Microsoft.Extensions.HotReload
 {
     internal sealed class HotReloadAgent : IDisposable
     {
+        private delegate void ApplyUpdateDelegate(Assembly assembly, ReadOnlySpan<byte> metadataDelta, ReadOnlySpan<byte> ilDelta, ReadOnlySpan<byte> pdbDelta);
+
         private readonly Action<string> _log;
         private readonly AssemblyLoadEventHandler _assemblyLoad;
         private readonly ConcurrentDictionary<Guid, List<UpdateDelta>> _deltas = new();
         private readonly ConcurrentDictionary<Assembly, Assembly> _appliedAssemblies = new();
+        private readonly ApplyUpdateDelegate? _applyUpdate;
+        private readonly string? _capabilities;
         private volatile UpdateHandlerActions? _handlerActions;
 
         public HotReloadAgent(Action<string> log)
         {
+            var metadataUpdater = Type.GetType("System.Reflection.Metadata.MetadataUpdater, System.Runtime.Loader", throwOnError: false);
+
+            if (metadataUpdater != null)
+            {
+                _applyUpdate = (ApplyUpdateDelegate?)metadataUpdater.GetMethod("ApplyUpdate", BindingFlags.Public | BindingFlags.Static, binder: null,
+                    new[] { typeof(Assembly), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>) }, modifiers: null)?.CreateDelegate(typeof(ApplyUpdateDelegate));
+
+                if (_applyUpdate != null)
+                {
+                    try
+                    {
+                        _capabilities = metadataUpdater.GetMethod("GetCapabilities", BindingFlags.NonPublic | BindingFlags.Static, binder: null, Type.EmptyTypes, modifiers: null)?.
+                            Invoke(obj: null, parameters: null) as string;
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+
             _log = log;
             _assemblyLoad = OnAssemblyLoad;
             AppDomain.CurrentDomain.AssemblyLoad += _assemblyLoad;
         }
+
+        public string Capabilities => _capabilities ?? string.Empty;
 
         private void OnAssemblyLoad(object? _, AssemblyLoadEventArgs eventArgs)
         {
@@ -107,7 +133,7 @@ namespace Microsoft.Extensions.HotReload
 
             Action<Type[]?> CreateAction(MethodInfo update)
             {
-                Action<Type[]?> action = update.CreateDelegate<Action<Type[]?>>();
+                var action = (Action<Type[]?>)update.CreateDelegate(typeof(Action<Type[]?>));
                 return types =>
                 {
                     try
@@ -123,7 +149,7 @@ namespace Microsoft.Extensions.HotReload
 
             MethodInfo? GetUpdateMethod(Type handlerType, string name)
             {
-                if (handlerType.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, new[] { typeof(Type[]) }) is MethodInfo updateMethod &&
+                if (handlerType.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, binder: null, new[] { typeof(Type[]) }, modifiers: null) is MethodInfo updateMethod &&
                     updateMethod.ReturnType == typeof(void))
                 {
                     return updateMethod;
@@ -178,6 +204,9 @@ namespace Microsoft.Extensions.HotReload
 
         public void ApplyDeltas(IReadOnlyList<UpdateDelta> deltas)
         {
+            Debug.Assert(Capabilities.Length > 0);
+            Debug.Assert(_applyUpdate != null);
+
             for (var i = 0; i < deltas.Count; i++)
             {
                 var item = deltas[i];
@@ -185,7 +214,7 @@ namespace Microsoft.Extensions.HotReload
                 {
                     if (TryGetModuleId(assembly) is Guid moduleId && moduleId == item.ModuleId)
                     {
-                        MetadataUpdater.ApplyUpdate(assembly, item.MetadataDelta, item.ILDelta, ReadOnlySpan<byte>.Empty);
+                        _applyUpdate(assembly, item.MetadataDelta, item.ILDelta, ReadOnlySpan<byte>.Empty);
                     }
                 }
 
@@ -244,11 +273,13 @@ namespace Microsoft.Extensions.HotReload
 
         public void ApplyDeltas(Assembly assembly, IReadOnlyList<UpdateDelta> deltas)
         {
+            Debug.Assert(_applyUpdate != null);
+
             try
             {
                 foreach (var item in deltas)
                 {
-                    MetadataUpdater.ApplyUpdate(assembly, item.MetadataDelta, item.ILDelta, ReadOnlySpan<byte>.Empty);
+                    _applyUpdate(assembly, item.MetadataDelta, item.ILDelta, ReadOnlySpan<byte>.Empty);
                 }
 
                 _log("Deltas applied.");

--- a/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
+++ b/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Intentionally pinned. This feature is supported in projects targeting 6.0 or newer.-->
-    <TargetFramework>net7.0</TargetFramework>
+    <!--
+      dotnet-watch may inject this assembly to .NET 6.0+ app, so we can't target a newer version.
+      At the same time source build requires us to not target 6.0, so we fall back to netstandard.
+     -->
+    <TargetFramework>netstandard2.1</TargetFramework>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
 
     <IsPackable>false</IsPackable>

--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -74,16 +74,11 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return false;
             }
 
-            var payload = new UpdatePayload
-            {
-                Deltas = ImmutableArray.CreateRange(solutionUpdate, c => new UpdateDelta
-                {
-                    ModuleId = c.ModuleId,
-                    ILDelta = c.ILDelta.ToArray(),
-                    MetadataDelta = c.MetadataDelta.ToArray(),
-                    UpdatedTypes = c.UpdatedTypes.ToArray(),
-                }),
-            };
+            var payload = new UpdatePayload(ImmutableArray.CreateRange(solutionUpdate, c => new UpdateDelta(
+                c.ModuleId,
+                metadataDelta: c.MetadataDelta.ToArray(),
+                ilDelta: c.ILDelta.ToArray(),
+                c.UpdatedTypes.ToArray())));
 
             await payload.WriteAsync(_pipe, cancellationToken);
             await _pipe.FlushAsync(cancellationToken);

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -196,7 +196,7 @@
     <ItemGroup>
       <DotNetWatchFile Include="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**" />
       <DotNetWatchFile Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Watch.BrowserRefresh\$(Configuration)\netcoreapp3.1\*.dll" DeploymentSubpath="middleware" />
-      <DotNetWatchFile Include="$(ArtifactsDir)bin\Microsoft.Extensions.DotNetDeltaApplier\$(Configuration)\net7.0\*.dll" DeploymentSubpath="hotreload" />
+      <DotNetWatchFile Include="$(ArtifactsDir)bin\Microsoft.Extensions.DotNetDeltaApplier\$(Configuration)\netstandard2.1\*.dll" DeploymentSubpath="hotreload" />
       <DotNetWatchFile Include="$(ArtifactsDir)bin\DotNetWatchTasks\$(Configuration)\netstandard2.0\DotNetWatchTasks.dll" />
     </ItemGroup>
 

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -77,7 +77,7 @@
       <DotNetWatchOverlay Remove="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\Microsoft.CodeAnalysis.CSharp.dll" />
       <DotNetWatchOverlay Remove="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\Microsoft.CodeAnalysis.dll" />
       <DotNetWatchOverlay Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Watch.BrowserRefresh\$(Configuration)\netcoreapp3.1\*.dll" TargetDir="middleware" />
-      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\Microsoft.Extensions.DotNetDeltaApplier\$(Configuration)\net7.0\*.dll" TargetDir="hotreload" />
+      <DotNetWatchOverlay Include="$(ArtifactsDir)bin\Microsoft.Extensions.DotNetDeltaApplier\$(Configuration)\netstandard2.1\*.dll" TargetDir="hotreload" />
       <DotNetWatchOverlay Include="$(ArtifactsDir)bin\DotNetWatchTasks\$(Configuration)\netstandard2.0\DotNetWatchTasks.dll" />
     </ItemGroup>
 

--- a/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/DotNetWatcherTests.cs
@@ -195,5 +195,18 @@ namespace Microsoft.DotNet.Watcher.Tools
             await standardInput.WriteLineAsync(inputString);
             await app.Process.GetOutputLineAsync($"Echo: {inputString}");
         }
+
+        [CoreMSBuildOnlyFact]
+        public async Task TargetNet60()
+        {
+            var testAsset = _testAssetsManager.CopyTestAsset("WatchApp60")
+                .WithSource()
+                .Path;
+
+            using var app = new WatchableApp(testAsset, _logger);
+
+            await app.StartWatcherAsync();
+            await app.GetProcessIdentifier();
+        }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/HotReload/UpdatePayloadTest.cs
+++ b/src/Tests/dotnet-watch.Tests/HotReload/UpdatePayloadTest.cs
@@ -15,24 +15,20 @@ namespace Microsoft.Extensions.HotReload
         [Fact]
         public async Task UpdatePayload_CanRoundTrip()
         {
-            var initial = new UpdatePayload
-            {
-                Deltas = new[]
+            var initial = new UpdatePayload(
+                new[]
                 {
-                    new UpdateDelta
-                    {
-                        ModuleId = Guid.NewGuid(),
-                        ILDelta = new byte[] { 0, 0, 1 },
-                        MetadataDelta = new byte[] { 0, 1, 1 },
-                    },
-                    new UpdateDelta
-                    {
-                        ModuleId = Guid.NewGuid(),
-                        ILDelta = new byte[] { 1, 0, 0 },
-                        MetadataDelta = new byte[] { 1, 0, 1 },
-                    }
-                },
-            };
+                    new UpdateDelta(
+                        moduleId: Guid.NewGuid(),
+                        ilDelta: new byte[] { 0, 0, 1 },
+                        metadataDelta: new byte[] { 0, 1, 1 },
+                        updatedTypes: Array.Empty<int>()),
+                    new UpdateDelta(
+                        moduleId: Guid.NewGuid(),
+                        ilDelta: new byte[] { 1, 0, 0 },
+                        metadataDelta: new byte[] { 1, 0, 1 },
+                        updatedTypes: Array.Empty<int>())
+                });
 
             using var stream = new MemoryStream();
             await initial.WriteAsync(stream, default);
@@ -46,26 +42,20 @@ namespace Microsoft.Extensions.HotReload
         [Fact]
         public async Task UpdatePayload_CanRoundTripUpdatedTypes()
         {
-            var initial = new UpdatePayload
-            {
-                Deltas = new[]
+            var initial = new UpdatePayload(
+                new[]
                 {
-                    new UpdateDelta
-                    {
-                        ModuleId = Guid.NewGuid(),
-                        ILDelta = new byte[] { 0, 0, 1 },
-                        MetadataDelta = new byte[] { 0, 1, 1 },
-                        UpdatedTypes = new int[] { 60, 74, 22323 },
-                    },
-                    new UpdateDelta
-                    {
-                        ModuleId = Guid.NewGuid(),
-                        ILDelta = new byte[] { 1, 0, 0 },
-                        MetadataDelta = new byte[] { 1, 0, 1 },
-                        UpdatedTypes = new int[] { -18 },
-                    }
-                },
-            };
+                    new UpdateDelta(
+                        moduleId: Guid.NewGuid(),
+                        ilDelta: new byte[] { 0, 0, 1 },
+                        metadataDelta: new byte[] { 0, 1, 1 },
+                        updatedTypes: new int[] { 60, 74, 22323 }),
+                    new UpdateDelta(
+                        moduleId: Guid.NewGuid(),
+                        ilDelta: new byte[] { 1, 0, 0 },
+                        metadataDelta: new byte[] { 1, 0, 1 },
+                        updatedTypes: new int[] { -18 })
+                });
 
             using var stream = new MemoryStream();
             await initial.WriteAsync(stream, default);
@@ -79,18 +69,15 @@ namespace Microsoft.Extensions.HotReload
         [Fact]
         public async Task UpdatePayload_WithLargeDeltas_CanRoundtrip()
         {
-            var initial = new UpdatePayload
-            {
-                Deltas = new[]
+            var initial = new UpdatePayload(
+                new[]
                 {
-                    new UpdateDelta
-                    {
-                        ModuleId = Guid.NewGuid(),
-                        ILDelta = Enumerable.Range(0, 68200).Select(c => (byte)(c%2)).ToArray(),
-                        MetadataDelta = new byte[] { 0, 1, 1 },
-                    },
-                },
-            };
+                    new UpdateDelta(
+                        moduleId: Guid.NewGuid(),
+                        ilDelta: Enumerable.Range(0, 68200).Select(c => (byte)(c%2)).ToArray(),
+                        metadataDelta: new byte[] { 0, 1, 1 },
+                        updatedTypes: Array.Empty<int>())
+                });
 
             using var stream = new MemoryStream();
             await initial.WriteAsync(stream, default);


### PR DESCRIPTION
## Description

`Microsoft.Extensions.DotNetDeltaApplier.dll` from the current .NET SDK version can be loaded to an app that targets any version of .NET >= 6.0 and equal or lower than the current version. We could target the dll to `net6.0` to satisfy these requirements, but that would add more prebuilds to source build. Instead, we target `netstandard2.1`.

Fixes https://github.com/dotnet/aspnetcore/issues/45129, https://github.com/aspnet/AspNetCore-ManualTests/issues/1635

## Customer Impact

Customers can't use `dotnet-watch` from .NET 7.0 when .NET 6.0 is also installed.

## Regression?

- [x] Yes
- [ ] No

Regressed by https://github.com/dotnet/sdk/pull/27012

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change is small and the affected code paths are well covered by tests.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [x] Yes
- [ ] No
- [ ] N/A


