### PR TITLE
Guard ILCompilerTargetsPath import

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1186,8 +1186,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.CSharp.targets" Condition="'$(Language)' == 'C#'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.VisualBasic.targets" Condition="'$(Language)' == 'VB'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.FSharp.targets" Condition="'$(Language)' == 'F#'" />
-  <Import Project="$(ILCompilerTargetsPath)" Condition="'$(PublishAot)' == 'true'"/>
-  <Import Project="$(ILLinkTargetsPath)" Condition="'$(ILLinkTargetsPath)' != '' And '$(Language)' != 'C++'" />
+  <Import Project="$(ILCompilerTargetsPath)" Condition="'$(ILCompilerTargetsPath)' != '' and '$(PublishAot)' == 'true'"/>
+  <Import Project="$(ILLinkTargetsPath)" Condition="'$(ILLinkTargetsPath)' != '' and '$(Language)' != 'C++'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Analyzers.targets" Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'" />
 
   <!-- Import WindowsDesktop targets if necessary -->


### PR DESCRIPTION
Apparently, in some cases, msbuild fails when the Project attribute in an Import statement is empty.

from a binlog created by Jiri Cincura (during publish):
`D:\repos\performance\tools\dotnet\x64\sdk\8.0.100-alpha.1.23073.15\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(1189,3): error MSB4020: The value "" of the "Project" attribute in element <Import> is invalid. [D:\repos\performance\src\scenarios\emptyconsolenativeaot\app\emptyconsolenativeaot.csproj]`

vs. when I tried something similar on my machine (during restore):
`NoImport: $(ILCompilerTargetsPath) at (1184;3) empty expression`

I think it's best to guard the Import via a Condition as the `ILCompilerTargetsPath` property isn't availble during Restore (which doesn't import nuget props and targets) and possibly during design time builds. Still, we should follow-up and understand why MSBuild sometimes accepts an empty expression vs when it errors out.

cc @rainersigwald