### PR TITLE
Make sure the test theories go into different folders.

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
@@ -295,7 +295,9 @@ public class ReferencedExeProgram
 
             CreateProjects();
 
-            RunTest();
+            RunTest(callingMethod: System.Reflection.MethodBase.GetCurrentMethod().ToString()
+                .Replace("Void ","")
+                .Replace("Boolean",referenceExeInCode.ToString()));
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]


### PR DESCRIPTION
Fixes #29008

The two test theories currently are going into the same folder.  This can cause issues and if the test failures and tries to rerun, it'll end up throwing an exception early as it'll find the test folder already exists.