### PR TITLE
Prevent editors from auto-trimming trailing whitespaces in test approval files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -501,3 +501,6 @@ dotnet_diagnostic.IDE0040.severity = warning
 
 [*.txt]
 insert_final_newline = false
+
+[src/Tests/dotnet-new.Tests/**/Approvals/**]
+trim_trailing_whitespace = false


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/5805

### Solution
Disable trimming trailing whitespaces in .editorconfig for test approval or snapshot files.