### PR TITLE
Use linker matching TFM

### DIFF
--- a/src/Layout/redist/targets/BundledSdks.targets
+++ b/src/Layout/redist/targets/BundledSdks.targets
@@ -4,6 +4,5 @@
     <BundledSdk Include="Microsoft.NET.Sdk.WindowsDesktop" Version="$(MicrosoftNETSdkWindowsDesktopPackageVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.4-bundled-0100" />
     <BundledSdk Include="Microsoft.Docker.Sdk" Version="1.1.0" />
-    <BundledSdk Include="Microsoft.NET.ILLink.Tasks" Version="$(MicrosoftNETILLinkTasksPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -63,6 +63,7 @@
     <OverrideAndCreateBundledNETCoreAppPackageVersion
       Stage0MicrosoftNETCoreAppRefPackageVersionPath="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/Microsoft.NETCoreSdk.BundledVersions.props"
       MicrosoftNETCoreAppRefPackageVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
+      MicrosoftNETILLinkTasksPackageVersion="$(MicrosoftNETILLinkTasksPackageVersion)"
       NewSDKVersion="$(Version)"
       OutputPath="$(SdkOutputDirectory)/Microsoft.NETCoreSdk.BundledVersions.props"/>
 

--- a/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
+++ b/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
+++ b/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
@@ -35,6 +35,11 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required] public string Stage0MicrosoftNETCoreAppRefPackageVersionPath { get; set; }
 
         [Required] public string MicrosoftNETCoreAppRefPackageVersion { get; set; }
+
+        // TODO: remove this once linker packages are produced from dotnet/runtime
+        // and replace it with MicrosoftNETCoreAppRefPackageVersion.
+        [Required] public string MicrosoftNETILLinkTasksPackageVersion { get; set; }
+
         [Required] public string NewSDKVersion { get; set; }
 
         [Required] public string OutputPath { get; set; }
@@ -45,6 +50,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 ExecuteInternal(
                     File.ReadAllText(Stage0MicrosoftNETCoreAppRefPackageVersionPath),
                     MicrosoftNETCoreAppRefPackageVersion,
+                    MicrosoftNETILLinkTasksPackageVersion,
                     NewSDKVersion));
             return true;
         }
@@ -52,6 +58,7 @@ namespace Microsoft.DotNet.Build.Tasks
         public static string ExecuteInternal(
             string stage0MicrosoftNETCoreAppRefPackageVersionContent,
             string microsoftNETCoreAppRefPackageVersion,
+            string microsoftNETILLinkTasksPackageVersion,
             string newSDKVersion)
         {
             var projectXml = XDocument.Parse(stage0MicrosoftNETCoreAppRefPackageVersionContent);
@@ -125,6 +132,24 @@ namespace Microsoft.DotNet.Build.Tasks
 
             CheckAndReplaceAttribute(itemGroup
                 .Elements(ns + "KnownRuntimePack").First().Attribute("LatestRuntimeFrameworkVersion"));
+
+            // TODO: remove this once we're using an SDK that contains KnownILLinkPack.
+            {
+                itemGroup.Add(new XElement(ns + "KnownILLinkPack",
+                    new XAttribute("Include", "Microsoft.NET.ILLink.Tasks"),
+                    new XAttribute("TargetFramework", "net8.0"),
+                    new XAttribute("ILLinkPackVersion", microsoftNETILLinkTasksPackageVersion)));
+
+                // Use 7.0 linker when targeting supported RIDS <= net7.0.
+                var net70Version = "7.0.100-1.22579.2";
+
+                foreach (var tfm in new[] { "net7.0", "net6.0", "net5.0", "netcoreapp3.1", "netcoreapp3.0" }) {
+                    itemGroup.Add(new XElement(ns + "KnownILLinkPack",
+                        new XAttribute("Include", "Microsoft.NET.ILLink.Tasks"),
+                        new XAttribute("TargetFramework", tfm),
+                        new XAttribute("ILLinkPackVersion", net70Version)));
+                }
+            }
 
             return projectXml.ToString();
         }

--- a/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
+++ b/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.Build.Tasks
             CheckAndReplaceAttribute(itemGroup
                 .Elements(ns + "KnownRuntimePack").First().Attribute("LatestRuntimeFrameworkVersion"));
 
