### PR TITLE
Don't Infer RID outside of dotnet publish for PublishSingleFile/PublishAot

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -80,12 +80,14 @@ Copyright (c) .NET Foundation. All rights reserved.
                  '$(RuntimeIdentifier)' == '' and
                  '$(_IsExecutable)' == 'true' and '$(IsTestProject)' != 'true' and
                  '$(IsRidAgnostic)' != 'true' and
-                 ('$(_IsPublishing)' == 'true' or '$(SelfContained)' == 'true') and
-                  (
-                    '$(SelfContained)' == 'true' or
-                    '$(PublishReadyToRun)' == 'true' or
-                    '$(PublishSingleFile)' == 'true' or
-                    '$(PublishAot)' == 'true'
+                 (
+                   '$(SelfContained)' == 'true' or
+                   ('$(_IsPublishing)' == 'true' and
+                    (
+                      '$(PublishReadyToRun)' == 'true' or
+                      '$(PublishSingleFile)' == 'true' or
+                      '$(PublishAot)' == 'true'
+                    )
                   )">true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 
@@ -184,7 +186,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
 
     <!-- The following RID errors are asserts, and we don't expect them to ever occur. The error message is added as a safeguard.-->
-    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == '''"
+    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="SelfContained"/>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -83,12 +83,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                  (
                    '$(SelfContained)' == 'true' or
                    ('$(_IsPublishing)' == 'true' and
-                    (
-                      '$(PublishReadyToRun)' == 'true' or
-                      '$(PublishSingleFile)' == 'true' or
-                      '$(PublishAot)' == 'true'
-                    )
-                  )">true</UseCurrentRuntimeIdentifier>
+                      (
+                        '$(PublishReadyToRun)' == 'true' or
+                        '$(PublishSingleFile)' == 'true' or
+                        '$(PublishAot)' == 'true'
+                      )
+                   )
+                 )">true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseCurrentRuntimeIdentifier)' == 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -176,19 +176,19 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
 
     <!-- The following RID errors are asserts, and we don't expect them to ever occur. The error message is added as a safeguard.-->
-    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
+    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true'"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="SelfContained"/>
 
-    <NETSdkError Condition="'$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' == ''"
+    <NETSdkError Condition="'$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true'"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="PublishReadyToRun"/>
 
-    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == ''"
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true'"
                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                 FormatArguments="PublishSingleFile"/>
 
-    <NETSdkError Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == ''"
+    <NETSdkError Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true'"
                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                 FormatArguments="PublishAot"/>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -72,11 +72,12 @@ Copyright (c) .NET Foundation. All rights reserved.
                  '$(RuntimeIdentifier)' == '' and
                  '$(_IsExecutable)' == 'true' and '$(IsTestProject)' != 'true' and
                  '$(IsRidAgnostic)' != 'true' and
+                 '$(_IsPublishing)' == 'true' and
                   (
                     '$(SelfContained)' == 'true' or
-                    ('$(_IsPublishing)' == 'true' and '$(PublishReadyToRun)' == 'true') or
-                    ('$(_IsPublishing)' == 'true' and '$(PublishSingleFile)' == 'true') or
-                    ('$(_IsPublishing)' == 'true' and '$(PublishAot)' == 'true')
+                    '$(PublishReadyToRun)' == 'true' or
+                    '$(PublishSingleFile)' == 'true' or
+                    '$(PublishAot)' == 'true'
                   )">true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -74,9 +74,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                  '$(IsRidAgnostic)' != 'true' and
                   (
                     '$(SelfContained)' == 'true' or
-                    '$(PublishReadyToRun)' == 'true' or
-                    '$(PublishSingleFile)' == 'true' or
-                    '$(PublishAot)' == 'true'
+                    ('$(_IsPublishing)' == 'true' and '$(PublishReadyToRun)' == 'true') or
+                    ('$(_IsPublishing)' == 'true' and '$(PublishSingleFile)' == 'true') or
+                    ('$(_IsPublishing)' == 'true' and '$(PublishAot)' == 'true')
                   )">true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -67,6 +67,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <SelfContained>$(PublishSelfContained)</SelfContained>
   </PropertyGroup>
 
+  <!-- Automatically infer the RuntimeIdentifier for properties that require it.
+  SelfContained without a RID is a no-op and semantically hints towards the fact that it can change the behavior of build, publish, and friends.
+  ... So, we infer the RID for SelfContained regardless of the context.
+
+  The other publish properties are specifically labelled Publish* and don't 'NEED' their RID unless we are doing a publish, so the RID inference
+  ... for these properties is limited to publishing only scenarios.
+
+  Finally, library projects and non-executable projects have awkward interactions here so they are excluded.-->
   <PropertyGroup Condition="'$(UseCurrentRuntimeIdentifier)' == ''">
     <UseCurrentRuntimeIdentifier Condition="
                  '$(RuntimeIdentifier)' == '' and
@@ -74,6 +82,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                  '$(IsRidAgnostic)' != 'true' and
                  ('$(_IsPublishing)' == 'true' or '$(SelfContained)' == 'true') and
                   (
+                    '$(SelfContained)' == 'true' or
                     '$(PublishReadyToRun)' == 'true' or
                     '$(PublishSingleFile)' == 'true' or
                     '$(PublishAot)' == 'true'
@@ -175,7 +184,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
 
     <!-- The following RID errors are asserts, and we don't expect them to ever occur. The error message is added as a safeguard.-->
-    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true'"
+    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == '''"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="SelfContained"/>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -72,9 +72,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                  '$(RuntimeIdentifier)' == '' and
                  '$(_IsExecutable)' == 'true' and '$(IsTestProject)' != 'true' and
                  '$(IsRidAgnostic)' != 'true' and
-                 '$(_IsPublishing)' == 'true' and
+                 ('$(_IsPublishing)' == 'true' or '$(SelfContained)' == 'true') and
                   (
-                    '$(SelfContained)' == 'true' or
                     '$(PublishReadyToRun)' == 'true' or
                     '$(PublishSingleFile)' == 'true' or
                     '$(PublishAot)' == 'true'
@@ -88,7 +87,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(_IsPublishing)' == 'true' and '$(PublishRuntimeIdentifier)' != ''">
     <RuntimeIdentifier>$(PublishRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(PlatformTarget)' == ''">
     <_UsingDefaultPlatformTarget>true</_UsingDefaultPlatformTarget>
   </PropertyGroup>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -405,10 +405,10 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData("--p:PublishReadyToRun=true")]
-        [InlineData("-p:PublishSingleFile=true")]
-        [InlineData("-p:PublishSelfContained=true")]
-        [InlineData("-p:PublishAot=true")]
+        [InlineData("PublishReadyToRun")]
+        [InlineData("PublishSingleFile")]
+        [InlineData("PublishSelfContained")]
+        [InlineData("PublishAot")]
         public void It_builds_without_implicit_rid_with_RuntimeIdentifier_specific_during_publish_only_properties(string property)
         {
             var tfm = ToolsetInfo.CurrentTargetFramework;
@@ -417,12 +417,13 @@ namespace Microsoft.NET.Build.Tests
                 IsExe = true,
                 TargetFrameworks = tfm,
             };
+            testProject.AdditionalProperties[property] = "true";
             testProject.RecordProperties("RuntimeIdentifier");
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: $"ItBuildsWithoutImplicitRIDOnRIDRequiringPropertiesDuringPublish_{property}");
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: property);
 
             var buildCommand = new DotnetBuildCommand(testAsset);
             buildCommand
-               .Execute(property)
+               .Execute()
                .Should()
                .Pass();
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -408,13 +408,13 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("--p:PublishReadyToRun=true")]
         [InlineData("-p:PublishSingleFile=true")]
         [InlineData("-p:PublishSelfContained=true")]
