### PR TITLE
Remove tmp from the default includes for tests

### DIFF
--- a/src/Assets/Directory.Build.props
+++ b/src/Assets/Directory.Build.props
@@ -6,5 +6,6 @@ get the build customization from the rest of the repo.
 <Project>
   <PropertyGroup>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/*.tmp</DefaultItemExcludes>
   </PropertyGroup>
 </Project>

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/*.tmp</DefaultItemExcludes>
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.props" />


### PR DESCRIPTION
https://github.com/dotnet/sdk/issues/27658

Test builds have been failing occasionally trying to copy a .tmp file that vanishes during the build. Let's try excluding that from the test builds and see if that helps.