### PR TITLE
Add support for an explicit interface implementation methods

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.GenAPI.Task
         public string[]? ExcludeAttributesFiles { get; set; }
 
         /// <summary>
-        /// IncludeInclude internal API's. Default is false.
+        /// Include internal API's. Default is false.
         /// </summary>
         public bool IncludeVisibleOutsideOfAssembly { get; set; }
 

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/AssemblySymbolOrderer.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/AssemblySymbolOrderer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.GenAPI
         /// </summary>
         /// <param name="namespaces">List of namespaces to be sorted.</param>
         /// <returns>Returns namespaces in sorted order.</returns>
-        public static IEnumerable<INamespaceSymbol> Order(IEnumerable<INamespaceSymbol> namespaces)
+        public static IEnumerable<INamespaceSymbol> Order(this IEnumerable<INamespaceSymbol> namespaces)
         {
             return namespaces.OrderBy(s => s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase);
         }
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.GenAPI
         /// </summary>
         /// <param name="namespaces">List of TypeMembers to be sorted.</param>
         /// <returns>Returns TypeMembers in sorted order.</returns>
-        public static IEnumerable<T> Order<T>(IEnumerable<T> symbols) where T : ITypeSymbol
+        public static IEnumerable<T> Order<T>(this IEnumerable<T> symbols) where T : ITypeSymbol
         {
             return symbols.OrderBy(s => s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase);
         }
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.GenAPI
         /// </summary>
         /// <param name="namespaces">List of Members to be sorted.</param>
         /// <returns>Returns Members in sorted order.</returns>
