### PR TITLE
Fix copy failures when building Microsoft.NET.Sdk.Razor.Tasks.csproj

### DIFF
--- a/src/RazorSdk/Tasks/Microsoft.NET.Sdk.Razor.Tasks.csproj
+++ b/src/RazorSdk/Tasks/Microsoft.NET.Sdk.Razor.Tasks.csproj
@@ -101,6 +101,7 @@
   </Target>
 
   <Target Name="CopyAdditionalFilesToLayout"
+          Condition="'$(TargetFramework)' == ''"
           DependsOnTargets="PrepareAdditionalFilesToLayout"
           AfterTargets="Build" Inputs="@(LayoutFile)"
           Outputs="@(LayoutFile->'$(PackageLayoutOutputPath)%(TargetPath)')">


### PR DESCRIPTION
Fix #29289

All of the other `CopyAdditionalFilesToLayout` tasks have `Condition="'$(TargetFramework)' == ''"`, but this was missing from the Razor Tasks project.  This meant the target was running in both inner and outer builds and could sometimes cause file access errors when building.