### PR TITLE
[release/7.0.1xx] Fix templating support for multiple parameters with same prefix

### DIFF
--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithParamsSharingPrefix/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithParamsSharingPrefix/.template.config/template.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithParamsSharingPrefix",
+  "identity": "TestAssets.TemplateWithParamsSharingPrefix",
+  "groupIdentity": "TestAssets.TemplateWithParamsSharingPrefix",
+  "shortName": "TestAssets.TemplateWithParamsSharingPrefix",
+  "tags": { "type": "project" },
+  "symbols": {
+    "Param1": {
+      "type": "parameter"
+    },
+    "Param2": {
+      "type": "parameter"
+    },
+    "Param3": {
+      "type": "parameter"
+    },
+    "Param4": {
+      "type": "parameter"
+    }
+  }
+}

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.DotNet.Cli.Utils;
+
 namespace Microsoft.TemplateEngine.Cli.Commands
 {
     /// <summary>
@@ -157,7 +159,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 takenAliases.Add(qualifiedShortName);
                 return;
             }
-            errors.Add(string.Format(LocalizableStrings.AliasAssignmentCoordinator_Error_ShortAlias, parameter.Name, shortName, qualifiedShortName));
+            Reporter.Verbose.WriteLine(string.Format(LocalizableStrings.AliasAssignmentCoordinator_Error_ShortAlias, parameter.Name, shortName, qualifiedShortName));
         }
 
         private static string GetFreeShortName(Func<string, bool> isAliasTaken, string name, string prefix = "")

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
@@ -16,9 +16,9 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             List<string> predefinedLongOverrides = parameters.SelectMany(p => p.LongNameOverrides).Where(n => !string.IsNullOrEmpty(n)).Select(n => $"--{n}").ToList();
             List<string> predefinedShortOverrides = parameters.SelectMany(p => p.ShortNameOverrides).Where(n => !string.IsNullOrEmpty(n)).Select(n => $"-{n}").ToList();
 
-            Func<string, bool> isAliasTaken = (s) => takenAliases.Contains(s);
-            Func<string, bool> isLongNamePredefined = (s) => predefinedLongOverrides.Contains(s);
-            Func<string, bool> isShortNamePredefined = (s) => predefinedShortOverrides.Contains(s);
+            Func<string, bool> isAliasTaken = takenAliases.Contains;
+            Func<string, bool> isLongNamePredefined = predefinedLongOverrides.Contains;
+            Func<string, bool> isShortNamePredefined = predefinedShortOverrides.Contains;
 
             foreach (var parameter in parameters)
             {
@@ -154,6 +154,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             if (!isAliasTaken(qualifiedShortName))
             {
                 aliases.Add(qualifiedShortName);
+                takenAliases.Add(qualifiedShortName);
                 return;
             }
             errors.Add(string.Format(LocalizableStrings.AliasAssignmentCoordinator_Error_ShortAlias, parameter.Name, shortName, qualifiedShortName));

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
@@ -142,6 +142,27 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 .BeFalse("Duplicate option aliases should not be generated.");
         }
 
+        [Fact]
+        public void ShortNameSkippedAfter4Reps()
+        {
+            List<CliTemplateParameter> paramList = new List<CliTemplateParameter>();
+            for (int i = 0; i < 8; i++)
+            {
+                paramList.Add(new CliTemplateParameter("par" + i));
+            }
+
+            var result = AliasAssignmentCoordinator.AssignAliasesForParameter(paramList, InitiallyTakenAliases);
+
+            result[0].Aliases.Should().BeEquivalentTo(new[] { "-p", "--par0" });
+            result[1].Aliases.Should().BeEquivalentTo(new[] { "-pa", "--par1" });
+            result[2].Aliases.Should().BeEquivalentTo(new[] { "-p:p", "--par2" });
+            result[3].Aliases.Should().BeEquivalentTo(new[] { "-p:pa", "--par3" });
+            result[4].Aliases.Should().BeEquivalentTo(new[] { "--par4" });
+            result[5].Aliases.Should().BeEquivalentTo(new[] { "--par5" });
+            result[6].Aliases.Should().BeEquivalentTo(new[] { "--par6" });
+            result[7].Aliases.Should().BeEquivalentTo(new[] { "--par7" });
+        }
+
         // This reflects the MVC 2.0 tempalte as of May 24, 2017
         [Fact(DisplayName = nameof(CheckAliasAssignmentsMvc20))]
         public void CheckAliasAssignmentsMvc20()

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
@@ -125,6 +125,21 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.DoesNotContain(result, r => r.Value.Errors.Any());
         }
 
+        [Fact]
+        public void ShortNameGenerationShouldNotProduceDuplicates()
+        {
+            List<CliTemplateParameter> paramList = new List<CliTemplateParameter>();
+            for (int i = 0; i < 10; i++)
+            {
+                paramList.Add(new CliTemplateParameter("par" + i));
+            }
+
+            var result = AliasAssignmentCoordinator.AssignAliasesForParameter(paramList, InitiallyTakenAliases);
+
+            result.SelectMany(p => p.Aliases).HasDuplicates().Should()
+                .BeFalse("Duplicate option aliases should not be generated.");
+        }
+
         // This reflects the MVC 2.0 tempalte as of May 24, 2017
         [Fact(DisplayName = nameof(CheckAliasAssignmentsMvc20))]
         public void CheckAliasAssignmentsMvc20()

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using FluentAssertions;
 using Microsoft.TemplateEngine.Cli.Commands;
+using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests
 {

--- a/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.cs
@@ -207,6 +207,25 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         }
 
         [Fact]
+        public void CanInstantiateTemplate_WithParamsSharingPrefix()
+        {
+            string workingDirectory = CreateTemporaryFolder();
+            string home = CreateTemporaryFolder(folderName: "Home");
+            string templateLocation = GetTestTemplateLocation("TemplateWithParamsSharingPrefix");
+
+            InstallTestTemplate(templateLocation, _log, home, workingDirectory);
+
+            // not asserting on actual generated content - as there is none
+            new DotnetNewCommand(_log, "TestAssets.TemplateWithParamsSharingPrefix")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .Pass()
+                .And.NotHaveStdErr();
+        }
+
+        [Fact]
         public void CanInstantiateTemplate_Angular_CanReplaceTextInLargeFile()
         {
             string workingDirectory = CreateTemporaryFolder();


### PR DESCRIPTION
### Problem
Some 3rd party templates experience instantiation errors after upgrade to net7.0

### Customer Impact 
Yes - customer reported issue https://github.com/dotnet/templating/issues/5588

### Regression
Yes - affected templates worked fine on net6.0

### Risk
Very-low - one-liner fix. Added unit- and integration- tests targetting the problematic scenario. Existing scenarios covered by extensive test suite.

