### PR TITLE
Migrate the nuget state from earlier SDKs

### DIFF
--- a/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -58,6 +58,9 @@ namespace Microsoft.DotNet.Configurer
             if (ShouldPrintFirstTimeUseNotice())
             {
                 Stopwatch beforeFirstTimeUseNotice = Stopwatch.StartNew();
+                // Migrate the nuget state from earlier SDKs
+                NuGet.Common.Migrations.MigrationRunner.Run();
+
                 if (!_dotnetFirstRunConfiguration.NoLogo)
                 {
                     PrintFirstTimeMessageWelcome();


### PR DESCRIPTION
## Description

NuGet made available an API for fixing the NuGet folder permissions state. In the October release of NuGet, they released this change in the SDK so that code path triggers whenever a restore operation is run. This change adds it to any dotnet command to ensure that the state gets fixed as early as possible in the customer workflow.

## Customer Impact

Without this change, it's possible a customer would do a direct call to NuGet prior to running any dotnet restore commands and have the prior behavior.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change only runs in the first run config code path so it'll run once per new SDK (even patch updates) and the NuGet api also has its own sentinel to ensure it only runs once.

## Verification

- [ ] Manual (required)
- [ ] Automated
