### PR TITLE
Re-enable single-file tests

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -92,7 +92,7 @@ namespace Microsoft.NET.Publish.Tests
                                                      runtimeIdentifier: RuntimeInformation.RuntimeIdentifier);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/29602")]
+        [Fact]
         public void Incremental_add_single_file()
         {
             var testProject = new TestProject()
@@ -678,10 +678,9 @@ class C
         [InlineData(ToolsetInfo.CurrentTargetFramework, false, IncludeDefault)]
         [InlineData(ToolsetInfo.CurrentTargetFramework, false, IncludeNative)]
         [InlineData(ToolsetInfo.CurrentTargetFramework, false, IncludeAllContent)]
-        // https://github.com/dotnet/sdk/issues/29602
-        //[InlineData(ToolsetInfo.CurrentTargetFramework, true, IncludeDefault)]
-        //[InlineData(ToolsetInfo.CurrentTargetFramework, true, IncludeNative)]
-        //[InlineData(ToolsetInfo.CurrentTargetFramework, true, IncludeAllContent)]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, true, IncludeDefault)]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, true, IncludeNative)]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, true, IncludeAllContent)]
         public void It_runs_single_file_apps(string targetFramework, bool selfContained, string bundleOption)
         {
             var testProject = new TestProject()
@@ -842,7 +841,7 @@ class C
             uncompressedSize.Should().Be(compressedSize);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/29602")]
+        [RequiresMSBuildVersionFact("17.0.0.32901")]
         public void User_can_get_bundle_info_before_bundling()
         {
             var testProject = new TestProject()


### PR DESCRIPTION
The product issue was fixed in https://github.com/dotnet/runtime/pull/80294 - cc @janvorli 

It was actually caught during the update of runtime bits in https://github.com/dotnet/sdk/pull/29406, but the tests were disabled in https://github.com/dotnet/sdk/pull/29406/commits/a0d00407fd989053040c6d14da71cd301d2eb0ac. This change re-enables the tests disabled by that commit.

Resolves https://github.com/dotnet/sdk/issues/29602