### PR TITLE
[release/7.0.2xx] inverted language version conditions in console / classlib templates to support new language features for newer language versions

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -85,23 +85,31 @@
       "defaultValue": "false",
       "displayName": "Skip restore"
     },
-    "csharp10orLater": {
+    "csharp9orOlder": {
       "type": "generated",
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|11|11\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(ISO-1|ISO-2|[1-7]|[8-9]|[8-9]\\.0|7\\.[0-3])$",
         "source": "langVersion"
       }
     },
-    "csharp8orLater": {
+    "csharp7orOlder": {
       "type": "generated",
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|11|11\\.0|preview|latest|default|latestMajor)$",
+        "pattern": "^(ISO-1|ISO-2|[1-7]|7\\.[0-3])$",
         "source": "langVersion"
       }
+    },
+    "csharp10orLater": {
+      "type": "computed",
+      "value": "!csharp9orOlder"
+    },
+    "csharp8orLater": {
+      "type": "computed",
+      "value": "!csharp7orOlder"
     },
     "csharpFeature_ImplicitUsings": {
       "type": "computed",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -68,32 +68,44 @@
       "description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
       "displayName": "Do not use _top-level statements"
     },
-    "csharp10orLater": {
+    "csharp9orOlder": {
       "type": "generated",
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|11|11\\.0|preview|latest|default|latestMajor)$",
+        "pattern": "^(ISO-1|ISO-2|[1-7]|[8-9]|[8-9]\\.0|7\\.[0-3])$",
         "source": "langVersion"
       }
+    },
+    "csharp8orOlder": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "pattern": "^(ISO-1|ISO-2|[1-7]|8|8\\.0|7\\.[0-3])$",
+        "source": "langVersion"
+      }
+    },
+    "csharp7orOlder": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "pattern": "^(ISO-1|ISO-2|[1-7]|7\\.[0-3])$",
+        "source": "langVersion"
+      }
+    },
+    "csharp10orLater": {
+      "type": "computed",
+      "value": "!csharp9orOlder"
     },
     "csharp9orLater": {
-      "type": "generated",
-      "generator": "regexMatch",
-      "datatype": "bool",
-      "parameters": {
-        "pattern": "^(|9|9\\.0|10\\.0|10|11|11\\.0|preview|latest|default|latestMajor)$",
-        "source": "langVersion"
-      }
+      "type": "computed",
+      "value": "!csharp8orOlder"
     },
     "csharp8orLater": {
-      "type": "generated",
-      "generator": "regexMatch",
-      "datatype": "bool",
-      "parameters": {
-        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|11|11\\.0|preview|latest|default|latestMajor)$",
-        "source": "langVersion"
-      }
+      "type": "computed",
+      "value": "!csharp7orOlder"
     },
     "csharpFeature_ImplicitUsings": {
       "type": "computed",


### PR DESCRIPTION
### Problem
fixes https://github.com/dotnet/templating/issues/5668

### Description
The net7.0 templates will generate the old syntax for the next version of C# (when it is released).
In the fix the condition on language version was reverted, so the default behavior is new syntax and further language versions will use the new syntax.


