### PR TITLE
Switch to OSX 12 for 7.0.1xx 

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -158,9 +158,9 @@ stages:
         pool:
           vmImage: 'macOS-latest'
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: OSX.1100.Amd64.Open
+          helixTargetQueue: OSX.1200.Amd64.Open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: OSX.1100.Amd64
+          helixTargetQueue: OSX.1200.Amd64
         strategy:
           matrix:
             Build_Release:

--- a/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRid/NativeCode.cs
+++ b/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRid/NativeCode.cs
@@ -29,6 +29,7 @@ namespace LibraryWithRid
                 case "'osx.10.14-x64'":
                 case "'osx.10.15-x64'":
                 case "'osx.11.0-x64'":
+                case "'osx.12.0-x64'":
                     return Marshal.PtrToStringAnsi(MacNativeMethods.sqlite3_libversion());
                 case "'win10-x64'":
                 case "'win10-x86'":

--- a/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRid/NativeCode.cs
+++ b/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRid/NativeCode.cs
@@ -29,7 +29,7 @@ namespace LibraryWithRid
                 case "'osx.10.14-x64'":
                 case "'osx.10.15-x64'":
                 case "'osx.11.0-x64'":
-                case "'osx.12.0-x64'":
+                case "'osx.12-x64'":
                     return Marshal.PtrToStringAnsi(MacNativeMethods.sqlite3_libversion());
                 case "'win10-x64'":
                 case "'win10-x86'":

--- a/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/NativeCode.cs
+++ b/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/NativeCode.cs
@@ -29,7 +29,7 @@ namespace LibraryWithRids
                 case "'osx.10.14-x64'":
                 case "'osx.10.15-x64'":
                 case "'osx.11.0-x64'":
-                case "'osx.12.0-x64'":
+                case "'osx.12-x64'":
                     return Marshal.PtrToStringAnsi(MacNativeMethods.sqlite3_libversion());
                 case "'win10-x64'":
                 case "'win10-x86'":

--- a/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/NativeCode.cs
+++ b/src/Assets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/NativeCode.cs
@@ -29,6 +29,7 @@ namespace LibraryWithRids
                 case "'osx.10.14-x64'":
                 case "'osx.10.15-x64'":
                 case "'osx.11.0-x64'":
