### PR TITLE
[release/7.0.2xx] tab completion to suggest only first from short name synonyms

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.TabCompletion.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.TabCompletion.cs
@@ -16,23 +16,23 @@ namespace Microsoft.TemplateEngine.Cli.Commands
     {
         private static readonly TimeSpan ConstraintEvaluationTimeout = TimeSpan.FromMilliseconds(1000);
 
-        internal static IEnumerable<CompletionItem> GetTemplateNameCompletions(string? tempalteName, IEnumerable<TemplateGroup> templateGroups, IEngineEnvironmentSettings environmentSettings)
+        internal static IEnumerable<CompletionItem> GetTemplateNameCompletions(string? templateName, IEnumerable<TemplateGroup> templateGroups, IEngineEnvironmentSettings environmentSettings)
         {
             TemplateConstraintManager constraintManager = new(environmentSettings);
-            if (string.IsNullOrWhiteSpace(tempalteName))
+            if (string.IsNullOrWhiteSpace(templateName))
             {
                 return GetAllowedTemplateGroups(constraintManager, templateGroups)
-                    .SelectMany(g => g.ShortNames, (g, shortName) => new CompletionItem(shortName, documentation: g.Description))
+                    .Select(g => new CompletionItem(g.ShortNames[0], documentation: g.Description))
                     .Distinct()
                     .OrderBy(c => c.Label, StringComparer.OrdinalIgnoreCase)
                     .ToArray();
             }
 
-            IEnumerable<TemplateGroup> matchingTemplateGroups = templateGroups.Where(t => t.ShortNames.Any(sn => sn.StartsWith(tempalteName, StringComparison.OrdinalIgnoreCase)));
+            IEnumerable<TemplateGroup> matchingTemplateGroups =
+                templateGroups.Where(t => t.ShortNames.Any(sn => sn.StartsWith(templateName, StringComparison.OrdinalIgnoreCase)));
 
             return GetAllowedTemplateGroups(constraintManager, matchingTemplateGroups)
-                .SelectMany(g => g.ShortNames, (g, shortName) => new CompletionItem(shortName, documentation: g.Description))
-                .Where(c => c.Label.StartsWith(tempalteName))
+                .Select(g => new CompletionItem(g.ShortNames.First(sn => sn.StartsWith(templateName, StringComparison.OrdinalIgnoreCase)), documentation: g.Description))
                 .Distinct()
                 .OrderBy(c => c.Label, StringComparer.OrdinalIgnoreCase)
                 .ToArray();

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Create_GetAllSuggestions.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Create_GetAllSuggestions.verified.txt
@@ -49,13 +49,6 @@
     Documentation: Create an empty solution containing no projects
   },
   {
-    Label: solution,
-    Kind: Value,
-    SortText: solution,
-    InsertText: solution,
-    Documentation: Create an empty solution containing no projects
-  },
-  {
     Label: tool-manifest,
     Kind: Value,
     SortText: tool-manifest,

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.RootCommand_GetAllSuggestions.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.RootCommand_GetAllSuggestions.verified.txt
@@ -49,13 +49,6 @@
     Documentation: Create an empty solution containing no projects
   },
   {
-    Label: solution,
-    Kind: Value,
-    SortText: solution,
-    InsertText: solution,
-    Documentation: Create an empty solution containing no projects
-  },
-  {
     Label: tool-manifest,
     Kind: Value,
     SortText: tool-manifest,

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Linux.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Linux.verified.txt
@@ -16,12 +16,10 @@ nunit
 nunit-test
 page
 proto
-razor
 razorclasslib
 razorcomponent
 react
 sln
-solution
 tool-manifest
 viewimports
 viewstart

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.OSX.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.OSX.verified.txt
@@ -16,12 +16,10 @@ nunit
 nunit-test
 page
 proto
-razor
 razorclasslib
 razorcomponent
 react
 sln
-solution
 tool-manifest
 viewimports
 viewstart

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Windows.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Windows.verified.txt
@@ -16,12 +16,10 @@ nunit
 nunit-test
 page
 proto
-razor
 razorclasslib
 razorcomponent
 react
 sln
-solution
 tool-manifest
 viewimports
 viewstart


### PR DESCRIPTION
Ports small fix from https://github.com/dotnet/sdk/pull/27486: tab completion to suggest only first from short name synonyms