### PR TITLE
Add switch to disable apphost pack restore

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -54,6 +54,8 @@ namespace Microsoft.NET.Build.Tasks
         public bool NuGetRestoreSupported { get; set; } = true;
 
         public string NetCoreTargetingPackRoot { get; set; }
+        
+        public bool EnableAppHostPackDownload { get; set; }
 
         [Output]
         public ITaskItem[] PackagesToDownload { get; set; }
@@ -276,7 +278,6 @@ namespace Microsoft.NET.Build.Tasks
                 string hostRelativePathInPackage = Path.Combine("runtimes", bestAppHostRuntimeIdentifier, "native",
                     hostNameWithoutExtension + (isExecutable ? ExecutableExtension.ForRuntimeIdentifier(bestAppHostRuntimeIdentifier) : ".dll"));
 
-
                 TaskItem appHostItem = new TaskItem(itemName);
                 string appHostPackPath = null;
                 if (!string.IsNullOrEmpty(TargetingPackRoot))
@@ -289,7 +290,7 @@ namespace Microsoft.NET.Build.Tasks
                     appHostItem.SetMetadata(MetadataKeys.PackageDirectory, appHostPackPath);
                     appHostItem.SetMetadata(MetadataKeys.Path, Path.Combine(appHostPackPath, hostRelativePathInPackage));
                 }
-                else
+                else if (EnableAppHostPackDownload)
                 {
                     // C++/CLI does not support package download && dedup error
                     if (!NuGetRestoreSupported && !packagesToDownload.ContainsKey(hostPackName))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -55,7 +55,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public string NetCoreTargetingPackRoot { get; set; }
         
-        public bool EnableAppHostPackDownload { get; set; }
+        public bool EnableAppHostPackDownload { get; set; } = true;
 
         [Output]
         public ITaskItem[] PackagesToDownload { get; set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -132,10 +132,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AppHostRuntimeIdentifier>$(RuntimeIdentifier)</AppHostRuntimeIdentifier>
       <AppHostRuntimeIdentifier Condition="'$(AppHostRuntimeIdentifier)' == ''">$(DefaultAppHostRuntimeIdentifier)</AppHostRuntimeIdentifier>
     </PropertyGroup>
-    
-    <PropertyGroup>
-      <EnableAppHostPackDownload Condition="'$(EnableAppHostPackDownload)' == '' and '$(_NuGetRestoreSupported)' != 'false'">true</EnableAppHostPackDownload>
-    </PropertyGroup>
 
     <ResolveAppHosts TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                      TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -150,7 +150,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                      DotNetIjwHostLibraryNameWithoutExtension="$(_DotNetIjwHostLibraryNameWithoutExtension)"
                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                      KnownAppHostPacks="@(KnownAppHostPack)"
-                     NuGetRestoreSupported="$(EnableAppHostPackDownload)"
+                     NuGetRestoreSupported="$(_NuGetRestoreSupported)"
+                     EnableAppHostPackDownload="$(EnableAppHostPackDownload)"
                      NetCoreTargetingPackRoot="$(NetCoreTargetingPackRoot)">
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackageToDownload" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -132,6 +132,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AppHostRuntimeIdentifier>$(RuntimeIdentifier)</AppHostRuntimeIdentifier>
       <AppHostRuntimeIdentifier Condition="'$(AppHostRuntimeIdentifier)' == ''">$(DefaultAppHostRuntimeIdentifier)</AppHostRuntimeIdentifier>
     </PropertyGroup>
+    
+    <PropertyGroup>
+      <EnableAppHostPackDownload Condition="'$(EnableAppHostPackDownload)' == '' and '$(_NuGetRestoreSupported)' != 'false'">true</EnableAppHostPackDownload>
+    </PropertyGroup>
 
     <ResolveAppHosts TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                      TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
@@ -146,7 +150,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                      DotNetIjwHostLibraryNameWithoutExtension="$(_DotNetIjwHostLibraryNameWithoutExtension)"
                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                      KnownAppHostPacks="@(KnownAppHostPack)"
-                     NuGetRestoreSupported="$([MSBuild]::ValueOrDefault('$(EnableAppHostPackDownload)', '$(_NuGetRestoreSupported)'))"
+                     NuGetRestoreSupported="$(EnableAppHostPackDownload)"
                      NetCoreTargetingPackRoot="$(NetCoreTargetingPackRoot)">
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackageToDownload" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -146,7 +146,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                      DotNetIjwHostLibraryNameWithoutExtension="$(_DotNetIjwHostLibraryNameWithoutExtension)"
                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                      KnownAppHostPacks="@(KnownAppHostPack)"
-                     NuGetRestoreSupported="$(_NuGetRestoreSupported)"
+                     NuGetRestoreSupported="$([MSBuild]::ValueOrDefault('$(EnableAppHostPackDownload)', '$(_NuGetRestoreSupported)'))"
                      NetCoreTargetingPackRoot="$(NetCoreTargetingPackRoot)">
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackageToDownload" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/58109
Mimics https://github.com/dotnet/sdk/pull/15944

In dotnet/runtime we live build targeting packs, runtime packs and app host packs. For the former two, switches already exist to disable nuget restore:
- EnableTargetingPackDownload
- EnableRuntimePackDownload

The latter one doesn't yet have such a switch and therefore is always restored by NuGet. In the cases where want to use the live built apphost pack, restore fails, i.e. from a runtime build:

`artifacts/bin/trimmingTests/projects/Microsoft.Extensions.DependencyInjection.TrimmingTests/ActivatorUtilitiesTests/osx-x64/project.csproj(0,0): error NU1102: (NETCORE_ENGINEERING_TELEMETRY=Build) Unable to find package Microsoft.NETCore.App.Host.osx-x64 with version (= 8.0.0)`