### PR TITLE
add named monitor for fixing floating tests

### DIFF
--- a/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
+++ b/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         public SharedHomeDirectory(IMessageSink messageSink)
         {
             Log = new SharedTestOutputHelper(messageSink);
+            Log.WriteLine("Initializing SharedHomeDirectory for folder {0}", HomeDirectory);
             Initialize();
         }
 
@@ -59,14 +60,16 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             new DotnetNewCommand(Log)
                 .WithCustomHive(HomeDirectory)
+                .WithDebug()
                 .Execute()
                 .Should()
                 .ExitWith(0)
                 .And
                 .NotHaveStdErr();
 
-            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path, "--force")
+            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path)
                 .WithCustomHive(HomeDirectory)
+                .WithDebug()
                 .Execute()
                 .Should()
                 .ExitWith(0)

--- a/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
+++ b/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .And
                 .NotHaveStdErr();
 
-            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path, "force")
+            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path, "--force")
                 .WithCustomHive(HomeDirectory)
                 .Execute()
                 .Should()

--- a/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
+++ b/src/Tests/dotnet-new.Tests/SharedHomeDirectory.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .And
                 .NotHaveStdErr();
 
-            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path)
+            new DotnetNewCommand(Log, "install", TemplatePackagesPaths.MicrosoftDotNetCommonProjectTemplates60Path, "force")
                 .WithCustomHive(HomeDirectory)
                 .Execute()
                 .Should()

--- a/src/Tests/dotnet-new.Tests/Utilities.cs
+++ b/src/Tests/dotnet-new.Tests/Utilities.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
     internal static class Utilities
     {
-        private static NamedMonitor locker = new NamedMonitor();
+        private static readonly NamedMonitor Locker = new NamedMonitor();
 
         /// <summary>
         /// Gets a folder that dotnet-new.IntegrationTests tests can use for temp files.
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             string baseDir = Path.Combine(GetTestExecutionTempFolder(), caller, customName);
 
-            lock (locker[baseDir.ToLowerInvariant()])
+            lock (Locker[baseDir.ToLowerInvariant()])
             {
                 string workingDir = Path.Combine(baseDir, DateTime.UtcNow.ToString("yyyyMMddHHmmssfff"));
                 if (!Directory.Exists(workingDir))

--- a/src/Tests/dotnet-new.Tests/Utilities.cs
+++ b/src/Tests/dotnet-new.Tests/Utilities.cs
@@ -10,6 +10,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
     internal static class Utilities
     {
+        private static NamedMonitor locker = new NamedMonitor();
+
         /// <summary>
         /// Gets a folder that dotnet-new.IntegrationTests tests can use for temp files.
         /// </summary>
@@ -26,9 +28,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             string baseDir = Path.Combine(GetTestExecutionTempFolder(), caller, customName);
 
-            var locker = new NamedMonitor();
-
-            lock (locker[string.Intern(baseDir.ToLowerInvariant())])
+            lock (locker[baseDir.ToLowerInvariant()])
             {
                 string workingDir = Path.Combine(baseDir, DateTime.UtcNow.ToString("yyyyMMddHHmmssfff"));
                 if (!Directory.Exists(workingDir))

--- a/src/Tests/dotnet-new.Tests/Utilities.cs
+++ b/src/Tests/dotnet-new.Tests/Utilities.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             string baseDir = Path.Combine(GetTestExecutionTempFolder(), caller, customName);
 
-            lock (Locker[baseDir.ToLowerInvariant()])
+            lock (Locker[baseDir])
             {
                 string workingDir = Path.Combine(baseDir, DateTime.UtcNow.ToString("yyyyMMddHHmmssfff"));
                 if (!Directory.Exists(workingDir))
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         internal class NamedMonitor
         {
-            private readonly ConcurrentDictionary<string, object> _dictionary = new ConcurrentDictionary<string, object>();
+            private readonly ConcurrentDictionary<string, object> _dictionary = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
             public object this[string name] => _dictionary.GetOrAdd(name, _ => new object());
         }

--- a/src/Tests/dotnet-new.Tests/Utilities.cs
+++ b/src/Tests/dotnet-new.Tests/Utilities.cs
@@ -53,6 +53,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             }
         }
 
+        //Provides thread safe Dictionary for creating critical section
         internal class NamedMonitor
         {
             private readonly ConcurrentDictionary<string, object> _dictionary = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
Fixes race condition:
`
 System.AggregateException : One or more errors occurred. (Expected command to exit with 0 but it did not.\r\nFile Name: D:\a\_work\1\s\artifacts\bin\redist\Release\dotnet\dotnet.exe\r\nArguments: new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --debug:custom-hive D:\a\_work\1\s\artifacts\tmp\Release\dotnet-new.IntegrationTests\SharedHomeDirectory\20230125013446370\r\nExit Code: 106\r\nStdOut:\r\nThe following template packages will be installed:\r\n   D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405\r\nStdErr:\r\nD:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 is already installed.\r\nTo reinstall the same version of the template package, use '--force' option:\r\n   dotnet new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --force\r\n\r\nFor details on the exit code, refer to https://aka.ms/templating-exit-codes#106\r\n) (The following constructor parameters did not have matching fixture data: WebProjectsFixture fixture)\r\n---- Expected command to exit with 0 but it did not.\r\nFile Name: D:\a\_work\1\s\artifacts\bin\redist\Release\dotnet\dotnet.exe\r\nArguments: new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --debug:custom-hive D:\a\_work\1\s\artifacts\tmp\Release\dotnet-new.IntegrationTests\SharedHomeDirectory\20230125013446370\r\nExit Code: 106\r\nStdOut:\r\nThe following template packages will be installed:\r\n   D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405\r\nStdErr:\r\nD:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 is already installed.\r\nTo reinstall the same version of the template package, use '--force' option:\r\n   dotnet new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --force\r\n\r\nFor details on the exit code, refer to https://aka.ms/templating-exit-codes#106\r\n\r\n---- The following constructor parameters did not have matching fixture data: WebProjectsFixture fixture`