### PR TITLE
Fix templating support for multiple parameters with same prefix

### DIFF
--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithParamsSharingPrefix/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithParamsSharingPrefix/.template.config/template.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithParamsSharingPrefix",
+  "identity": "TestAssets.TemplateWithParamsSharingPrefix",
+  "groupIdentity": "TestAssets.TemplateWithParamsSharingPrefix",
+  "shortName": "TestAssets.TemplateWithParamsSharingPrefix",
+  "tags": { "type": "project" },
+  "symbols": {
+    "Param1": {
+      "type": "parameter"
+    },
+    "Param2": {
+      "type": "parameter"
+    },
+    "Param3": {
+      "type": "parameter"
+    },
+    "Param4": {
+      "type": "parameter"
+    }
+  }
+}

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
@@ -16,9 +16,9 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             List<string> predefinedLongOverrides = parameters.SelectMany(p => p.LongNameOverrides).Where(n => !string.IsNullOrEmpty(n)).Select(n => $"--{n}").ToList();
             List<string> predefinedShortOverrides = parameters.SelectMany(p => p.ShortNameOverrides).Where(n => !string.IsNullOrEmpty(n)).Select(n => $"-{n}").ToList();
 
-            Func<string, bool> isAliasTaken = (s) => takenAliases.Contains(s);
-            Func<string, bool> isLongNamePredefined = (s) => predefinedLongOverrides.Contains(s);
-            Func<string, bool> isShortNamePredefined = (s) => predefinedShortOverrides.Contains(s);
+            Func<string, bool> isAliasTaken = takenAliases.Contains;
+            Func<string, bool> isLongNamePredefined = predefinedLongOverrides.Contains;
+            Func<string, bool> isShortNamePredefined = predefinedShortOverrides.Contains;
 
             foreach (var parameter in parameters)
             {
@@ -154,6 +154,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             if (!isAliasTaken(qualifiedShortName))
             {
                 aliases.Add(qualifiedShortName);
+                takenAliases.Add(qualifiedShortName);
                 return;
             }
             errors.Add(string.Format(LocalizableStrings.AliasAssignmentCoordinator_Error_ShortAlias, parameter.Name, shortName, qualifiedShortName));

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
@@ -4,11 +4,13 @@
 
 using System.CommandLine;
 using FakeItEasy;
+using FluentAssertions;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Mocks;
+using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests
@@ -130,6 +132,21 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.Contains("--f", result["f"].Aliases);
             Assert.Contains("-p:f", result["f"].Aliases);
             Assert.DoesNotContain(result, r => r.Value.Errors.Any());
+        }
+
+        [Fact]
+        public void ShortNameGenerationShouldNotProduceDuplicates()
+        {
+            List<CliTemplateParameter> paramList = new List<CliTemplateParameter>();
+            for (int i = 0; i < 10; i++)
+            {
+                paramList.Add(new CliTemplateParameter("par" + i));
+            }
+
+            var result = AliasAssignmentCoordinator.AssignAliasesForParameter(paramList, InitiallyTakenAliases);
+
+            result.SelectMany(p => p.Aliases).HasDuplicates().Should()
+                .BeFalse("Duplicate option aliases should not be generated.");
         }
 
         // This reflects the MVC 2.0 tempalte as of May 24, 2017

--- a/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.cs
@@ -207,6 +207,25 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         }
 
         [Fact]
+        public void CanInstantiateTemplate_WithParamsSharingPrefix()
+        {
+            string workingDirectory = CreateTemporaryFolder();
+            string home = CreateTemporaryFolder(folderName: "Home");
+            string templateLocation = GetTestTemplateLocation("TemplateWithParamsSharingPrefix");
+
+            InstallTestTemplate(templateLocation, _log, home, workingDirectory);
+
+            // not asserting on actual generated content - as there is none
+            new DotnetNewCommand(_log, "TestAssets.TemplateWithParamsSharingPrefix")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .Pass()
+                .And.NotHaveStdErr();
+        }
+
+        [Fact]
         public void CanInstantiateTemplate_Angular_CanReplaceTextInLargeFile()
         {
             string workingDirectory = CreateTemporaryFolder();


### PR DESCRIPTION
## Problem

Regression in 7.0 for templates with multiple symbols sharing prefix
https://github.com/dotnet/templating/issues/5588

## Solution

Make sure option aliases with conlicting names are not created