### PR TITLE
Add new option for json output of dotnet list package to release 7.2.xx branch

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -61,6 +61,11 @@ namespace Microsoft.DotNet.Cli
                 ArgumentHelpName = CommonLocalizableStrings.LevelArgumentName
             }.ForwardAsSingle(o => $"--verbosity:{o}");
 
+        public static readonly Option FormatOption = new ForwardedOption<string>("--format", LocalizableStrings.CmdFormatDescription)
+        {
+            ArgumentHelpName = LocalizableStrings.CmdConfig
+        }.ForwardAsMany(o => new[] { "--format", o });
+
         private static readonly Command Command = ConstructCommand();
 
         public static Command GetCommand()
@@ -84,6 +89,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(ConfigOption);
             command.AddOption(SourceOption);
             command.AddOption(InteractiveOption);
+            command.AddOption(FormatOption);
 
             command.SetHandler((parseResult) => new ListPackageReferencesCommand(parseResult).Execute());
 

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -1,10 +1,9 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
 using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.List.PackageReferences;
 using LocalizableStrings = Microsoft.DotNet.Tools.List.PackageReferences.LocalizableStrings;
@@ -61,10 +60,10 @@ namespace Microsoft.DotNet.Cli
                 ArgumentHelpName = CommonLocalizableStrings.LevelArgumentName
             }.ForwardAsSingle(o => $"--verbosity:{o}");
 
-        public static readonly Option FormatOption = new ForwardedOption<string>("--format", LocalizableStrings.CmdFormatDescription)
+        public static readonly Option FormatOption = new ForwardedOption<ReportOutputFormat>("--format", LocalizableStrings.CmdFormatDescription)
         {
-            ArgumentHelpName = LocalizableStrings.CmdConfig
-        }.ForwardAsMany(o => new[] { "--format", o });
+            ArgumentHelpName = LocalizableStrings.CmdFormat
+        }.ForwardAsSingle(o => $"--format:{o}");
 
         private static readonly Command Command = ConstructCommand();
 

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -61,9 +61,7 @@ namespace Microsoft.DotNet.Cli
             }.ForwardAsSingle(o => $"--verbosity:{o}");
 
         public static readonly Option FormatOption = new ForwardedOption<ReportOutputFormat>("--format", LocalizableStrings.CmdFormatDescription)
-        {
-            ArgumentHelpName = LocalizableStrings.CmdFormat
-        }.ForwardAsSingle(o => $"--format:{o}");
+        { }.ForwardAsSingle(o => $"--format:{o}");
 
         private static readonly Command Command = ConstructCommand();
 

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
@@ -168,4 +168,7 @@
   <data name="CmdVulnerableDescription" xml:space="preserve">
     <value>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</value>
   </data>
+  <data name="CmdFormatDescription" xml:space="preserve">
+    <value>Specify output format type for list packages command. Requires the "console", "json" option.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
@@ -171,7 +171,4 @@
   <data name="CmdFormatDescription" xml:space="preserve">
     <value>Specifies the output format type for the list packages command.</value>
   </data>
-  <data name="CmdFormat" xml:space="preserve">
-    <value>FORMAT</value>
-  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
@@ -169,6 +169,9 @@
     <value>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</value>
   </data>
   <data name="CmdFormatDescription" xml:space="preserve">
