### PR TITLE
Upgrade helix queues

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -159,9 +159,9 @@ stages:
         pool:
           vmImage: 'macOS-latest'
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: OSX.1015.Amd64.Open
+          helixTargetQueue: OSX.1100.Amd64.Open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: OSX.1015.Amd64
+          helixTargetQueue: OSX.1100.Amd64
         strategy:
           matrix:
             Build_Release:

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -50,9 +50,9 @@ jobs:
         pool:
           vmImage: 'macOS-latest'
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: OSX.1015.Amd64.Open
+          helixTargetQueue: OSX.1100.Amd64.Open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: OSX.1015.Amd64
+          helixTargetQueue: OSX.1100.Amd64
         strategy:
           matrix:
             Build_Release:

--- a/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRid/NativeCode.cs
+++ b/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRid/NativeCode.cs
@@ -28,6 +28,7 @@ namespace LibraryWithRid
                 case "'osx.10.12-x64'":
                 case "'osx.10.14-x64'":
                 case "'osx.10.15-x64'":
+				case "'osx.11.0-x64'":
                     return Marshal.PtrToStringAnsi(MacNativeMethods.sqlite3_libversion());
                 case "'win10-x64'":
                 case "'win10-x86'":

--- a/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/NativeCode.cs
+++ b/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/NativeCode.cs
@@ -28,6 +28,7 @@ namespace LibraryWithRids
                 case "'osx.10.12-x64'":
                 case "'osx.10.14-x64'":
                 case "'osx.10.15-x64'":
+				case "'osx.11.0-x64'":
                     return Marshal.PtrToStringAnsi(MacNativeMethods.sqlite3_libversion());
                 case "'win10-x64'":
                 case "'win10-x86'":

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -24,8 +24,8 @@ namespace Microsoft.NET.TestFramework
 
         public const string LatestWinRuntimeIdentifier = "win10";
         public const string LatestLinuxRuntimeIdentifier = "ubuntu.22.04";
-        public const string LatestMacRuntimeIdentifier = "osx.10.15";
-        public const string LatestRuntimeIdentifiers = $"{LatestWinRuntimeIdentifier}-x64;{LatestWinRuntimeIdentifier}-x86;osx.10.10-x64;osx.10.11-x64;osx.10.12-x64;osx.10.14-x64;{LatestMacRuntimeIdentifier}-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;ubuntu.18.04-x64;ubuntu.20.04-x64;{LatestLinuxRuntimeIdentifier}-x64;centos.9-x64;rhel.9-x64;debian.9-x64;fedora.37-x64;opensuse.42.3-x64;linux-musl-x64";
+        public const string LatestMacRuntimeIdentifier = "osx.11.0";
+        public const string LatestRuntimeIdentifiers = $"{LatestWinRuntimeIdentifier}-x64;{LatestWinRuntimeIdentifier}-x86;osx.10.10-x64;osx.10.11-x64;osx.10.12-x64;osx.10.14-x64;osx.11.15-x64;{LatestMacRuntimeIdentifier}-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;ubuntu.18.04-x64;ubuntu.20.04-x64;{LatestLinuxRuntimeIdentifier}-x64;centos.9-x64;rhel.9-x64;debian.9-x64;fedora.37-x64;opensuse.42.3-x64;linux-musl-x64";
 
         public string DotNetRoot { get; }
         public string DotNetHostPath { get; }

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NET.TestFramework
         public const string LatestWinRuntimeIdentifier = "win10";
         public const string LatestLinuxRuntimeIdentifier = "ubuntu.22.04";
         public const string LatestMacRuntimeIdentifier = "osx.11.0";
-        public const string LatestRuntimeIdentifiers = $"{LatestWinRuntimeIdentifier}-x64;{LatestWinRuntimeIdentifier}-x86;osx.10.10-x64;osx.10.11-x64;osx.10.12-x64;osx.10.14-x64;osx.11.15-x64;{LatestMacRuntimeIdentifier}-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;ubuntu.18.04-x64;ubuntu.20.04-x64;{LatestLinuxRuntimeIdentifier}-x64;centos.9-x64;rhel.9-x64;debian.9-x64;fedora.37-x64;opensuse.42.3-x64;linux-musl-x64";
+        public const string LatestRuntimeIdentifiers = $"{LatestWinRuntimeIdentifier}-x64;{LatestWinRuntimeIdentifier}-x86;osx.10.10-x64;osx.10.11-x64;osx.10.12-x64;osx.10.14-x64;osx.10.15-x64;{LatestMacRuntimeIdentifier}-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;ubuntu.18.04-x64;ubuntu.20.04-x64;{LatestLinuxRuntimeIdentifier}-x64;centos.9-x64;rhel.9-x64;debian.9-x64;fedora.37-x64;opensuse.42.3-x64;linux-musl-x64";
 
         public string DotNetRoot { get; }
         public string DotNetHostPath { get; }


### PR DESCRIPTION
### Problem

SDK pipelines failing with
```
SENDHELIXJOB(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Helix queue osx.1015.amd64.open is set for estimated removal date of 2023-01-01. In most cases the queue will be removed permanently due to end-of-life; please contact dnceng for any questions or concerns, and we can help you decide how to proceed and discuss other options.
```

### Solution

Upgrade the helix queue to a one with newer OSX