### PR TITLE
[release/7.0.2xx] [Backport] Prevent `dotnet test` verbosity from being ignored

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.Tools.Test
                 msbuildArgs.Add($"-property:VSTestCLIRunSettings=\"{runSettingsArg}\"");
             }
 
-            string verbosityArg = result.ForwardedOptionValues<IReadOnlyCollection<string>>(TestCommandParser.GetCommand(), "verbosity")?.SingleOrDefault() ?? null;
+            string verbosityArg = result.ForwardedOptionValues<IReadOnlyCollection<string>>(TestCommandParser.GetCommand(), "--verbosity")?.SingleOrDefault() ?? null;
             if (verbosityArg != null)
             {
                 string[] verbosity = verbosityArg.Split(':', 2);


### PR DESCRIPTION
Backport from https://github.com/dotnet/sdk/pull/27992 - cherry-picked commit https://github.com/dotnet/sdk/commit/c4b8dccb8f8a0feb2cd479115c227b313e30d7da.

-------

One of the two aliases of `Command` instance (obtained from static class `TestCommandParser`, not a runtime instance of a command) needs to be passed to `ForwardedOptionValues`.

Debug visualization after the fix (note `alias` value):
![New Picture (2)](https://user-images.githubusercontent.com/11148519/191203879-29b6231d-240a-4037-a39e-892b2566127c.png)

The existing test `ItUsesVerbosityPassedToDefineVerbosityOfConsoleLoggerOfTheTests` was using only `quiet` mode and was testing for the wrong strings anyway  (`TestNamespace.VSTestTests.VSTestPassTest` and `TestNamespace.VSTestTests.VSTestFailTest`, when only tests names are shown nowadays in case of verbosity >= `normal`), hence the regression.


This fixed 16122.