-            // TODO: remove this once we're using an SDK that contains KnownILLinkPack.
+            // TODO: remove this once we're using an SDK that contains KnownILLinkPack: https://github.com/dotnet/installer/pull/15106
             {
                 itemGroup.Add(new XElement(ns + "KnownILLinkPack",
                     new XAttribute("Include", "Microsoft.NET.ILLink.Tasks"),

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -883,4 +883,8 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1194: The "--output" option isn't supported when building a solution.</value>
     <comment>{StrBegin="NETSDK1194: "}</comment>
   </data>
+  <data name="ILLinkNoValidRuntimePackageError" xml:space="preserve">
+    <value>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</value>
+    <comment>{StrBegin="NETSDK1195: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: Optimalizace velikosti sestavení neproběhla úspěšně. Optimalizaci je možné zakázat tím, že se nastaví vlastnost PublishTrimmed na false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: Pro vybranou konfiguraci publikování se optimalizace velikosti sestavení nepodporuje. Ujistěte se, že publikujete samostatnou aplikaci.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: Fehler bei der Größenoptimierung von Assemblys. Die Optimierung kann durch Festlegen der PublishTrimmed-Eigenschaft auf FALSE deaktiviert werden.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: Die Größenoptimierung von Assemblys wird für die ausgewählte Veröffentlichungskonfiguration nicht unterstützt. Stellen Sie sicher, dass Sie eine eigenständige App veröffentlichen.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: Error al optimizar el tamaño de los ensamblados. Para deshabilitar la optimización, establezca la propiedad PublishTrimmed en false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: No se admite la optimización de tamaño de los ensamblados para la configuración de publicación seleccionada. Asegúrese de que está publicando una aplicación autónoma.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: L'optimisation de la taille des assemblys a échoué. Vous pouvez désactiver l'optimisation en affectant à la propriété PublishTrimmed la valeur false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: l'optimisation de la taille des assemblys n'est pas prise en charge pour la configuration de publication sélectionnée. Vérifiez que vous publiez une application autonome.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: l'ottimizzazione degli assembly per le dimensioni non è riuscita. È possibile disabilitare l'ottimizzazione impostando la proprietà PublishTrimmed su false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: l'ottimizzazione degli assembly per le dimensioni non è supportata per la configurazione di pubblicazione selezionata. Assicurarsi di pubblicare un'app indipendente.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -454,6 +454,11 @@
         <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="new">NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: 어셈블리의 크기를 최적화하지 못했습니다. PublishTrimmed 속성을 false로 설정하여 최적화를 사용하지 않도록 설정할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: 선택한 게시 구성에서는 크기에 대한 어셈블리 최적화가 지원되지 않습니다. 자체 포함 앱을 게시하고 있는지 확인하세요.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: Optymalizacja zestawów pod kątem rozmiaru nie powiodła się. Optymalizacja może zostać wyłączona przez ustawienie właściwości PublishTrimmed na wartość false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: Optymalizacja zestawów pod kątem rozmiaru nie jest obsługiwana w przypadku wybranej konfiguracji publikowania. Upewnij się, że publikujesz niezależną aplikację.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: Falha na otimização de assemblies de tamanho. A otimização pode ser desabilitada definindo a propriedade PublishTrimmed como false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: não há suporte para a otimização de assemblies para tamanho na configuração de publicação selecionada. Verifique se você está publicando um aplicativo independente.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: не удалось оптимизировать сборки под размер. Оптимизацию можно отключить, установив значение false для свойства PublishTrimmed.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: оптимизация сборок по размеру не поддерживается для выбранной конфигурации публикации. Убедитесь, что вы публикуете автономное приложение.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: Bütünleştirilmiş kodlar boyut için iyileştirilemedi. İyileştirme, PublishTrimmed özelliği false olarak ayarlanarak devre dışı bırakılabilir.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: Derlemeleri boyut için iyileştirme, seçilen yayımlama yapılandırması için desteklenmiyor. Lütfen kendi içinde bulunan bir uygulama yayımladığınızdan emin olun.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: 优化程序集的大小失败。通过将 PublishTrimmed 属性设置为 false 可禁用优化。</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: 所选发布配置不支持优化程序集的大小。请确保你发布的是独立应用。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -454,6 +454,11 @@
         <target state="translated">NETSDK1144: 將元件大小最佳化失敗。將 PublishTrimmed 屬性設定為 false，可停用最佳化。</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkNoValidRuntimePackageError">
+        <source>NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</source>
+        <target state="new">NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing.</target>
+        <note>{StrBegin="NETSDK1195: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: 選取的發佈設定不支援最佳化組件的大小。請確定您發佈的是獨立式應用程式。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -125,7 +125,6 @@
       <!-- Include some of the Sdks from the Stage 0 CLI for performance tests-->
       <Stage0SdkFile Include="$(_Stage0SdksFolder)\FSharp.NET.Sdk\**" SdkName="FSharp.NET.Sdk" />
       <Stage0SdkFile Include="$(_Stage0SdksFolder)\Microsoft.NET.Sdk.WindowsDesktop\**" SdkName="Microsoft.NET.Sdk.WindowsDesktop" />
-      <Stage0SdkFile Include="$(_Stage0SdksFolder)\Microsoft.NET.ILLink.Tasks\**" SdkName="Microsoft.NET.ILLink.Tasks" />
       <LayoutFile Include="@(Stage0SdkFile)">
         <TargetPath>..\%(Stage0SdkFile.SdkName)\%(Stage0SdkFile.RecursiveDir)%(Stage0SdkFile.Filename)%(Stage0SdkFile.Extension)</TargetPath>
       </LayoutFile>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -631,7 +631,8 @@ namespace Microsoft.NET.Build.Tasks
 
             
             // Crossgen and ILCompiler have RID-specific bits.
-            if (toolPackType is ToolPackType.Crossgen2 or ToolPackType.ILCompiler) {
+            if (toolPackType is ToolPackType.Crossgen2 or ToolPackType.ILCompiler)
+            {
                 var packNamePattern = knownPack.GetMetadata(packName + "PackNamePattern");
                 var packSupportedRuntimeIdentifiers = knownPack.GetMetadata(packName + "RuntimeIdentifiers").Split(';');
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -377,8 +377,8 @@ namespace Microsoft.NET.Build.Tasks
                     return;
                 }
             }
-            // Only add ILLink for non-AOT trimming.
-            else if (TrimmingEnabled)
+
+            if (TrimmingEnabled)
             {
                 if (!AddToolPack(ToolPackType.ILLink, _normalizedTargetFrameworkVersion, packagesToDownload, implicitPackageReferences))
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -44,6 +44,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool ReadyToRunUseCrossgen2 { get; set; }
 
+        public bool TrimmingEnabled { get; set; }
+
         public bool AotEnabled { get; set; }
 
         public string RuntimeIdentifier { get; set; }
@@ -72,7 +74,9 @@ namespace Microsoft.NET.Build.Tasks
 
         public ITaskItem[] KnownCrossgen2Packs { get; set; } = Array.Empty<ITaskItem>();
 
-        public ITaskItem[] KnownILCompilerPacks { get; set; } = Array.Empty<ITaskItem>();        
+        public ITaskItem[] KnownILCompilerPacks { get; set; } = Array.Empty<ITaskItem>();
+
+        public ITaskItem[] KnownILLinkPacks { get; set; } = Array.Empty<ITaskItem>();
 
         [Required]
         public string NETCoreSdkRuntimeIdentifier { get; set; }
@@ -354,9 +358,11 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
+            List<ITaskItem> implicitPackageReferences = new List<ITaskItem>();
+
             if (ReadyToRunEnabled && ReadyToRunUseCrossgen2)
             {
-                if (!AddAotOrR2RRuntimePackage(AotPackageType.Crossgen2, _normalizedTargetFrameworkVersion, packagesToDownload))
+                if (!AddToolPack(ToolPackType.Crossgen2, _normalizedTargetFrameworkVersion, packagesToDownload, implicitPackageReferences))
                 {
                     Log.LogError(Strings.ReadyToRunNoValidRuntimePackageError);
                     return;
@@ -365,12 +371,21 @@ namespace Microsoft.NET.Build.Tasks
             
             if (AotEnabled)
             {
-                if (!AddAotOrR2RRuntimePackage(AotPackageType.ILCompiler, _normalizedTargetFrameworkVersion, packagesToDownload))
+                if (!AddToolPack(ToolPackType.ILCompiler, _normalizedTargetFrameworkVersion, packagesToDownload, implicitPackageReferences))
                 {
                     Log.LogError(Strings.AotNoValidRuntimePackageError);
                     return;
                 }
-            }            
+            }
+            // Only add ILLink for non-AOT trimming.
+            else if (TrimmingEnabled)
+            {
+                if (!AddToolPack(ToolPackType.ILLink, _normalizedTargetFrameworkVersion, packagesToDownload, implicitPackageReferences))
+                {
+                    Log.LogError(Strings.ILLinkNoValidRuntimePackageError);
+                    return;
+                }
+            }
 
             if (packagesToDownload.Any())
             {
@@ -395,6 +410,11 @@ namespace Microsoft.NET.Build.Tasks
             if (unavailableRuntimePacks.Any())
             {
                 UnavailableRuntimePacks = unavailableRuntimePacks.ToArray();
+            }
+
+            if (implicitPackageReferences.Any())
+            {
+                ImplicitPackageReferences = implicitPackageReferences.ToArray();
             }
         }
 
@@ -569,15 +589,27 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private enum AotPackageType
+        // Enum values should match the name of the pack: Known<Foo>Pack
+        private enum ToolPackType
         {
             Crossgen2,
-            ILCompiler
+            ILCompiler,
+            ILLink
         }
 
-        private bool AddAotOrR2RRuntimePackage(AotPackageType packageType, Version normalizedTargetFrameworkVersion, List<ITaskItem> packagesToDownload)
+        private bool AddToolPack(
+            ToolPackType toolPackType,
+            Version normalizedTargetFrameworkVersion,
+            List<ITaskItem> packagesToDownload,
+            List<ITaskItem> implicitPackageReferences)
         {
-            var knownPacks = packageType == AotPackageType.Crossgen2 ? KnownCrossgen2Packs : KnownILCompilerPacks;
+            var knownPacks = toolPackType switch {
+                ToolPackType.Crossgen2 => KnownCrossgen2Packs,
+                ToolPackType.ILCompiler => KnownILCompilerPacks,
+                ToolPackType.ILLink => KnownILLinkPacks,
+                _ => throw new ArgumentException($"Unknown package type {toolPackType}", nameof(toolPackType))
+            };
+
             var knownPack = knownPacks.Where(pack =>
             {
                 var packTargetFramework = NuGetFramework.Parse(pack.GetMetadata("TargetFramework"));
@@ -590,67 +622,78 @@ namespace Microsoft.NET.Build.Tasks
                 return false;
             }
 
-            var packageName = packageType == AotPackageType.Crossgen2 ? "Crossgen2" : "ILCompiler";
-
-            var packPattern = knownPack.GetMetadata(packageName + "PackNamePattern");
-            var packVersion = knownPack.GetMetadata(packageName + "PackVersion");
-            var packSupportedRuntimeIdentifiers = knownPack.GetMetadata(packageName + "RuntimeIdentifiers").Split(';');
-
-            // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture
-            var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
-            var hostRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, NETCoreSdkRuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph);
-            if (hostRuntimeIdentifier == null)
-            {
-                return false;
-            }
-
-            var runtimePackName = packPattern.Replace("**RID**", hostRuntimeIdentifier);
+            var packName = toolPackType.ToString();
+            var packVersion = knownPack.GetMetadata(packName + "PackVersion");
             if (!string.IsNullOrEmpty(RuntimeFrameworkVersion))
             {
                 packVersion = RuntimeFrameworkVersion;
             }
 
-            if (EnableRuntimePackDownload)
-            {
-                // We need to download the runtime pack
-                TaskItem runtimePackToDownload = new TaskItem(runtimePackName);
-                runtimePackToDownload.SetMetadata(MetadataKeys.Version, packVersion);
-                packagesToDownload.Add(runtimePackToDownload);
-            }
+            
+            // Crossgen and ILCompiler have RID-specific bits.
+            if (toolPackType is ToolPackType.Crossgen2 or ToolPackType.ILCompiler) {
+                var packNamePattern = knownPack.GetMetadata(packName + "PackNamePattern");
+                var packSupportedRuntimeIdentifiers = knownPack.GetMetadata(packName + "RuntimeIdentifiers").Split(';');
 
-            var newItem = new TaskItem(runtimePackName);
-            newItem.SetMetadata(MetadataKeys.NuGetPackageId, runtimePackName);
-            newItem.SetMetadata(MetadataKeys.NuGetPackageVersion, packVersion);
-
-            if (packageType == AotPackageType.Crossgen2)
-            {
-                Crossgen2Packs = new[] { newItem };
-            }
-            else
-            {
-                HostILCompilerPacks = new[] { newItem };
-                var ilCompilerBuildPackageReference = new TaskItem(knownPack.ItemSpec);
-                ilCompilerBuildPackageReference.SetMetadata(MetadataKeys.Version, packVersion);
-                ImplicitPackageReferences = new[] { ilCompilerBuildPackageReference };
-                // ILCompiler supports cross target compilation. If there is a cross-target request, we need to download that package as well
-                // We expect RuntimeIdentifier to be defined during publish but can allow during build
-                if (RuntimeIdentifier != null)
+                // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture
+                var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
+                var hostRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, NETCoreSdkRuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph);
+                if (hostRuntimeIdentifier == null)
                 {
-                    var targetRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, RuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph2);
-                    if (targetRuntimeIdentifier == null)
+                    return false;
+                }
+
+                var runtimePackName = packNamePattern.Replace("**RID**", hostRuntimeIdentifier);
+
+                if (EnableRuntimePackDownload)
+                {
+                    // We need to download the runtime pack
+                    TaskItem runtimePackToDownload = new TaskItem(runtimePackName);
+                    runtimePackToDownload.SetMetadata(MetadataKeys.Version, packVersion);
+                    packagesToDownload.Add(runtimePackToDownload);
+                }
+
+                var runtimePackItem = new TaskItem(runtimePackName);
+                runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageId, runtimePackName);
+                runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageVersion, packVersion);
+
+                switch (toolPackType) {
+                case ToolPackType.Crossgen2:
+                    Crossgen2Packs = new[] { runtimePackItem };
+                    break;
+                case ToolPackType.ILCompiler:
+                    HostILCompilerPacks = new[] { runtimePackItem };
+
+                    // ILCompiler supports cross target compilation. If there is a cross-target request, we need to download that package as well
+                    // We expect RuntimeIdentifier to be defined during publish but can allow during build
+                    if (RuntimeIdentifier != null)
                     {
-                        return false;
+                        var targetRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, RuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph2);
+                        if (targetRuntimeIdentifier == null)
+                        {
+                            return false;
+                        }
+                        if (!hostRuntimeIdentifier.Equals(targetRuntimeIdentifier))
+                        {
+                            var targetIlcPackName = packNamePattern.Replace("**RID**", targetRuntimeIdentifier);
+                            var targetIlcPack = new TaskItem(targetIlcPackName);
+                            targetIlcPack.SetMetadata(MetadataKeys.NuGetPackageId, targetIlcPackName);
+                            targetIlcPack.SetMetadata(MetadataKeys.NuGetPackageVersion, packVersion);
+                            TargetILCompilerPacks = new[] { targetIlcPack };
+                        }
                     }
-                    if (!hostRuntimeIdentifier.Equals(targetRuntimeIdentifier))
-                    {
-                        var runtimeIlcPackName = packPattern.Replace("**RID**", targetRuntimeIdentifier);
-                        var newItem2 = new TaskItem(runtimeIlcPackName);
-                        newItem2.SetMetadata(MetadataKeys.NuGetPackageId, runtimeIlcPackName);
-                        newItem2.SetMetadata(MetadataKeys.NuGetPackageVersion, packVersion);
-                        TargetILCompilerPacks = new[] { newItem2 };
-                    }
+                    break;
                 }
             }
+
+            // ILCompiler and ILLink have RID-agnostic build packages that contain MSBuild targets.
+            if (toolPackType is ToolPackType.ILCompiler or ToolPackType.ILLink)
+            {
+                var buildPackageName = knownPack.ItemSpec;
+                var buildPackage = new TaskItem(buildPackageName);
+                buildPackage.SetMetadata(MetadataKeys.Version, packVersion);
+                implicitPackageReferences.Add(buildPackage);
+           }
 
             return true;
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -17,6 +17,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IsPublishable Condition="'$(IsPublishable)' == ''">true</IsPublishable>
     <!-- PublishAot depends on PublishTrimmed. This must be set early enough for the KnownILLinkPack to be restored. -->
     <PublishTrimmed Condition="'$(PublishTrimmed)' == '' And '$(PublishAot)' == 'true'">true</PublishTrimmed>
+    <_IsTrimmingEnabled Condition="'$(_IsTrimmingEnabled)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</_IsTrimmingEnabled>
+    <_IsTrimmingEnabled Condition="'$(_IsTrimmingEnabled)' == ''">false</_IsTrimmingEnabled>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -15,6 +15,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultCopyToPublishDirectoryMetadata Condition="'$(DefaultCopyToPublishDirectoryMetadata)' == ''">true</DefaultCopyToPublishDirectoryMetadata>
     <_GetChildProjectCopyToPublishDirectoryItems Condition="'$(_GetChildProjectCopyToPublishDirectoryItems)' == ''">true</_GetChildProjectCopyToPublishDirectoryItems>
     <IsPublishable Condition="'$(IsPublishable)' == ''">true</IsPublishable>
+    <!-- PublishAot depends on PublishTrimmed. This must be set early enough for the KnownILLinkPack to be restored. -->
+    <PublishTrimmed Condition="'$(PublishTrimmed)' == '' And '$(PublishAot)' == 'true'">true</PublishTrimmed>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -352,7 +354,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="ComputeFilesToPublish"
           DependsOnTargets="PrepareForPublish;
                             ComputeResolvedFilesToPublishList;
-                            ILLink;
                             CreateReadyToRunImages;
                             GeneratePublishDependencyFile;
                             GenerateSingleFileBundle">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -356,10 +356,22 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="ComputeFilesToPublish"
           DependsOnTargets="PrepareForPublish;
                             ComputeResolvedFilesToPublishList;
+                            ILLink;
                             CreateReadyToRunImages;
                             GeneratePublishDependencyFile;
                             GenerateSingleFileBundle">
   </Target>
+
+  <!--
+    ============================================================
+                                        ILLink
+
+    Initially an empty placeholder target. When trimming, this
+    will be redefined to invoke ILLink to perform IL trimming.
+    The placeholder exists to allow other targets to depend on it for ordering purposes.
+    ============================================================
+    -->
+  <Target Name="ILLink" />
 
   <PropertyGroup>
     <CopyBuildOutputToPublishDirectory Condition="'$(CopyBuildOutputToPublishDirectory)'==''">true</CopyBuildOutputToPublishDirectory>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -99,6 +99,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 SelfContained="$(SelfContained)"
                                 ReadyToRunEnabled="$(PublishReadyToRun)"
                                 ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
+                                TrimmingEnabled="$(PublishTrimmed)"
                                 AotEnabled="$(PublishAot)"
                                 RuntimeIdentifier="$(RuntimeIdentifier)"
                                 RuntimeIdentifiers="$(RuntimeIdentifiers)"
@@ -111,6 +112,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 DisableTransitiveFrameworkReferenceDownloads="$(DisableTransitiveFrameworkReferenceDownloads)"
                                 KnownCrossgen2Packs="@(KnownCrossgen2Pack)"
                                 KnownILCompilerPacks="@(KnownILCompilerPack)"
+                                KnownILLinkPacks="@(KnownILLinkPack)"
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
                                 NetCoreRoot="$(NetCoreRoot)"
                                 NETCoreSdkVersion="$(NETCoreSdkVersion)">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -99,7 +99,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 SelfContained="$(SelfContained)"
                                 ReadyToRunEnabled="$(PublishReadyToRun)"
                                 ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
-                                TrimmingEnabled="$(PublishTrimmed)"
+                                TrimmingEnabled="$(_IsTrimmingEnabled)"
                                 AotEnabled="$(PublishAot)"
                                 RuntimeIdentifier="$(RuntimeIdentifier)"
                                 RuntimeIdentifiers="$(RuntimeIdentifiers)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -151,7 +151,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.CSharp.props" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.VisualBasic.props" Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.FSharp.props" Condition="'$(MSBuildProjectExtension)' == '.fsproj'" />
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.ILLink.Tasks" />
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.PackTool.props" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.PackProjectTool.props" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1182,7 +1182,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.VisualBasic.targets" Condition="'$(Language)' == 'VB'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.FSharp.targets" Condition="'$(Language)' == 'F#'" />
   <Import Project="$(ILCompilerTargetsPath)" Condition="'$(PublishAot)' == 'true'"/>
-  <Import Project="$(ILLinkTargetsPath)" Condition="'$(Language)' != 'C++'" />
+  <Import Project="$(ILLinkTargetsPath)" Condition="'$(PublishTrimmed)' == 'true' And '$(Language)' != 'C++'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Analyzers.targets" Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'" />
 
   <!-- Import WindowsDesktop targets if necessary -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1182,7 +1182,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.VisualBasic.targets" Condition="'$(Language)' == 'VB'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.FSharp.targets" Condition="'$(Language)' == 'F#'" />
   <Import Project="$(ILCompilerTargetsPath)" Condition="'$(PublishAot)' == 'true'"/>
-  <Import Project="$(ILLinkTargetsPath)" Condition="'$(PublishTrimmed)' == 'true' And '$(Language)' != 'C++'" />
+  <Import Project="$(ILLinkTargetsPath)" Condition="'$(ILLinkTargetsPath)' != '' And '$(Language)' != 'C++'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Analyzers.targets" Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'" />
 
   <!-- Import WindowsDesktop targets if necessary -->

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -638,13 +638,13 @@ namespace Microsoft.NET.Publish.Tests
 
             // Set up a project with an invalid feature substitution, just to produce an error.
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName);
-            testProject.SourceFiles[$"{projectName}.xml"] = $"""
-                <linker>
-                <assembly fullname="{projectName}">
-                    <type fullname="Program" feature="featuremissingvalue" />
-                </assembly>
-                </linker>
-                """;
+            testProject.SourceFiles[$"{projectName}.xml"] = $@"
+<linker>
+  <assembly fullname=""{projectName}"">
+    <type fullname=""Program"" feature=""featuremissingvalue"" />
+  </assembly>
+</linker>
+";
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework)
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{projectName}.xml"));
 
@@ -1517,18 +1517,17 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = targetFramework,
                 SourceFiles =
                 {
-                    ["Program.cs"] = """
+                    ["Program.cs"] = @"
                         class Program
                         {
                             static void Main() {}
-                        }
-                        """,
-                    ["Test.cshtml"] = """
+                        }",
+                    ["Test.cshtml"] = @"
                         @page
                         @{
-                            System.IO.Compression.ZipFile.OpenRead("test.zip");
+                            System.IO.Compression.ZipFile.OpenRead(""test.zip"");
                         }
-                        """,
+                    ",
                 },
                 AdditionalProperties =
                 {
@@ -1759,15 +1758,15 @@ namespace Microsoft.NET.Publish.Tests
         private void AddFeatureDefinition(TestProject testProject, string assemblyName)
         {
             // Add a feature definition that replaces the FeatureDisabled property when DisableFeature is true.
-            testProject.EmbeddedResources[substitutionsFilename] = $"""
-                <linker>
-                <assembly fullname="{assemblyName}" feature="DisableFeature" featurevalue="true">
-                    <type fullname="ClassLib">
-                    <method signature="System.Boolean get_FeatureDisabled()" body="stub" value="true" />
-                    </type>
-                </assembly>
-                </linker>
-                """;
+            testProject.EmbeddedResources[substitutionsFilename] = $@"
+<linker>
+  <assembly fullname=""{assemblyName}"" feature=""DisableFeature"" featurevalue=""true"">
+    <type fullname=""ClassLib"">
+      <method signature=""System.Boolean get_FeatureDisabled()"" body=""stub"" value=""true"" />
+    </type>
+  </assembly>
+</linker>
+";
 
             testProject.AddItem("EmbeddedResource", new Dictionary<string, string>
             {
@@ -1805,60 +1804,57 @@ namespace Microsoft.NET.Publish.Tests
             // If we're actually testing that we build with no warnings, the test will still fail.
             testProject.AdditionalProperties["WarningsNotAsErrors"] = "CS9057;";
 
-            testProject.SourceFiles[$"{projectName}.cs"] = """
-                using System;
-                using System.Reflection;
-                using System.Diagnostics.CodeAnalysis;
-                namespace TestProjectWithAnalysisWarnings
-                {
-                    public class Program
-                    {
-                        public static void Main()
-                        {
-                            IL_2075();
-                            IL_2026();
-                            _ = IL_2043;
-                            new Derived().IL_2046();
-                            new Derived().IL_2093();
-                        }
+            testProject.SourceFiles[$"{projectName}.cs"] = @"
+using System;
+using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
+public class Program
+{
+    public static void Main()
+    {
+        IL_2075();
+        IL_2026();
+        _ = IL_2043;
+        new Derived().IL_2046();
+        new Derived().IL_2093();
+    }
 
-                        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-                        public static string typeName;
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+    public static string typeName;
 
-                        public static void IL_2075()
-                        {
-                            _ = Type.GetType(typeName).GetMethod("SomeMethod");
-                        }
+    public static void IL_2075()
+    {
+        _ = Type.GetType(typeName).GetMethod(""SomeMethod"");
+    }
 
-                        [RequiresUnreferencedCode("Testing analysis warning IL2026")]
-                        public static void IL_2026()
-                        {
-                        }
+    [RequiresUnreferencedCode(""Testing analysis warning IL2026"")]
+    public static void IL_2026()
+    {
+    }
 
-                        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-                        public static string IL_2043 {
-                            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-                            get => null;
-                        }
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+    public static string IL_2043 {
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        get => null;
+    }
 
-                        public class Base
-                        {
-                            [RequiresUnreferencedCode("Testing analysis warning IL2046")]
-                            public virtual void IL_2046() {}
+    public class Base
+    {
+        [RequiresUnreferencedCode(""Testing analysis warning IL2046"")]
+        public virtual void IL_2046() {}
 
-                            public virtual string IL_2093() => null;
-                        }
+        public virtual string IL_2093() => null;
+    }
 
-                        public class Derived : Base
-                        {
-                            public override void IL_2046() {}
+    public class Derived : Base
+    {
+        public override void IL_2046() {}
 
-                            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
-                            public override string IL_2093() => null;
-                        }
-                    }
-                }
-                """;
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        public override string IL_2093() => null;
+    }
+}
+";
 
             return testProject;
         }
@@ -1875,17 +1871,16 @@ namespace Microsoft.NET.Publish.Tests
             };
             testProject.AdditionalProperties["PublishTrimmed"] = "true";
 
-            testProject.SourceFiles[$"{projectName}.cs"] = """
-                using System;
-                public class Program
-                {
-                    public static void Main()
-                    {
-                        TrimmableAssembly.UsedMethod();
-                        NonTrimmableAssembly.UsedMethod();
-                    }
-                }
-                """;
+            testProject.SourceFiles[$"{projectName}.cs"] = @"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        TrimmableAssembly.UsedMethod();
+        NonTrimmableAssembly.UsedMethod();
+    }
+}";
 
             var trimmableProject = new TestProject()
             {
@@ -1893,22 +1888,21 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = targetFramework
             };
 
