### PR TITLE
Convert the DotnetCommand that call "new" to DotnetNewCommand

### DIFF
--- a/src/Tests/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
+++ b/src/Tests/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
@@ -26,8 +26,9 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         {
             string projectDirectory = _testAssetsManager.CreateTestDirectory().Path;
 
-            string [] newArgs = new[] { "console", "--debug:ephemeral-hive", "--no-restore" };
-            new DotnetCommand(Log, "new")
+            string [] newArgs = new[] { "console", "--no-restore" };
+            new DotnetNewCommand(Log)
+                .WithVirtualHive()
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)
                 .Should().Pass();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -674,17 +674,17 @@ class Program
 
             if (useSolution)
             {
-                var dotnetCommand = new DotnetCommand(Log)
-                {
-                    WorkingDirectory = testAsset.TestRoot
-                };
-
-                dotnetCommand.Execute("new", "sln", "--debug:ephemeral-hive")
+                new DotnetNewCommand(Log)
+                    .WithVirtualHive()
+                    .WithWorkingDirectory(testAsset.TestRoot)
+                    .Execute("sln")
                     .Should()
                     .Pass();
 
                 var relativePathToProject = Path.Combine(testProject.Name, testProject.Name + ".csproj");
-                dotnetCommand.Execute($"sln", "add", relativePathToProject)
+                new DotnetCommand(Log)
+                    .WithWorkingDirectory(testAsset.TestRoot)
+                    .Execute($"sln", "add", relativePathToProject)
                     .Should()
                     .Pass();
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -154,9 +154,10 @@ namespace Microsoft.NET.Build.Tests
         public void It_builds_successfully_when_targeting_net_framework()
         {
             var testDirectory = _testAssetsManager.CreateTestDirectory().Path;
-            var newCommand = new DotnetCommand(Log, "new", "wpf", "--no-restore");
-            newCommand.WorkingDirectory = testDirectory;
-            newCommand.Execute()
+            new DotnetNewCommand(Log, "wpf", "--no-restore")
+                .WithVirtualHive()
+                .WithWorkingDirectory(testDirectory)
+                .Execute()
                 .Should()
                 .Pass();
 
@@ -257,10 +258,12 @@ namespace Microsoft.NET.Build.Tests
         {
             var testDir = _testAssetsManager.CreateTestDirectory();
 
-            var newCommand = new DotnetCommand(Log);
-            newCommand.WorkingDirectory = testDir.Path;
-
-            newCommand.Execute("new", "wpf", "--debug:ephemeral-hive").Should().Pass();
+            new DotnetNewCommand(Log)
+                .WithVirtualHive()
+                .WithWorkingDirectory(testDir.Path)
+                .Execute("wpf")
+                .Should()
+                .Pass();
 
             var projectPath = Path.Combine(testDir.Path, Path.GetFileName(testDir.Path) + ".csproj");
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
@@ -185,9 +185,12 @@ namespace Microsoft.NET.Build.Tests
         {
             var testDirectory = _testAssetsManager.CreateTestDirectory().Path;
 
-            var newCommand = new DotnetCommand(Log, "new", "wpf", "-lang", "vb");
-            newCommand.WorkingDirectory = testDirectory;
-            newCommand.Execute().Should().Pass();
+            new DotnetNewCommand(Log, "wpf", "-lang", "vb")
+                .WithVirtualHive()
+                .WithWorkingDirectory(testDirectory)
+                .Execute()
+                .Should()
+                .Pass();
 
             var buildCommand = new BuildCommand(Log, testDirectory);
             buildCommand.Execute().Should().Pass();

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
@@ -168,9 +168,12 @@ namespace Microsoft.NET.Publish.Tests
             var testDir = _testAssetsManager.CreateTestDirectory();
             var assetName = "MVCPublishProject";
             var runtimeId = "win-x86";
-            var newCommand = new DotnetCommand(Log);
-            newCommand.WorkingDirectory = testDir.Path;
-            newCommand.Execute("new", "mvc", "-n", assetName, "--debug:ephemeral-hive").Should().Pass();
+            new DotnetNewCommand(Log)
+                .WithVirtualHive()
+                .WithWorkingDirectory(testDir.Path)
+                .Execute("mvc", "-n", assetName)
+                .Should()
+                .Pass();
 
             var expectedRegularFiles = new string[] { ".dll", ".deps.json", ".runtimeconfig.json" }
                 .Select(ending => assetName + ending);

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishWpfApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishWpfApp.cs
@@ -23,10 +23,12 @@ namespace Microsoft.NET.Publish.Tests
         {
             var testDir = _testAssetsManager.CreateTestDirectory();
 
-            var newCommand = new DotnetCommand(Log);
-            newCommand.WorkingDirectory = testDir.Path;
-
-            newCommand.Execute("new", "wpf", "--debug:ephemeral-hive").Should().Pass();
+            new DotnetNewCommand(Log)
+                .WithVirtualHive()
+                .WithWorkingDirectory(testDir.Path)
+                .Execute("wpf")
+                .Should()
+                .Pass();
 
             var project = XDocument.Load(Path.Combine(testDir.Path, Path.GetFileName(testDir.Path) + ".csproj"));
             var ns = project.Root.Name.Namespace;

--- a/src/Tests/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
+++ b/src/Tests/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
@@ -81,7 +81,8 @@ Commands:
 
             try
             {
-                new DotnetCommand(Log, "new", "classlib", "-o", projDir.Path, "--debug:ephemeral-hive",  "--no-restore")
+                new DotnetNewCommand(Log, "classlib", "-o", projDir.Path, "--no-restore")
+                    .WithVirtualHive()
                     .WithWorkingDirectory(projDir.Path)
                     .Execute()
                 .Should().Pass();

--- a/src/Tests/dotnet-list-reference.Tests/GivenDotnetListReference.cs
+++ b/src/Tests/dotnet-list-reference.Tests/GivenDotnetListReference.cs
@@ -233,7 +233,8 @@ Commands:
 
             try
             {
-                new DotnetCommand(Log, "new", "classlib", "-o", dir.Path, "--debug:ephemeral-hive", "--no-restore")
+                new DotnetNewCommand(Log, "classlib", "-o", dir.Path, "--no-restore")
+                    .WithVirtualHive()
                     .WithWorkingDirectory(dir.Path)
                     .Execute()
                 .Should().Pass();

--- a/src/Tests/dotnet-pack.Tests/PackTests.cs
+++ b/src/Tests/dotnet-pack.Tests/PackTests.cs
@@ -249,7 +249,8 @@ namespace Microsoft.DotNet.Pack.Tests
 
             string dir = "pkgs";
 
-            new DotnetCommand(Log, "new", "console", "-o", rootPath, "--no-restore", "--debug:ephemeral-hive")
+            new DotnetNewCommand(Log, "console", "-o", rootPath, "--no-restore")
+                .WithVirtualHive()
                 .WithWorkingDirectory(rootPath)
                 .Execute()
                 .Should()

--- a/src/Tests/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
+++ b/src/Tests/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
@@ -80,7 +80,8 @@ Options:
             try
             {
                 string [] newArgs = new[] { "classlib", "-o", projDir.Path, "--no-restore" };
-                new DotnetCommand(Log, "new","--debug:ephemeral-hive")
+                new DotnetNewCommand(Log)
+                    .WithVirtualHive()
                     .WithWorkingDirectory(projDir.Path)
                     .Execute(newArgs)
                 .Should().Pass();

--- a/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -141,7 +141,8 @@ namespace Microsoft.DotNet.Restore.Test
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
             string[] newArgs = new[] { "console", "-o", rootPath, "--no-restore" };
-            new DotnetCommand(Log, "new","--debug:ephemeral-hive")
+            new DotnetNewCommand(Log)
+                .WithVirtualHive()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
                 .Should()
@@ -164,7 +165,8 @@ namespace Microsoft.DotNet.Restore.Test
             var rootPath = _testAssetsManager.CreateTestDirectory().Path;
 
             string[] newArgs = new[] { "console", "-o", rootPath, "--no-restore" };
-            new DotnetCommand(Log, "new", "--debug:ephemeral-hive")
+            new DotnetNewCommand(Log)
+                .WithVirtualHive()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
                 .Should()

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -234,7 +234,8 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             string[] args = new string[] { "--packages", dir };
 
             string[] newArgs = new string[] { "console", "-o", rootPath, "--no-restore" };
-            new DotnetCommand(Log, "new", "--debug:ephemeral-hive")
+            new DotnetNewCommand(Log)
+                .WithVirtualHive()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
                 .Should()

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -169,7 +169,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            new DotnetCommand(Log, "new", "sln", "--debug:ephemeral-hive")
+            new DotnetNewCommand(Log, "sln")
+                .WithVirtualHive()
                 .WithWorkingDirectory(testAsset.TestRoot)
                 .Execute()
                 .Should()

--- a/src/Tests/dotnet.Tests/OutputPathOptionTests.cs
+++ b/src/Tests/dotnet.Tests/OutputPathOptionTests.cs
@@ -61,9 +61,10 @@ namespace dotnet.Tests
 
             Log.WriteLine($"Test root: {slnDirectory}");
 
-            new DotnetCommand(Log)
+            new DotnetNewCommand(Log)
+                .WithVirtualHive()
                 .WithWorkingDirectory(slnDirectory)
-                .Execute("new", "sln","--debug:ephemeral-hive")
+                .Execute("sln")
                 .Should().Pass();
 
             new DotnetCommand(Log)


### PR DESCRIPTION
Fixes #29438 