### PR TITLE
Differentiate logging messages between CLI and MSBuild

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
@@ -37,22 +37,18 @@ namespace Microsoft.DotNet.ApiCompat
         /// <summary>
         /// Log whether or not we found breaking changes. If we are writing to a suppression file, no need to log anything.
         /// </summary>
-        public static void LogApiCompatSuccessOrFailure(bool generateSuppressionFile, ISuppressableLog compatibilityLogger)
+        public static void LogApiCompatSuccessOrFailure(bool generateSuppressionFile, ISuppressableLog log)
         {
-            if (compatibilityLogger.SuppressionWasLogged)
+            if (log.SuppressionWasLogged)
             {
                 if (!generateSuppressionFile)
                 {
-                    compatibilityLogger.LogMessage(
-                    MessageImportance.High,
-                    CommonResources.BreakingChangesFound);
+                    log.LogMessage(MessageImportance.High, Resources.BreakingChangesFoundRegenerateSuppressionFileCommandHelp);
                 }
             }
             else
             {
-                compatibilityLogger.LogMessage(
-                    MessageImportance.Normal,
-                    CommonResources.NoBreakingChangesFound);
+                log.LogMessage(MessageImportance.Normal, CommonResources.NoBreakingChangesFound);
             }
         }
     }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.cs.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.cs.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">Při zařazování pracovních položek do fronty na sestavení musí být počet předaných sestavení vlevo a vpravo stejný.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.de.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.de.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">Beim Einreihen von Arbeitselementen pro Assembly muss die Anzahl der übergebenen linken und rechten Assemblys gleich sein.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.es.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.es.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">Al poner en cola los elementos de trabajo por ensamblado, el número de ensamblados pasados a la izquierda y a la derecha debe ser igual.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.fr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.fr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">Lors de la mise en file d’attente des éléments de travail par assembly, le nombre d’assemblys passés à gauche et à droite doit être égal.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.it.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.it.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">Quando si accodano elementi di lavoro per assembly, il numero di assembly a sinistra e a destra deve essere uguale.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.ja.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.ja.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">アセンブリごとに作業項目をキューに登録する場合、左右のアセンブリで渡される数が等しい必要があります。</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.ko.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.ko.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">어셈블리당 작업 항목을 큐에 넣은 경우 왼쪽 및 오른쪽 어셈블리에 전달된 개수는 같아야 합니다.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.pl.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.pl.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">Podczas kolejkowania elementów roboczych na zestaw liczba przekazanych zestawów w lewo i w prawo musi być równa.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.pt-BR.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.pt-BR.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">Ao enfileirar itens de trabalho por montagem, o número de passadas nas montagens esquerda e direita deve ser igual.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.ru.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.ru.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">При постановке рабочих элементов в очередь на сборку число переданных левой и правой сборок должно совпадать</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.tr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.tr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">Bütünleştirilmiş kod başına iş öğeleri kuyruğa alınırken, sol ve sağ bütünleştirilmiş kodlara geçirilenlerin sayısı eşit olmalıdır.</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.zh-Hans.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.zh-Hans.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">按程序集对工作项进行排队时，左侧和右侧程序集的传递数必须相等。</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.zh-Hant.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/xlf/CommonResources.zh-Hant.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CommonResources.resx">
     <body>
-      <trans-unit id="BreakingChangesFound">
-        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</source>
-        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with /p:ApiCompatGenerateSuppressionFile=true or --generate-suppression-file.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CreateWorkItemPerAssemblyAssembliesNotEqual">
         <source>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</source>
         <target state="translated">將每個元件加入工作專案佇列時，傳入的左邊元件和右元件數目必須相等。</target>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -23,9 +23,14 @@
     <Compile Include="..\..\Tasks\Common\Message.cs" LinkBase="Common" />
     <Compile Include="..\..\Tasks\Common\MessageLevel.cs" LinkBase="Common" />
   </ItemGroup>
