### PR TITLE
Do not copy dotnet-watch to Redist in redist.csproj

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -1,6 +1,4 @@
 <Project>
-  <Import Project="PublishDotnetWatch.targets"/>
-
   <Target Name="PublishVersionFile"
           BeforeTargets="Build">
 
@@ -188,10 +186,6 @@
       Projects="$(RepoRoot)/src/Layout/tool_fsharp/tool_fsc.csproj"
       Properties="Configuration=$(Configuration);PublishDir=$(OutputPath)/FSharp" />
   </Target>
-
-  <Target Name="PublishBuiltInTools"
-          DependsOnTargets="PublishDotnetWatch"
-          BeforeTargets="Build" />
 
   <Target Name="GenerateCliRuntimeConfigurationFiles"
           AfterTargets="Build">


### PR DESCRIPTION
It is already done in dontet-watch.csproj.

Fixes build race conditions like https://github.com/dotnet/sdk/pull/29257#issuecomment-1333985395:

```
src\Layout\redist\targets\PublishDotnetWatch.targets(16,5): error MSB3026: (NETCORE_ENGINEERING_TELEMETRY=Build) Could not copy "D:\a_work\1\s\artifacts\bin\dotnet-watch\Release\net8.0\cs\Microsoft.CodeAnalysis.Features.resources.dll" to "D:\a_work\1\s\artifacts\bin\redist\Release\dotnet\sdk\8.0.100-ci\DotnetTools\dotnet-watch\8.0.100-ci\tools\net8.0\any\cs\Microsoft.CodeAnalysis.Features.resources.dll". Beginning retry 1 in 1000ms. The process cannot access the file 'D:\a_work\1\s\artifacts\bin\redist\Release\dotnet\sdk\8.0.100-ci\DotnetTools\dotnet-watch\8.0.100-ci\tools\net8.0\any\cs\Microsoft.CodeAnalysis.Features.resources.dll' because it is being used by another process.
```