### PR TITLE
[DO NOT MERGE] add workaround for fixing floating tests

### DIFF
--- a/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
+++ b/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         public SharedHomeDirectory(IMessageSink messageSink)
         {
             Log = new SharedTestOutputHelper(messageSink);
+            Log.WriteLine("Initializing SharedHomeDirectory for folder {0}", HomeDirectory);
             Initialize();
         }
 
@@ -59,14 +60,16 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             new DotnetNewCommand(Log)
                 .WithCustomHive(HomeDirectory)
+                .WithDebug()
                 .Execute()
                 .Should()
                 .ExitWith(0)
                 .And
                 .NotHaveStdErr();
 
-            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path, "--force")
+            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path)
                 .WithCustomHive(HomeDirectory)
+                .WithDebug()
                 .Execute()
                 .Should()
                 .ExitWith(0)

--- a/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
+++ b/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .And
                 .NotHaveStdErr();
 
-            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path, "force")
+            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path, "--force")
                 .WithCustomHive(HomeDirectory)
                 .Execute()
                 .Should()

--- a/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
+++ b/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .And
                 .NotHaveStdErr();
 
-            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path)
+            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path, "force")
                 .WithCustomHive(HomeDirectory)
                 .Execute()
                 .Should()


### PR DESCRIPTION
Fixes
` System.AggregateException : One or more errors occurred. (Expected command to exit with 0 but it did not.\r\nFile Name: D:\a\_work\1\s\artifacts\bin\redist\Release\dotnet\dotnet.exe\r\nArguments: new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --debug:custom-hive D:\a\_work\1\s\artifacts\tmp\Release\dotnet-new.IntegrationTests\SharedHomeDirectory\20230125013446370\r\nExit Code: 106\r\nStdOut:\r\nThe following template packages will be installed:\r\n   D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405\r\nStdErr:\r\nD:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 is already installed.\r\nTo reinstall the same version of the template package, use '--force' option:\r\n   dotnet new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --force\r\n\r\nFor details on the exit code, refer to https://aka.ms/templating-exit-codes#106\r\n) (The following constructor parameters did not have matching fixture data: WebProjectsFixture fixture)\r\n---- Expected command to exit with 0 but it did not.\r\nFile Name: D:\a\_work\1\s\artifacts\bin\redist\Release\dotnet\dotnet.exe\r\nArguments: new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --debug:custom-hive D:\a\_work\1\s\artifacts\tmp\Release\dotnet-new.IntegrationTests\SharedHomeDirectory\20230125013446370\r\nExit Code: 106\r\nStdOut:\r\nThe following template packages will be installed:\r\n   D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405\r\nStdErr:\r\nD:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 is already installed.\r\nTo reinstall the same version of the template package, use '--force' option:\r\n   dotnet new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --force\r\n\r\nFor details on the exit code, refer to https://aka.ms/templating-exit-codes#106\r\n\r\n---- The following constructor parameters did not have matching fixture data: WebProjectsFixture fixture`


The issue for the further investigation:
https://github.com/dotnet/templating/issues/5992