-        [InlineData("-p:SelfContained=true")]
+        [InlineData("-p:PublishAot=true")]
         public void It_builds_without_implicit_rid_with_RuntimeIdentifier_specific_during_publish_only_properties(string property)
         {
             var tfm = ToolsetInfo.CurrentTargetFramework;
             var testProject = new TestProject()
             {
-                Name = "PublishImplicitRid",
+                IsExe = true,
                 TargetFrameworks = tfm,
             };
             testProject.RecordProperties("RuntimeIdentifier");

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -405,6 +405,32 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
+        [InlineData("--p:PublishReadyToRun=true")]
+        [InlineData("-p:PublishSingleFile=true")]
+        [InlineData("-p:PublishSelfContained=true")]
+        [InlineData("-p:SelfContained=true")]
+        public void It_builds_without_implicit_rid_with_RuntimeIdentifier_specific_during_publish_only_properties(string property)
+        {
+            var tfm = ToolsetInfo.CurrentTargetFramework;
+            var testProject = new TestProject()
+            {
+                Name = "PublishImplicitRid",
+                TargetFrameworks = tfm,
+            };
+            testProject.RecordProperties("RuntimeIdentifier");
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: $"ItBuildsWithoutImplicitRIDOnRIDRequiringPropertiesDuringPublish_{property}");
+
+            var buildCommand = new DotnetBuildCommand(testAsset);
+            buildCommand
+               .Execute(property)
+               .Should()
+               .Pass();
+
+            var properties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework: tfm);
+            properties["RuntimeIdentifier"].Should().Be("");
+        }
+
+        [Theory]
         [InlineData("net7.0")]
         public void It_builds_a_runnable_output_with_Prefer32Bit(string targetFramework)
         {

--- a/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.NET.Build.Tests
 
             bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
             ValidateProperties(testAsset, _referencedProject, expectSelfContained: false, expectRuntimeIdentifier: false);
         }
 
