### PR TITLE
Update GenerateLayout.targets for Microsoft.CodeAnalysis.NetAnalyzers packaging structure changes 

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,7 +3,7 @@
   <ProductDependencies>
     <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="8.0.100-alpha.1.23061.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>bf9cf318137c92fa79278dfa67b33dbca870f40a</Sha>
+      <Sha>bf9cf318137c92fa79278dfa67b33dbca870f40a</Sha>RR
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-alpha.1.23059.14">
@@ -237,13 +237,13 @@
       <Sha>9a1c3e1b7f0c8763d4c96e593961a61a72679a7b</Sha>
       <SourceBuild RepoName="xdt" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0-preview1.23059.1">
+    <Dependency Name="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0-preview1.23063.1">
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>
-      <Sha>6f4bfac4c7ad970b59be66cd1d2bee75516348fc</Sha>
+      <Sha>afee469c0c862c6af3670d30a4b4e5ff6f8fe45c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn-analyzers" Version="3.3.4-beta1.23059.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn-analyzers" Version="3.3.4-beta1.23063.1">
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>
-      <Sha>6f4bfac4c7ad970b59be66cd1d2bee75516348fc</Sha>
+      <Sha>afee469c0c862c6af3670d30a4b4e5ff6f8fe45c</Sha>
       <SourceBuild RepoName="roslyn-analyzers" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22564.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,7 +3,7 @@
   <ProductDependencies>
     <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="8.0.100-alpha.1.23061.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>bf9cf318137c92fa79278dfa67b33dbca870f40a</Sha>RR
+      <Sha>bf9cf318137c92fa79278dfa67b33dbca870f40a</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-alpha.1.23059.14">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -100,7 +100,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn-analyzers -->
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview1.23059.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview1.23063.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -53,9 +53,9 @@
     <ItemGroup>
       <AnalyzerAssemblies Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/analyzers/dotnet/cs/**/*.dll" />
       <AnalyzerAssemblies Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/analyzers/dotnet/vb/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.dll" />
-      <AnalyzerTargets Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/build/Microsoft.CodeAnalysis.NetAnalyzers.props" />
-      <AnalyzerTargets Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/build/Microsoft.CodeAnalysis.NetAnalyzers.targets" />
-      <AnalyzerConfig Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/build/config/**/*" />
+      <AnalyzerTargets Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/buildtransitive/Microsoft.CodeAnalysis.NetAnalyzers.props" />
+      <AnalyzerTargets Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/buildtransitive/Microsoft.CodeAnalysis.NetAnalyzers.targets" />
+      <AnalyzerConfig Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/buildtransitive/config/**/*" />
       
       <ILLinkAnalyzersTargets Include="$(PkgMicrosoft_NET_ILLink_Analyzers)/build/Microsoft.NET.ILLink.Analyzers.props" />
       <ILLinkAnalyzersAssemblies Include="$(PkgMicrosoft_NET_ILLink_Analyzers)/analyzers/dotnet/cs/**/*.dll" />


### PR DESCRIPTION
React to package structure updates in https://github.com/dotnet/roslyn-analyzers/pull/6325 and https://github.com/dotnet/roslyn-analyzers/pull/6427 to copy props/targets/config files from the `buildtransitive` folder in the NuGet package