-        public static IEnumerable<ISymbol> Order(IEnumerable<ISymbol> members)
+        public static IEnumerable<ISymbol> Order(this IEnumerable<ISymbol> members)
         {
             if (members is IOrderedEnumerable<ITypeSymbol> orderedTypeDefinitionMembers)
             {

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.GenAPI
             IEnumerable<INamespaceSymbol> namespaceSymbols = EnumerateNamespaces(assembly).Where(_symbolFilter.Include);
             List<SyntaxNode> namespaceSyntaxNodes = new();
 
-            foreach (INamespaceSymbol namespaceSymbol in AssemblySymbolOrderer.Order(namespaceSymbols))
+            foreach (INamespaceSymbol namespaceSymbol in namespaceSymbols.Order())
             {
                 SyntaxNode? syntaxNode = Visit(namespaceSymbol);
 
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.GenAPI
                 return null;
             }
 
-            foreach (INamedTypeSymbol typeMember in AssemblySymbolOrderer.Order(typeMembers))
+            foreach (INamedTypeSymbol typeMember in typeMembers.Order())
             {
                 SyntaxNode typeDeclaration = _syntaxGenerator.DeclarationExt(typeMember);
 
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.GenAPI
             namedTypeNode = VisitInnerNamedTypes(namedTypeNode, namedType);
             IEnumerable<ISymbol> members = namedType.GetMembers().Where(_symbolFilter.Include);
 
-            foreach (ISymbol member in AssemblySymbolOrderer.Order(members))
+            foreach (ISymbol member in members.Order())
             {
                 SyntaxNode memberDeclaration = _syntaxGenerator.DeclarationExt(member);
 
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.GenAPI
         {
             IEnumerable<INamedTypeSymbol> innerNamedTypes = namedType.GetTypeMembers().Where(_symbolFilter.Include);
 
-            foreach (INamedTypeSymbol innerNamedType in AssemblySymbolOrderer.Order(innerNamedTypes))
+            foreach (INamedTypeSymbol innerNamedType in innerNamedTypes.Order())
             {
                 SyntaxNode typeDeclaration = _syntaxGenerator.DeclarationExt(innerNamedType);
                 typeDeclaration = Visit(typeDeclaration, innerNamedType);

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -91,7 +91,8 @@ namespace Microsoft.DotNet.GenAPI
                 .Add<ImplicitSymbolsFilter>()
                 .Add(new SymbolAccessibilityBasedFilter(
                     context.IncludeVisibleOutsideOfAssembly,
-                    includeEffectivelyPrivateSymbols: true));
+                    includeEffectivelyPrivateSymbols: true,
+                    includeExplicitInterfaceImplementationSymbols: true));
 
             if (context.ExcludeAttributesFiles != null)
             {

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.GenAPI
                 .Add<ImplicitSymbolsFilter>()
                 .Add(new SymbolAccessibilityBasedFilter(
                     context.IncludeVisibleOutsideOfAssembly,
-                    /*IncludeEffectivelyPrivateSymbols*/true));
+                    includeEffectivelyPrivateSymbols: true));
 
             if (context.ExcludeAttributesFiles != null)
             {

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editing;
 

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -76,7 +76,6 @@ namespace Microsoft.DotNet.GenAPI
                 name,
                 parameters: method.Parameters.Select(p => syntaxGenerator.ParameterDeclaration(p)),
                 returnType: method.ReturnType?.SpecialType == SpecialType.System_Void ? null : syntaxGenerator.TypeExpression(method.ReturnType!),
-                accessibility: method.DeclaredAccessibility,
                 modifiers: DeclarationModifiers.From(method),
                 statements: statements);
 

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
@@ -52,31 +52,63 @@ namespace Microsoft.DotNet.GenAPI
                         break;
                 }
 
-                /// this is copy/paste from private method `SyntaxGenerator.WithTypeParametersAndConstraints`
                 if (declaration != null)
                 {
-                    if (type.TypeParameters.Length > 0)
-                    {
-                        declaration = syntaxGenerator.WithTypeParameters(declaration, type.TypeParameters.Select(tp => tp.Name));
-
-                        foreach (var tp in type.TypeParameters)
-                        {
-                            if (tp.HasConstructorConstraint || tp.HasReferenceTypeConstraint || tp.HasValueTypeConstraint || tp.ConstraintTypes.Length > 0)
-                            {
-                                declaration = syntaxGenerator.WithTypeConstraint(declaration, tp.Name,
-                                    kinds: (tp.HasConstructorConstraint ? SpecialTypeConstraintKind.Constructor : SpecialTypeConstraintKind.None)
-                                           | (tp.HasReferenceTypeConstraint ? SpecialTypeConstraintKind.ReferenceType : SpecialTypeConstraintKind.None)
-                                           | (tp.HasValueTypeConstraint ? SpecialTypeConstraintKind.ValueType : SpecialTypeConstraintKind.None),
-                                    types: tp.ConstraintTypes.Select(t => syntaxGenerator.TypeExpression(t)));
-                            }
-                        }
-                    }
-
-                    return declaration;
+                    return syntaxGenerator.WithTypeParametersAndConstraintsCopyExt(declaration, type.TypeParameters);
+                }
+            }
+            else if (symbol.Kind == SymbolKind.Method)
+            {
+                var method = (IMethodSymbol)symbol;
+                if (method.MethodKind == MethodKind.ExplicitInterfaceImplementation)
+                {
+                    return syntaxGenerator.ExplicitInterfaceImplementationMethodDeclaration(method, method.Name);
                 }
             }
 
             return syntaxGenerator.Declaration(symbol);
+        }
+
+        // Temporary solution till corresponding Roslyn API is added: https://github.com/dotnet/arcade/issues/11895.
+        private static SyntaxNode ExplicitInterfaceImplementationMethodDeclaration(this SyntaxGenerator syntaxGenerator, IMethodSymbol method, string name, IEnumerable<SyntaxNode>? statements = null)
+        {
+            var decl = syntaxGenerator.MethodDeclaration(
+                name,
+                parameters: method.Parameters.Select(p => syntaxGenerator.ParameterDeclaration(p)),
+                returnType: method.ReturnType?.SpecialType == SpecialType.System_Void ? null : syntaxGenerator.TypeExpression(method.ReturnType!),
+                accessibility: method.DeclaredAccessibility,
+                modifiers: DeclarationModifiers.From(method),
+                statements: statements);
+
+            if (method.TypeParameters.Length > 0)
+            {
+                decl = syntaxGenerator.WithTypeParametersAndConstraintsCopyExt(decl, method.TypeParameters);
+            }
+
+            return decl;
+        }
+
+        // this is copy/paste from private method `SyntaxGenerator.WithTypeParametersAndConstraints`
+        private static SyntaxNode WithTypeParametersAndConstraintsCopyExt(this SyntaxGenerator syntaxGenerator, SyntaxNode declaration, ImmutableArray<ITypeParameterSymbol> typeParameters)
+        {
+            if (typeParameters.Length > 0)
+            {
+                declaration = syntaxGenerator.WithTypeParameters(declaration, typeParameters.Select(tp => tp.Name));
+
+                foreach (var tp in typeParameters)
+                {
+                    if (tp.HasConstructorConstraint || tp.HasReferenceTypeConstraint || tp.HasValueTypeConstraint || tp.ConstraintTypes.Length > 0)
+                    {
+                        declaration = syntaxGenerator.WithTypeConstraint(declaration, tp.Name,
+                            kinds: (tp.HasConstructorConstraint ? SpecialTypeConstraintKind.Constructor : SpecialTypeConstraintKind.None)
+                                   | (tp.HasReferenceTypeConstraint ? SpecialTypeConstraintKind.ReferenceType : SpecialTypeConstraintKind.None)
+                                   | (tp.HasValueTypeConstraint ? SpecialTypeConstraintKind.ValueType : SpecialTypeConstraintKind.None),
+                            types: tp.ConstraintTypes.Select(t => syntaxGenerator.TypeExpression(t)));
+                    }
+                }
+            }
+
+            return declaration;
         }
     }
 }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.GenAPI
                 modifiers: DeclarationModifiers.From(method),
                 statements: statements);
 
