### PR TITLE
Deps.json should include project references that aren't present in project.assets.json

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -47,13 +47,11 @@ namespace Microsoft.NET.Build.Tasks
 
         private const string NetCorePlatformLibrary = "Microsoft.NETCore.App";
 
-        public DependencyContextBuilder(SingleProjectInfo mainProjectInfo, bool includeRuntimeFileVersions, RuntimeGraph runtimeGraph, ProjectContext projectContext)
+        public DependencyContextBuilder(SingleProjectInfo mainProjectInfo, bool includeRuntimeFileVersions, RuntimeGraph runtimeGraph, ProjectContext projectContext, LockFileLookup libraryLookup)
         {
             _mainProjectInfo = mainProjectInfo;
             _includeRuntimeFileVersions = includeRuntimeFileVersions;
             _runtimeGraph = runtimeGraph;
-
-            var libraryLookup = new LockFileLookup(projectContext.LockFile);
 
             _dependencyLibraries = projectContext.LockFileTarget.Libraries
                 .Select(lockFileTargetLibrary =>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -94,6 +94,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool IncludeRuntimeFileVersions { get; set; }
 
+        public bool IncludeProjectsNotInAssetsFile { get; set; }
+
         [Required]
         public string RuntimeGraphPath { get; set; }
 
@@ -125,20 +127,19 @@ namespace Microsoft.NET.Build.Tasks
 
         private void WriteDepsFile(string depsFilePath)
         {
-            ProjectContext projectContext;
-            if (AssetsFilePath == null)
-            {
-                projectContext = null;
-            }
-            else
+            ProjectContext projectContext = null;
+            LockFileLookup lockFileLookup = null;
+            if (AssetsFilePath != null)
             {
                 LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
                 projectContext = lockFile.CreateProjectContext(
-                 TargetFramework,
-                 RuntimeIdentifier,
-                 PlatformLibraryName,
-                 RuntimeFrameworks,
-                 IsSelfContained);
+                    TargetFramework,
+                    RuntimeIdentifier,
+                    PlatformLibraryName,
+                    RuntimeFrameworks,
+                    IsSelfContained);
+
+                lockFileLookup = new LockFileLookup(lockFile);
             }
 
             CompilationOptions compilationOptions = CompilationOptionsConverter.ConvertFrom(CompilerOptions);
@@ -156,13 +157,15 @@ namespace Microsoft.NET.Build.Tasks
             IEnumerable<ReferenceInfo> referenceAssemblyInfos =
                 ReferenceInfo.CreateReferenceInfos(ReferenceAssemblies);
 
-            // If there is a generated asset file. The projectContext will have project reference.
-            // So remove it from directReferences to avoid duplication
-            var projectContextHasProjectReferences = projectContext != null;
+            // If there is a generated asset file, the projectContext will contain most of the project references.
+            // So remove any project reference contained within projectContext from directReferences to avoid duplication
             IEnumerable<ReferenceInfo> directReferences =
-                ReferenceInfo.CreateDirectReferenceInfos(ReferencePaths,
+                ReferenceInfo.CreateDirectReferenceInfos(
+                    ReferencePaths,
                     ReferenceSatellitePaths,
-                    projectContextHasProjectReferences, isUserRuntimeAssembly);
+                    lockFileLookup,
+                    isUserRuntimeAssembly,
+                    IncludeProjectsNotInAssetsFile);
 
             IEnumerable<ReferenceInfo> dependencyReferences =
                 ReferenceInfo.CreateDependencyReferenceInfos(ReferenceDependencyPaths, ReferenceSatellitePaths, isUserRuntimeAssembly);
@@ -210,7 +213,7 @@ namespace Microsoft.NET.Build.Tasks
                 RuntimeGraph runtimeGraph =
                     IsSelfContained ? new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath) : null;
 
-                builder = new DependencyContextBuilder(mainProject, IncludeRuntimeFileVersions, runtimeGraph, projectContext);
+                builder = new DependencyContextBuilder(mainProject, IncludeRuntimeFileVersions, runtimeGraph, projectContext, lockFileLookup);
             }
             else
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
@@ -54,17 +54,49 @@ namespace Microsoft.NET.Build.Tasks
         public static IEnumerable<ReferenceInfo> CreateDirectReferenceInfos(
             IEnumerable<ITaskItem> referencePaths,
             IEnumerable<ITaskItem> referenceSatellitePaths,
-            bool projectContextHasProjectReferences,
-            Func<ITaskItem, bool> isRuntimeAssembly)
+            LockFileLookup lockFileLookup,
+            Func<ITaskItem, bool> isRuntimeAssembly,
+            bool includeProjectsNotInAssetsFile)
         {
-
-            bool filterOutProjectReferenceIfInProjectContextAlready(ITaskItem referencePath)
+            bool lockFileContainsProject(ITaskItem referencePath)
             {
-                return (projectContextHasProjectReferences ? !IsProjectReference(referencePath) : true);
+                if (lockFileLookup == null)
+                {
+                    return false;
+                }
+
+                if (!IsProjectReference(referencePath))
+                {
+                    return false;
+                }
+
+                if (!includeProjectsNotInAssetsFile)
+                {
+                    return true;
+                }
+
+                string projectName;
+                string projectFilePath = referencePath.GetMetadata(MetadataKeys.MSBuildSourceProjectFile);
+                if (!string.IsNullOrEmpty(projectFilePath))
+                {
+                    projectName = Path.GetFileNameWithoutExtension(projectFilePath);
+                }
+                else
+                {
+                    // fall back to using the path to the output DLL
+                    projectName = Path.GetFileNameWithoutExtension(referencePath.ItemSpec);
+                    if (string.IsNullOrEmpty(projectName))
+                    {
+                        // unexpected - let's assume this project was already included in the assets file.
+                        return true;
+                    }
+                }
+
+                return lockFileLookup.GetProject(projectName) != null;
             }
 
             IEnumerable<ITaskItem> directReferencePaths = referencePaths
-                .Where(r => filterOutProjectReferenceIfInProjectContextAlready(r) && !IsNuGetReference(r) && isRuntimeAssembly(r));
+                .Where(r => !lockFileContainsProject(r) && !IsNuGetReference(r) && isRuntimeAssembly(r));
 
             return CreateFilteredReferenceInfos(directReferencePaths, referenceSatellitePaths);
         }
