### PR TITLE
Use better AOT defaults in Web SDK

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProject.cs
@@ -256,7 +256,7 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
-        public Dictionary<string, string> GetPropertyValues(string testRoot, string project, string configuration = "Debug", string targetFramework = null)
+        public Dictionary<string, string> GetPropertyValues(string testRoot, string project, string targetFramework = null, string configuration = "Debug")
         {
             var propertyValues = new Dictionary<string, string>();
 

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -474,7 +474,7 @@ namespace {safeThisName}
         /// A dictionary of property keys to property value strings, case sensitive.
         /// Only properties added to the <see cref="PropertiesToRecord"/> member will be observed.
         /// </returns>
-        public Dictionary<string, string> GetPropertyValues(string testRoot, string configuration = "Debug", string targetFramework = null)
+        public Dictionary<string, string> GetPropertyValues(string testRoot, string targetFramework = null, string configuration = "Debug")
         {
             var propertyValues = new Dictionary<string, string>();
 

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -87,7 +87,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <EFSQLScriptsFolderName Condition="$(EFSQLScriptsFolderName) == ''">EFSQLScripts</EFSQLScriptsFolderName>
 
     <!-- If TrimMode has not already been set, default to partial trimming, as AspNet is not currently fully trim-compatible -->
-    <TrimMode Condition="'$(PublishTrimmed)' == 'true' and '$(TrimMode)' == ''">partial</TrimMode>
+    <!-- We allow the full trimming default with PublishAot enabled, because the parts that are not trim-compatible are not aot-compatible either -->
+    <TrimMode Condition="'$(PublishTrimmed)' == 'true' and '$(PubishAot)' != 'true' and '$(TrimMode)' == ''">partial</TrimMode>
   </PropertyGroup>
 
   <!--

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -36,7 +36,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
              And '$(RuntimeIdentifier)' != ''
              And !$(RuntimeIdentifier.StartsWith('win'))
              And '$(PublishIISAssets)' == ''">false</PublishIISAssets>
-    <PublishIISAssets Condition="'$(PublishAot)' == 'true' And '$(PublishIISAssets)' == ''">false</PublishIISAssets>
+    <PublishIISAssets Condition="'$(PublishIISAssets)' == '' and '$(PublishAot)' == 'true'">false</PublishIISAssets>
   </PropertyGroup>
 
   <!-- Extension points for BeforePublish and AfterPublish-->
@@ -89,7 +89,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- If TrimMode has not already been set, default to partial trimming, as AspNet is not currently fully trim-compatible -->
     <!-- We allow the full trimming default with PublishAot enabled, because the parts that are not trim-compatible are not aot-compatible either -->
-    <TrimMode Condition="'$(PublishTrimmed)' == 'true' and '$(PubishAot)' != 'true' and '$(TrimMode)' == ''">partial</TrimMode>
+    <TrimMode Condition="'$(TrimMode)' == '' and '$(PublishTrimmed)' == 'true' and '$(PubishAot)' != 'true'">partial</TrimMode>
   </PropertyGroup>
 
   <!--

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -89,7 +89,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- If TrimMode has not already been set, default to partial trimming, as AspNet is not currently fully trim-compatible -->
     <!-- We allow the full trimming default with PublishAot enabled, because the parts that are not trim-compatible are not aot-compatible either -->
-    <TrimMode Condition="'$(TrimMode)' == '' and '$(PublishTrimmed)' == 'true' and '$(PubishAot)' != 'true'">partial</TrimMode>
+    <TrimMode Condition="'$(TrimMode)' == '' and '$(PublishTrimmed)' == 'true' and '$(PublishAot)' != 'true'">partial</TrimMode>
   </PropertyGroup>
 
   <!--

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -36,6 +36,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
              And '$(RuntimeIdentifier)' != ''
              And !$(RuntimeIdentifier.StartsWith('win'))
              And '$(PublishIISAssets)' == ''">false</PublishIISAssets>
+    <PublishIISAssets Condition="'$(PublishAot)' == 'true' And '$(PublishIISAssets)' == ''">false</PublishIISAssets>
   </PropertyGroup>
 
   <!-- Extension points for BeforePublish and AfterPublish-->


### PR DESCRIPTION
This PR provides better defaults for the TrimMode and PublishIISAssets properties when the PublishAot property is set to true.

Once this is merged, we should be able to follow up by removing [these properties](https://github.com/dotnet/aspnetcore/blob/e5238763bddd7100823751c4a4ae0220d78160aa/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in#L12-L13) from the AOT version of the new "api" project template.

Fixes dotnet/sdk#30059
Fixes dotnet/sdk#29896