+
   <!-- Include MSBuild logger -->
   <ItemGroup>
     <Compile Include="..\..\Microsoft.DotNet.ApiSymbolExtensions\Logging\MSBuildLog.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources.resx" GenerateSource="true" SubType="Designer" Generator="MSBuild:_GenerateResxSource" ClassName="Microsoft.DotNet.ApiCompat.Resources" ManifestResourceName="Microsoft.DotNet.ApiCompat.Resources" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Resources.resx
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Resources.resx
@@ -117,22 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CreateWorkItemPerAssemblyAssembliesNotEqual" xml:space="preserve">
-    <value>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</value>
-  </data>
-  <data name="InvalidRexegStringTransformationPattern" xml:space="preserve">
-    <value>Invalid transformation pattern provided: '{0} - {1}'.</value>
-  </data>
-  <data name="NoBreakingChangesFound" xml:space="preserve">
-    <value>APICompat ran successfully without finding any breaking changes.</value>
-  </data>
-  <data name="SuppressionsFileNotSpecified" xml:space="preserve">
-    <value>A file path must be passed in to successfully generate a compatibility suppression file.</value>
-  </data>
-  <data name="UpdateSdkVersion" xml:space="preserve">
-    <value>The minimum version required of Roslyn is '{1}' and you are using '{0}' version of the Roslyn. You can update the sdk to get the latest version.</value>
-  </data>
-  <data name="WroteSuppressions" xml:space="preserve">
-    <value>Successfully wrote compatibility suppressions to '{0}'.</value>
+  <data name="BreakingChangesFoundRegenerateSuppressionFileCommandHelp" xml:space="preserve">
+    <value>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</value>
   </data>
 </root>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.cs.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.cs.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.de.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.de.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.es.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.es.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.fr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.fr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.it.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.it.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.ja.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.ja.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.ko.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.ko.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.pl.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.pl.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.pt-BR.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.pt-BR.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.ru.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.ru.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.tr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.tr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.zh-Hans.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.zh-Hans.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.zh-Hant.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/xlf/Resources.zh-Hant.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Resources.resx" GenerateSource="true" SubType="Designer" Generator="MSBuild:_GenerateResxSource" ClassName="Microsoft.DotNet.ApiCompat.Resources" ManifestResourceName="Microsoft.DotNet.ApiCompat.Resources" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <ProjectReference Include="..\Microsoft.DotNet.PackageValidation\Microsoft.DotNet.PackageValidation.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" />

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Resources.resx
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Resources.resx
@@ -117,22 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CreateWorkItemPerAssemblyAssembliesNotEqual" xml:space="preserve">
-    <value>When enqueuing work items per assembly, the number of passed in left and right assemblies must be equal.</value>
-  </data>
-  <data name="InvalidRexegStringTransformationPattern" xml:space="preserve">
-    <value>Invalid transformation pattern provided: '{0} - {1}'.</value>
-  </data>
-  <data name="NoBreakingChangesFound" xml:space="preserve">
-    <value>APICompat ran successfully without finding any breaking changes.</value>
-  </data>
-  <data name="SuppressionsFileNotSpecified" xml:space="preserve">
-    <value>A file path must be passed in to successfully generate a compatibility suppression file.</value>
-  </data>
-  <data name="UpdateSdkVersion" xml:space="preserve">
-    <value>The minimum version required of Roslyn is '{1}' and you are using '{0}' version of the Roslyn. You can update the sdk to get the latest version.</value>
-  </data>
-  <data name="WroteSuppressions" xml:space="preserve">
-    <value>Successfully wrote compatibility suppressions to '{0}'.</value>
+  <data name="BreakingChangesFoundRegenerateSuppressionFileCommandHelp" xml:space="preserve">
+    <value>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</value>
   </data>
 </root>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.cs.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.cs.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.de.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.de.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.es.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.es.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.fr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.fr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.it.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.it.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.ja.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.ja.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.ko.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.ko.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.pl.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.pl.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.pt-BR.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.pt-BR.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.ru.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.ru.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.tr.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.tr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.zh-Hans.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.zh-Hans.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.zh-Hant.xlf
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/xlf/Resources.zh-Hant.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
+    <body>
+      <trans-unit id="BreakingChangesFoundRegenerateSuppressionFileCommandHelp">
+        <source>API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</source>
+        <target state="new">API breaking changes found. If those are intentional, the APICompat suppression file can be updated by specifying the '--generate-suppression-file' parameter.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tests/Microsoft.DotNet.ApiCompat.Tests/Microsoft.DotNet.ApiCompat.Tests.csproj
+++ b/src/Tests/Microsoft.DotNet.ApiCompat.Tests/Microsoft.DotNet.ApiCompat.Tests.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="..\..\ApiCompat\Microsoft.DotNet.ApiCompat.Task\Resources.resx" GenerateSource="true" SubType="Designer" Generator="MSBuild:_GenerateResxSource" ClassName="Microsoft.DotNet.ApiCompat.Resources" ManifestResourceName="Microsoft.DotNet.ApiCompat.Resources" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\ApiCompat\Microsoft.DotNet.PackageValidation\Microsoft.DotNet.PackageValidation.csproj" />
     <ProjectReference Include="..\..\ApiCompat\Microsoft.DotNet.ApiCompat.Task\Microsoft.DotNet.ApiCompat.Task.csproj" />
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/sdk/commit/39740d8505bb1d10eecb042e10b3e1ad66391401

Differentiate between CLI and MSBuild to avoid confusion over which switch to use in which frontend. The number of satellite assemblies doesn't grow via this change as the newly declared embedded resources are merged together with the CommonResources.resx ones.