### PR TITLE
 Improve build stability by ensuring we aren't double publishing everywhere

### DIFF
--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -52,7 +52,12 @@ stages:
           - _SignArgs: ''
           - _InternalRuntimeDownloadArgs: ''
         steps:
-        - script: eng\CIBuild.cmd
+        - powershell: eng\common\build.ps1
+                    -restore
+                    -ci
+                    -build
+                    -pack
+                    -sign
                     -configuration $(_BuildConfig)
                     $(_PublishArgs)
                     $(_SignArgs)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -14,6 +14,8 @@ variables:
     value: Roslyn-Project-System
   - name: _DotNetPublishToBlobFeed
     value: false
+  - name: _CIBuild
+    value: -restore -build -sign -pack -ci
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory

--- a/eng/CIBuild.cmd
+++ b/eng/CIBuild.cmd
@@ -1,2 +1,0 @@
-@echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" -restore -build -sign -pack -ci %*"

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -65,7 +65,8 @@ jobs:
         env:
           Token: $(dn-bot-dnceng-artifact-feeds-rw)
     - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-      - script: eng\CIBuild.cmd
+      - powershell: eng\common\build.ps1
+                  $(_CIBuild)
                   -configuration $(_BuildConfig)
                   $(_PublishArgs)
                   $(_SignArgs)
@@ -90,7 +91,8 @@ jobs:
             HelixAccessToken: $(_HelixApiToken)
 
     - ${{ if eq(parameters.agentOs, 'Windows_NT_FullFramework') }}:
-      - script: eng\CIBuild.cmd
+      - powershell: eng\common\build.ps1
+                  $(_CIBuild)
                   -configuration $(_BuildConfig)
                   $(_SignArgs)
                   $(_OfficialBuildIdArgs)
@@ -116,11 +118,11 @@ jobs:
             HelixAccessToken: $(_HelixApiToken)
 
     - ${{ if eq(parameters.agentOs, 'Windows_NT_TestAsTools') }}:
-      - script: eng\CIBuild.cmd
+      - powershell: eng\common\build.ps1
+                  $(_CIBuild)
                   -configuration $(_BuildConfig)
                   $(_SignArgs)
                   $(_OfficialBuildIdArgs)
-                  $(_Test)
                   $(_InternalRuntimeDownloadArgs)
                   /p:RunTestsAsTool=true
         displayName: Build
@@ -128,7 +130,8 @@ jobs:
           BuildConfig: $(_BuildConfig)
 
     - ${{ if notIn(parameters.agentOs, 'Windows_NT', 'Windows_NT_FullFramework', 'Windows_NT_TestAsTools') }}:
-      - script: eng/common/cibuild.sh
+      - script: eng/common/build.sh
+                  $(_CIBuild)
                   --configuration $(_BuildConfig)
                   $(_SignArgs)
                   $(_OfficialBuildIdArgs)


### PR DESCRIPTION
Port change from 7.0.1xx as we're still seeing the double publish in the 6.0.Nxx branches as well.