@@ -103,8 +103,8 @@ namespace Microsoft.NET.Build.Tests
 
             bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
-            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
         }
 
 
@@ -139,9 +139,9 @@ namespace Microsoft.NET.Build.Tests
 
                 bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-                ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
+                ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
                 //  SelfContained will only flow to referenced project if it's explicitly passed in this case
-                ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
+                ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: buildingSelfContained);
             }
         }
 
@@ -159,9 +159,11 @@ namespace Microsoft.NET.Build.Tests
 
             bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
-            ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier,
-                expectedRuntimeIdentifier: passRuntimeIdentifier ? "" : _referencedProject.RuntimeIdentifier);
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: buildingSelfContained,
+                //  Right now passing "--self-contained" also causes the RuntimeIdentifier to be passed as a global property.
+                //  That should change with https://github.com/dotnet/sdk/pull/26143, which will likely require updating this and other tests in this class
+                expectedRuntimeIdentifier: buildingSelfContained ? "" : _referencedProject.RuntimeIdentifier);
         }
 
         [RequiresMSBuildVersionTheory("17.4.0.41702")]
@@ -184,13 +186,13 @@ namespace Microsoft.NET.Build.Tests
 
             bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier,
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained,
                 targetFramework: "net6.0");
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier,
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained,
                 targetFramework: "net7.0");
             ValidateProperties(testAsset, _referencedProject, expectSelfContained: false, expectRuntimeIdentifier: false,
                 targetFramework: "net6.0");
-            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier,
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained,
                 targetFramework: "net7.0");
         }
 
@@ -251,7 +253,7 @@ namespace Microsoft.NET.Build.Tests
             targetFramework = targetFramework ?? testProject.TargetFrameworks;
 
 
-            if (string.IsNullOrEmpty(expectedRuntimeIdentifier) && expectRuntimeIdentifier)
+            if (string.IsNullOrEmpty(expectedRuntimeIdentifier) && (expectSelfContained || expectRuntimeIdentifier))
             {
                 //  RuntimeIdentifier might be inferred, so look at the output path to figure out what the actual value used was
                 string dir = (Path.Combine(testAsset.TestRoot, testProject.Name, "bin", "Debug", targetFramework));

--- a/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.NET.Build.Tests
 
             bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
             ValidateProperties(testAsset, _referencedProject, expectSelfContained: false, expectRuntimeIdentifier: false);
         }
 
@@ -103,8 +103,8 @@ namespace Microsoft.NET.Build.Tests
 
             bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
-            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
         }
 
 
@@ -139,9 +139,9 @@ namespace Microsoft.NET.Build.Tests
 
                 bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-                ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+                ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
                 //  SelfContained will only flow to referenced project if it's explicitly passed in this case
-                ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: buildingSelfContained);
+                ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
             }
         }
 
@@ -159,11 +159,9 @@ namespace Microsoft.NET.Build.Tests
 
             bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained);
