### PR TITLE
Remove unnecessary sources from the test used nuget.config file to reduce 429s

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -28,7 +28,18 @@ robocopy %HELIX_CORRELATION_PAYLOAD%\t\TestExecutionDirectoryFiles %TestExecutio
 REM call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive
 REM avoid potetial concurrency issues when nuget is creating nuget.config
-dotnet nuget list source
+dotnet nuget list source --configfile %TestExecutionDirectory%\nuget.config
 REM We downloaded a special zip of files to the .nuget folder so add that as a source
-dotnet new nugetconfig
-dotnet nuget add source %DOTNET_ROOT%\.nuget --configfile nuget.config
+dotnet nuget add source %DOTNET_ROOT%\.nuget --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet6-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet6-internal-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet7-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet7-internal-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source richnav --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source vs-impl --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet-libraries-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet-tools-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet-libraries --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet-tools --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet-eng --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget list source --configfile %TestExecutionDirectory%\nuget.config

--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -40,6 +40,5 @@ dotnet nuget remove source vs-impl --configfile %TestExecutionDirectory%\nuget.c
 dotnet nuget remove source dotnet-libraries-transport --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget remove source dotnet-tools-transport --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget remove source dotnet-libraries --configfile %TestExecutionDirectory%\nuget.config
-dotnet nuget remove source dotnet-tools --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget remove source dotnet-eng --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget list source --configfile %TestExecutionDirectory%\nuget.config

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -17,6 +17,17 @@ cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionD
 # call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive
 # We downloaded a special zip of files to the .nuget folder so add that as a source
-dotnet new nugetconfig
-dotnet nuget add source $DOTNET_ROOT/.nuget --configfile nuget.config
-dotnet nuget list source
+dotnet nuget add source $DOTNET_ROOT/.nuget --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget list source --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source dotnet6-transport --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source dotnet6-internal-transport --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source dotnet7-transport --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source dotnet7-internal-transport --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source richnav --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source vs-impl --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source dotnet-libraries-transport --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source dotnet-tools-transport --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source dotnet-libraries --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source dotnet-tools --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget remove source dotnet-eng --configfile $TestExecutionDirectory/nuget.config
+dotnet nuget list source --configfile $TestExecutionDirectory/nuget.config

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -28,6 +28,5 @@ dotnet nuget remove source vs-impl --configfile $TestExecutionDirectory/nuget.co
 dotnet nuget remove source dotnet-libraries-transport --configfile $TestExecutionDirectory/nuget.config
 dotnet nuget remove source dotnet-tools-transport --configfile $TestExecutionDirectory/nuget.config
 dotnet nuget remove source dotnet-libraries --configfile $TestExecutionDirectory/nuget.config
-dotnet nuget remove source dotnet-tools --configfile $TestExecutionDirectory/nuget.config
 dotnet nuget remove source dotnet-eng --configfile $TestExecutionDirectory/nuget.config
 dotnet nuget list source --configfile $TestExecutionDirectory/nuget.config


### PR DESCRIPTION
Every package is simultaneously queried on every source. We believe this is what's causing us to get throttled and results in 429s and 503 errors in our tests when there are lots of PRs open at once.