### PR TITLE
Introduce MSBuild task frontend for the Roslyn-based GenAPI

### DIFF
--- a/sdk.sln
+++ b/sdk.sln
@@ -409,6 +409,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.ApiSymbolE
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.GenAPI", "src\GenAPI\Microsoft.DotNet.GenAPI\Microsoft.DotNet.GenAPI.csproj", "{5F74AD67-A4AD-4660-A63C-844DAAF354C4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.GenAPI.Task", "src\GenAPI\Microsoft.DotNet.GenAPI.Task\Microsoft.DotNet.GenAPI.Task.csproj", "{C419AE2D-D318-49EB-8ECA-6A5DC13FE4EA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -787,6 +789,10 @@ Global
 		{5F74AD67-A4AD-4660-A63C-844DAAF354C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5F74AD67-A4AD-4660-A63C-844DAAF354C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5F74AD67-A4AD-4660-A63C-844DAAF354C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C419AE2D-D318-49EB-8ECA-6A5DC13FE4EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C419AE2D-D318-49EB-8ECA-6A5DC13FE4EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C419AE2D-D318-49EB-8ECA-6A5DC13FE4EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C419AE2D-D318-49EB-8ECA-6A5DC13FE4EA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -930,6 +936,7 @@ Global
 		{5D81D6AA-E198-4537-AE1C-549367DAF187} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 		{E2BC296E-2660-4692-B471-F6FCD4C19F6E} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 		{5F74AD67-A4AD-4660-A63C-844DAAF354C4} = {95D8B040-FD7F-4C86-8E47-341AF630EDA9}
+		{C419AE2D-D318-49EB-8ECA-6A5DC13FE4EA} = {95D8B040-FD7F-4C86-8E47-341AF630EDA9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB8F26CE-4DE6-433F-B32A-79183020BBD6}

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.NET.Build.Tasks;
+using static Microsoft.DotNet.GenAPI.GenAPIApp;
+
+namespace Microsoft.DotNet.GenAPI.Task
+{
+    /// <summary>
+    /// MSBuild task frontend for the Roslyn-based GenAPI.
+    /// </summary>
+    public class GenAPITask : TaskBase
+    {
+        /// <summary>
+        /// The path to one or more assemblies or directories with assemblies.
+        /// </summary>
+        [Required]
+        public string[]? Assemblies { get; set; }
+
+        /// <summary>
+        /// Paths to assembly references or their underlying directories for a specific target framework in the package.
+        /// </summary>
+        public string[]? AssemblyReferences { get; set; }
+
+        /// <summary>
+        /// Output path. Default is the console. Can specify an existing directory as well and
+        /// then a file will be created for each assembly with the matching name of the assembly.
+        /// </summary>
+        public string? OutputPath { get; set; }
+
+        /// <summary>
+        /// Specify a file with an alternate header content to prepend to output.
+        /// </summary>
+        public string? HeaderFile { get; set; }
+
+        /// <summary>
+        /// Method bodies should throw PlatformNotSupportedException.
+        /// </summary>
+        public string? ExceptionMessage { get; set; }
+
+        /// <summary>
+        /// The path to one or more attribute exclusion files with types in DocId format.
+        /// </summary>
+        public string[]? ExcludeAttributesFiles { get; set; }
+
+        /// <summary>
+        /// Include all API's not just public APIs. The default is public only.
+        /// </summary>
+        public bool IncludeVisibleOutsideOfAssembly { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            GenAPIApp.Run(new GenAPIApp.Context(
+                Assemblies!,
+                AssemblyReferences,
+                OutputPath,
+                HeaderFile,
+                ExceptionMessage,
+                ExcludeAttributesFiles,
+                IncludeVisibleOutsideOfAssembly
+            ));
+        }
+    }
+}

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.NET.Build.Tasks;
-using static Microsoft.DotNet.GenAPI.GenAPIApp;
 
 namespace Microsoft.DotNet.GenAPI.Task
 {

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
@@ -1,0 +1,86 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net7.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- This package doesn't contain any lib or ref assemblies because it's a tooling package.-->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <Nullable>enable</Nullable>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
+    <_MicrosoftCodeAnalysisVersion>4.0.1</_MicrosoftCodeAnalysisVersion>
+    <_MicrosoftCodeAnalysisVersion Condition="'$(DotNetBuildFromSource)' == 'true'">$(MicrosoftCodeAnalysisPackageVersion)</_MicrosoftCodeAnalysisVersion>
+  </PropertyGroup>
+
+  <!-- SDK's task infrastructure -->
+  <ItemGroup>
+    <Compile Include="..\..\Tasks\Common\TaskBase.cs" LinkBase="Common" />
+    <Compile Include="..\..\Tasks\Common\Logger.cs" LinkBase="Common" />
+    <Compile Include="..\..\Tasks\Common\LogAdapter.cs" LinkBase="Common" />
+    <Compile Include="..\..\Tasks\Common\BuildErrorException.cs" LinkBase="Common" />
+    <Compile Include="..\..\Tasks\Common\Message.cs" LinkBase="Common" />
+    <Compile Include="..\..\Tasks\Common\MessageLevel.cs" LinkBase="Common" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- ExcludeAssets="Runtime" is being set to avoid adding package references and dependencies of package and project references into the package. -->
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="Runtime" />
+    <ProjectReference Include="..\Microsoft.DotNet.GenAPI\Microsoft.DotNet.GenAPI.csproj" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(_MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(_MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(_MicrosoftCodeAnalysisVersion)" />
+    <!-- We carry NuGet as part of the package in case the package is used with an older SDKs or with full framework MSBuild. -->
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetBuildTasksPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetBuildTasksPackageVersion)" />
+    <PackageReference Include="NuGet.Protocol" Version="$(NuGetBuildTasksPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="**\*.props;**\*.targets" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
+    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
+  </ItemGroup>
+
+  
+  <ItemGroup>
+    <!--
+      Update all PackageReference and ProjectReference Items to have
+      PrivateAssets="All" and default Publish to true.
+      This removes the dependency nodes from the generated nuspec and
+      forces the publish output to contain the dlls.
+     -->
+    <PackageReference Update="@(PackageReference)">
+      <PrivateAssets>All</PrivateAssets>
+      <Publish Condition="'%(PackageReference.Publish)' == ''">true</Publish>
+      <ExcludeAssets Condition="'%(PackageReference.Publish)' == 'false'">runtime</ExcludeAssets>
+    </PackageReference>
+    <ProjectReference Update="@(ProjectReference)">
+      <PrivateAssets>All</PrivateAssets>
+      <Publish Condition="'%(ProjectReference.Publish)' == ''">true</Publish>
+    </ProjectReference>
+
+    <!--
+      Update all Reference items to have Pack="false"
+      This removes the frameworkDependency nodes from the generated nuspec
+    -->
+    <Reference Update="@(Reference)">
+      <Pack>false</Pack>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="_AddBuildOutputToPackageCore" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <ItemGroup>
+      <!-- Publish .NET Core assets and include them in the package under tools directory. -->
+      <TfmSpecificPackageFile Include="$(PublishDir)**" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_AddBuildOutputToPackageDesktop" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <ItemGroup>
+      <!-- Include .NET Framework build outputs in the package under tools directory. -->
+      <TfmSpecificPackageFile Include="$(OutputPath)**" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
@@ -42,7 +42,6 @@
     <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
   </ItemGroup>
 
-  
   <ItemGroup>
     <!--
       Update all PackageReference and ProjectReference Items to have

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -1,0 +1,60 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <PropertyGroup>
+    <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and Exists('$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.GenAPI.Task.dll')">$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
+    <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(DotNetGenAPITaskAssembly)' == ''">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Hook onto the TargetsTriggeredByCompilation target which only runs when the compiler is invoked. -->
+    <TargetsTriggeredByCompilation Condition="'$(GenAPIGenerateReferenceAssemblySource)' == 'true'">
+      $(TargetsTriggeredByCompilation);
+      GenAPIGenerateReferenceAssemblySource
+    </TargetsTriggeredByCompilation>
+  </PropertyGroup>
+
+  <!-- Only run this target when the GenAPIGenerateReferenceAssemblySource target is invoked directly
+       which means that GenAPIGenerateReferenceAssemblySource property is false. -->
+  <Target Name="_GenAPIDontBuildProjectReferences" 
+          Condition="'$(GenAPIGenerateReferenceAssemblySource)' != 'true'">
+    <PropertyGroup>
+      <BuildProjectReferences>false</BuildProjectReferences>
+    </PropertyGroup>
+  </Target>
+
+  <!-- GenAPIGenerateReferenceSource was the old target's name. Keep it to not break existing dev workflows. -->
+  <Target Name="GenAPIGenerateReferenceSource"
+          DependsOnTargets="GenAPIGenerateReferenceAssemblySource" />
+
+  <UsingTask TaskName="Microsoft.DotNet.GenAPI.Task.GenAPITask" AssemblyFile="$(DotNetGenAPITaskAssembly)" />
+
+  <Target Name="GenAPIGenerateReferenceAssemblySource"
+          DependsOnTargets="_GenAPIDontBuildProjectReferences;ResolveAssemblyReferences">
+    <ItemGroup Condition="'$(GenAPILibPath)' == ''">
+      <!-- Build out a list of directories where dependencies are located. -->
+      <_referencePathDirectories Include="@(ReferencePath->'%(RootDir)%(Directory)'->Distinct())" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <GenAPIInputAssembly Condition="'$(GenAPIInputAssembly)' == ''">@(IntermediateAssembly)</GenAPIInputAssembly>
+      <GenAPITargetPath Condition="'$(GenAPITargetPath)' == ''">$(TargetDir)$(TargetName).cs</GenAPITargetPath>
+      <GenAPILibPath Condition="'$(GenAPILibPath)' == ''">@(_referencePathDirectories)</GenAPILibPath>
+      <!-- When the GenAPIGenerateReferenceAssemblySource target is invoked directly, make sure the verbosity is high
+           so that the generated reference source path is printed to the console. Otherwise emit the message with
+           a low verbosity so that it doesn't appear on a console but still on logs. -->
+      <GenAPIVerbosity Condition="'$(GenAPIVerbosity)' == '' and '$(GenAPIGenerateReferenceAssemblySource)' == 'true'">low</GenAPIVerbosity>
+      <GenAPIVerbosity Condition="'$(GenAPIVerbosity)' == '' and '$(GenAPIGenerateReferenceAssemblySource)' != 'true'">high</GenAPIVerbosity>
+    </PropertyGroup>
+
+    <Microsoft.DotNet.GenAPI.Task.GenAPITask
+      Assemblies="$(GenAPIInputAssembly)"
+      AssemblyReferences="$(GenAPILibPath)"
+      OutputPath="$(GenAPITargetPath)"
+      HeaderFile="$(GenAPIHeaderFile)"
+      ExceptionMessage="$(GenAPIExceptionMessage)"
+      ExcludeAttributesFiles="$(GenAPIExcludeAttributesList)"
+      IncludeVisibleOutsideOfAssembly="$(GenAPIIncludeVisibleOutsideOfAssembly)" />
+
+    <Message Text="Generated reference assembly source code: $(GenAPITargetPath)" Importance="$(GenAPIVerbosity)" />
+  </Target>
+</Project>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -22,23 +22,14 @@
     </PropertyGroup>
   </Target>
 
-  <!-- GenAPIGenerateReferenceSource was the old target's name. Keep it to not break existing dev workflows. -->
-  <Target Name="GenAPIGenerateReferenceSource"
-          DependsOnTargets="GenAPIGenerateReferenceAssemblySource" />
-
   <UsingTask TaskName="Microsoft.DotNet.GenAPI.Task.GenAPITask" AssemblyFile="$(DotNetGenAPITaskAssembly)" />
 
   <Target Name="GenAPIGenerateReferenceAssemblySource"
-          DependsOnTargets="_GenAPIDontBuildProjectReferences;ResolveAssemblyReferences">
-    <ItemGroup Condition="'$(GenAPILibPath)' == ''">
-      <!-- Build out a list of directories where dependencies are located. -->
-      <_referencePathDirectories Include="@(ReferencePath->'%(RootDir)%(Directory)'->Distinct())" />
-    </ItemGroup>
-
+          DependsOnTargets="_GenAPIDontBuildProjectReferences;FindReferenceAssembliesForReferences">
     <PropertyGroup>
       <GenAPIInputAssembly Condition="'$(GenAPIInputAssembly)' == ''">@(IntermediateAssembly)</GenAPIInputAssembly>
       <GenAPITargetPath Condition="'$(GenAPITargetPath)' == ''">$(TargetDir)$(TargetName).cs</GenAPITargetPath>
-      <GenAPILibPath Condition="'$(GenAPILibPath)' == ''">@(_referencePathDirectories)</GenAPILibPath>
+      <GenAPILibPath Condition="'$(GenAPILibPath)' == ''">@(ReferencePathWithRefAssemblies)</GenAPILibPath>
       <!-- When the GenAPIGenerateReferenceAssemblySource target is invoked directly, make sure the verbosity is high
            so that the generated reference source path is printed to the console. Otherwise emit the message with
            a low verbosity so that it doesn't appear on a console but still on logs. -->

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -27,9 +27,7 @@
   <Target Name="GenAPIGenerateReferenceAssemblySource"
           DependsOnTargets="_GenAPIDontBuildProjectReferences;FindReferenceAssembliesForReferences">
     <PropertyGroup>
-      <GenAPIInputAssembly Condition="'$(GenAPIInputAssembly)' == ''">@(IntermediateAssembly)</GenAPIInputAssembly>
       <GenAPITargetPath Condition="'$(GenAPITargetPath)' == ''">$(TargetDir)$(TargetName).cs</GenAPITargetPath>
-      <GenAPILibPath Condition="'$(GenAPILibPath)' == ''">@(ReferencePathWithRefAssemblies)</GenAPILibPath>
       <!-- When the GenAPIGenerateReferenceAssemblySource target is invoked directly, make sure the verbosity is high
            so that the generated reference source path is printed to the console. Otherwise emit the message with
            a low verbosity so that it doesn't appear on a console but still on logs. -->
@@ -37,13 +35,18 @@
       <GenAPIVerbosity Condition="'$(GenAPIVerbosity)' == '' and '$(GenAPIGenerateReferenceAssemblySource)' != 'true'">high</GenAPIVerbosity>
     </PropertyGroup>
 
+    <ItemGroup>
+      <GenAPIInputAssembly Include="@(IntermediateAssembly)" Condition="'@(GenAPIInputAssembly)' == ''" />
+      <GenAPILibPath Include="@(ReferencePathWithRefAssemblies)" Condition="'@(GenAPILibPath)' == ''" />
+    </ItemGroup>
+
     <Microsoft.DotNet.GenAPI.Task.GenAPITask
-      Assemblies="$(GenAPIInputAssembly)"
-      AssemblyReferences="$(GenAPILibPath)"
+      Assemblies="@(GenAPIInputAssembly)"
+      AssemblyReferences="@(GenAPILibPath)"
       OutputPath="$(GenAPITargetPath)"
       HeaderFile="$(GenAPIHeaderFile)"
       ExceptionMessage="$(GenAPIExceptionMessage)"
-      ExcludeAttributesFiles="$(GenAPIExcludeAttributesList)"
+      ExcludeAttributesFiles="@(GenAPIExcludeAttributesList)"
       IncludeVisibleOutsideOfAssembly="$(GenAPIIncludeVisibleOutsideOfAssembly)" />
 
     <Message Text="Generated reference assembly source code: $(GenAPITargetPath)" Importance="$(GenAPIVerbosity)" />

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and Exists('$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.GenAPI.Task.dll')">$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
     <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(DotNetGenAPITaskAssembly)' == ''">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
-  </PropertyGroup>
 
-  <PropertyGroup>
     <!-- Hook onto the TargetsTriggeredByCompilation target which only runs when the compiler is invoked. -->
     <TargetsTriggeredByCompilation Condition="'$(GenAPIGenerateReferenceAssemblySource)' == 'true'">
       $(TargetsTriggeredByCompilation);
       GenAPIGenerateReferenceAssemblySource
     </TargetsTriggeredByCompilation>
+    
+    <GenAPIGenerateReferenceAssemblySourceDependsOn>$(GenAPIGenerateReferenceAssemblySourceDependsOn);_GenAPIDontBuildProjectReferences;FindReferenceAssembliesForReferences</GenAPIGenerateReferenceAssemblySourceDependsOn>
   </PropertyGroup>
 
   <!-- Only run this target when the GenAPIGenerateReferenceAssemblySource target is invoked directly
@@ -25,7 +25,7 @@
   <UsingTask TaskName="Microsoft.DotNet.GenAPI.Task.GenAPITask" AssemblyFile="$(DotNetGenAPITaskAssembly)" />
 
   <Target Name="GenAPIGenerateReferenceAssemblySource"
-          DependsOnTargets="_GenAPIDontBuildProjectReferences;FindReferenceAssembliesForReferences">
+          DependsOnTargets="$(GenAPIGenerateReferenceAssemblySourceDependsOn)">
     <PropertyGroup>
       <GenAPITargetPath Condition="'$(GenAPITargetPath)' == ''">$(TargetDir)$(TargetName).cs</GenAPITargetPath>
       <!-- When the GenAPIGenerateReferenceAssemblySource target is invoked directly, make sure the verbosity is high

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -37,12 +37,12 @@
 
     <ItemGroup>
       <GenAPIInputAssembly Include="@(IntermediateAssembly)" Condition="'@(GenAPIInputAssembly)' == ''" />
-      <GenAPILibPath Include="@(ReferencePathWithRefAssemblies)" Condition="'@(GenAPILibPath)' == ''" />
+      <GenAPIAssemblyReference Include="@(ReferencePathWithRefAssemblies)" Condition="'@(GenAPIAssemblyReference)' == ''" />
     </ItemGroup>
 
     <Microsoft.DotNet.GenAPI.Task.GenAPITask
       Assemblies="@(GenAPIInputAssembly)"
-      AssemblyReferences="@(GenAPILibPath)"
+      AssemblyReferences="@(GenAPIAssemblyReference)"
       OutputPath="$(GenAPITargetPath)"
       HeaderFile="$(GenAPIHeaderFile)"
       ExceptionMessage="$(GenAPIExceptionMessage)"


### PR DESCRIPTION
* Implement and test MSBuild task for the Roslyn-based GenAPI.
* Introduced target similar to the CCi-based GenAPI, but with GenAPI prefix

https://github.com/dotnet/arcade/issues/11691