### PR TITLE
Avoid potential NRE

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -307,8 +307,8 @@ namespace Microsoft.DotNet.Watcher
             }
 
             var rootVariableName = EnvironmentVariableNames.TryGetDotNetRootVariableName(
-                project.RuntimeIdentifier,
-                project.DefaultAppHostRuntimeIdentifier,
+                project.RuntimeIdentifier ?? "",
+                project.DefaultAppHostRuntimeIdentifier ?? "",
                 project.TargetFrameworkVersion);
 
             if (rootVariableName != null && string.IsNullOrEmpty(Environment.GetEnvironmentVariable(rootVariableName)))


### PR DESCRIPTION
Add defensive null check.

Some tests in main are failing with NRE. These tests seem to pass in 7.0.2xx but it's not currently clear when RuntimeIdentifier and DefaultAppHostRuntimeIdentifier are non-null. Will follow up with adding null annotations in main.

Fixes https://github.com/dotnet/sdk/issues/29085