### PR TITLE
Add tests to verify analyzer configuration with analysis properties 

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -273,6 +273,19 @@ namespace Microsoft.NET.Build.Tests
         [RequiresMSBuildVersionTheory("16.8")]
         public void It_maps_analysis_properties_to_globalconfig(string analysisLevel, string analysisMode, string codeAnalysisTreatWarningsAsErrors)
         {
+            // NOTE: This test will fail for "latest" analysisLevel when the "_LatestAnalysisLevel" property
+            // is bumped in Microsoft.NET.Sdk.Analyzers.targets without a corresponding change in dotnet/roslyn-analyzers
+            // repo that generates and maps to the globalconfig. This is an important regression test to ensure the
+            // "latest" analysisLevel setting keeps working as expected when moving to a newer version of the .NET SDK.
+            // Following changes are needed to ensure the failing test scenario passes again:
+            //  1. In dotnet/roslyn-analyzers repo:
+            //     a. Update "src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md"to create a new release
+            //        for the prior "_LatestAnalysisLevel" value and move all the entries from
+            //        "src/NetAnalyzers/Core/AnalyzerReleases.Unshipped.md" to the shipped file.
+            //        For example, see https://github.com/dotnet/roslyn-analyzers/pull/6246.
+            //  2. In dotnet/sdk repo:
+            //     a. Consume the new Microsoft.CodeAnalysis.NetAnalyzers package with the above sha.
+
             var testProject = new TestProject
             {
                 Name = "HelloWorld",

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -448,11 +448,12 @@ namespace Microsoft.NET.Build.Tests
                 },
             };
 
-            testProject.AdditionalProperties.Add("AnalysisLevel", $"8-{analysisMode}");
+            var analysisLevel = $"8-{analysisMode}";
+            testProject.AdditionalProperties.Add("AnalysisLevel", analysisLevel);
             testProject.AdditionalProperties.Add("CodeAnalysisTreatWarningsAsErrors", codeAnalysisTreatWarningsAsErrors);
 
             var testAsset = _testAssetsManager
-                .CreateTestProject(testProject, identifier: "analysisLevelConsoleApp" + ToolsetInfo.CurrentTargetFramework + "8", targetExtension: ".csproj");
+                .CreateTestProject(testProject, identifier: "analysisLevelConsoleApp" + ToolsetInfo.CurrentTargetFramework + analysisLevel + $"Warnaserror:{codeAnalysisTreatWarningsAsErrors}", targetExtension: ".csproj");
 
             var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             var buildResult = buildCommand.Execute();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -134,52 +134,6 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
-        [Theory]
-        [InlineData("C#", "AppWithLibrary")]
-        [InlineData("VB", "AppWithLibraryVB")]
-        public void It_contains_latest_analysis_level_config_files(string language, string testAssetName)
-        {
-            var asset = _testAssetsManager
-                .CopyTestAsset(testAssetName, identifier: language)
-                .WithSource();
-
-            var command = new GetValuesCommand(
-                Log,
-                Path.Combine(asset.Path, "TestApp"),
-                ToolsetInfo.CurrentTargetFramework,
-                "AnalyzerConfig",
-                GetValuesCommand.ValueType.Item)
-            {
-                DependsOnTargets = "PublishNETAnalyzers"
-            };
-
-            command
-                .WithWorkingDirectory(asset.Path)
-                .Execute().Should().Pass();
-
-            var analyzerConfigs = command.GetValues();
-            Assert.NotEmpty(analyzerConfigs);
-
-            var analyzerConfigFileNames = analyzerConfigs.Select(Path.GetFileName);
-            Assert.All(analyzerConfigFileNames, name => name.EndsWith(".globalconfig"));
-
-            command = new GetValuesCommand(
-                Log,
-                Path.Combine(asset.Path, "TestApp"),
-                ToolsetInfo.CurrentTargetFramework,
-                "_LatestAnalysisLevel");
-            command.DependsOnTargets = "";
-            command.Execute().Should().Pass();
-
-            var latestAnalysisLevel = command.GetValues().Single();
-            Assert.EndsWith(latestAnalysisLevel, ".0");
-            var latestAnalysisLevelIntegral = latestAnalysisLevel.Substring(0, latestAnalysisLevel.Length - 2);
-
-            var latestAnalysisLevelConfigFileNames = analyzerConfigFileNames.Where(
-                name => name.StartsWith($"analysislevel_{latestAnalysisLevelIntegral}_", StringComparison.Ordinal));
-            Assert.NotEmpty(latestAnalysisLevelConfigFileNames);
-        }
-
         [Fact]
         public void It_resolves_multitargeted_analyzers()
         {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -134,6 +134,52 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
+        [Theory]
+        [InlineData("C#", "AppWithLibrary")]
+        [InlineData("VB", "AppWithLibraryVB")]
+        public void It_contains_latest_analysis_level_config_files(string language, string testAssetName)
+        {
+            var asset = _testAssetsManager
+                .CopyTestAsset(testAssetName, identifier: language)
+                .WithSource();
+
+            var command = new GetValuesCommand(
+                Log,
+                Path.Combine(asset.Path, "TestApp"),
+                ToolsetInfo.CurrentTargetFramework,
+                "AnalyzerConfig",
+                GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "PublishNETAnalyzers"
+            };
+
+            command
+                .WithWorkingDirectory(asset.Path)
+                .Execute().Should().Pass();
+
+            var analyzerConfigs = command.GetValues();
+            Assert.NotEmpty(analyzerConfigs);
+
+            var analyzerConfigFileNames = analyzerConfigs.Select(Path.GetFileName);
+            Assert.All(analyzerConfigFileNames, name => name.EndsWith(".globalconfig"));
+
+            command = new GetValuesCommand(
+                Log,
+                Path.Combine(asset.Path, "TestApp"),
+                ToolsetInfo.CurrentTargetFramework,
+                "_LatestAnalysisLevel");
+            command.DependsOnTargets = "";
+            command.Execute().Should().Pass();
+
+            var latestAnalysisLevel = command.GetValues().Single();
+            Assert.EndsWith(latestAnalysisLevel, ".0");
+            var latestAnalysisLevelIntegral = latestAnalysisLevel.Substring(0, latestAnalysisLevel.Length - 2);
+
+            var latestAnalysisLevelConfigFileNames = analyzerConfigFileNames.Where(
+                name => name.StartsWith($"analysislevel_{latestAnalysisLevelIntegral}_", StringComparison.Ordinal));
+            Assert.NotEmpty(latestAnalysisLevelConfigFileNames);
+        }
+
         [Fact]
         public void It_resolves_multitargeted_analyzers()
         {


### PR DESCRIPTION
Tests added:

1. Add test to verify mapping from analysis properties to analyzer config file
2. Add test to verify bulk escalation of CA rules with different analysis modes
