### PR TITLE
Set server GC for F# FSC/FSI

### DIFF
--- a/src/Layout/tool_fsharp/tool_fsc.csproj
+++ b/src/Layout/tool_fsharp/tool_fsc.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As we figured out [here](https://github.com/dotnet/fsharp/pull/13740#issuecomment-1304870562), SDK is not getting `runtimeconfig.json` files from F# itself, but from the https://github.com/dotnet/sdk/blob/main/src/Layout/tool_fsharp/tool_fsc.csproj:

https://github.com/dotnet/sdk/blob/a50339473c041a9099a27b808b09e1faf506920b/src/Layout/redist/targets/GenerateLayout.targets#L254-L262

Hopefully, it's the proper place to make the change, if not, please advise what would be thecorrect one.

**Update:** will also need to verify that these changes do affect runtimeconfig, when build is complete.