-            ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: buildingSelfContained,
-                //  Right now passing "--self-contained" also causes the RuntimeIdentifier to be passed as a global property.
-                //  That should change with https://github.com/dotnet/sdk/pull/26143, which will likely require updating this and other tests in this class
-                expectedRuntimeIdentifier: buildingSelfContained ? "" : _referencedProject.RuntimeIdentifier);
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier);
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: passSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier,
+                expectedRuntimeIdentifier: passRuntimeIdentifier ? "" : _referencedProject.RuntimeIdentifier);
         }
 
         [RequiresMSBuildVersionTheory("17.4.0.41702")]
@@ -186,13 +184,13 @@ namespace Microsoft.NET.Build.Tests
 
             bool buildingSelfContained = passSelfContained || passRuntimeIdentifier;
 
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained,
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier,
                 targetFramework: "net6.0");
-            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained,
+            ValidateProperties(testAsset, _testProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier,
                 targetFramework: "net7.0");
             ValidateProperties(testAsset, _referencedProject, expectSelfContained: false, expectRuntimeIdentifier: false,
                 targetFramework: "net6.0");
-            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: buildingSelfContained,
+            ValidateProperties(testAsset, _referencedProject, expectSelfContained: buildingSelfContained, expectRuntimeIdentifier: passRuntimeIdentifier,
                 targetFramework: "net7.0");
         }
 
@@ -253,7 +251,7 @@ namespace Microsoft.NET.Build.Tests
             targetFramework = targetFramework ?? testProject.TargetFrameworks;
 
 
-            if (string.IsNullOrEmpty(expectedRuntimeIdentifier) && (expectSelfContained || expectRuntimeIdentifier))
+            if (string.IsNullOrEmpty(expectedRuntimeIdentifier) && expectRuntimeIdentifier)
             {
                 //  RuntimeIdentifier might be inferred, so look at the output path to figure out what the actual value used was
                 string dir = (Path.Combine(testAsset.TestRoot, testProject.Name, "bin", "Debug", targetFramework));

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Xml.Linq;
+using FluentAssertions;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.DependencyModel;
@@ -1081,7 +1082,6 @@ public static class Program
         [InlineData("--p:PublishReadyToRun=true")]
         [InlineData("-p:PublishSingleFile=true")]
         [InlineData("-p:PublishSelfContained=true")]
-        [InlineData("")]
         public void It_publishes_with_implicit_rid_with_rid_specific_properties(string executeOptionsAndProperties)
         {
             var testProject = new TestProject()
@@ -1092,7 +1092,7 @@ public static class Program
             testProject.AdditionalProperties.Add("IsPublishable", "false");
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: executeOptionsAndProperties);
 
-            var publishCommand = new PublishCommand(testAsset);
+            var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand
                .Execute(executeOptionsAndProperties)
                .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -658,7 +658,8 @@ namespace Microsoft.NET.Publish.Tests
                 var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
                 publishCommand
                     .Execute()
-                    .Should().Pass();
+                    .Should()
+                    .Pass();
             }
         }
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -655,7 +655,7 @@ namespace Microsoft.NET.Publish.Tests
                 testProject.AdditionalProperties["PublishAot"] = "true";
                 var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
                 publishCommand
                     .Execute()
                     .Should().Pass();

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -335,7 +335,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties["PublishReadyToRun"] = "true";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(testAsset);
+            var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -285,7 +285,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(testAsset);
+            var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
@@ -59,6 +59,7 @@ namespace Microsoft.NET.TestFramework
         /// <param name="callingMethod">Defaults to the name of the caller function (presumably the test).
         /// Used to prevent file collisions on tests which share the same test project.</param>
         /// <param name="identifier">Use this for theories.
+        /// Pass in the unique theory parameters that can indentify that theory from others.
         /// The Identifier is used to distinguish between theory child tests.  Generally it should be created using a combination of all of the theory parameter values.
         /// This is distinct from the test project name and is used to prevent file collisions between theory tests that use the same test project.</param>
         /// <param name="targetExtension">The extension type of the desired test project, e.g. .csproj, or .fsproj.</param>

--- a/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -254,24 +254,30 @@ namespace Microsoft.DotNet.Cli.Build.Tests
 
         [Theory]
         [InlineData("--self-contained")]
