### PR TITLE
Fix publish test TFMs

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishTestUtils.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishTestUtils.cs
@@ -16,6 +16,7 @@ namespace Microsoft.NET.Publish.Tests
             new object[] { "netcoreapp3.1" },
             new object[] { "net5.0" },
             new object[] { "net6.0" },
+            new object[] { "net7.0" },
             new object[] { ToolsetInfo.CurrentTargetFramework },
         };
 
@@ -24,6 +25,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             new object[] { "net5.0" },
             new object[] { "net6.0" },
+            new object[] { "net7.0" },
             new object[] { ToolsetInfo.CurrentTargetFramework },
         };
 
@@ -31,10 +33,11 @@ namespace Microsoft.NET.Publish.Tests
         public static IEnumerable<object[]> Net6Plus { get; } = new List<object[]>
         {
             new object[] { "net6.0" },
+            new object[] { "net7.0" },
             new object[] { ToolsetInfo.CurrentTargetFramework },
         };
 #else
-#error If building for a newer TFM, please update the values above
+#error If building for a newer TFM, please update the values above to include both the old and new TFMs.
 #endif
     }
 }


### PR DESCRIPTION
The "net7.0" TFM was dropped in the move to "net8.0" in https://github.com/dotnet/sdk/pull/29316.