### PR TITLE
BlazorWasmSdk: Serve .webcil as application/octet-stream

### DIFF
--- a/src/BlazorWasmSdk/Targets/BlazorWasm.web.config
+++ b/src/BlazorWasmSdk/Targets/BlazorWasm.web.config
@@ -5,12 +5,14 @@
       <remove fileExtension=".blat" />
       <remove fileExtension=".dat" />
       <remove fileExtension=".dll" />
+      <remove fileExtension=".webcil" />
       <remove fileExtension=".json" />
       <remove fileExtension=".wasm" />
       <remove fileExtension=".woff" />
       <remove fileExtension=".woff2" />
       <mimeMap fileExtension=".blat" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".dll" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".webcil" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".json" mimeType="application/json" />
       <mimeMap fileExtension=".wasm" mimeType="application/wasm" />


### PR DESCRIPTION
WebCIL is a new container format for .NET assemblies when publishing to webassembly.  (See https://github.com/dotnet/runtime/pull/79416)

Related to https://github.com/dotnet/runtime/issues/80807