### PR TITLE
Add DynamicCodeSupport Feature Switch

### DIFF
--- a/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -25,7 +25,7 @@
     <NullabilityInfoContextSupport>false</NullabilityInfoContextSupport>
     <CustomResourceTypesSupport>false</CustomResourceTypesSupport>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
-    <DynamicCodeSupport>false</DynamicCodeSupport>
+    <DynamicCodeSupport>true</DynamicCodeSupport>
     <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
     <_EnableConsumingManagedCodeFromNativeHosting>false</_EnableConsumingManagedCodeFromNativeHosting>
     <EnableCppCLIHostActivation>false</EnableCppCLIHostActivation>

--- a/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -25,6 +25,7 @@
     <NullabilityInfoContextSupport>false</NullabilityInfoContextSupport>
     <CustomResourceTypesSupport>false</CustomResourceTypesSupport>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <DynamicCodeSupport>false</DynamicCodeSupport>
     <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
     <_EnableConsumingManagedCodeFromNativeHosting>false</_EnableConsumingManagedCodeFromNativeHosting>
     <EnableCppCLIHostActivation>false</EnableCppCLIHostActivation>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -19,6 +19,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishTrimmed Condition="'$(PublishTrimmed)' == '' And '$(PublishAot)' == 'true'">true</PublishTrimmed>
     <_IsTrimmingEnabled Condition="'$(_IsTrimmingEnabled)' == '' And ('$(PublishTrimmed)' == 'true' Or '$(IsTrimmable)' == 'true')">true</_IsTrimmingEnabled>
     <_IsTrimmingEnabled Condition="'$(_IsTrimmingEnabled)' == ''">false</_IsTrimmingEnabled>
+    <DynamicCodeSupport Condition="'$(DynamicCodeSupport)' == '' And '$(PublishAot)' == 'true'">false</DynamicCodeSupport>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -474,6 +474,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Value="$(UseSystemResourceKeys)"
                                     Trim="true" />
 
+    <RuntimeHostConfigurationOption Include="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported"
+                                    Condition="'$(DynamicCodeSupport)' != ''"
+                                    Value="$(DynamicCodeSupport)"
+                                    Trim="true" />
+
     <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.BuiltInComInterop.IsSupported"
                                     Condition="'$(BuiltInComInteropSupport)' != ''"
                                     Value="$(BuiltInComInteropSupport)"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -83,7 +83,7 @@ namespace Microsoft.NET.Publish.Tests
             ""System.Reflection.NullabilityInfoContext.IsSupported"": false,
             ""System.Resources.ResourceManager.AllowCustomResourceTypes"": false,
             ""System.Resources.UseSystemResourceKeys"": true,
-            ""System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported"": false,
+            ""System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported"": true,
             ""System.Runtime.InteropServices.BuiltInComInterop.IsSupported"": false,
             ""System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting"": false,
             ""System.Runtime.InteropServices.EnableCppCLIHostActivation"": false,

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -83,6 +83,7 @@ namespace Microsoft.NET.Publish.Tests
             ""System.Reflection.NullabilityInfoContext.IsSupported"": false,
             ""System.Resources.ResourceManager.AllowCustomResourceTypes"": false,
             ""System.Resources.UseSystemResourceKeys"": true,
+            ""System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported"": false,
             ""System.Runtime.InteropServices.BuiltInComInterop.IsSupported"": false,
             ""System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting"": false,
             ""System.Runtime.InteropServices.EnableCppCLIHostActivation"": false,

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -705,6 +705,34 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void It_builds_with_dynamiccodesupport_false(string targetFramework)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var projectName = "DynamicCodeSupportFalseApp";
+                var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
+                testProject.AdditionalProperties["PublishAot"] = "true";
+                var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+                var buildCommand = new DotnetBuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                buildCommand
+                    .Execute()
+                    .Should()
+                    .Pass();
+
+                string outputDirectory = buildCommand.GetOutputDirectory(targetFramework: targetFramework).FullName;
+                string runtimeConfigFile = Path.Combine(outputDirectory, $"{projectName}.runtimeconfig.json");
+                string runtimeConfigContents = File.ReadAllText(runtimeConfigFile);
+
+                JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
+                JToken configProperties = runtimeConfig["runtimeOptions"]["configProperties"];
+                configProperties["System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported"].Value<bool>()
+                    .Should().BeFalse();
+            }
+        }
+
         private void CheckIlcVersions(string projectPath, string targetFramework, string rid, string expectedVersion)
         {
             // Compiler version matches expected version


### PR DESCRIPTION
Adds support in the SDK for the new RuntimeFeature.IsDynamicCodeSupported feature switch added in  https://github.com/dotnet/runtime/issues/39806. When PublishAot is set in a project, DynamicCodeSupport gets defaulted to false.