### PR TITLE
Improve the stage 0 template error message to be actionable

### DIFF
--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -23,7 +23,7 @@
         <FolderName>$([System.IO.Path]::GetFileName(`%(Identity)`))</FolderName>
       </TemplatesFolderPath>
     </ItemGroup>
-    <Error Text="SDK Stage 0 has more than one folder with templates: @(TemplatesFolderPath->'%(FolderName)')" Condition="@(TemplatesFolderPath->Count()) > 1"></Error>
+    <Error Text="SDK Stage 0 has more than one folder with templates: @(TemplatesFolderPath->'%(Identity)'). Please delete all but one and rebuild" Condition="@(TemplatesFolderPath->Count()) > 1"></Error>
 
     <!--Prepare Microsoft.DotNet.Common.*.nupkg and pack them directly to target <redist root>\templates\<runtime version> folder. -->
     <Exec Command="$(DotnetTool) pack $(RepoRoot)template_feed\Microsoft.DotNet.Common.ProjectTemplates.8.0 --configuration $(Configuration) --output $(RedistLayoutPath)\templates\@(TemplatesFolderPath->'%(FolderName)')\" />


### PR DESCRIPTION
C:\repos\sdk\src\Layout\redist\targets\OverlaySdkOnLKG.targets(26,5): error : SDK Stage 0 has more than one folder with
 templates: C:\repos\sdk\.dotnet/templates\8.0.0-alpha.1.22558.5;C:\repos\sdk\.dotnet/templates\8.0.0-alpha.1.22558.5 -
 Copy. Please delete all but one and rebuild [C:\repos\sdk\src\Layout\redist\redist.csproj]