### PR TITLE
Do a two-phase publish to mimic VS behavior

### DIFF
--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Cli
         private bool checkSolutions;
 
         /// <summary>
-        /// Returns dotnet CLI command-line parameters (or an empty list) to change configuration based on 
+        /// Returns dotnet CLI command-line parameters (or an empty list) to change configuration based on
         /// a boolean that may or may not exist in the targeted project.
         /// <param name="defaultedConfigurationProperty">The boolean property to check the project for. Ex: PublishRelease</param>
         /// <param name="slnOrProjectArgs">The arguments or solution passed to a dotnet invocation.</param>
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Cli
                         {
                             return GetSlnProject(potentialSln, globalProps, slnProjectPropertytoCheck);
                         }
-                    } // If nothing can be found: that's caught by MSBuild XMake::ProcessProjectSwitch -- don't change the behavior by failing here. 
+                    } // If nothing can be found: that's caught by MSBuild XMake::ProcessProjectSwitch -- don't change the behavior by failing here.
                 }
             }
 
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Cli
         }
 
         /// <returns>A case-insensitive dictionary of any properties passed from the user and their values.</returns>
-        private Dictionary<string, string> GetGlobalPropertiesFromUserArgs(ParseResult parseResult)
+        public Dictionary<string, string> GetGlobalPropertiesFromUserArgs(ParseResult parseResult)
         {
             Dictionary<string, string> globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Cli
 
         /// <param name="slnProjectPropertytoCheck">A property to enforce if we are looking into SLN files. If projects disagree on the property, throws exception.</param>
         /// <returns>A project instance that will be targeted to publish/pack, etc. null if one does not exist.</returns>
-        public ProjectInstance GetTargetedProject(IEnumerable<string> slnOrProjectArgs, Dictionary<string, string> globalProps, string slnProjectPropertytoCheck = "")
+        public ProjectInstance GetTargetedProject(IEnumerable<string> slnOrProjectArgs, Dictionary<string, string> globalProps, string slnProjectPropertytoCheck = "", bool includeSolutions = true)
         {
             string potentialProject = "";
 
@@ -85,6 +85,11 @@ namespace Microsoft.DotNet.Cli
                     }
                     catch (GracefulException)
                     {
+                        if (!includeSolutions)
+                        {
+                            continue;
+                        }
+
                         // Fall back to looking for a solution if multiple project files are found.
                         string potentialSln = Directory.GetFiles(arg, "*.sln", SearchOption.TopDirectoryOnly).FirstOrDefault();
 

--- a/src/Cli/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/Program.cs
@@ -34,12 +34,14 @@ namespace Microsoft.DotNet.Tools.Publish
         /// build via the Microsoft.Net.Sdk.Publish props and targets.
         /// </remarks>
         private static string[] PropertiesToForwardFromProfile = new [] {
-            "LastUsedBuildConfiguration",
             "Configuration",
+            "LastUsedBuildConfiguration",
+            "LastUsedPlatform",
             "Platform",
+            "RuntimeIdentifier",
+            "RuntimeIdentifiers",
             "TargetFramework",
             "TargetFrameworks",
-            "RuntimeIdentifier"
         };
 
         private PublishCommand(

--- a/src/Cli/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/Program.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Tools.Publish
             {
                 ReleasePropertyProjectLocator projectLocator = new ReleasePropertyProjectLocator(Environment.GetEnvironmentVariable(EnvironmentVariableNames.ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS) != null);
                 var cliProps = projectLocator.GetGlobalPropertiesFromUserArgs(parseResult);
-                var projectInstance = projectLocator.GetTargetedProject(parseResult.GetValueForArgument(PublishCommandParser.SlnOrProjectArgument), cliProps);
+                var projectInstance = projectLocator.GetTargetedProject(parseResult.GetValueForArgument(PublishCommandParser.SlnOrProjectArgument), cliProps, MSBuildPropertyNames.PUBLISH_RELEASE);
                 // this can happen if the project wasn't loadable, or if we're at a solution context
                 if (projectInstance == null)
                 {

--- a/src/Cli/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/Program.cs
@@ -102,6 +102,11 @@ namespace Microsoft.DotNet.Tools.Publish
                 ReleasePropertyProjectLocator projectLocator = new ReleasePropertyProjectLocator(Environment.GetEnvironmentVariable(EnvironmentVariableNames.ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS) != null);
                 var cliProps = projectLocator.GetGlobalPropertiesFromUserArgs(parseResult);
                 var projectInstance = projectLocator.GetTargetedProject(parseResult.GetValueForArgument(PublishCommandParser.SlnOrProjectArgument), cliProps);
+                // this can happen if the project wasn't loadable, or if we're at a solution context
+                if (projectInstance == null)
+                {
+                    return new List<string>();
+                }
                 var importedPropValue = projectInstance.GetPropertyValue(MSBuildPropertyNames.PUBLISH_PROFILE_IMPORTED);
                 if (!String.IsNullOrEmpty(importedPropValue) && bool.TryParse(importedPropValue, out var wasImported) && wasImported) {
                     try {

--- a/src/Cli/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/Program.cs
@@ -69,7 +69,6 @@ namespace Microsoft.DotNet.Tools.Publish
 
 
             var publishProfileProperties = DiscoverPropertiesFromPublishProfile(parseResult);
-            Console.WriteLine($"Read publish properties: {string.Join(",", publishProfileProperties)}");
             var standardMSbuildProperties = CreatePropertyListForPublishInvocation(parseResult);
             return new PublishCommand(
                 // properties defined by the selected publish profile should override any other properties,

--- a/src/Cli/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/Program.cs
@@ -33,8 +33,12 @@ namespace Microsoft.DotNet.Tools.Publish
         /// are set very early on in the build (RID, Configuration, etc).  The remainder will be imported during the
         /// build via the Microsoft.Net.Sdk.Publish props and targets.
         /// </remarks>
-        private static const string[] PropertiesToForwardFromProfile = new [] {
+        private static string[] PropertiesToForwardFromProfile = new [] {
+            "LastUsedBuildConfiguration",
             "Configuration",
+            "Platform",
+            "TargetFramework",
+            "TargetFrameworks",
             "RuntimeIdentifier"
         };
 

--- a/src/Common/MSBuildPropertyNames.cs
+++ b/src/Common/MSBuildPropertyNames.cs
@@ -12,5 +12,7 @@ namespace Microsoft.DotNet.Cli
         public static readonly string CONFIGURATION_DEBUG_VALUE = "Debug";
         public static readonly string OUTPUT_TYPE = "OutputType";
         public static readonly string OUTPUT_TYPE_EXECUTABLE = "Exe";
+        public static readonly string PUBLISH_PROFILE_IMPORTED = "PublishProfileImported";
+        public static readonly string PUBLISH_PROFILE_FULL_PATH = "PublishProfileFullPath";
     }
 }

--- a/src/Common/MSBuildPropertyNames.cs
+++ b/src/Common/MSBuildPropertyNames.cs
@@ -5,14 +5,21 @@ namespace Microsoft.DotNet.Cli
 {
     static class MSBuildPropertyNames
     {
-        public static readonly string PUBLISH_RELEASE = "PublishRelease";
-        public static readonly string PACK_RELEASE = "PackRelease";
         public static readonly string CONFIGURATION = "Configuration";
-        public static readonly string CONFIGURATION_RELEASE_VALUE = "Release";
         public static readonly string CONFIGURATION_DEBUG_VALUE = "Debug";
+        public static readonly string CONFIGURATION_RELEASE_VALUE = "Release";
+        public static readonly string LAST_USED_BUILD_CONFIGURATION = "LastUsedBuildConfiguration";
+        public static readonly string LAST_USED_PLATFORM = "LastUsedPlatform";
         public static readonly string OUTPUT_TYPE = "OutputType";
         public static readonly string OUTPUT_TYPE_EXECUTABLE = "Exe";
-        public static readonly string PUBLISH_PROFILE_IMPORTED = "PublishProfileImported";
+        public static readonly string PACK_RELEASE = "PackRelease";
+        public static readonly string PLATFORM = "Platform";
         public static readonly string PUBLISH_PROFILE_FULL_PATH = "PublishProfileFullPath";
+        public static readonly string PUBLISH_PROFILE_IMPORTED = "PublishProfileImported";
+        public static readonly string PUBLISH_RELEASE = "PublishRelease";
+        public static readonly string RUNTIME_IDENTIFIER = "RuntimeIdentifier";
+        public static readonly string RUNTIME_IDENTIFIERS = "RuntimeIdentifiers";
+        public static readonly string TARGET_FRAMEWORK = "TargetFramework";
+        public static readonly string TARGET_FRAMEWORKS = "TargetFrameworks";
     }
 }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -680,7 +680,7 @@ public static class Program
             .HaveStdOutContaining("PublishRelease");
 
             var releaseAssetPath = System.IO.Path.Combine(helloWorldAsset.Path, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "HelloWorld.dll");
-            Assert.False(File.Exists(releaseAssetPath)); // build will produce a debug asset, need to make sure this doesn't exist either.       
+            Assert.False(File.Exists(releaseAssetPath)); // build will produce a debug asset, need to make sure this doesn't exist either.
         }
 
         [Theory]
@@ -794,16 +794,8 @@ public static class Program
             .Execute("/p:PublishProfile=test");
 
             publishOutput.Should().Pass();
-            var releaseAssetPath = System.IO.Path.Combine(helloWorldAsset.Path, "bin", "Release", ToolsetInfo.CurrentTargetFramework, rid, "HelloWorld.dll");
-            if (config == "Debug")
-            {
-                Assert.True(File.Exists(releaseAssetPath)); // We ignore Debug configuration and override it, IF its custom though, we dont use publishrelease.
-            }
-            else
-            {
-                Assert.False(File.Exists(releaseAssetPath)); // build will produce a debug asset, need to make sure this doesn't exist either.       
-                publishOutput.Should().HaveStdOutContaining("PublishRelease");
-            }
+            var configAssetPath = System.IO.Path.Combine(helloWorldAsset.Path, "bin", config, ToolsetInfo.CurrentTargetFramework, rid, "HelloWorld.dll");
+            Assert.True(File.Exists(configAssetPath)); // We cannot ignore Debug configuration and override it, because it's set as a globalproperty during publish.
         }
 
         [Fact]
@@ -1098,7 +1090,7 @@ public static class Program
                .Should()
                .Pass()
                .And
-               .NotHaveStdErrContaining("NETSDK1191"); // Publish Properties Requiring RID Checks 
+               .NotHaveStdErrContaining("NETSDK1191"); // Publish Properties Requiring RID Checks
         }
 
         [Fact]


### PR DESCRIPTION
I wanted to take a run at this because it just makes sense to me.

Publish profiles work in VS from a technical level because they operate in two phases - one to locate and parse build properties from a specified publish profile pubxml, and the second to run the build's Publish target with those properties applied. This allows users to put properties that are specific to that publish configuration in a single file, not cluttering their project file.

This PR emulates this behavior. It 
* does an evaluation, adhering to any user-specified CLI options that might be relevant to MSBuild evaluation, 
  * LastUsedBuildConfiguration
  * Configuration
  * Platform
  * TargetFramework
  * TargetFrameworks
  * RuntimeIdentifier
* checks the results of that evaluation to determine a) if a profile was imported at all and b) if so, the path to the profile that was chosen
* loads the properties from the profile that was chosen
* appends those properties to the end of the MSBuild publish invocation, so that those properties take precedence (since MSBuild CLI properties are a latest-takes-precedence ordering)