### PR TITLE
Enable PRs for all release builds and remove some CI

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,12 +2,17 @@ trigger:
   batch: true
   branches:
     include:
-    - master
+    - main
+    - release/7.0.3xx
+    - internal/release/*
+
+pr:
+  branches:
+    include:
     - main
     - release/*
-    - internal/release/3.*
-    - internal/release/5.*
-    - internal/release/6.*
+    - internal/release/*
+
 
 variables:
   - name: teamName


### PR DESCRIPTION
except the public branches. The goal of this PR is to continue to have PR builds on all changes going into key branches of the sdk repo but exclude CI builds from public branches for non-public releases.