### PR TITLE
Use Runtime ILLink package on SDK

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -112,7 +112,7 @@
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-alpha.1.23066.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>258025c1f0f003a7457f5b3499839146ca34c034</Sha>
-      <SourceBuild RepoName="linker" ManagedOnly="true" />
+      <SourceBuild RepoName="runtime" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="8.0.100-1.23067.1">
       <Uri>https://github.com/dotnet/linker</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -109,9 +109,9 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>5e9c3debd9d0007c53e7510ac030ea5e8fc483f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.100-1.23064.1">
-      <Uri>https://github.com/dotnet/linker</Uri>
-      <Sha>44520382eda0c82c5a4d3f38d3f59965f3ba90b0</Sha>
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-alpha.1.23066.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>258025c1f0f003a7457f5b3499839146ca34c034</Sha>
       <SourceBuild RepoName="linker" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="8.0.100-1.23064.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -112,7 +112,6 @@
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-alpha.1.23066.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>258025c1f0f003a7457f5b3499839146ca34c034</Sha>
-      <SourceBuild RepoName="runtime" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="8.0.100-1.23067.1">
       <Uri>https://github.com/dotnet/linker</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -85,8 +85,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/mono/linker -->
-    <MicrosoftNETILLinkTasksPackageVersion>8.0.100-1.23064.1</MicrosoftNETILLinkTasksPackageVersion>
-    <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksPackageVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>8.0.0-alpha.1.23066.1</MicrosoftNETILLinkTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,6 +48,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
+    <MicrosoftNETILLinkTasksPackageVersion>8.0.0-alpha.1.23066.1</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>8.0.0-alpha.1.23067.2</MicrosoftNETCoreAppRefPackageVersion>
     <VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>8.0.0-alpha.1.23067.2</VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>8.0.0-alpha.1.23067.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
@@ -82,10 +83,6 @@
     <MicrosoftNETTestSdkPackageVersion>17.6.0-preview-20230117-02</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Dependencies from https://github.com/mono/linker -->
-    <MicrosoftNETILLinkTasksPackageVersion>8.0.0-alpha.1.23066.1</MicrosoftNETILLinkTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
-    <PackageReference Include="Microsoft.NET.ILLink.Analyzers" Version="$(MicrosoftNETILLinkAnalyzerPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="$(MicrosoftNETILLinkTasksPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Sdk.Razor.SourceGenerators.Transport" Version="$(MicrosoftNETSdkRazorSourceGeneratorsTransportPackageVersion)" GeneratePathProperty="true" />
 

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -57,8 +57,8 @@
       <AnalyzerTargets Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/buildTransitive/Microsoft.CodeAnalysis.NetAnalyzers.targets" />
       <AnalyzerConfig Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)/buildTransitive/config/**/*" />
       
-      <ILLinkAnalyzersTargets Include="$(PkgMicrosoft_NET_ILLink_Analyzers)/build/Microsoft.NET.ILLink.Analyzers.props" />
-      <ILLinkAnalyzersAssemblies Include="$(PkgMicrosoft_NET_ILLink_Analyzers)/analyzers/dotnet/cs/**/*.dll" />
+      <ILLinkAnalyzersTargets Include="$(PkgMicrosoft_NET_ILLink_Tasks)/build/Microsoft.NET.ILLink.Analyzers.props" />
+      <ILLinkAnalyzersAssemblies Include="$(PkgMicrosoft_NET_ILLink_Tasks)/analyzers/dotnet/cs/**/*.dll" />
 
       <CodeStyleCSharpAssemblies Include="$(PkgMicrosoft_CodeAnalysis_CSharp_CodeStyle)/analyzers/dotnet/cs/**/*.dll" />
       <CodeStyleVisualBasicAssemblies Include="$(PkgMicrosoft_CodeAnalysis_VisualBasic_CodeStyle)/analyzers/dotnet/vb/**/*.dll" />

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -443,6 +443,7 @@ namespace Microsoft.NET.Publish.Tests
             };
             referenceProject.SourceFiles[$"{referenceProjectName}.cs"] = @"
 using System;
+#pragma warning disable CA1050
 public class Classlib
 {
     public string Func()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -1808,6 +1808,7 @@ namespace Microsoft.NET.Publish.Tests
 using System;
 using System.Reflection;
 using System.Diagnostics.CodeAnalysis;
+#pragma warning disable CA1050 // Declare types in namespaces
 public class Program
 {
     public static void Main()


### PR DESCRIPTION
Use the dotnet/runtime ILLink.Tasks package instead of the dotnet/linker one
Runtime enables Stylecop Analyzer which warns for some of the SDK tests
Modify how we lookup for the analyzer info

Creating this as a draft PR to only verify that CI is able to handle the runtime packages, this will not be merged.