@@ -147,7 +179,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (!string.IsNullOrEmpty(fusionName))
                 {
                     AssemblyName assemblyName = new AssemblyName(fusionName);
-                    version = assemblyName.Version.ToString();
+                    version = assemblyName.Version?.ToString();
                 }
 
                 if (string.IsNullOrEmpty(version))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -68,6 +68,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ResolvedRuntimeTargetsFiles="@(RuntimeTargetsCopyLocalItems)"
       TargetFramework="$(TargetFramework)"
       RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
+      IncludeProjectsNotInAssetsFile="$(IncludeProjectsNotInAssetsFileInDepsFile)"
       />
 
     <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -980,7 +980,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                       IsSelfContained="$(SelfContained)"
                       IsSingleFile="$(_IsSingleFilePublish)"
                       IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)"
-                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"/>
+                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
+                      IncludeProjectsNotInAssetsFile="$(IncludeProjectsNotInAssetsFileInDepsFile)"/>
 
     <ItemGroup>
       <ResolvedFileToPublish Include="$(IntermediateDepsFilePath)">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -110,8 +110,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Turn on IncludeProjectsNotInAssetsFileInDepsFile by default. -->
-    <IncludeProjectsNotInAssetsFileInDepsFile Condition="'$(IncludeProjectsNotInAssetsFileInDepsFile)' == ''">true</IncludeProjectsNotInAssetsFileInDepsFile>
+    <!-- Turn off IncludeProjectsNotInAssetsFileInDepsFile by default. -->
+    <IncludeProjectsNotInAssetsFileInDepsFile Condition="'$(IncludeProjectsNotInAssetsFileInDepsFile)' == ''">false</IncludeProjectsNotInAssetsFileInDepsFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -110,6 +110,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Turn on IncludeProjectsNotInAssetsFileInDepsFile by default. -->
+    <IncludeProjectsNotInAssetsFileInDepsFile Condition="'$(IncludeProjectsNotInAssetsFileInDepsFile)' == ''">true</IncludeProjectsNotInAssetsFileInDepsFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <CoreBuildDependsOn>
       _CheckForBuildWithNoBuild;
       $(CoreBuildDependsOn);
