### PR TITLE
Add a reminder for the Area-AspNetCore PR authors to help with finding the schedule

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -170,6 +170,44 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "Area-AspNetCore"
+              }
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Remind ASP.NET Core PR authors the process to follow ",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Thanks for your PR, @${issueAuthor}.\nTo learn about the PR process of this repo as well as the branching schedule please take a look at the [SDK PR Guide](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/SDK-PR-guide.md)."
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -203,7 +203,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Thanks for your PR, @${issueAuthor}.\nTo learn about the PR process of this repo as well as the branching schedule please take a look at the [SDK PR Guide](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/SDK-PR-guide.md)."
+              "comment": "Thanks for your PR, @${issueAuthor}.\nTo learn about the PR process and branching schedule of this repo, please take a look at the [SDK PR Guide](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/SDK-PR-guide.md)."
             }
           }
         ]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -198,7 +198,7 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Remind ASP.NET Core PR authors the process to follow ",
+        "taskName": "Remind ASP.NET Core PR authors the process to follow",
         "actions": [
           {
             "name": "addReply",


### PR DESCRIPTION
This rule will add a comment on PRs, as soon as those will be labeled with the `Area-AspNetCore` label, which will point to the SDK PR Guide so that the PR authors can easily find out the processes to follow and learn if the branch is open or not.

Note, the SDK PR Guide is still in PR, so this PR will be merged only after https://github.com/dotnet/sdk/pull/29562