-            trimmableProject.SourceFiles["TrimmableAssembly.cs"] = """
-                using System.Reflection;
+            trimmableProject.SourceFiles["TrimmableAssembly.cs"] = @"
+using System.Reflection;
 
-                [assembly: AssemblyMetadata("IsTrimmable", "True")]
+[assembly: AssemblyMetadata(""IsTrimmable"", ""True"")]
 
-                public static class TrimmableAssembly
-                {
-                    public static void UsedMethod()
-                    {
-                    }
+public static class TrimmableAssembly
+{
+    public static void UsedMethod()
+    {
+    }
 
-                    public static void UnusedMethod()
-                    {
-                    }
-                }
-                """;
+    public static void UnusedMethod()
+    {
+    }
+}";
             testProject.ReferencedProjects.Add(trimmableProject);
 
             var nonTrimmableProject = new TestProject()
@@ -1917,18 +1911,17 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = targetFramework
             };
 
-            nonTrimmableProject.SourceFiles["NonTrimmableAssembly.cs"] = """
-                public static class NonTrimmableAssembly
-                {
-                    public static void UsedMethod()
-                    {
-                    }
+            nonTrimmableProject.SourceFiles["NonTrimmableAssembly.cs"] = @"
+public static class NonTrimmableAssembly
+{
+    public static void UsedMethod()
+    {
+    }
 
-                    public static void UnusedMethod()
-                    {
-                    }
-                }
-                """;
+    public static void UnusedMethod()
+    {
+    }
+}";
             testProject.ReferencedProjects.Add(nonTrimmableProject);
 
             var unusedTrimmableProject = new TestProject()
