### PR TITLE
Fix for ClickOnce publish test failure 

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Publish.Tests
         {
         }
 
-        [FullMSBuildOnlyTheory(Skip = "https://github.com/dotnet/sdk/issues/27766")]
+        [FullMSBuildOnlyTheory]
         [InlineData(false)]
         [InlineData(true)]
         public void PublishClickOnceWithPublishProfile(bool? publishSingleFile)
@@ -44,12 +44,24 @@ namespace Microsoft.NET.Publish.Tests
 
             var projectDirectory = Path.Combine(testProjectInstance.Path, testProject.Name);
             var publishProfilesDirectory = Path.Combine(projectDirectory, "Properties", "PublishProfiles");
-            Directory.CreateDirectory(publishProfilesDirectory);
 
+            var command = new PublishCommand(testProjectInstance);
+            DirectoryInfo outputDirectory = null;
+            if (publishSingleFile == true)
+            {
+                outputDirectory = command.GetOutputDirectory(targetFramework: tfm, runtimeIdentifier: rid);
+            }
+            else
+            {
+                outputDirectory = command.GetOutputDirectory(targetFramework: tfm);
+            }
+
+            Directory.CreateDirectory(publishProfilesDirectory);
             File.WriteAllText(Path.Combine(publishProfilesDirectory, "test.pubxml"), $@"
 <Project>
   <PropertyGroup>
     <PublishUrl>publish\</PublishUrl>
+    <PublishDir>{outputDirectory}</PublishDir>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
     <ApplicationRevision>4</ApplicationRevision>
@@ -63,55 +75,43 @@ namespace Microsoft.NET.Publish.Tests
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <SelfContained>false</SelfContained>
     {(publishSingleFile.HasValue ? $"<PublishSingleFile>{publishSingleFile}</PublishSingleFile>" : "")}
-    {(publishSingleFile ?? false ? $"<RuntimeIdentifier>{rid}</RuntimeIdentifier>" : "")}
+    {(publishSingleFile == true ? $"<RuntimeIdentifier>{rid}</RuntimeIdentifier>" : "")}
   </PropertyGroup>
 </Project>
 ");
 
-            var command = new PublishCommand(testProjectInstance);
             command
                 .Execute("/p:PublishProfile=test")
                 .Should()
                 .Pass();
 
-            DirectoryInfo output = null;
-            if (publishSingleFile ?? false)
-            {
-                output = command.GetOutputDirectory(targetFramework: tfm, runtimeIdentifier: rid);
-            }
-            else
-            {
-                output = command.GetOutputDirectory(targetFramework: tfm);
-            }
-            output = output.Parent;
-
-            output.Should().HaveFiles(new[] {
-                $"app.Publish\\setup.exe",
-                $"app.Publish\\{testProject.Name}.application",
-                $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\launcher{Constants.ExeSuffix}",
+            outputDirectory.Should().HaveFiles(new[] {
+                $"setup.exe",
+                $"{testProject.Name}.application",
+                $"application files\\{testProject.Name}_1_2_3_4\\launcher{Constants.ExeSuffix}",
             });
 
-            if (publishSingleFile ?? false)
+            if (publishSingleFile == true)
             {
-                output.Should().HaveFiles(new[] {
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}{Constants.ExeSuffix}",
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll.manifest",
+                outputDirectory.Should().HaveFiles(new[] {
+                    $"application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}{Constants.ExeSuffix}",
+                    $"application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll.manifest",
                 });
-                output.Should().NotHaveFiles(new[] {
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll",
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\Newtonsoft.Json.dll",
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.deps.json",
+                outputDirectory.Should().NotHaveFiles(new[] {
+                    $"application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll",
+                    $"application files\\{testProject.Name}_1_2_3_4\\Newtonsoft.Json.dll",
+                    $"application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.deps.json",
                 });
             }
             else
             {
-                output.Should().HaveFiles(new[] {
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll",
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll.manifest",
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\Newtonsoft.Json.dll",
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.deps.json",
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.runtimeconfig.json",
-                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}{Constants.ExeSuffix}",
+                outputDirectory.Should().HaveFiles(new[] {
+                    $"application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll",
+                    $"application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll.manifest",
+                    $"application files\\{testProject.Name}_1_2_3_4\\Newtonsoft.Json.dll",
+                    $"application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.deps.json",
+                    $"application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.runtimeconfig.json",
+                    $"application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}{Constants.ExeSuffix}",
                 });
             }
         }


### PR DESCRIPTION
Fixes #27766 

The ClickOnce test is failing because it has not been updated for a corresponding change in the msbuild repo to set PublishDir property in the publish profile. 