### PR TITLE
Add option for specifying the version of machine-readable output of dotnet list package command

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -63,6 +63,9 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option FormatOption = new ForwardedOption<ReportOutputFormat>("--format", LocalizableStrings.CmdFormatDescription)
         { }.ForwardAsSingle(o => $"--format:{o}");
 
+        public static readonly Option OutputVersiontOption = new ForwardedOption<int>("--output-version", LocalizableStrings.CmdOutputVersionDescription)
+        { }.ForwardAsSingle(o => $"--output-version:{o}");
+
         private static readonly Command Command = ConstructCommand();
 
         public static Command GetCommand()
@@ -87,6 +90,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(SourceOption);
             command.AddOption(InteractiveOption);
             command.AddOption(FormatOption);
+            command.AddOption(OutputVersiontOption);
 
             command.SetHandler((parseResult) => new ListPackageReferencesCommand(parseResult).Execute());
 

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(SourceOption);
             command.AddOption(InteractiveOption);
             command.AddOption(FormatOption);
-            command.AddOption(OutputVersiontOption);
+            command.AddOption(OutputVersionOption);
 
             command.SetHandler((parseResult) => new ListPackageReferencesCommand(parseResult).Execute());
 

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option FormatOption = new ForwardedOption<ReportOutputFormat>("--format", LocalizableStrings.CmdFormatDescription)
         { }.ForwardAsSingle(o => $"--format:{o}");
 
-        public static readonly Option OutputVersiontOption = new ForwardedOption<int>("--output-version", LocalizableStrings.CmdOutputVersionDescription)
+        public static readonly Option OutputVersionOption = new ForwardedOption<int>("--output-version", LocalizableStrings.CmdOutputVersionDescription)
         { }.ForwardAsSingle(o => $"--output-version:{o}");
 
         private static readonly Command Command = ConstructCommand();

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
@@ -171,4 +171,7 @@
   <data name="CmdFormatDescription" xml:space="preserve">
     <value>Specifies the output format type for the list packages command.</value>
   </data>
+  <data name="CmdOutputVersionDescription" xml:space="preserve">
+    <value>Specifies the output version for the machine readable list packages command output.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
@@ -172,6 +172,6 @@
     <value>Specifies the output format type for the list packages command.</value>
   </data>
   <data name="CmdOutputVersionDescription" xml:space="preserve">
-    <value>Specifies the output version for the machine readable list packages command output.</value>
+    <value>Specifies the version of machine-readable output with '--format json' option</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
@@ -172,6 +172,6 @@
     <value>Specifies the output format type for the list packages command.</value>
   </data>
   <data name="CmdOutputVersionDescription" xml:space="preserve">
-    <value>Specifies the version of machine-readable output with '--format json' option</value>
+    <value>Specifies the version of machine-readable output. Requires the '--format json' option.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Vypíše balíčky, které mají novější verze. Nedá se kombinovat s možností --deprecated ani --vulnerable.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Vypíše seznam přenosných balíčků a balíčků nejvyšší úrovně.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Listet Pakete mit neueren Versionen auf. Kann nicht mit den Optionen "--deprecated" oder "--vulnerable" kombiniert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Listet transitive Pakete und Pakete der obersten Ebene auf.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Muestra los paquetes que tienen versiones más recientes. No se puede combinar con las opciones '--deprecated" o "--vulnerable".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Contiene paquetes de transitivos y de nivel superior.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Liste les packages qui ont versions plus récentes. Impossible à combiner avec les options '--deprecated' ou '--vulnerable'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Liste les packages transitifs et de niveau supérieur.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Elenca i pacchetti con versioni più recenti. Non può essere combinato con l'opzione '--deprecated' o '--vulnerable'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Elenca i pacchetti transitivi e di primo livello.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">新しいバージョンのパッケージを一覧表示します。'--deprecated' または '--vulnerable' オプションと組み合わせることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">推移的なパッケージと最上位レベルのパッケージを一覧表示します。</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">최신 버전이 포함된 패키지를 나열합니다. '--deprecated' 또는 '--vulnerable' 옵션과 함께 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">전이적 패키지 및 최상위 패키지를 나열합니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Wyświetla pakiety, które mają nowszą wersję. Nie można łączyć z opcją „--deprecated” ani „--vulnerable”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Zwraca listę pakietów przejściowych i pakietów najwyższego poziomu.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Lista os pacotes que têm versões mais recentes. Não pode ser combinado com a opção '--deprecated' nem com a opção '--vulnerable'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Lista os pacotes de nível superior e transitivos.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Возвращает список пакетов, у которых есть более новые версии. Не может использоваться с параметрами "--deprecated" или "--vulnerable".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Список транзитивных пакетов и пакетов верхнего уровня.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Daha yeni sürümlere sahip paketleri listeler. '--deprecated' veya '--vulnerable' seçenekleriyle birleştirilemez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Geçişli ve üst düzey paketleri listeler.</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">列出具有较新版本的包。不能与 "--deprecated" 或 "--vulnerable" 选项结合使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">列出可传递的包和顶级包。</target>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the version of machine-readable output with '--format json' option</source>
-        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
+        <source>Specifies the version of machine-readable output. Requires the '--format json' option.</source>
+        <target state="new">Specifies the version of machine-readable output. Requires the '--format json' option.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutputVersionDescription">
-        <source>Specifies the output version for the machine readable list packages command output.</source>
-        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <source>Specifies the version of machine-readable output with '--format json' option</source>
+        <target state="new">Specifies the version of machine-readable output with '--format json' option</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">列出有更新版本的套件。無法與 '--deprecated' 或 '--vulnerable' 選項一併使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOutputVersionDescription">
+        <source>Specifies the output version for the machine readable list packages command output.</source>
+        <target state="new">Specifies the output version for the machine readable list packages command output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">列出可轉移和頂層套件。</target>


### PR DESCRIPTION
Related to: https://github.com/NuGet/NuGet.Client/pull/4855
Add new `--output-version` option for machine readable output of `dotnet list package` command. I forgot to include in https://github.com/dotnet/sdk/pull/29017
It would be used like below:
` dotnet list package --format json --output-version 1`