@@ -1937,18 +1930,18 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = targetFramework
             };
 
-            unusedTrimmableProject.SourceFiles["UnusedTrimmableAssembly.cs"] = """
-                using System.Reflection;
+            unusedTrimmableProject.SourceFiles["UnusedTrimmableAssembly.cs"] = @"
+using System.Reflection;
 
-                [assembly: AssemblyMetadata("IsTrimmable", "True")]
+[assembly: AssemblyMetadata(""IsTrimmable"", ""True"")]
 
-                public static class UnusedTrimmableAssembly
-                {
-                    public static void UnusedMethod()
-                    {
-                    }
-                }
-                """;
+public static class UnusedTrimmableAssembly
+{
+    public static void UnusedMethod()
+    {
+    }
+}
+";
             testProject.ReferencedProjects.Add(unusedTrimmableProject);
 
             var unusedNonTrimmableProject = new TestProject()
@@ -1957,14 +1950,14 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = targetFramework
             };
 
-            unusedNonTrimmableProject.SourceFiles["UnusedNonTrimmableAssembly.cs"] = """
-                public static class UnusedNonTrimmableAssembly
-                {
-                    public static void UnusedMethod()
-                    {
-                    }
-                }
-                """;
+            unusedNonTrimmableProject.SourceFiles["UnusedNonTrimmableAssembly.cs"] = @"
+public static class UnusedNonTrimmableAssembly
+{
+    public static void UnusedMethod()
+    {
+    }
+}
+";
             testProject.ReferencedProjects.Add(unusedNonTrimmableProject);
 
             return testProject;