-    <value>Specify output format type for list packages command. Requires the "console", "json" option.</value>
+    <value>Specifies the output format type for the list packages command.</value>
+  </data>
+  <data name="CmdFormat" xml:space="preserve">
+    <value>FORMAT</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ReportOutputFormat.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ReportOutputFormat.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.DotNet.Cli
+{
+    internal enum ReportOutputFormat
+    {
+        console = 0,
+        json = 1
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Vypíše balíčky, které jsou zastaralé. Nedá se kombinovat s možností --vulnerable ani --outdated.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Vypíše balíčky, které jsou zastaralé. Nedá se kombinovat s možností --vulnerable ani --outdated.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
@@ -12,9 +12,14 @@
         <target state="translated">Vypíše balíčky, které jsou zastaralé. Nedá se kombinovat s možností --vulnerable ani --outdated.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Listet Pakete auf, die veraltet sind. Kann nicht mit den Optionen "--vulnerable" oder "--outdated" kombiniert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
@@ -12,9 +12,14 @@
         <target state="translated">Listet Pakete auf, die veraltet sind. Kann nicht mit den Optionen "--vulnerable" oder "--outdated" kombiniert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Listet Pakete auf, die veraltet sind. Kann nicht mit den Optionen "--vulnerable" oder "--outdated" kombiniert werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Muestra los paquetes que han quedado en desuso. No se puede combinar con las opciones "--outdated" o "--vulnerable".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Muestra los paquetes que han quedado en desuso. No se puede combinar con las opciones "--outdated" o "--vulnerable".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
@@ -12,9 +12,14 @@
         <target state="translated">Muestra los paquetes que han quedado en desuso. No se puede combinar con las opciones "--outdated" o "--vulnerable".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Liste les packages qui ont été dépréciés. Impossible à combiner avec les options '--vulnerable' ou '--outdated'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Liste les packages qui ont été dépréciés. Impossible à combiner avec les options '--vulnerable' ou '--outdated'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
@@ -12,9 +12,14 @@
         <target state="translated">Liste les packages qui ont été dépréciés. Impossible à combiner avec les options '--vulnerable' ou '--outdated'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Elenca i pacchetti che sono stati deprecati. Non può essere combinato con l'opzione '--vulnerable' o '--outdated'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
@@ -12,9 +12,14 @@
         <target state="translated">Elenca i pacchetti che sono stati deprecati. Non può essere combinato con l'opzione '--vulnerable' o '--outdated'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Elenca i pacchetti che sono stati deprecati. Non può essere combinato con l'opzione '--vulnerable' o '--outdated'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">非推奨化されたパッケージを一覧表示します。'--vulnerable' または '--outdated' オプションと組み合わせることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
@@ -12,11 +12,6 @@
         <target state="translated">非推奨化されたパッケージを一覧表示します。'--vulnerable' または '--outdated' オプションと組み合わせることはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
@@ -12,9 +12,14 @@
         <target state="translated">非推奨化されたパッケージを一覧表示します。'--vulnerable' または '--outdated' オプションと組み合わせることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">사용되지 않는 패키지를 나열합니다. '--vulnerable' 또는 '--outdated' 옵션과 함께 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
@@ -12,9 +12,14 @@
         <target state="translated">사용되지 않는 패키지를 나열합니다. '--vulnerable' 또는 '--outdated' 옵션과 함께 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
@@ -12,11 +12,6 @@
         <target state="translated">사용되지 않는 패키지를 나열합니다. '--vulnerable' 또는 '--outdated' 옵션과 함께 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Wyświetla pakiety, które są przestarzałe. Nie można łączyć z opcją „--vulnerable” ani „--outdated”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Wyświetla pakiety, które są przestarzałe. Nie można łączyć z opcją „--vulnerable” ani „--outdated”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
@@ -12,9 +12,14 @@
         <target state="translated">Wyświetla pakiety, które są przestarzałe. Nie można łączyć z opcją „--vulnerable” ani „--outdated”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Lista os pacotes que foram preteridos. Não pode ser combinado com a opção '--vulnerable' nem com a opção '--outdated'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Lista os pacotes que foram preteridos. Não pode ser combinado com a opção '--vulnerable' nem com a opção '--outdated'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,9 +12,14 @@
         <target state="translated">Lista os pacotes que foram preteridos. Não pode ser combinado com a opção '--vulnerable' nem com a opção '--outdated'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Возвращает список устаревших пакетов. Не может использоваться с параметрами "--vulnerable" или "--outdated".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Возвращает список устаревших пакетов. Не может использоваться с параметрами "--vulnerable" или "--outdated".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
@@ -12,9 +12,14 @@
         <target state="translated">Возвращает список устаревших пакетов. Не может использоваться с параметрами "--vulnerable" или "--outdated".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Kullanım dışı bırakılan paketleri listeler. '--vulnerable' veya '--outdated' seçenekleriyle birleştirilemez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Kullanım dışı bırakılan paketleri listeler. '--vulnerable' veya '--outdated' seçenekleriyle birleştirilemez.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
@@ -12,9 +12,14 @@
         <target state="translated">Kullanım dışı bırakılan paketleri listeler. '--vulnerable' veya '--outdated' seçenekleriyle birleştirilemez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">列出已被弃用的包。不能与 "--vulnerable" 或 "--outdated" 选项结合使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,11 +12,6 @@
         <target state="translated">列出已被弃用的包。不能与 "--vulnerable" 或 "--outdated" 选项结合使用。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,9 +12,14 @@
         <target state="translated">列出已被弃用的包。不能与 "--vulnerable" 或 "--outdated" 选项结合使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">列出已淘汰的套件。無法與 '--vulnerable' 或 '--outdated' 選項一併使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
+        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,11 +12,6 @@
         <target state="translated">列出已淘汰的套件。無法與 '--vulnerable' 或 '--outdated' 選項一併使用。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdFormat">
-        <source>FORMAT</source>
-        <target state="new">FORMAT</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdFormatDescription">
         <source>Specifies the output format type for the list packages command.</source>
         <target state="new">Specifies the output format type for the list packages command.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,9 +12,14 @@
         <target state="translated">列出已淘汰的套件。無法與 '--vulnerable' 或 '--outdated' 選項一併使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormat">
+        <source>FORMAT</source>
+        <target state="new">FORMAT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFormatDescription">
-        <source>Specify output format type for list packages command. Requires the "console", "json" option.</source>
-        <target state="new">Specify output format type for list packages command. Requires the "console", "json" option.</target>
+        <source>Specifies the output format type for the list packages command.</source>
+        <target state="new">Specifies the output format type for the list packages command.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">


### PR DESCRIPTION
Related to: https://github.com/NuGet/NuGet.Client/pull/4855
Add new `--format` option for `dotnet list package` command. NuGet change was inserted to sdk here:  https://github.com/dotnet/sdk/pull/28913