### PR TITLE
Bump sdk container version

### DIFF
--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -74,7 +74,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <PropertyGroup>
-    <SdkContainerSupportPackageVersion>0.2.7</SdkContainerSupportPackageVersion>
+    <SdkContainerSupportPackageVersion>0.3.2</SdkContainerSupportPackageVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableSdkContainerSupport)' == 'true'">


### PR DESCRIPTION
## Description

The next release of the SDK Container support package (to sync with the 7.0.2xx release) is 0.3.2. It's undergone final testing now. This updates the built-in reference for WebSDK projects with VS-generated PublishProfiles to use this version (which has already been published to NuGet).

## Customer Impact

Without this change, users will default to an older version of the Container support that doesn't support authentication to certain kinds of Container Registries, doesn't support targeting RIDs other than linux-x64, and doesn't have resilience fixes to our Registry HTTP call logic.

## Regression

No - this bump was planned to occur during this cycle, it just took longer than expected to polish and test the new features.

## Risk

Low - VS 17.5 is the first version that will write the EnableSdkContainerSupport flag to generated PublishProfiles, which conditions this PackageReference, so the exposure is very low.

## Tasks
- [x] testing of 0.3.2 completed
- [x] 0.3.2 pushed to NuGet