### PR TITLE
add PreferDefaultName property to CliTemplateInfo

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="8.0.100-alpha.1.22629.1">
+   <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="8.0.100-alpha.1.23053.4">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>36a4e3d1cd606ea51bc02a85cd701668015fa8d0</Sha>
+      <Sha>95dcca494c63563562fa494f64b71065955e4e7c</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-alpha.1.23052.5">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -124,7 +124,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>8.0.100-alpha.1.22629.1</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>8.0.100-alpha.1.23053.4</MicrosoftTemplateEngineAbstractionsPackageVersion>
     <MicrosoftTemplateEngineEdgePackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineEdgePackageVersion>
     <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
     <MicrosoftTemplateEngineUtilsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineUtilsPackageVersion>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateInfo.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateInfo.cs
@@ -70,6 +70,8 @@ namespace Microsoft.TemplateEngine.Cli
 
         public string? ThirdPartyNotices => _templateInfo.ThirdPartyNotices;
 
+        public bool PreferDefaultName => _templateInfo.PreferDefaultName;
+
         public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo => _templateInfo.BaselineInfo;
 
         [Obsolete]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/pull/29696/files#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67

In the scope of work on https://github.com/dotnet/templating/issues/2303 ITemplateInfo.cs was extended with the new property.