@@ -1987,29 +1980,28 @@ namespace Microsoft.NET.Publish.Tests
                 IsExe = true
             };
 
-            testProject.SourceFiles[$"{mainProjectName}.cs"] = """
-                using System;
-                public class Program
-                {
-                    public static void Main()
-                    {
-                        Console.WriteLine("Hello world");
-                    }
+            testProject.SourceFiles[$"{mainProjectName}.cs"] = @"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(""Hello world"");
+    }
 
-                    public static void UnusedMethod()
-                    {
-                    }
-                """;
+    public static void UnusedMethod()
+    {
+    }
+";
 
             if (addAssemblyReference)
             {
-                testProject.SourceFiles[$"{mainProjectName}.cs"] += """
-                    public static void UseClassLib()
-                    {
-                        ClassLib.UsedMethod();
-                    }
-                }
-                """;
+                testProject.SourceFiles[$"{mainProjectName}.cs"] += @"
+    public static void UseClassLib()
+    {
+        ClassLib.UsedMethod();
+    }
+}";
             }
             else
             {
@@ -2031,38 +2023,38 @@ namespace Microsoft.NET.Publish.Tests
                 // of these tests to prevent conflicts.
                 TargetFrameworks = usePackageReference ? "netcoreapp3.0" : targetFramework,
             };
