### PR TITLE
Add *.swp to gitignore template

### DIFF
--- a/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -475,3 +475,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Vim temporary swap files
+*.swp

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -475,3 +475,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Vim temporary swap files
+*.swp


### PR DESCRIPTION
*.swp are vim swap file (for recovering files when it crashes, etc).