@@ -197,7 +202,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                       ResolvedRuntimeTargetsFiles="@(RuntimeTargetsCopyLocalItems)"
                       IsSelfContained="$(SelfContained)"
                       IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)"
-                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"/>
+                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
+                      IncludeProjectsNotInAssetsFile="$(IncludeProjectsNotInAssetsFileInDepsFile)"/>
 
     <ItemGroup>
       <!-- Do this in an ItemGroup instead of as an output parameter of the GenerateDepsFile task so that it still gets added to the item set

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveNonSdkProjectRefs.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveNonSdkProjectRefs.cs
@@ -102,7 +102,7 @@ namespace Microsoft.NET.Build.Tests
                 IsSdkProject = false,
                 TargetFrameworkVersion = targetFrameworkVersion
             };
-            auxLibraryProject.SourceFiles["Helper.cs"] = """
+            auxLibraryProject.SourceFiles["Helper.cs"] = @"
                 using System;
 
                 namespace AuxLibrary
@@ -111,11 +111,11 @@ namespace Microsoft.NET.Build.Tests
                     {
                         public static void WriteMessage()
                         {
-                            Console.WriteLine("This string came from AuxLibrary!");
+                            Console.WriteLine(""This string came from AuxLibrary!"");
                         }
                     }
                 }
-                """;
+                ";
 
             var mainLibraryProject = new TestProject("MainLibrary")
             {
@@ -123,7 +123,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworkVersion = targetFrameworkVersion
             };
             mainLibraryProject.ReferencedProjects.Add(auxLibraryProject);
-            mainLibraryProject.SourceFiles["Helper.cs"] = """
+            mainLibraryProject.SourceFiles["Helper.cs"] = @"
                 using System;
 
                 namespace MainLibrary
@@ -132,12 +132,12 @@ namespace Microsoft.NET.Build.Tests
                     {
                         public static void WriteMessage()
                         {
-                            Console.WriteLine("This string came from MainLibrary!");
+                            Console.WriteLine(""This string came from MainLibrary!"");
                             AuxLibrary.Helper.WriteMessage();
                         }
                     }
                 }
-                """;
+            ";
 
             var testAppProject = new TestProject("TestApp")
             {
@@ -146,7 +146,7 @@ namespace Microsoft.NET.Build.Tests
             };
             testAppProject.AdditionalProperties["ProduceReferenceAssembly"] = "false";
             testAppProject.ReferencedProjects.Add(mainLibraryProject);
-            testAppProject.SourceFiles["Program.cs"] = """
+            testAppProject.SourceFiles["Program.cs"] = @"
                 using System;
 
                 namespace TestApp
@@ -155,12 +155,12 @@ namespace Microsoft.NET.Build.Tests
                     {
                         public static void Main(string[] args)
                         {
-                            Console.WriteLine("TestApp --depends on--> MainLibrary --depends on--> AuxLibrary");
+                            Console.WriteLine(""TestApp --depends on--> MainLibrary --depends on--> AuxLibrary"");
                             MainLibrary.Helper.WriteMessage();
                         }
                     }
                 }
-                """;
+                ";
 
             return testAppProject;
         }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveNonSdkProjectRefs.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveNonSdkProjectRefs.cs
