### PR TITLE
dotnet nuget commands show correct help text

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -291,7 +291,7 @@ namespace Microsoft.DotNet.Cli
                 }
                 else if (command.Name.Equals(NuGetCommandParser.GetCommand().Name))
                 {
-                    NuGetCommand.Run(helpArgs);
+                    NuGetCommand.Run(context.ParseResult);
                 }
                 else if (command.Name.Equals(MSBuildCommandParser.GetCommand().Name))
                 {

--- a/src/Cli/dotnet/commands/dotnet-nuget/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/Program.cs
@@ -29,7 +29,12 @@ namespace Microsoft.DotNet.Tools.NuGet
             {
                 throw new ArgumentNullException(nameof(nugetCommandRunner));
             }
-
+            // replace -? with --help for NuGet CLI
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] == "-?")
+                    args[i] = "--help";
+            }
             return nugetCommandRunner.Run(args);
         }
 


### PR DESCRIPTION
Fixes #27833 
Pass in the entire `ParseResult` to `NuGetCommand` to forward the entire token stream so the help text displayed as a result of running `dotnet nuget [command] -h` is the correct help text for that specific command.

### Example
Running a specific NuGet command
```
PS C:\Users\Jacky\Documents\workspace\test-proj> dotnet nuget add -h


Usage: dotnet nuget add [options] [command]

Options:
  -h|--help  Show help information

Commands:
  client-cert  Adds a client certificate configuration that matches the given package source name.
  source       Add a NuGet source.

Use "add [command] --help" for more information about a command.
```
Running the NuGet top level command shows the top level help text
```
PS C:\Users\Jacky\Documents\workspace\test-proj> dotnet nuget -h
NuGet Command Line 6.5.0.104

Usage: dotnet nuget [options] [command]

Options:
  -h|--help  Show help information
  --version  Show version information

Commands:
  add      Add a NuGet source.
  delete   Deletes a package from the server.
  disable  Disable a NuGet source.
  enable   Enable a NuGet source.
  list     List configured NuGet sources.
  locals   Clears or lists local NuGet resources such as http requests cache, packages folder, plugin operations cache  or machine-wide global packages folder.
  push     Pushes a package to the server and publishes it.
  remove   Remove a NuGet source.
  sign     Signs NuGet package(s) at <package-paths> with the specified certificate.
  trust    Manage the trusted signers.
  update   Update a NuGet source.
  verify   Verifies a signed NuGet package.

Use "dotnet nuget [command] --help" for more information about a command.
```