-        [InlineData("-p:PublishTrimmed=true")]
-        [InlineData("")]
-        public void It_builds_with_implicit_rid_with_rid_specific_properties(string executeOptionsAndProperties)
+        public void It_builds_with_implicit_rid_with_SelfContained(string executeOptions)
         {
-            var testInstance = _testAssetsManager.CopyTestAsset("HelloWorld")
-                .WithSource()
-                .WithTargetFrameworkOrFrameworks("net6.0", false)
-                .Restore(Log);
+            var targetFramework = ToolsetInfo.CurrentTargetFramework;
+            var testProject = new TestProject()
+            {
+                IsExe = true,
+                TargetFrameworks = targetFramework
+            };
 
-            new DotnetBuildCommand(Log)
-               .WithWorkingDirectory(testInstance.Path)
-               .Execute(executeOptionsAndProperties)
+            testProject.RecordProperties("RuntimeIdentifier");
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+
+            new DotnetBuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+               .Execute(executeOptions)
                .Should()
                .Pass()
                .And
                .NotHaveStdOutContaining("NETSDK1031") // Self Contained Checks
                .And
-               .NotHaveStdErrContaining("NETSDK1190"); // Check that publish properties don't interfere with build either 
+               .NotHaveStdErrContaining("NETSDK1190"); // Check that publish properties don't interfere with build either
+
+            var properties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework: targetFramework);
+            Assert.NotEqual("", properties["RuntimeIdentifier"]);
         }
 
         [RequiresMSBuildVersionFact("17.4.0.41702")]

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
@@ -143,36 +143,5 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 .Should()
                 .Pass();
         }
-
-        [Fact]
-        public void ItUsesImplicitRidWhenNoneIsSpecifiedForSelfContained()
-        {
-            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
-            {
-                var msbuildPath = "<msbuildpath>";
-                var currentRid = CommonOptions.GetCurrentRuntimeId();
-                var command = BuildCommand.FromArgs(new string[] { "--self-contained" }, msbuildPath);
-                command.GetArgumentsToMSBuild()
-                    .Should()
-                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary " +
-                    $"-property:SelfContained=True -property:_CommandLineDefinedSelfContained=true");
-            });
-        }
-
-        [Fact]
-        public void ItDoesNotUseImplicitRidWhenOneIsSpecifiedForSelfContained()
-        {
-            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
-            {
-                var msbuildPath = "<msbuildpath>";
-                var currentRid = CommonOptions.GetCurrentRuntimeId();
-                var command = BuildCommand.FromArgs(new string[] { "--self-contained", "--runtime", "fake-rid" }, msbuildPath);
-                command.GetArgumentsToMSBuild()
-                    .Should()
-                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary " +
-                    $"-property:RuntimeIdentifier=fake-rid -property:_CommandLineDefinedRuntimeIdentifier=true " +
-                    $"-property:SelfContained=True -property:_CommandLineDefinedSelfContained=true");
-            });
-        }
     }
 }


### PR DESCRIPTION
# Summary

With the new implicit runtime identifier changes, if you do something like `PublishSingleFile=true` and build (on windows) it could work locally by inferring your local RID, but then you push to Azure (linux) and it wouldn't be for the correct runtime. Previously it just wouldn't work if you didn't set the RID, but this is a confusing behavior that emerged since these properties shouldn't affect operations outside of publishing. Thank you @DamianEdwards for pointing this behavior out.

## Concerns 

This should be highly considered for December servicing @marcpopMSFT.
But the risk that it breaks something is very high until we lab this out more. Like, does this break the restore feature with publish single file in that it will require another restore as the first would be RID Agnostic, and when publishing it wouldn't be? If so we need to add `_IsRestoring` and if we do that then the RID inference for these properties would be locked to CLI only and not work in MSBuild / VS. 

Another consideration is: are there other times when `PublishAot`, `PublishSingleFile`, or `PublishReadyToRun` need to be active outside of publish? I have pinged @ CLR AppModel Team to comment on this after talking with @LakshanF. 


EDIT: This will break publish with `-no-restore` if someone migrated to using a RIDless restore (or started using no-restore) unless we add `_IsRestoring`: 
![image](https://user-images.githubusercontent.com/23152278/204670378-309edf62-de07-4b32-b66b-ff580798d47c.png)

Concern: How will `SelfContained` and friends work in VS if they no longer error but don't get a RID? 

cc @richlander 