@@ -1,0 +1,202 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using FluentAssertions;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildAnAppWithTransitiveNonSdkProjectRefs : SdkTest
+    {
+        public GivenThatWeWantToBuildAnAppWithTransitiveNonSdkProjectRefs(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [WindowsOnlyFact]
+        public void It_builds_the_project_successfully()
+        {
+            // NOTE the projects created by CreateTestProject:
+            // TestApp --depends on--> MainLibrary --depends on--> AuxLibrary (non-SDK)
+            // (TestApp transitively depends on AuxLibrary)
+            var testAsset = _testAssetsManager
+                .CreateTestProject(CreateTestProject());
+
+            VerifyAppBuilds(testAsset, string.Empty);
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("")]
+        [InlineData("TestApp.")]
+        public void It_builds_deps_correctly_when_projects_do_not_get_restored(string prefix)
+        {
+            // NOTE the projects created by CreateTestProject:
+            // TestApp --depends on--> MainLibrary --depends on--> AuxLibrary
+            // (TestApp transitively depends on AuxLibrary)
+            var testAsset = _testAssetsManager
+                .CreateTestProject(CreateTestProject())
+                .WithProjectChanges(
+                    (projectName, project) =>
+                    {
+                        string projectFileName = Path.GetFileNameWithoutExtension(projectName);
+                        if (StringComparer.OrdinalIgnoreCase.Equals(projectFileName, "AuxLibrary") ||
+                            StringComparer.OrdinalIgnoreCase.Equals(projectFileName, "MainLibrary"))
+                        {
+                            var ns = project.Root.Name.Namespace;
+
+                            XElement propertyGroup = project.Root.Element(ns + "PropertyGroup");
+                            if (!string.IsNullOrEmpty(prefix))
+                            {
+                                XElement assemblyName = propertyGroup.Element(ns + "AssemblyName");
+                                assemblyName.RemoveAll();
+                                assemblyName.Add(prefix + projectFileName);
+                            }
+
+                            // indicate that project restore is not supported for these projects:
+                            var target = new XElement(ns + "Target",
+                                new XAttribute("Name", "_IsProjectRestoreSupported"),
+                                new XAttribute("Returns", "@(_ValidProjectsForRestore)"));
+
+                            project.Root.Add(target);
+                        }
+                        else // if (StringComparer.OrdinalIgnoreCase.Equals(projectFileName, "TestApp"))
+                        {
+                            var ns = project.Root.Name.Namespace;
+
+                            XElement propertyGroup = project.Root.Element(ns + "PropertyGroup");
+
+                            XElement includeProjectsNotInAssetsFileInDepsFile = new XElement(ns + "IncludeProjectsNotInAssetsFileInDepsFile");
+                            includeProjectsNotInAssetsFileInDepsFile.Add("true");
+                            propertyGroup.Add(includeProjectsNotInAssetsFileInDepsFile);
+                        }
+                    });
+
+            string outputDirectory = VerifyAppBuilds(testAsset, prefix);
+
+            using (var depsJsonFileStream = File.OpenRead(Path.Combine(outputDirectory, "TestApp.deps.json")))
+            {
+                var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
+
+                var projectNames = dependencyContext.RuntimeLibraries.Select(library => library.Name).ToList();
+                projectNames.Should().BeEquivalentTo(new[] { "TestApp", prefix + "AuxLibrary", prefix + "MainLibrary" });
+            }
+        }
+
+        private TestProject CreateTestProject()
+        {
+            string targetFrameworkVersion = "v4.8";
+
+            var auxLibraryProject = new TestProject("AuxLibrary")
+            {
+                IsSdkProject = false,
+                TargetFrameworkVersion = targetFrameworkVersion
+            };
+            auxLibraryProject.SourceFiles["Helper.cs"] = """
+                using System;
+
+                namespace AuxLibrary
+                {
+                    public static class Helper
+                    {
+                        public static void WriteMessage()
+                        {
+                            Console.WriteLine("This string came from AuxLibrary!");
+                        }
+                    }
+                }
+                """;
+
+            var mainLibraryProject = new TestProject("MainLibrary")
+            {
+                IsSdkProject = false,
+                TargetFrameworkVersion = targetFrameworkVersion
+            };
+            mainLibraryProject.ReferencedProjects.Add(auxLibraryProject);
+            mainLibraryProject.SourceFiles["Helper.cs"] = """
+                using System;
+
+                namespace MainLibrary
+                {
+                    public static class Helper
+                    {
+                        public static void WriteMessage()
+                        {
+                            Console.WriteLine("This string came from MainLibrary!");
+                            AuxLibrary.Helper.WriteMessage();
+                        }
+                    }
+                }
+                """;
+
+            var testAppProject = new TestProject("TestApp")
+            {
+                IsExe = true,
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework
+            };
+            testAppProject.AdditionalProperties["ProduceReferenceAssembly"] = "false";
+            testAppProject.ReferencedProjects.Add(mainLibraryProject);
+            testAppProject.SourceFiles["Program.cs"] = """
+                using System;
+
+                namespace TestApp
+                {
+                    public class Program
+                    {
+                        public static void Main(string[] args)
+                        {
+                            Console.WriteLine("TestApp --depends on--> MainLibrary --depends on--> AuxLibrary");
+                            MainLibrary.Helper.WriteMessage();
+                        }
+                    }
+                }
+                """;
+
+            return testAppProject;
+        }
+
+        private string VerifyAppBuilds(TestAsset testAsset, string prefix)
+        {
+            var buildCommand = new BuildCommand(testAsset, "TestApp");
+            var outputDirectory = buildCommand.GetOutputDirectory(ToolsetInfo.CurrentTargetFramework);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "TestApp.dll",
+                "TestApp.pdb",
+                $"TestApp{EnvironmentInfo.ExecutableExtension}",
+                "TestApp.deps.json",
+                "TestApp.runtimeconfig.json",
+                prefix + "MainLibrary.dll",
+                prefix + "MainLibrary.pdb",
+                prefix + "AuxLibrary.dll",
+                prefix + "AuxLibrary.pdb",
+            });
+
+            new DotnetCommand(Log, Path.Combine(outputDirectory.FullName, "TestApp.dll"))
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("This string came from MainLibrary!")
+                .And
+                .HaveStdOutContaining("This string came from AuxLibrary!");
+
+            return outputDirectory.FullName;
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
@@ -123,7 +123,9 @@ namespace Microsoft.NET.Build.Tests
             buildCommand
                 .Execute("/p:DisableTransitiveProjectReferences=true")
                 .Should()
-                .Fail();
+                .Fail()
+                .And
+                .HaveStdOutContaining("CS0103");
         }
     }
 }