-            referenceProject.SourceFiles[$"{referenceProjectName}.cs"] = """
-                using System;
+            referenceProject.SourceFiles[$"{referenceProjectName}.cs"] = @"
+using System;
 
-                public class ClassLib
-                {
-                    public static void UsedMethod()
-                    {
-                    }
+public class ClassLib
+{
+    public static void UsedMethod()
+    {
+    }
 
-                    public void UnusedMethod()
-                    {
-                    }
+    public void UnusedMethod()
+    {
+    }
 
-                    public void UnusedMethodToRoot()
-                    {
-                    }
+    public void UnusedMethodToRoot()
+    {
+    }
 
-                    public static bool FeatureDisabled { get; }
+    public static bool FeatureDisabled { get; }
 
-                    public static void FeatureAPI()
-                    {
-                        if (FeatureDisabled)
-                            return;
+    public static void FeatureAPI()
+    {
+        if (FeatureDisabled)
+            return;
 
-                        FeatureImplementation();
-                    }
+        FeatureImplementation();
+    }
 
-                    public static void FeatureImplementation()
-                    {
-                    }
-                }
-                """;
+    public static void FeatureImplementation()
+    {
+    }
+}
+";
             if (modifyReferencedProject != null)
                 modifyReferencedProject(referenceProject);
 
@@ -2077,16 +2069,16 @@ namespace Microsoft.NET.Publish.Tests
             }
 
 
-            testProject.SourceFiles[$"{referenceProjectName}.xml"] = $"""
-                <linker>
-                <assembly fullname="{referenceProjectName}">
-                    <type fullname="ClassLib">
-                    <method name="UnusedMethodToRoot" />
-                    <method name="FeatureAPI" />
-                    </type>
-                </assembly>
-                </linker>
-                """;
+            testProject.SourceFiles[$"{referenceProjectName}.xml"] = $@"
+<linker>
+  <assembly fullname=""{referenceProjectName}"">
+    <type fullname=""ClassLib"">
+      <method name=""UnusedMethodToRoot"" />
+      <method name=""FeatureAPI"" />
+    </type>
+  </assembly>
+</linker>
+";
 
             return testProject;
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -132,7 +132,31 @@ namespace Microsoft.NET.Publish.Tests
                 var command = new RunExeCommand(Log, exe)
                     .Execute().Should().Pass()
                     .And.HaveStdOutContaining("Hello world");
+
+                CheckILLinkVersion(testAsset, targetFramework);
             }
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void ILLink_fails_when_no_matching_pack_is_found(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework)
+                .WithProjectChanges(project => {
+                    var ns = project.Root.Name.Namespace;
+                    project.Root.Add(new XElement(ns + "ItemGroup",
+                        new XElement("KnownILLinkPack",
+                            new XAttribute("Remove", "Microsoft.NET.ILLink.Tasks"))));
+                });
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:PublishTrimmed=true")
+                .Should().Fail()
+                .And.HaveStdOutContaining("error NETSDK1195");
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
@@ -2057,6 +2081,26 @@ public class ClassLib
 ";
 
             return testProject;