+                case "'osx.12.0-x64'":
                     return Marshal.PtrToStringAnsi(MacNativeMethods.sqlite3_libversion());
                 case "'win10-x64'":
                 case "'win10-x86'":

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -69,10 +69,16 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Theory]
+        [InlineData("netcoreapp1.1")]
         [InlineData("netcoreapp2.0")]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void It_publishes_self_contained_apps_to_the_publish_folder_and_the_app_should_run(string targetFramework)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
             var helloWorldAsset = _testAssetsManager

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -54,7 +54,21 @@ namespace Microsoft.NET.TestFramework
         //  able to run on the current OS
         public static bool SupportsTargetFramework(string targetFramework)
         {
-            var nugetFramework = NuGetFramework.Parse(targetFramework);
+            NuGetFramework nugetFramework = null;
+            try
+            {
+                nugetFramework = NuGetFramework.Parse(targetFramework);
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (nugetFramework == null)
+            {
+                return false;
+            }
+
             string currentRid = RuntimeInformation.RuntimeIdentifier;
 
             string ridOS = currentRid.Split('.')[0];

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -139,9 +139,9 @@ namespace Microsoft.NET.TestFramework
             {
                 string restOfRid = currentRid.Substring(ridOS.Length + 1);
                 string ubuntuVersionString = restOfRid.Split('-')[0];
-                if (float.TryParse(ubuntuVersionString, out float ubuntuVersion))
+                if (float.TryParse(ubuntuVersionString, System.Globalization.CultureInfo.InvariantCulture, out float ubuntuVersion))
                 {
-                    if (ubuntuVersion > 16.04)
+                    if (ubuntuVersion > 16.04f)
                     {
                         if (nugetFramework.Version < new Version(2, 0, 0, 0))
                         {

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -145,32 +145,58 @@ namespace Microsoft.NET.TestFramework
                 string restOfRid = currentRid.Substring(ridOS.Length + 1);
                 string osxVersionString = restOfRid.Split('-')[0];
                 //  From a string such as "10.14", get the second part, e.g. "14"
-                string osxVersionString2 = osxVersionString.Split('.')[1];
-                if (int.TryParse(osxVersionString2, out int osxVersion))
+                if (osxVersionString.Contains('.'))
                 {
-                    //  .NET Core 1.1 - 10.11, 10.12
-                    //  .NET Core 2.0 - 10.12+
-                    if (osxVersion <= 11)
+                    string osxVersionString2 = osxVersionString.Split('.')[1];
+                    if (int.TryParse(osxVersionString2, out int osxVersion))
                     {
-                        if (nugetFramework.Version >= new Version(2, 0, 0, 0))
+                        //  .NET Core 1.1 - 10.11, 10.12
+                        //  .NET Core 2.0 - 10.12+
+                        if (osxVersion <= 11)
                         {
-                            return false;
+                            if (nugetFramework.Version >= new Version(2, 0, 0, 0))
+                            {
+                                return false;
+                            }
+                        }
+                        else if (osxVersion == 12)
+                        {
+                            if (nugetFramework.Version < new Version(2, 0, 0, 0))
+                            {
+                                return false;
+                            }
+                        }
+                        else if (osxVersion > 12)
+                        {
+                            //  .NET Core 2.0 is out of support, and doesn't seem to work with OS X 10.14
+                            //  (it finds no assets for the RID), even though the support page says "10.12+"
+                            if (nugetFramework.Version < new Version(2, 1, 0, 0))
+                            {
+                                return false;
+                            }
                         }
                     }
-                    else if (osxVersion == 12)
+                }
+                else
+                {
+                    if (int.TryParse(osxVersionString, out int osxVersionMajor))
                     {
-                        if (nugetFramework.Version < new Version(2, 0, 0, 0))
+                        //  .NET 5 <= 11.0
+                        //  .NET 6 <= 12
+                        //  .NET 7 <= 13
+                        if (osxVersionMajor == 12)
                         {
-                            return false;
+                            if (nugetFramework.Version < new Version(6, 0, 0, 0))
+                            {
+                                return false;
+                            }
                         }
-                    }
-                    else if (osxVersion > 12)
-                    {
-                        //  .NET Core 2.0 is out of support, and doesn't seem to work with OS X 10.14
-                        //  (it finds no assets for the RID), even though the support page says "10.12+"
-                        if (nugetFramework.Version < new Version(2, 1, 0, 0))
+                        else if (osxVersionMajor > 12)
                         {
-                            return false;
+                            if (nugetFramework.Version < new Version(7, 0, 0, 0))
+                            {
+                                return false;
+                            }
                         }
                     }
                 }

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.TestFramework
 
         public const string LatestWinRuntimeIdentifier = "win10";
         public const string LatestLinuxRuntimeIdentifier = "ubuntu.22.04";
-        public const string LatestMacRuntimeIdentifier = "osx.12.0";
+        public const string LatestMacRuntimeIdentifier = "osx.12";
         public const string LatestRuntimeIdentifiers = $"{LatestWinRuntimeIdentifier}-x64;{LatestWinRuntimeIdentifier}-x86;osx.10.10-x64;osx.10.11-x64;osx.10.12-x64;osx.10.14-x64;{LatestMacRuntimeIdentifier}-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;ubuntu.18.04-x64;ubuntu.20.04-x64;{LatestLinuxRuntimeIdentifier}-x64;centos.9-x64;rhel.9-x64;debian.9-x64;fedora.37-x64;opensuse.42.3-x64;linux-musl-x64";
 
         public string DotNetRoot { get; }

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.TestFramework
 
         public const string LatestWinRuntimeIdentifier = "win10";
         public const string LatestLinuxRuntimeIdentifier = "ubuntu.22.04";
-        public const string LatestMacRuntimeIdentifier = "osx.11.0";
+        public const string LatestMacRuntimeIdentifier = "osx.12.0";
         public const string LatestRuntimeIdentifiers = $"{LatestWinRuntimeIdentifier}-x64;{LatestWinRuntimeIdentifier}-x86;osx.10.10-x64;osx.10.11-x64;osx.10.12-x64;osx.10.14-x64;{LatestMacRuntimeIdentifier}-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;ubuntu.18.04-x64;ubuntu.20.04-x64;{LatestLinuxRuntimeIdentifier}-x64;centos.9-x64;rhel.9-x64;debian.9-x64;fedora.37-x64;opensuse.42.3-x64;linux-musl-x64";
 
         public string DotNetRoot { get; }


### PR DESCRIPTION
So as to load balance between 11 and 12.  All of the SDK branches are now targeting osx.11 but they helix queues have equal machines between 12 and 11. We've started seeing timeouts at the beginning of the month and we want to try to reduce that as we're overloading the machine resources available.

After this, 6.0.Nxx will target 11 and 7.0.Nxx will target 12 to load balance some.