### PR TITLE
Don't stabilize package versions in main

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <!-- Production Dependencies -->


### PR DESCRIPTION
Stable branding was enabled in the 7.0.1xx release branch via https://github.com/dotnet/sdk/commit/ac62cb18bc09b308e0cc42d7a0c8b3ad5e1428cb and accidentally got forward merged into main. Disable it so that new packages are pushed to the dotnet8/dotnet8-transport feeds.