-            if (method.TypeParameters.Length > 0)
+            if (!method.TypeParameters.IsEmpty)
             {
                 decl = syntaxGenerator.WithTypeParametersAndConstraintsCopyExt(decl, method.TypeParameters);
             }

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolAccessibilityBasedFilter.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolAccessibilityBasedFilter.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;
-using Microsoft.DotNet.ApiSymbolExtensions;
 
 namespace Microsoft.DotNet.ApiSymbolExtensions
 {
@@ -10,14 +9,18 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
     {
         private readonly bool _includeInternalSymbols;
         private readonly bool _includeEffectivelyPrivateSymbols;
+        private readonly bool _includeExplicitInterfaceImplementationSymbols;
 
-        public SymbolAccessibilityBasedFilter(bool includeInternalSymbols, bool includeEffectivelyPrivateSymbols = false)
+        public SymbolAccessibilityBasedFilter(bool includeInternalSymbols,
+            bool includeEffectivelyPrivateSymbols = false, bool includeExplicitInterfaceImplementationSymbols = false)
         {
             _includeInternalSymbols = includeInternalSymbols;
             _includeEffectivelyPrivateSymbols = includeEffectivelyPrivateSymbols;
+            _includeExplicitInterfaceImplementationSymbols = includeExplicitInterfaceImplementationSymbols;
         }
 
         public bool Include(ISymbol symbol) =>
-            symbol.IsVisibleOutsideOfAssembly(_includeInternalSymbols, _includeEffectivelyPrivateSymbols);
+            symbol.IsVisibleOutsideOfAssembly(_includeInternalSymbols,
+                _includeEffectivelyPrivateSymbols, _includeExplicitInterfaceImplementationSymbols);
     }
 }

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolAccessibilityBasedFilter.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolAccessibilityBasedFilter.cs
@@ -12,7 +12,8 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         private readonly bool _includeExplicitInterfaceImplementationSymbols;
 
         public SymbolAccessibilityBasedFilter(bool includeInternalSymbols,
-            bool includeEffectivelyPrivateSymbols = false, bool includeExplicitInterfaceImplementationSymbols = false)
+            bool includeEffectivelyPrivateSymbols = false,
+            bool includeExplicitInterfaceImplementationSymbols = false)
         {
             _includeInternalSymbols = includeInternalSymbols;
             _includeEffectivelyPrivateSymbols = includeEffectivelyPrivateSymbols;

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
@@ -92,8 +92,10 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
                     yield return baseInterface;
         }
 
-        public static bool IsVisibleOutsideOfAssembly(this ISymbol symbol, bool includeInternals,
-            bool includeEffectivelyPrivateSymbols = false, bool includeExplicitInterfaceImplementationSymbols = false) =>
+        public static bool IsVisibleOutsideOfAssembly(this ISymbol symbol,
+            bool includeInternals,
+            bool includeEffectivelyPrivateSymbols = false,
+            bool includeExplicitInterfaceImplementationSymbols = false) =>
             symbol.DeclaredAccessibility switch
             {
                 Accessibility.Public => true,

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -92,15 +92,16 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
                     yield return baseInterface;
         }
 
-        public static bool IsVisibleOutsideOfAssembly(this ISymbol symbol, bool includeInternals, bool includeEffectivelyPrivateSymbols = false) =>
+        public static bool IsVisibleOutsideOfAssembly(this ISymbol symbol, bool includeInternals,
+            bool includeEffectivelyPrivateSymbols = false, bool includeExplicitInterfaceImplementationSymbols = false) =>
             symbol.DeclaredAccessibility switch
             {
                 Accessibility.Public => true,
                 Accessibility.Protected => includeEffectivelyPrivateSymbols || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternals),
                 Accessibility.ProtectedOrInternal => includeEffectivelyPrivateSymbols || includeInternals || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternals),
                 Accessibility.ProtectedAndInternal => includeInternals && (includeEffectivelyPrivateSymbols || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternals)),
