### PR TITLE
Port two better fixes for installer crashes from main

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -69,10 +69,16 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Theory]
+        [InlineData("netcoreapp1.1")]
         [InlineData("netcoreapp2.0")]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void It_publishes_self_contained_apps_to_the_publish_folder_and_the_app_should_run(string targetFramework)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
             var helloWorldAsset = _testAssetsManager

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -54,7 +54,21 @@ namespace Microsoft.NET.TestFramework
         //  able to run on the current OS
         public static bool SupportsTargetFramework(string targetFramework)
         {
-            var nugetFramework = NuGetFramework.Parse(targetFramework);
+            NuGetFramework nugetFramework = null;
+            try
+            {
+                nugetFramework = NuGetFramework.Parse(targetFramework);
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (nugetFramework == null)
+            {
+                return false;
+            }
+
             string currentRid = RuntimeInformation.RuntimeIdentifier;
 
             string ridOS = currentRid.Split('.')[0];

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -125,9 +125,9 @@ namespace Microsoft.NET.TestFramework
             {
                 string restOfRid = currentRid.Substring(ridOS.Length + 1);
                 string ubuntuVersionString = restOfRid.Split('-')[0];
-                if (float.TryParse(ubuntuVersionString, out float ubuntuVersion))
+                if (float.TryParse(ubuntuVersionString, System.Globalization.CultureInfo.InvariantCulture, out float ubuntuVersion))
                 {
-                    if (ubuntuVersion > 16.04)
+                    if (ubuntuVersion > 16.04f)
                     {
                         if (nugetFramework.Version < new Version(2, 0, 0, 0))
                         {
@@ -144,27 +144,25 @@ namespace Microsoft.NET.TestFramework
             {
                 string restOfRid = currentRid.Substring(ridOS.Length + 1);
                 string osxVersionString = restOfRid.Split('-')[0];
-                //  From a string such as "10.14", get the second part, e.g. "14"
-                string osxVersionString2 = osxVersionString.Split('.')[1];
-                if (int.TryParse(osxVersionString2, out int osxVersion))
+                if (float.TryParse(osxVersionString, System.Globalization.CultureInfo.InvariantCulture, out float osxVersion))
                 {
                     //  .NET Core 1.1 - 10.11, 10.12
                     //  .NET Core 2.0 - 10.12+
-                    if (osxVersion <= 11)
+                    if (osxVersion <= 10.11f)
                     {
                         if (nugetFramework.Version >= new Version(2, 0, 0, 0))
                         {
                             return false;
                         }
                     }
-                    else if (osxVersion == 12)
+                    else if (osxVersion == 10.12f)
                     {
                         if (nugetFramework.Version < new Version(2, 0, 0, 0))
                         {
                             return false;
                         }
                     }
-                    else if (osxVersion > 12)
+                    else if (osxVersion > 10.12f)
                     {
                         //  .NET Core 2.0 is out of support, and doesn't seem to work with OS X 10.14
                         //  (it finds no assets for the RID), even though the support page says "10.12+"


### PR DESCRIPTION
We are still seeing internal instability in the installer tests. My prior fix was not sufficient as it doesn't work on all legs. I believe the fixes from Alex and Kasper are better approaches long term so I'm cherry-picking them into 7.0.1xx to help improve stability in installer.