### PR TITLE
Copying the files to publish intermediate path to help with .NET SDK container publish

### DIFF
--- a/src/WebSdk/Publish/Targets/ComputeTargets/Microsoft.NET.Sdk.Publish.ComputeFiles.targets
+++ b/src/WebSdk/Publish/Targets/ComputeTargets/Microsoft.NET.Sdk.Publish.ComputeFiles.targets
@@ -30,7 +30,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_IsAspNetCoreProject Condition="%(ProjectCapability.Identity) == 'AspNetCore'">true</_IsAspNetCoreProject>
       <_PublishProjectType Condition="'$(_PublishProjectType)' == '' and '$(_IsAspNetCoreProject)' == 'true' ">AspNetCore</_PublishProjectType>
       <_PublishProjectType Condition="'$(_PublishProjectType)' == '' and '$(WebJobName)' != '' and '$(WebJobType)' != ''">WebJob</_PublishProjectType>
-      <_PublishProjectType Condition="'$(_PublishProjectType)' == '' ">UnKnown</_PublishProjectType>
+      <_PublishProjectType Condition="'$(_PublishProjectType)' == '' ">Console</_PublishProjectType>
     </PropertyGroup>
   </Target>
 

--- a/src/WebSdk/Publish/Targets/CopyTargets/Microsoft.NET.Sdk.Publish.CopyFiles.targets
+++ b/src/WebSdk/Publish/Targets/CopyTargets/Microsoft.NET.Sdk.Publish.CopyFiles.targets
@@ -20,6 +20,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       _CopyFilesToPublishIntermediateOutputPath;
       _CopyAspNetCoreFilesToIntermediateOutputPath;
       _CopyWebJobFilesToIntermediateOutputPath;
+      _CopyConsoleFilesToIntermediateOutputPath;
     </_DotNetPublishCopyFiles>
   </PropertyGroup>
 
@@ -90,7 +91,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
   </Target>
 
-   <!--********************************************************************-->
+  <!--********************************************************************-->
   <!-- Target _CopyWebJobFilesToIntermediateOutputPath -->
   <!--********************************************************************-->
   <PropertyGroup>
@@ -112,6 +113,32 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="_PrepareForWebJobPublish">
     <PropertyGroup>
       <PublishDir>$(PublishIntermediateOutputPath)\app_data\Jobs\$(WebJobType)\$(WebJobName)\</PublishDir>
+      <Configuration>$(PublishConfiguration)</Configuration>
+    </PropertyGroup>
+  </Target>
+
+  <!--********************************************************************-->
+  <!-- Target _CopyConsoleFilesToIntermediateOutputPath -->
+  <!--********************************************************************-->
+  <PropertyGroup>
+    <_CopyConsoleFilesToIntermediateOutputPathDependsOn>
+      $(_CopyConsoleFilesToIntermediateOutputPathDependsOn);
+      _PrepareForConsolePublish;
+      Publish;
+    </_CopyConsoleFilesToIntermediateOutputPathDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_CopyConsoleFilesToIntermediateOutputPath"
+    Condition="'$(_PublishProjectType)' == 'Console'"
+    DependsOnTargets="$(_CopyConsoleFilesToIntermediateOutputPathDependsOn)">
+  </Target>
+
+  <!--********************************************************************-->
+  <!-- Target _PrepareForConsolePublish -->
+  <!--********************************************************************-->
+  <Target Name="_PrepareForConsolePublish">
+    <PropertyGroup>
+      <PublishDir>$(PublishIntermediateOutputPath)</PublishDir>
       <Configuration>$(PublishConfiguration)</Configuration>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
Issue: 
Publishing console applications to Container registries fails with the error that the publish files are not present in the $(PublishDir) folder.

Fix: 
For Web Applications and WebJobs, there are existing targets to copy the files to the $(PublishDir). The same logic is not present for other console applications. The fix is the add the same fix for console applications as well. 

Risk: 
Low