### PR TITLE
Update Verify and Verify.Diffplex

### DIFF
--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
-    <PackageReference Include="Verify.XUnit" Version="17.1.4" />
-    <PackageReference Include="Verify.DiffPlex" Version="1.3.0" />
+    <PackageReference Include="Verify.XUnit" Version="19.5.0" />
+    <PackageReference Include="Verify.DiffPlex" Version="2.0.1" />
     <PackageReference Include="Microsoft.TemplateEngine.Mocks" Version="$(MicrosoftTemplateEngineMocksPackageVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.TestHelper" Version="$(MicrosoftTemplateEngineTestHelperPackageVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="$(MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion)" />

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/VerifySettingsFixture.cs
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/VerifySettingsFixture.cs
@@ -2,13 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using VerifyTests.DiffPlex;
+
 namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 {
     public class VerifySettingsFixture : IDisposable
     {
+        private static bool _called;
+
         public VerifySettingsFixture()
         {
-            VerifierSettings.DerivePathInfo(
+            if (_called)
+            {
+                return;
+            }
+            _called = true;
+            Verifier.DerivePathInfo(
                 (_, _, type, method) => new(
                     directory: "Approvals",
                     typeName: type.Name,

--- a/src/Tests/dotnet-new.Tests/VerifySettingsFixture.cs
+++ b/src/Tests/dotnet-new.Tests/VerifySettingsFixture.cs
@@ -2,12 +2,21 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using VerifyTests.DiffPlex;
+
 namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
     public class VerifySettingsFixture : IDisposable
     {
+        private static bool _called;
+
         public VerifySettingsFixture()
         {
+            if (_called)
+            {
+                return;
+            }
+            _called = true;
             Verifier.DerivePathInfo(
                 (_, _, type, method) => new(
                     directory: "Approvals",

--- a/src/Tests/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
+++ b/src/Tests/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
@@ -15,8 +15,8 @@
     <ProjectReference Include="..\..\Cli\dotnet-new3\dotnet-new3.csproj" />
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-    <PackageReference Include="Verify.Xunit" Version="19.3.0" />
-    <PackageReference Include="Verify.DiffPlex" Version="1.3.0" />
+    <PackageReference Include="Verify.Xunit" Version="19.5.0" />
+    <PackageReference Include="Verify.DiffPlex" Version="2.0.1" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.TestHelper" Version="$(MicrosoftTemplateEngineTestHelperPackageVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Authoring.TemplateVerifier" Version="$(MicrosoftTemplateEngineAuthoringTemplateVerifierVersion)" />


### PR DESCRIPTION
### Problem
Verify.Diffple 1.3.0 have some flaws in reporting diff outputs (e.g. nonactionable output for whitespace only changes)

### Solution
Updating manually now - as it needs code adjustments
Changes from Needs https://github.com/dotnet/templating/pull/5798 needs to flow in as well to unblock this