### PR TITLE
Update the version of the Microsoft.CodeAnalysis.CSharp.Worspaces used in the GenAPI

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -148,6 +148,7 @@
     <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.5.0-2.22613.14</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.5.0-2.22613.14</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftCodeAnalysisWorkspacesGenAPIPackageVersion>4.6.0-1.23059.11</MicrosoftCodeAnalysisWorkspacesGenAPIPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
@@ -9,7 +9,7 @@
     <!-- This package doesn't contain any lib or ref assemblies because it's a tooling package.-->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <Nullable>enable</Nullable>
-    <_MicrosoftCodeAnalysisVersion>4.5.0-3.22601.3</_MicrosoftCodeAnalysisVersion>
+    <_MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisWorkspacesGenAPIPackageVersion)</_MicrosoftCodeAnalysisVersion>
     <_MicrosoftCodeAnalysisVersion Condition="'$(DotNetBuildFromSource)' == 'true'">$(MicrosoftCodeAnalysisPackageVersion)</_MicrosoftCodeAnalysisVersion>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
     <PackageDescription>MSBuild tasks and targets to emit Roslyn based source code from input assemblies.</PackageDescription>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
     <Nullable>enable</Nullable>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <_MicrosoftCodeAnalysisVersion>4.5.0-3.22601.3</_MicrosoftCodeAnalysisVersion>
+    <_MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisWorkspacesGenAPIPackageVersion)</_MicrosoftCodeAnalysisVersion>
     <_MicrosoftCodeAnalysisVersion Condition="'$(DotNetBuildFromSource)' == 'true'">$(MicrosoftCodeAnalysisPackageVersion)</_MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -131,17 +131,17 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 {
                     internal partial struct InternalStruct { }
 
-                    public partial struct PublicReadonlyRefStruct { }
+                    public readonly partial struct PublicReadonlyRefStruct { }
 
-                    public partial struct PublicReadonlyStruct { }
+                    public readonly partial struct PublicReadonlyStruct { }
 
                     public partial struct PublicRefStruct { }
 
                     public partial struct PublicStruct { }
 
-                    internal partial struct ReadonlyRecordStruct : System.IEquatable<ReadonlyRecordStruct> { }
+                    internal readonly partial struct ReadonlyRecordStruct : System.IEquatable<ReadonlyRecordStruct> { }
 
-                    internal partial struct ReadonlyStruct { }
+                    internal readonly partial struct ReadonlyStruct { }
 
                     internal partial struct RecordStruct : System.IEquatable<RecordStruct> { }
                 }
@@ -392,7 +392,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                         Disable = 1
                     }
 
-                    public partial struct Options
+                    public readonly partial struct Options
                     {
                         public readonly bool BoolMember;
                         public readonly Kind KindMember;


### PR DESCRIPTION
The issue https://github.com/dotnet/arcade/issues/11850 was solved on the Roslyn side https://github.com/dotnet/roslyn/issues/65834.
* Update the version of the `Microsoft.CodeAnalysis.CSharp.Worspaces`
* Update Tests to cover "The DeclarationModifiers class does not properly handle readonly keyword for struct \s"