### PR TITLE
Use File.OpenRead when loading tool configuration (6.0.4xx backport)

### DIFF
--- a/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.ToolPackage
 
             try
             {
-                using (var fs = new FileStream(pathToXml, FileMode.Open))
+                using (var fs = File.OpenRead(pathToXml))
                 {
                     var reader = XmlReader.Create(fs);
                     dotNetCliTool = (DotNetCliTool)serializer.Deserialize(reader);


### PR DESCRIPTION
A backport of #29540 (supporting #29535) to SDK 6.0.4xx.

## Description

When running `dotnet tool restore` in parallel (for example, multiple jobs on a shared-hosting CI server), a read-only metadata file in the restored dotnet tool's NuGet package would be locked with both read and write access, preventing all but one of the restore commands from completing.

## Customer Impact

Customers saw errors around file access to this tool metadata file, and would need to retry restore operations. This could lead to build flakiness if the restore was done in a CI system, or even a local repo 'init' script. **This issue was reported by a customer on a 6.x SDK**.

## Regression

**No**, this has been present for quite some time - potentially since the beginning of .NET SDK tools.

## Risk

**Low** - The fix is to explicitly open the metadata file with a Read-Only stream.