### PR DESCRIPTION
## Description

Port of https://github.com/dotnet/sdk/pull/28963
Fixes https://github.com/dotnet/sdk/issues/28891

When there is a reference to a project that is not included in the project.assets.json file for some reason (e.g. it has opted out of nuget restore), it does not get included into deps.json.

This fix is to include all references in the deps.json file even those not in the project.assets.json. In 7.0.2xx the change is on by default but for 6.0.4xx, we are leaving it as opt-in so as to reduce risk.

## Customer Impact

While rare and not the default, this will result in the application not being able to find all of it's dependencies at runtime and fail to run. This particular case came because of using internal build tools when referencing a cppCLI project and those tools were disabling nuget restore for those projects by default.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [x] Automated


Port of https://github.com/dotnet/sdk/pull/28963

Although most projects are included in project.assets.json after a restore takes place, there are some (rare) scenarios when this is not the case. When that happens, project references end up being skipped and excluded from deps.json.

One can work around this by adding a binary Reference, that is inconvenient and can lead to issues when one forgets. Instead, it would be good to check whether the project reference is included in project.assets.json before skipping it when generating the list of dependencies.

Also added a functional test (.NET 6.0 project referencing a .NET Framework project) that failed previously and succeeds now.

(Continues #28892, retargeting release/7.0.2xx) 