+        }
+
+        private void CheckILLinkVersion(TestAsset testAsset, string targetFramework)
+        {
+            var getKnownPacks = new GetValuesCommand(testAsset, "KnownILLinkPack", GetValuesCommand.ValueType.Item, targetFramework) {
+                MetadataNames = new List<string> { "TargetFramework", "ILLinkPackVersion" }
+            };
+            getKnownPacks.Execute().Should().Pass();
+            var knownPacks = getKnownPacks.GetValuesWithMetadata();
+            var expectedVersion = knownPacks
+                .Where(i => i.metadata["TargetFramework"] == targetFramework)
+                .Select(i => i.metadata["ILLinkPackVersion"])
+                .Single();
+
+            var illinkTargetsCommand = new GetValuesCommand(testAsset, "ILLinkTargetsPath", targetFramework: targetFramework);
+            illinkTargetsCommand.Properties.Add("PublishTrimmed", "true");
+            illinkTargetsCommand.Execute().Should().Pass();
+            var illinkTargetsPath = illinkTargetsCommand.GetValues()[0];
+            var illinkVersion = Path.GetFileName(Path.GetDirectoryName(Path.GetDirectoryName(illinkTargetsPath)));
+            illinkVersion.Should().Be(expectedVersion);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -1670,7 +1670,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Fact]
-        public void It_warns_when_targetting_netcoreapp_2_x_illink()
+        public void It_warns_when_targeting_netcoreapp_2_x_illink()
         {
             var testProject = new TestProject()
             {

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -638,13 +638,13 @@ namespace Microsoft.NET.Publish.Tests
 
             // Set up a project with an invalid feature substitution, just to produce an error.
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName);
-            testProject.SourceFiles[$"{projectName}.xml"] = $@"
-<linker>
-  <assembly fullname=""{projectName}"">
-    <type fullname=""Program"" feature=""featuremissingvalue"" />
-  </assembly>
-</linker>
-";
+            testProject.SourceFiles[$"{projectName}.xml"] = $"""
+                <linker>
+                <assembly fullname="{projectName}">
+                    <type fullname="Program" feature="featuremissingvalue" />
+                </assembly>
+                </linker>
+                """;
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework)
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{projectName}.xml"));
 
@@ -1517,17 +1517,18 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = targetFramework,
                 SourceFiles =
                 {
-                    ["Program.cs"] = @"
+                    ["Program.cs"] = """
                         class Program
                         {
                             static void Main() {}
-                        }",
-                    ["Test.cshtml"] = @"
+                        }
+                        """,
+                    ["Test.cshtml"] = """
                         @page
                         @{
-                            System.IO.Compression.ZipFile.OpenRead(""test.zip"");
+                            System.IO.Compression.ZipFile.OpenRead("test.zip");
                         }
-                    ",
+                    """,
                 },
                 AdditionalProperties =
                 {
@@ -1758,15 +1759,15 @@ namespace Microsoft.NET.Publish.Tests
         private void AddFeatureDefinition(TestProject testProject, string assemblyName)
         {
             // Add a feature definition that replaces the FeatureDisabled property when DisableFeature is true.
-            testProject.EmbeddedResources[substitutionsFilename] = $@"
-<linker>
-  <assembly fullname=""{assemblyName}"" feature=""DisableFeature"" featurevalue=""true"">
-    <type fullname=""ClassLib"">
-      <method signature=""System.Boolean get_FeatureDisabled()"" body=""stub"" value=""true"" />
-    </type>
-  </assembly>
-</linker>
-";
+            testProject.EmbeddedResources[substitutionsFilename] = $"""
+                <linker>
+                <assembly fullname="{assemblyName}" feature="DisableFeature" featurevalue="true">
+                    <type fullname="ClassLib">
+                    <method signature="System.Boolean get_FeatureDisabled()" body="stub" value="true" />
+                    </type>
+                </assembly>
+                </linker>
+                """;
 
             testProject.AddItem("EmbeddedResource", new Dictionary<string, string>
             {
@@ -1804,57 +1805,60 @@ namespace Microsoft.NET.Publish.Tests
             // If we're actually testing that we build with no warnings, the test will still fail.
             testProject.AdditionalProperties["WarningsNotAsErrors"] = "CS9057;";
 
-            testProject.SourceFiles[$"{projectName}.cs"] = @"
-using System;
-using System.Reflection;
-using System.Diagnostics.CodeAnalysis;
-public class Program
-{
-    public static void Main()
-    {
-        IL_2075();
-        IL_2026();
-        _ = IL_2043;
-        new Derived().IL_2046();
-        new Derived().IL_2093();
-    }
+            testProject.SourceFiles[$"{projectName}.cs"] = """
+                using System;
+                using System.Reflection;
+                using System.Diagnostics.CodeAnalysis;
+                namespace TestProjectWithAnalysisWarnings
+                {
+                    public class Program
+                    {
+                        public static void Main()
+                        {
+                            IL_2075();
+                            IL_2026();
+                            _ = IL_2043;
+                            new Derived().IL_2046();
+                            new Derived().IL_2093();
+                        }
 
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-    public static string typeName;
+                        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+                        public static string typeName;
 
-    public static void IL_2075()
-    {
-        _ = Type.GetType(typeName).GetMethod(""SomeMethod"");
-    }
+                        public static void IL_2075()
+                        {
+                            _ = Type.GetType(typeName).GetMethod("SomeMethod");
+                        }
 
-    [RequiresUnreferencedCode(""Testing analysis warning IL2026"")]
-    public static void IL_2026()
-    {
-    }
+                        [RequiresUnreferencedCode("Testing analysis warning IL2026")]
+                        public static void IL_2026()
+                        {
+                        }
 
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-    public static string IL_2043 {
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-        get => null;
-    }
+                        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+                        public static string IL_2043 {
+                            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+                            get => null;
+                        }
 
-    public class Base
-    {
-        [RequiresUnreferencedCode(""Testing analysis warning IL2046"")]
-        public virtual void IL_2046() {}
+                        public class Base
+                        {
+                            [RequiresUnreferencedCode("Testing analysis warning IL2046")]
+                            public virtual void IL_2046() {}
 
-        public virtual string IL_2093() => null;
-    }
+                            public virtual string IL_2093() => null;
+                        }
 
-    public class Derived : Base
-    {
-        public override void IL_2046() {}
+                        public class Derived : Base
+                        {
+                            public override void IL_2046() {}
 
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
-        public override string IL_2093() => null;
-    }
-}
-";
+                            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+                            public override string IL_2093() => null;
+                        }
+                    }
+                }
+                """;
 
             return testProject;
         }
@@ -1871,16 +1875,17 @@ public class Program
             };
             testProject.AdditionalProperties["PublishTrimmed"] = "true";
 
-            testProject.SourceFiles[$"{projectName}.cs"] = @"
-using System;
-public class Program
-{
-    public static void Main()
-    {
-        TrimmableAssembly.UsedMethod();
-        NonTrimmableAssembly.UsedMethod();
-    }
-}";
+            testProject.SourceFiles[$"{projectName}.cs"] = """
+                using System;
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        TrimmableAssembly.UsedMethod();
+                        NonTrimmableAssembly.UsedMethod();
+                    }
+                }
+                """;
 
             var trimmableProject = new TestProject()
             {
@@ -1888,21 +1893,22 @@ public class Program
                 TargetFrameworks = targetFramework
             };
 
-            trimmableProject.SourceFiles["TrimmableAssembly.cs"] = @"
-using System.Reflection;
+            trimmableProject.SourceFiles["TrimmableAssembly.cs"] = """
+                using System.Reflection;
 
-[assembly: AssemblyMetadata(""IsTrimmable"", ""True"")]
+                [assembly: AssemblyMetadata("IsTrimmable", "True")]
 
-public static class TrimmableAssembly
-{
-    public static void UsedMethod()
-    {
-    }
+                public static class TrimmableAssembly
+                {
+                    public static void UsedMethod()
+                    {
+                    }
 
-    public static void UnusedMethod()
-    {
-    }
-}";
+                    public static void UnusedMethod()
+                    {
+                    }
+                }
+                """;
             testProject.ReferencedProjects.Add(trimmableProject);
 
             var nonTrimmableProject = new TestProject()
@@ -1911,17 +1917,18 @@ public static class TrimmableAssembly
                 TargetFrameworks = targetFramework
             };
 
-            nonTrimmableProject.SourceFiles["NonTrimmableAssembly.cs"] = @"
-public static class NonTrimmableAssembly
-{
-    public static void UsedMethod()
-    {
-    }
+            nonTrimmableProject.SourceFiles["NonTrimmableAssembly.cs"] = """
+                public static class NonTrimmableAssembly
+                {
+                    public static void UsedMethod()
+                    {
+                    }
 
-    public static void UnusedMethod()
-    {
-    }
-}";
+                    public static void UnusedMethod()
+                    {
+                    }
+                }
+                """;
             testProject.ReferencedProjects.Add(nonTrimmableProject);
 
             var unusedTrimmableProject = new TestProject()
@@ -1930,18 +1937,18 @@ public static class NonTrimmableAssembly
                 TargetFrameworks = targetFramework
             };
 
-            unusedTrimmableProject.SourceFiles["UnusedTrimmableAssembly.cs"] = @"
-using System.Reflection;
+            unusedTrimmableProject.SourceFiles["UnusedTrimmableAssembly.cs"] = """
+                using System.Reflection;
 
-[assembly: AssemblyMetadata(""IsTrimmable"", ""True"")]
+                [assembly: AssemblyMetadata("IsTrimmable", "True")]
 
-public static class UnusedTrimmableAssembly
-{
-    public static void UnusedMethod()
-    {
-    }
-}
-";
+                public static class UnusedTrimmableAssembly
+                {
+                    public static void UnusedMethod()
+                    {
+                    }
+                }
+                """;
             testProject.ReferencedProjects.Add(unusedTrimmableProject);
 
             var unusedNonTrimmableProject = new TestProject()
@@ -1950,14 +1957,14 @@ public static class UnusedTrimmableAssembly
                 TargetFrameworks = targetFramework
             };
 
-            unusedNonTrimmableProject.SourceFiles["UnusedNonTrimmableAssembly.cs"] = @"
-public static class UnusedNonTrimmableAssembly
-{
-    public static void UnusedMethod()
-    {
-    }
-}
-";
+            unusedNonTrimmableProject.SourceFiles["UnusedNonTrimmableAssembly.cs"] = """
+                public static class UnusedNonTrimmableAssembly
+                {
+                    public static void UnusedMethod()
+                    {
+                    }
+                }
+                """;
             testProject.ReferencedProjects.Add(unusedNonTrimmableProject);
 
             return testProject;
@@ -1980,28 +1987,29 @@ public static class UnusedNonTrimmableAssembly
                 IsExe = true
             };
 
