### PR TITLE
Deploy watch to redist

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="PublishDotnetWatch.targets"/>
+
   <Target Name="PublishVersionFile"
           BeforeTargets="Build">
 
@@ -187,20 +189,8 @@
   </Target>
 
   <Target Name="PublishBuiltInTools"
-          BeforeTargets="Build">
-
-    <PropertyGroup>
-      <DotnetWatchOutputDirectory>$(OutputPath)\DotnetTools\dotnet-watch\$(Version)\tools\$(SdkTargetFramework)\any\</DotnetWatchOutputDirectory>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <DotNetWatchFile Include="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**" />
-    </ItemGroup>
-
-    <Copy
-      SourceFiles="@(DotNetWatchFile)"
-      DestinationFiles="$(DotnetWatchOutputDirectory)%(RecursiveDir)%(Filename)%(Extension)" />
-  </Target>
+          DependsOnTargets="PublishDotnetWatch"
+          BeforeTargets="Build" />
 
   <Target Name="GenerateCliRuntimeConfigurationFiles"
           AfterTargets="Build">

--- a/src/Layout/redist/targets/PublishDotnetWatch.targets
+++ b/src/Layout/redist/targets/PublishDotnetWatch.targets
@@ -1,0 +1,23 @@
+<Project>
+  <Target Name="_PublishDotnetWatch_InputsOutputs">
+    <PropertyGroup>
+      <_DotnetWatchOutputDirectory>$(ArtifactsDir)bin\redist\$(Configuration)\dotnet\sdk\$(Version)\DotnetTools\dotnet-watch\$(Version)\tools\$(SdkTargetFramework)\any\</_DotnetWatchOutputDirectory>
+    </PropertyGroup>
+    <ItemGroup>
+      <_DotnetWatchInputFile Include="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**"/>
+      <_DotnetWatchOutputFile Include="@(_DotnetWatchInputFile->'$(_DotnetWatchOutputDirectory)%(RecursiveDir)%(Filename)%(Extension)')"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PublishDotnetWatch"
+          DependsOnTargets="_PublishDotnetWatch_InputsOutputs"
+          Inputs="@(_DotnetWatchInputFile)"
+          Outputs="@(_DotnetWatchOutputFile)">
+
+    <Copy SourceFiles="@(_DotnetWatchInputFile)" DestinationFiles="$(_DotnetWatchOutputDirectory)%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
+
+    <ItemGroup>
+      <FileWrites Include="@(_DotnetWatchOutputFile)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Layout/redist/targets/PublishDotnetWatch.targets
+++ b/src/Layout/redist/targets/PublishDotnetWatch.targets
@@ -5,14 +5,13 @@
     </PropertyGroup>
     <ItemGroup>
       <_DotnetWatchInputFile Include="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**"/>
-      <_DotnetWatchOutputFile Include="@(_DotnetWatchInputFile->'$(_DotnetWatchOutputDirectory)%(RecursiveDir)%(Filename)%(Extension)')"/>
     </ItemGroup>
   </Target>
 
   <Target Name="PublishDotnetWatch"
           DependsOnTargets="_PublishDotnetWatch_InputsOutputs"
           Inputs="@(_DotnetWatchInputFile)"
-          Outputs="@(_DotnetWatchOutputFile)">
+          Outputs="@(_DotnetWatchInputFile->'$(_DotnetWatchOutputDirectory)%(RecursiveDir)%(Filename)%(Extension)')">
 
     <Copy SourceFiles="@(_DotnetWatchInputFile)" DestinationFiles="$(_DotnetWatchOutputDirectory)%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
 

--- a/src/Tests/dotnet-watch.Tests/dotnet-watch.Tests.csproj
+++ b/src/Tests/dotnet-watch.Tests/dotnet-watch.Tests.csproj
@@ -1,4 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepoRoot)\src\Layout\redist\targets\PublishDotnetWatch.targets"/>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(ToolsetTargetFramework)</TargetFramework>
@@ -14,4 +16,11 @@
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
   </ItemGroup>
 
+  <!--
+  Tests are running dotnet.exe from redist artifacts. Publish the dotnet-watch binaries to the redist directory
+  before running them so that changes take effect without rebuilding the entire redist layout.
+  -->
+  <Target Name="PublishToRedist"
+          DependsOnTargets="PublishDotnetWatch"
+          BeforeTargets="AfterBuild" />
 </Project>


### PR DESCRIPTION
This allows us to avoid rebuilding the whole `redist` layout every single time a change is needed in donet-watch during inner loop.

Previous workflow in dotnet-watch project was extremely painful:

After every change:
1)  close VS to avoid 
```
D:\sdk\src\Layout\redist\targets\OverlaySdkOnLKG.targets(47,5): error MSB3026: Could not copy "D:\sdk\.dotnet\shared\Microsoft.NETCore.App\8.0.0-alpha.1.22575.4\mscordbi.dll" to "D:\sdk\artifacts\bin\redist\Debug\dotnet\\shared\Microsoft.NETCore.App\8.0.0-alpha.1.22575.4\mscordbi.dll". Beginning retry 1 in 1000ms. The process cannot access the file 'D:\sdk\artifacts\bin\redist\Debug\dotnet\shared\Microsoft.NETCore.App\8.0.0-alpha.1.22575.4\mscordbi.dll' because it is being used by another process. The file is locked by: "Microsoft Visual Studio 2022 Preview (65120)" [D:\sdk\src\Layout\redist\redist.csproj]
```
2) `taskkill /im dotnet.exe /f`
3) `taskkill /im msbuild.exe /f`
4) `build Redist.csproj`
5) Restart VS from `dogfood.cmd` environment.
6) Run test.
