### PR TITLE
Fix unhandled exception during test discovery on macOS

### DIFF
--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -125,9 +125,9 @@ namespace Microsoft.NET.TestFramework
             {
                 string restOfRid = currentRid.Substring(ridOS.Length + 1);
                 string ubuntuVersionString = restOfRid.Split('-')[0];
-                if (float.TryParse(ubuntuVersionString, out float ubuntuVersion))
+                if (float.TryParse(ubuntuVersionString, System.Globalization.CultureInfo.InvariantCulture, out float ubuntuVersion))
                 {
-                    if (ubuntuVersion > 16.04)
+                    if (ubuntuVersion > 16.04f)
                     {
                         if (nugetFramework.Version < new Version(2, 0, 0, 0))
                         {
@@ -144,27 +144,25 @@ namespace Microsoft.NET.TestFramework
             {
                 string restOfRid = currentRid.Substring(ridOS.Length + 1);
                 string osxVersionString = restOfRid.Split('-')[0];
-                //  From a string such as "10.14", get the second part, e.g. "14"
-                string osxVersionString2 = osxVersionString.Split('.')[1];
-                if (int.TryParse(osxVersionString2, out int osxVersion))
+                if (float.TryParse(osxVersionString, System.Globalization.CultureInfo.InvariantCulture, out float osxVersion))
                 {
                     //  .NET Core 1.1 - 10.11, 10.12
                     //  .NET Core 2.0 - 10.12+
-                    if (osxVersion <= 11)
+                    if (osxVersion <= 10.11f)
                     {
                         if (nugetFramework.Version >= new Version(2, 0, 0, 0))
                         {
                             return false;
                         }
                     }
-                    else if (osxVersion == 12)
+                    else if (osxVersion == 10.12f)
                     {
                         if (nugetFramework.Version < new Version(2, 0, 0, 0))
                         {
                             return false;
                         }
                     }
-                    else if (osxVersion > 12)
+                    else if (osxVersion > 10.12f)
                     {
                         //  .NET Core 2.0 is out of support, and doesn't seem to work with OS X 10.14
                         //  (it finds no assets for the RID), even though the support page says "10.12+"


### PR DESCRIPTION
While debugging https://github.com/dotnet/sdk/pull/29029 I noticed that we hit an unhandled exception because later macOS versions don't have an extra dot in the RID version number so the string split failed.

Switched to using float parsing for the version like we do for Ubuntu.