-            testProject.SourceFiles[$"{mainProjectName}.cs"] = @"
-using System;
-public class Program
-{
-    public static void Main()
-    {
-        Console.WriteLine(""Hello world"");
-    }
+            testProject.SourceFiles[$"{mainProjectName}.cs"] = """
+                using System;
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        Console.WriteLine("Hello world");
+                    }
 
-    public static void UnusedMethod()
-    {
-    }
-";
+                    public static void UnusedMethod()
+                    {
+                    }
+                """;
 
             if (addAssemblyReference)
             {
-                testProject.SourceFiles[$"{mainProjectName}.cs"] += @"
-    public static void UseClassLib()
-    {
-        ClassLib.UsedMethod();
-    }
-}";
+                testProject.SourceFiles[$"{mainProjectName}.cs"] += """
+                    public static void UseClassLib()
+                    {
+                        ClassLib.UsedMethod();
+                    }
+                }
+                """;
             }
             else
             {
@@ -2023,38 +2031,38 @@ public class Program
                 // of these tests to prevent conflicts.
                 TargetFrameworks = usePackageReference ? "netcoreapp3.0" : targetFramework,
             };
-            referenceProject.SourceFiles[$"{referenceProjectName}.cs"] = @"
-using System;
+            referenceProject.SourceFiles[$"{referenceProjectName}.cs"] = """
+                using System;
 
-public class ClassLib
-{
-    public static void UsedMethod()
-    {
-    }
+                public class ClassLib
+                {
+                    public static void UsedMethod()
+                    {
+                    }
 
-    public void UnusedMethod()
-    {
-    }
+                    public void UnusedMethod()
+                    {
+                    }
 
-    public void UnusedMethodToRoot()
-    {
-    }
+                    public void UnusedMethodToRoot()
+                    {
+                    }
 
-    public static bool FeatureDisabled { get; }
+                    public static bool FeatureDisabled { get; }
 
-    public static void FeatureAPI()
-    {
-        if (FeatureDisabled)
-            return;
+                    public static void FeatureAPI()
+                    {
+                        if (FeatureDisabled)
+                            return;
 
-        FeatureImplementation();
-    }
+                        FeatureImplementation();
+                    }
 
-    public static void FeatureImplementation()
-    {
-    }
-}
-";
+                    public static void FeatureImplementation()
+                    {
+                    }
+                }
+                """;
             if (modifyReferencedProject != null)
                 modifyReferencedProject(referenceProject);
 
@@ -2069,16 +2077,16 @@ public class ClassLib
             }
 
 
-            testProject.SourceFiles[$"{referenceProjectName}.xml"] = $@"
-<linker>
-  <assembly fullname=""{referenceProjectName}"">
-    <type fullname=""ClassLib"">
-      <method name=""UnusedMethodToRoot"" />
-      <method name=""FeatureAPI"" />
-    </type>
-  </assembly>
-</linker>
-";
+            testProject.SourceFiles[$"{referenceProjectName}.xml"] = $"""
+                <linker>
+                <assembly fullname="{referenceProjectName}">
+                    <type fullname="ClassLib">
+                    <method name="UnusedMethodToRoot" />
+                    <method name="FeatureAPI" />
+                    </type>
+                </assembly>
+                </linker>
+                """;
 
             return testProject;
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -1528,7 +1528,7 @@ namespace Microsoft.NET.Publish.Tests
                         @{
                             System.IO.Compression.ZipFile.OpenRead("test.zip");
                         }
-                    """,
+                        """,
                 },
                 AdditionalProperties =
                 {


### PR DESCRIPTION
Use a linker based on the current TargetFramework. This relies on KnownILLinkPack and the implicit packagereference mechanism used also for NativeAot to restore the right version of illink. See the KnownILLinkPack definitions here: https://github.com/dotnet/installer/pull/15106.

Fixes https://github.com/dotnet/linker/issues/3029