### PR TITLE
Respect EnableRuntimePackDownload switch for AOT and R2R

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -610,10 +610,13 @@ namespace Microsoft.NET.Build.Tasks
                 packVersion = RuntimeFrameworkVersion;
             }
 
-            // We need to download the runtime pack
-            TaskItem runtimePackToDownload = new TaskItem(runtimePackName);
-            runtimePackToDownload.SetMetadata(MetadataKeys.Version, packVersion);
-            packagesToDownload.Add(runtimePackToDownload);
+            if (EnableRuntimePackDownload)
+            {
+                // We need to download the runtime pack
+                TaskItem runtimePackToDownload = new TaskItem(runtimePackName);
+                runtimePackToDownload.SetMetadata(MetadataKeys.Version, packVersion);
+                packagesToDownload.Add(runtimePackToDownload);
+            }
 
             var newItem = new TaskItem(runtimePackName);
             newItem.SetMetadata(MetadataKeys.NuGetPackageId, runtimePackName);


### PR DESCRIPTION
The ILCompiler and R2R runtime packages are always restored, even when the `EnableRuntimePackDownload` is set to false. Fixing that so that we don't bring in a pre-built in dotnet/runtime and can use the live built components instead.