### PR TITLE
Clean up Razor Server pid file if the path doesn't exist

### DIFF
--- a/src/Cli/dotnet/BuildServer/RazorServer.cs
+++ b/src/Cli/dotnet/BuildServer/RazorServer.cs
@@ -36,6 +36,14 @@ namespace Microsoft.DotNet.BuildServer
 
         public void Shutdown()
         {
+            if(!_fileSystem.File.Exists(PidFile.ServerPath.Value))
+            {
+                // The razor server path doesn't exist anymore so trying to shut it down would fail
+                // Ensure the pid file is cleaned up so we don't try to shut it down again
+                DeletePidFile();
+                return;
+            }
+
             var command = _commandFactory
                 .Create(
                     "exec",
@@ -60,6 +68,11 @@ namespace Microsoft.DotNet.BuildServer
 
             // After a successful shutdown, ensure the pid file is deleted
             // If the pid file was left behind due to a rude exit, this ensures we don't try to shut it down again
+            DeletePidFile();
+        }
+
+        void DeletePidFile()
+        {
             try
             {
                 if (_fileSystem.File.Exists(PidFile.Path.Value))


### PR DESCRIPTION
When the server path in the pid file didn't exist we'd hit an error during `dotnet build-server shutdown`:

```
Razor build server (process 27970) failed to shut down: The shutdown command failed: The application to execute does not exist
```

This can happen when the file wasn't cleaned up and the SDK was uninstalled in the meantime. Ensure we delete the pid file in that case and don't error.

Fixes https://github.com/dotnet/sdk/issues/10573