-                Accessibility.Private => includeEffectivelyPrivateSymbols && IsExplicitInterfaceImplementation(symbol),
-                _ => includeInternals && symbol.DeclaredAccessibility != Accessibility.Private,
+                Accessibility.Private => includeExplicitInterfaceImplementationSymbols && IsExplicitInterfaceImplementation(symbol),
+                _ => includeInternals,
             };
 
         public static bool IsEventAdderOrRemover(this IMethodSymbol method) =>

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
@@ -56,8 +56,13 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         public static bool IsEffectivelySealed(this ITypeSymbol type, bool includeInternals) =>
             type.IsSealed || !HasVisibleConstructor(type, includeInternals);
 
+        /// <summary>
+        /// Determines where the symbol is the explicit interface implementation method.
+        /// </summary>
+        /// <param name="symbol"><see cref="ISymbol"/>  Represents a symbol (namespace, class, method, parameter, etc.) exposed by the compiler.</param>
+        /// <returns>true if the symbol is the explicit interface implementation method</returns>
         public static bool IsExplicitInterfaceImplementation(this ISymbol symbol) =>
-            symbol is IMethodSymbol method ? method.MethodKind == MethodKind.ExplicitInterfaceImplementation : false;
+            symbol is IMethodSymbol method && method.MethodKind == MethodKind.ExplicitInterfaceImplementation;
 
         private static bool HasVisibleConstructor(ITypeSymbol type, bool includeInternals)
         {

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -56,6 +56,9 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         public static bool IsEffectivelySealed(this ITypeSymbol type, bool includeInternals) =>
             type.IsSealed || !HasVisibleConstructor(type, includeInternals);
 
+        public static bool IsExplicitInterfaceImplementation(this ISymbol symbol) =>
+            symbol is IMethodSymbol method ? method.MethodKind == MethodKind.ExplicitInterfaceImplementation : false;
+
         private static bool HasVisibleConstructor(ITypeSymbol type, bool includeInternals)
         {
             if (type is INamedTypeSymbol namedType)
@@ -91,6 +94,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
                 Accessibility.Protected => includeEffectivelyPrivateSymbols || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternals),
                 Accessibility.ProtectedOrInternal => includeEffectivelyPrivateSymbols || includeInternals || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternals),
                 Accessibility.ProtectedAndInternal => includeInternals && (includeEffectivelyPrivateSymbols || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternals)),
+                Accessibility.Private => includeEffectivelyPrivateSymbols && IsExplicitInterfaceImplementation(symbol),
                 _ => includeInternals && symbol.DeclaredAccessibility != Accessibility.Private,
             };
 

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
         {
             var compositeFilter = new CompositeFilter()
                 .Add<ImplicitSymbolsFilter>()
-                .Add(new SymbolAccessibilityBasedFilter(true, true));
+                .Add(new SymbolAccessibilityBasedFilter(true, true, true));
             _csharpFileBuilder = new CSharpFileBuilder(compositeFilter, _stringWriter, _csharpSyntaxWriter, MetadataReferences);
         }
 

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -599,7 +599,6 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     public abstract class MemoryManager : System.IDisposable
                     {
                         void System.IDisposable.Dispose() { }
-                        public int? Owner { get; set; }
                     }
                 }
                 """,

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -613,6 +613,5 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 }
                 """);
         }
-
     }
 }

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -607,7 +607,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 {
                     public abstract partial class MemoryManager : System.IDisposable
                     {
-                        private void System.IDisposable.Dispose() { }
+                        void System.IDisposable.Dispose() { }
                     }
                 }
                 """);

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -589,5 +589,30 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 }
                 """);
         }
+
+        [Fact]
+        void TestExplicitInterfaceImplementationMethodGeneration()
+        {
+            RunTest(original: """
+                namespace Foo
+                {
+                    public abstract class MemoryManager : System.IDisposable
+                    {
+                        void System.IDisposable.Dispose() { }
+                        public int? Owner { get; set; }
+                    }
+                }
+                """,
+                expected: """
+                namespace Foo
+                {
+                    public abstract partial class MemoryManager : System.IDisposable
+                    {
+                        private void System.IDisposable.Dispose() { }
+                    }
+                }
+                """);
+        }
+
     }
 }


### PR DESCRIPTION
Issue: https://github.com/dotnet/arcade/issues/11895

* Add support to generate methods with `MethodKind.ExplicitInterfaceImplementation`
* Update common utility function `IsVisibleOutsideOfAssembly` to allow methods with visibility `Private` if they are of type ExplicitInterfaceImplementation