### PR TITLE
Use File.OpenRead when loading tool configuration

### DIFF
--- a/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.ToolPackage
 
             try
             {
-                using (var fs = new FileStream(pathToXml, FileMode.Open))
+                using (var fs = File.OpenRead(pathToXml))
                 {
                     var reader = XmlReader.Create(fs);
                     dotNetCliTool = (DotNetCliTool)serializer.Deserialize(reader);


### PR DESCRIPTION
Supports #29535. As noted, this explicitly opens the file with `Read`, rather than `ReadWrite`. This should prevent conflicts when the configuration files are accessed in parallel, such as when building multiple branches in a CI environment.

CC @baronfel in case you've any particular input in this case. (and thank you for the quick diagnosis in the original issue!)