### PR TITLE
Warn if the publish profile provided is not present in the project

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -888,7 +888,7 @@ You may need to build the project on another operating system or architecture, o
     <comment>{StrBegin="NETSDK1195: "}</comment>
   </data>
   <data name="PublishProfileNotPresent" xml:space="preserve">
-    <value>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</value>
+    <value>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</value>
     <comment>{StrBegin="NETSDK1198: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -887,4 +887,8 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1195: The SDK does not support ahead-of-time compilation. Set the PublishAot property to false.</value>
     <comment>{StrBegin="NETSDK1195: "}</comment>
   </data>
+  <data name="PublishProfileNotPresent" xml:space="preserve">
+    <value>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</value>
+    <comment>{StrBegin="NETSDK1198: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Nástroje projektu (DotnetCliTool) podporují jen cílení na .NET Core 2.2 a nižší.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: Kompilace ReadyToRun se přeskočí, protože se podporuje jen pro architekturu .NET Core 3.0 a vyšší.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Projekttools (DotnetCliTool) unterstützen als Ziel nur .NET Core 2.2 und früher.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: Die ReadyToRun-Kompilierung wird übersprungen, weil sie nur für .NET Core 3.0 oder höher unterstützt wird.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Las herramientas de proyecto (DotnetCliTool) solo admiten como destino .NET Core 2.2 y versiones inferiores.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: Se omitirá la compilación de ReadyToRun porque solo se admite para .NET Core 3.0 o versiones posteriores.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: les outils de projet (DotnetCliTool) prennent uniquement en charge le ciblage de .NET Core 2.2 et des versions antérieures.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: la compilation ReadyToRun va être ignorée, car elle est uniquement prise en charge pour .NET Core 3.0 ou une version ultérieure.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: gli strumenti del progetto (DotnetCliTool) supportano come destinazione solo .NET Core 2.2 e versioni precedenti.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: la compilazione eseguita con ReadyToRun verrà ignorata perché è supportata solo per .NET Core 3.0 o versioni successive.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -4,217 +4,217 @@
     <body>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
-        <target state="translated">NETSDK1076: è possibile usare AddResource solo con tipi di risorsa integer.</target>
+        <target state="new">NETSDK1076: AddResource can only be used with integer resource types.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
       <trans-unit id="AotNoValidRuntimePackageError">
         <source>NETSDK1183: Unable to optimize assemblies for ahead-of-time compilation: a valid runtime package was not found. Either set the PublishAot property to false, or use a supported runtime identifier when publishing. When targeting .NET 7 or higher, make sure to restore packages with the PublishAot property set to true.</source>
-        <target state="translated">NETSDK1183: non è possibile ottimizzare gli assembly per la compilazione Ahead Of Time perché non è stato trovato alcun pacchetto di runtime valido. Impostare la proprietà PublishAot su false oppure usare un identificatore di runtime supportato durante la pubblicazione. Quando si usa .NET 7 o versioni successive, assicurarsi di ripristinare i pacchetti con la proprietà PublishAot impostata su true.</target>
+        <target state="new">NETSDK1183: Unable to optimize assemblies for ahead-of-time compilation: a valid runtime package was not found. Either set the PublishAot property to false, or use a supported runtime identifier when publishing. When targeting .NET 7 or higher, make sure to restore packages with the PublishAot property set to true.</target>
         <note>{StrBegin="NETSDK1183: "}</note>
       </trans-unit>
       <trans-unit id="AotNotSupported">
         <source>NETSDK1195: The SDK does not support ahead-of-time compilation. Set the PublishAot property to false.</source>
-        <target state="translated">NETSDK1195: l'SDK non supporta la compilazione in anticipo. Imposta la proprietà PublishAot su false.</target>
+        <target state="new">NETSDK1195: The SDK does not support ahead-of-time compilation. Set the PublishAot property to false.</target>
         <note>{StrBegin="NETSDK1195: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: il file di configurazione dell'applicazione deve avere un elemento di configurazione radice.</target>
+        <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCreationFailedWithRetry">
         <source>NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</source>
-        <target state="translated">NETSDK1113: non è stato possibile creare apphost (tentativo {0} di {1}): {2}</target>
+        <target state="new">NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</target>
         <note>{StrBegin="NETSDK1113: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="translated">NETSDK1074: l'eseguibile dell'host applicazione non verrà personalizzato perché per aggiungere risorse è necessario eseguire la compilazione in Windows (escluso Nano Server).</target>
+        <target state="new">NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
       </trans-unit>
       <trans-unit id="AppHostHasBeenModified">
         <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: non è possibile usare '{0}' come eseguibile host dell'applicazione perché non contiene la sequenza di byte segnaposto prevista '{1}' che indica dove verrà scritto il nome dell'applicazione.</target>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
-        <target state="translated">NETSDK1078: non è possibile usare '{0}' come eseguibile dell'host applicazione perché non è un file di Windows PE.</target>
+        <target state="new">NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
         <note>{StrBegin="NETSDK1078: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
         <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
-        <target state="translated">NETSDK1072: non è possibile usare '{0}' come eseguibile dell'host applicazione perché non è un eseguibile Windows per il sottosistema CUI (Console).</target>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppHostSigningFailed">
         <source>NETSDK1177: Failed to sign apphost with error code {1}: {0}</source>
-        <target state="translated">NETSDK1177: impossibile firmare apphost con codice di errore {1}: {0}</target>
+        <target state="new">NETSDK1177: Failed to sign apphost with error code {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: il pacchetto Microsoft.AspNetCore.All non è supportato quando la destinazione è .NET Core 3.0 o versione successiva. È necessario un elemento FrameworkReference per Microsoft.AspNetCore.App, che verrà incluso in modo implicito da Microsoft.NET.Sdk.Web.</target>
+        <target state="new">NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</target>
         <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreUsesFrameworkReference">
         <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: non è necessario alcun elemento PackageReference per Microsoft.AspNetCore.App quando la destinazione è .NET Core 3.0 o versione successiva. Se si usa Microsoft.NET.Sdk.Web, il riferimento al framework condiviso verrà inserito automaticamente; in caso contrario, l'elemento PackageReference deve essere sostituito da un elemento FrameworkReference.</target>
+        <target state="new">NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</target>
         <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="translated">NETSDK1017: prima di elaborare le risorse, è necessario configurare il preprocessore di risorse.</target>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingRuntimeIdentifier">
         <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: il file di risorse '{0}' non contiene una destinazione per '{1}'. Assicurarsi che il ripristino sia stato eseguito e che '{2}' sia stato incluso negli elementi TargetFramework del progetto. Potrebbe anche essere necessario includere '{3}' negli elementi RuntimeIdentifier del progetto.</target>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
         <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingTarget">
         <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: il file di risorse '{0}' non contiene una destinazione per '{1}'. Assicurarsi che il ripristino sia stato eseguito e che '{2}' sia stato incluso negli elementi TargetFramework del progetto.</target>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
         <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotFound">
         <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: il file di risorse '{0}' non è stato trovato. Per generare questo file, eseguire un ripristino del pacchetto NuGet.</target>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
         <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
         <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: il percorso del file di risorse del progetto non è stato impostato. Per generare questo file, eseguire un ripristino del pacchetto NuGet.</target>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
         <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFilePathNotRooted">
         <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: il percorso dei file di risorse '{0}' non contiene una radice. Sono supportati solo percorsi completi.</target>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: è necessario specificare almeno un framework di destinazione possibile.</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="CannotEmbedClsidMapIntoComhost">
         <source>NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="translated">NETSDK1092: non è possibile incorporare l'elemento CLSIDMap nell'host COM perché per aggiungere risorse è necessario eseguire la compilazione in Windows (escluso Nano Server).</target>
+        <target state="new">NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</target>
         <note>{StrBegin="NETSDK1092: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindApphostForRid">
         <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: non è possibile trovare l'host delle app per {0}. {0} potrebbe essere un identificatore di runtime (RID) non valido. Per altre informazioni sul RID, vedere https://aka.ms/rid-catalog.</target>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
         <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindComhost">
         <source>NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</source>
-        <target state="translated">NETSDK1091: non è possibile trovare un host COM .NET Core. L'host COM .NET Core è disponibile solo in .NET Core 3.0 o versioni successive quando è destinato a Windows.</target>
+        <target state="new">NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</target>
         <note>{StrBegin="NETSDK1091: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindIjwhost">
         <source>NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</source>
-        <target state="translated">NETSDK1114: non è possibile trovare un host IJW .NET Core. L'host IJW .NET Core è disponibile solo in .NET Core 3.1 o versioni successive quando la destinazione è Windows.</target>
+        <target state="new">NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</target>
         <note>{StrBegin="NETSDK1114: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindProjectInfo">
         <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: le informazioni del progetto per '{0}' non sono state trovate. Questo errore può indicare la mancanza di un riferimento al progetto.</target>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: la piattaforma '{0}' di RuntimeIdentifier e quella '{1}' di PlatformTarget devono essere compatibili.</target>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
         <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="translated">NETSDK1031: non è possibile compilare o pubblicare un'applicazione indipendente senza specificare un elemento RuntimeIdentifier. Specificare un elemento RuntimeIdentifier o impostare SelfContained su false.</target>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="translated">NETSDK1097: non è possibile pubblicare un'applicazione in un singolo file senza specificare un elemento RuntimeIdentifier. Specificare un elemento RuntimeIdentifier o impostare PublishSingleFile su false.</target>
-        <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutAppHost">
         <source>NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1098: le applicazioni pubblicate in un singolo file sono necessarie per usare l'host dell'applicazione. Impostare PublishSingleFile su false o UseAppHost su true.</target>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1098: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutExecutable">
         <source>NETSDK1099: Publishing to a single-file is only supported for executable applications.</source>
-        <target state="translated">NETSDK1099: la pubblicazione in un singolo file è supportata solo per le applicazioni eseguibili.</target>
+        <target state="new">NETSDK1099: Publishing to a single-file is only supported for executable applications.</target>
         <note>{StrBegin="NETSDK1099: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
         <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: l'opzione "--output" non è supportata durante la compilazione di una soluzione.</target>
+        <target state="new">NETSDK1194: The "--output" option isn't supported when building a solution.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
-        <target state="translated">NETSDK1134: non è possibile compilare una soluzione con un parametro RuntimeIdentifier specifico. Per pubblicare per un singolo RID, specificare il RID a livello di singolo progetto.</target>
+        <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
         <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="translated">NETSDK1135: il valore di SupportedOSPlatformVersion {0} non può essere maggiore di quello di TargetPlatformVersion {1}.</target>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
         <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>
-        <target state="translated">NETSDK1143: se si include tutto il contenuto in un unico bundle di file, verranno incluse anche le librerie native. Se IncludeAllContentForSelfExtract è true, IncludeNativeLibrariesForSelfExtract non deve essere false.</target>
+        <target state="new">NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</target>
         <note>{StrBegin="NETSDK1143: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeSymbolsInSingleFile">
         <source>NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</source>
-        <target state="translated">NETSDK1142: l'inclusione dei simboli in un unico bundle di file non è supportata quando si esegue la pubblicazione per .NET 5 o versioni successive.</target>
+        <target state="new">NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</target>
         <note>{StrBegin="NETSDK1142: "}</note>
       </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: il valore {0}' di TargetFramework non è stato riconosciuto. È possibile che sia stato digitato in modo errato. In caso contrario, le proprietà TargetFrameworkIdentifier e/o TargetFrameworkVersion devono essere specificate in modo esplicito.</target>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: con le applicazioni complete è necessario usare l'host applicazione. Impostare SelfContained su false o UseAppHost su true.</target>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
-        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
-        <target state="translated">NETSDK1125: la pubblicazione in un file singolo è supportata solo per la destinazione netcoreapp.</target>
-        <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="translated">Verrà scelto '{0}' perché il valore di AssemblyVersion '{1}' è maggiore di '{2}'.</target>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingCopyLocalArbitrarily_Info">
         <source>Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</source>
-        <target state="translated">Verrà scelto '{0}' in modo arbitrario perché entrambi gli elementi sono una copia locale e contengono versioni di file e assembly uguali.</target>
+        <target state="new">Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingFileVersion_Info">
         <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="translated">Verrà scelto '{0}' perché la versione del file '{1}' è maggiore di '{2}'.</target>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPlatformItem_Info">
         <source>Choosing '{0}' because it is a platform item.</source>
-        <target state="translated">Verrà scelto '{0}' perché è un elemento della piattaforma.</target>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPreferredPackage_Info">
         <source>Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="translated">Verrà scelto '{0}' perché proviene da un pacchetto preferito.</target>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClsidMapConflictingGuids">
         <source>NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</source>
-        <target state="translated">NETSDK1089: per i tipi '{0}' e '{1}' è impostato lo stesso CLSID '{2}' nel relativo elemento GuidAttribute. Ogni classe COMVisible deve includere un GUID distinto per il CLSID.</target>
+        <target state="new">NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</target>
         <note>{StrBegin="NETSDK1089: "}
 {0} - The first type with the conflicting guid.
 {1} - The second type with the conflicting guid.
@@ -222,329 +222,329 @@
       </trans-unit>
       <trans-unit id="ClsidMapExportedTypesRequireExplicitGuid">
         <source>NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</source>
-        <target state="translated">NETSDK1088: la classe COMVisible '{0}' deve includere un elemento GuidAttribute con il CLSID della classe da rendere visibile per COM in .NET Core.</target>
+        <target state="new">NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</target>
         <note>{StrBegin="NETSDK1088: "}
 {0} - The ComVisible class that doesn't have a GuidAttribute on it.</note>
       </trans-unit>
       <trans-unit id="ClsidMapInvalidAssembly">
         <source>NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</source>
-        <target state="translated">NETSDK1090: l'assembly specificato '{0}' non è valido. Non può essere usato per generare un elemento CLSIDMap.</target>
+        <target state="new">NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</target>
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequires60">
         <source>NETSDK1167: Compression in a single file bundle is only supported when publishing for .NET6 or higher.</source>
-        <target state="translated">NETSDK1167: la compressione in un unico bundle di file è supportata solo quando si esegue la pubblicazione per .NET6 o versioni successive.</target>
+        <target state="new">NETSDK1167: Compression in a single file bundle is only supported when publishing for .NET6 or higher.</target>
         <note>{StrBegin="NETSDK1167: "}</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequiresSelfContained">
         <source>NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.</source>
-        <target state="translated">NETSDK1176: la compressione in un unico bundle di file è supportata solo quando si esegue la pubblicazione di un'applicazione indipendente.</target>
+        <target state="new">NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.</target>
         <note>{StrBegin="NETSDK1176: "}</note>
       </trans-unit>
       <trans-unit id="ConflictingRuntimePackInformation">
         <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
 {1}</source>
-        <target state="translated">NETSDK1133: sono presenti informazioni in conflitto sui pacchetti di runtime disponibili per {0}:
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
 {1}</target>
         <note>{StrBegin="NETSDK1133: "}</note>
       </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: l'elemento di contenuto per '{0}' imposta '{1}', ma non fornisce '{2}' o '{3}'.</target>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
         <note>{StrBegin="NETSDK1014: "}</note>
       </trans-unit>
       <trans-unit id="ContentPreproccessorParameterRequired">
         <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: per poter utilizzare il contenuto pre-elaborato, è necessario assegnare un valore per il parametro '{1}' nell'attività '{0}'.</target>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
         <note>{StrBegin="NETSDK1010: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesNotExist_Info">
         <source>Could not determine winner because '{0}' does not exist.</source>
-        <target state="translated">Non è stato possibile determinare la versione da usare perché '{0}' non esiste.</target>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_EqualVersions_Info">
         <source>Could not determine winner due to equal file and assembly versions.</source>
-        <target state="translated">Non è stato possibile determinare la versione da usare perché le versioni dell'assembly e del file sono uguali.</target>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NoFileVersion_Info">
         <source>Could not determine a winner because '{0}' has no file version.</source>
-        <target state="translated">Non è stato possibile determinare la versione da usare perché non esiste alcuna versione del file per '{0}'.</target>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NotAnAssembly_Info">
         <source>Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="translated">Non è stato possibile determinare la versione da usare perché '{0}' non è un assembly.</target>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
         <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
-        <target state="translated">NETSDK1181: errore durante il recupero della versione del pacchetto: il pacchetto '{0}' non era presente nei manifesti del carico di lavoro.</target>
+        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
         <note>{StrBegin="NETSDK1181: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: non è stato possibile caricare PlatformManifest da '{0}' perché non esiste.</target>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
         <note>{StrBegin="NETSDK1042: "}</note>
       </trans-unit>
       <trans-unit id="CppRequiresTFMVersion31">
         <source>NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</source>
-        <target state="translated">NETSDK1120: con i progetti C++/CLI destinati a .NET Core è il framework di destinazione deve essere impostato almeno su 'netcoreapp3.1'.</target>
+        <target state="new">NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</target>
         <note>{StrBegin="NETSDK1120: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2MissingRequiredMetadata">
         <source>NETSDK1158: Required '{0}' metadata missing on Crossgen2Tool item.</source>
-        <target state="translated">NETSDK1158: nell'elemento Crossgen2Tool mancano i metadati richiesti di '{0}'.</target>
+        <target state="new">NETSDK1158: Required '{0}' metadata missing on Crossgen2Tool item.</target>
         <note>{StrBegin="NETSDK1158: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2RequiresSelfContained">
         <source>NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</source>
-        <target state="translated">NETSDK1126: la pubblicazione di ReadyToRun tramite Crossgen2 è supportata solo per le applicazioni autonome.</target>
+        <target state="new">NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</target>
         <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolExecutableNotFound">
         <source>NETSDK1155: Crossgen2Tool executable '{0}' not found.</source>
-        <target state="translated">NETSDK1155: l'eseguibile '{0}' di Crossgen2Tool non è stato trovato.</target>
+        <target state="new">NETSDK1155: Crossgen2Tool executable '{0}' not found.</target>
         <note>{StrBegin="NETSDK1155: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolMissingWhenUseCrossgen2IsSet">
         <source>NETSDK1154: Crossgen2Tool must be specified when UseCrossgen2 is set to true.</source>
-        <target state="translated">NETSDK1154: è necessario specificare Crossgen2Tool quando UseCrossgen2 è impostato su true.</target>
+        <target state="new">NETSDK1154: Crossgen2Tool must be specified when UseCrossgen2 is set to true.</target>
         <note>{StrBegin="NETSDK1154: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
-        <target state="translated">NETSDK1166: non è possibile creare simboli durante la pubblicazione per .NET 5 con Crossgen2 usando la modalità composita.</target>
+        <target state="new">NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</target>
         <note>{StrBegin="NETSDK1166: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolExecutableNotFound">
         <source>NETSDK1160: CrossgenTool executable '{0}' not found.</source>
-        <target state="translated">NETSDK1160: l'eseguibile '{0}' di CrossgenTool non è stato trovato.</target>
+        <target state="new">NETSDK1160: CrossgenTool executable '{0}' not found.</target>
         <note>{StrBegin="NETSDK1160: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingInPDBCompilationMode">
         <source>NETSDK1153: CrossgenTool not specified in PDB compilation mode.</source>
-        <target state="translated">NETSDK1153: CrossgenTool non è stato specificato nella modalità di compilazione PDB.</target>
+        <target state="new">NETSDK1153: CrossgenTool not specified in PDB compilation mode.</target>
         <note>{StrBegin="NETSDK1153: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingWhenUseCrossgen2IsNotSet">
         <source>NETSDK1159: CrossgenTool must be specified when UseCrossgen2 is set to false.</source>
-        <target state="translated">NETSDK1159: è necessario specificare CrossgenTool quando UseCrossgen2 è impostato su false.</target>
+        <target state="new">NETSDK1159: CrossgenTool must be specified when UseCrossgen2 is set to false.</target>
         <note>{StrBegin="NETSDK1159: "}</note>
       </trans-unit>
       <trans-unit id="DiaSymReaderLibraryNotFound">
         <source>NETSDK1161: DiaSymReader library '{0}' not found.</source>
-        <target state="translated">NETSDK1161: la libreria '{0}' di DiaSymReader non è stata trovata.</target>
+        <target state="new">NETSDK1161: DiaSymReader library '{0}' not found.</target>
         <note>{StrBegin="NETSDK1161: "}</note>
       </trans-unit>
       <trans-unit id="DotNetHostExecutableNotFound">
         <source>NETSDK1156: .NET host executable '{0}' not found.</source>
-        <target state="translated">NETSDK1156: l'eseguibile '{0}' dell'host .NET non è stato trovato.</target>
+        <target state="new">NETSDK1156: .NET host executable '{0}' not found.</target>
         <note>{StrBegin="NETSDK1156: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
         <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool non supporta framework di destinazione di versioni precedenti a netcoreapp2.1.</target>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
         <note>{StrBegin="NETSDK1055: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolOnlySupportNetcoreapp">
         <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: supporta solo .NET Core.</target>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
         <note>{StrBegin="NETSDK1054: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateItemsError">
         <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: sono stati inclusi '{0}' elementi duplicati. Per impostazione predefinita, .NET SDK include '{0}' elementi della directory del progetto. È possibile rimuovere tali elementi dal file di progetto oppure impostare la proprietà '{1}' su '{2}' se si vuole includerli implicitamente nel file di progetto. Per altre informazioni, vedere {4}. Gli elementi duplicati sono: {3}</target>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
         <note>{StrBegin="NETSDK1022: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePreprocessorToken">
         <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: al token di preprocessore '{0}' è stato assegnato più di un valore. Come valore verrà scelto '{1}'.</target>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
         <note>{StrBegin="NETSDK1015: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePublishOutputFiles">
         <source>NETSDK1152: Found multiple publish output files with the same relative path: {0}.</source>
-        <target state="translated">NETSDK1152: sono stati trovati più file di output di pubblicazione con lo stesso percorso relativo: {0}.</target>
+        <target state="new">NETSDK1152: Found multiple publish output files with the same relative path: {0}.</target>
         <note>{StrBegin="NETSDK1152: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateRuntimePackAsset">
         <source>NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="translated">NETSDK1110: più di un asset nel pacchetto di runtime ha lo stesso percorso secondario di destinazione di '{0}'. Segnalare questo errore al team di .NET all'indirizzo: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="new">NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</target>
         <note>{StrBegin="NETSDK1110: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateTypeLibraryIds">
         <source>NETSDK1169: The same resource ID {0} was specified for two type libraries '{1}' and '{2}'. Duplicate type library IDs are not allowed.</source>
-        <target state="translated">NETSDK1169: è stato specificato lo stesso ID di risorsa {0} per due librerie dei tipi '{1}' e '{2}'. Gli ID della libreria dei tipi duplicati non sono consentiti.</target>
+        <target state="new">NETSDK1169: The same resource ID {0} was specified for two type libraries '{1}' and '{2}'. Duplicate type library IDs are not allowed.</target>
         <note>{StrBegin="NETSDK1169: "}</note>
       </trans-unit>
       <trans-unit id="EncounteredConflict_Info">
         <source>Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="translated">È stato rilevato un conflitto tra '{0}' e '{1}'.</target>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">
         <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: si è verificato un errore durante l'analisi di FrameworkList da '{0}'. {1} '{2}' non è valido.</target>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
         <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="translated">NETSDK1043: si è verificato un errore durante l'analisi di PlatformManifest da '{0}' a riga {1}. Il formato delle righe deve essere {2}.</target>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
         <note>{StrBegin="NETSDK1043: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="translated">NETSDK1044: si è verificato un errore durante l'analisi di PlatformManifest da '{0}' a riga {1}. Il valore {2} '{3}' non è valido.</target>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">
         <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: errore durante la lettura del file di asset: {0}</target>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
       <trans-unit id="FailedToDeleteApphost">
         <source>NETSDK1111: Failed to delete output apphost: {0}</source>
-        <target state="translated">NETSDK1111: non è stato possibile eliminare l'apphost di output: {0}</target>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
         <note>{StrBegin="NETSDK1111: "}</note>
       </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: non è stato possibile bloccare la risorsa.</target>
+        <target state="new">NETSDK1077: Failed to lock resource.</target>
         <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
       <trans-unit id="FileNameIsTooLong">
         <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: il nome file specificato '{0}' supera 1024 byte</target>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
         <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
       <trans-unit id="FolderAlreadyExists">
         <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: la cartella '{0}' esiste già. Eliminarla o specificare un elemento ComposeWorkingDir diverso</target>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: con l'host applicazione dipendente dal framework il framework di destinazione deve essere impostato almeno su 'netcoreapp2.1'.</target>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1052: il percorso '{0}' del file dell'elenco di framework non contiene una radice. Sono supportati solo percorsi completi.</target>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceDuplicateError">
         <source>NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</source>
-        <target state="translated">NETSDK1087: nel progetto sono stati inclusi più elementi FrameworkReference per '{0}'.</target>
+        <target state="new">NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</target>
         <note>{StrBegin="NETSDK1087: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceOverrideWarning">
         <source>NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1086: nel progetto è stato incluso un elemento FrameworkReference per '{0}'. Questo elemento viene usato come riferimento implicito da .NET SDK e non è in genere necessario farvi riferimento dal progetto. Per altre informazioni, vedere {1}</target>
+        <target state="new">NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
         <note>{StrBegin="NETSDK1086: "}</note>
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
         <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: il file risolto ha un'immagine danneggiata, non contiene metadati o è inaccessibile per altri motivi. {0} {1}</target>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
         <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
       <trans-unit id="GlobalJsonSDKResolutionFailed">
         <source>NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</source>
-        <target state="translated">NETSDK1141: non è possibile risolvere la versione di .NET SDK come specificato nel file global.json presente in {0}.</target>
+        <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
         <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
-        <target state="translated">NETSDK1144: l'ottimizzazione degli assembly per le dimensioni non è riuscita. È possibile disabilitare l'ottimizzazione impostando la proprietà PublishTrimmed su false.</target>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
-        <target state="translated">NETSDK1102: l'ottimizzazione degli assembly per le dimensioni non è supportata per la configurazione di pubblicazione selezionata. Assicurarsi di pubblicare un'app indipendente.</target>
+        <target state="new">NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</target>
         <note>{StrBegin="NETSDK1102: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkOptimizedAssemblies">
         <source>Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</source>
-        <target state="translated">L'ottimizzazione degli assembly per le dimensioni potrebbe comportare la modifica del comportamento dell'app. Assicurarsi di testarla dopo la pubblicazione. Vedere: https://aka.ms/dotnet-illink</target>
+        <target state="new">Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</target>
         <note />
       </trans-unit>
       <trans-unit id="ILLinkRunning">
         <source>Optimizing assemblies for size. This process might take a while.</source>
-        <target state="translated">Ottimizzazione degli assembly per le dimensioni. Questo processo potrebbe richiedere del tempo.</target>
+        <target state="new">Optimizing assemblies for size. This process might take a while.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed">
         <source>NETSDK1191: A runtime identifier for the property '{0}' couldn't be inferred. Specify a rid explicitly.</source>
-        <target state="translated">NETSDK1191: non è stato possibile dedurre un identificatore di runtime per la proprietà '{0}'. Specificare un RID in modo esplicito.</target>
+        <target state="new">NETSDK1191: A runtime identifier for the property '{0}' couldn't be inferred. Specify a rid explicitly.</target>
         <note>{StrBegin="NETSDK1191: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectPackageRoot">
         <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: la radice {0} del pacchetto specificata per la libreria risolta {1} non è corretta</target>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
         <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectTargetFormat">
         <source>NETSDK1025: The target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: il formato del manifesto di destinazione specificato {0} non è corretto</target>
+        <target state="new">NETSDK1025: The target manifest {0} provided is of not the correct format</target>
         <note>{StrBegin="NETSDK1025: "}</note>
       </trans-unit>
       <trans-unit id="InputAssemblyNotFound">
         <source>NETSDK1163: Input assembly '{0}' not found.</source>
-        <target state="translated">NETSDK1163: l'assembly di input '{0}' non è stato trovato.</target>
+        <target state="new">NETSDK1163: Input assembly '{0}' not found.</target>
         <note>{StrBegin="NETSDK1163: "}</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: nome di framework non valido: '{0}'.</target>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
         <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="translated">NETSDK1058: valore non valido per il parametro ItemSpecToUse: '{0}'. Questa proprietà deve essere vuota o impostata su 'Left' o 'Right'</target>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionString">
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: la stringa di versione '{0}' di NuGet non è valida.</target>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidResourceUpdate">
         <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: il punto di controllo dell'aggiornamento non è valido. Non è possibile usare questa istanza per ulteriori aggiornamenti.</target>
+        <target state="new">NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="InvalidRollForwardValue">
         <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
-        <target state="translated">NETSDK1104: il valore '{0}' di RollForward non è valido. I valori consentiti sono {1}.</target>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
         <note>{StrBegin="NETSDK1104: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTargetPlatformVersion">
         <source>NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
 {2}</source>
-        <target state="translated">NETSDK1140: {0} non è un valore valido di TargetPlatformVersion per or {1}. Le versioni valide includono:
+        <target state="new">NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
 {2}</target>
         <note>{StrBegin="NETSDK1140: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibrary">
         <source>NETSDK1173: The provided type library '{0}' is in an invalid format.</source>
-        <target state="translated">NETSDK1173: il formato della libreria dei tipi specificata '{0}' non è valido.</target>
+        <target state="new">NETSDK1173: The provided type library '{0}' is in an invalid format.</target>
         <note>{StrBegin="NETSDK1173: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibraryId">
         <source>NETSDK1170: The provided type library ID '{0}' for type library '{1}' is invalid. The ID must be a positive integer less than 65536.</source>
-        <target state="translated">NETSDK1170: l'ID '{0}' per la libreria dei tipi specificato '{1}' non è valido. L'ID deve essere un numero positivo intero inferiore a 65536.</target>
+        <target state="new">NETSDK1170: The provided type library ID '{0}' for type library '{1}' is invalid. The ID must be a positive integer less than 65536.</target>
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
-        <target state="translated">NETSDK1157: la libreria '{0}' di JIT non è stata trovata.</target>
+        <target state="new">NETSDK1157: JIT library '{0}' not found.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="translated">NETSDK1061: per il ripristino del progetto è stato usato {0} versione {1}, ma con le impostazioni correnti viene usata la versione {2}. Per risolvere il problema, assicurarsi di usare le stesse impostazioni per il ripristino e per le operazioni successive, quali compilazione o pubblicazione. In genere questo problema può verificarsi se la proprietà RuntimeIdentifier viene impostata durante la compilazione o la pubblicazione, ma non durante il ripristino. Per altre informazioni, vedere https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
         <note>{StrBegin="NETSDK1061: "}
 {0} - Package Identifier for platform package
 {1} - Restored version of platform package
@@ -552,441 +552,441 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="MissingItemMetadata">
         <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: mancano i metadati di '{0}' sull'elemento '{2}' di '{1}'.</target>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputPDBImagePath">
         <source>NETSDK1164: Missing output PDB path in PDB generation mode (OutputPDBImage metadata).</source>
-        <target state="translated">NETSDK1164: il percorso PDB di output non è presente nella modalità di generazione PDB (metadati di OutputPDBImage).</target>
+        <target state="new">NETSDK1164: Missing output PDB path in PDB generation mode (OutputPDBImage metadata).</target>
         <note>{StrBegin="NETSDK1164: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputR2RImageFileName">
         <source>NETSDK1165: Missing output R2R image path (OutputR2RImage metadata).</source>
-        <target state="translated">NETSDK1165: il percorso dell'immagine R2R di output non è presente (metadati di OutputR2RImage).</target>
+        <target state="new">NETSDK1165: Missing output R2R image path (OutputR2RImage metadata).</target>
         <note>{StrBegin="NETSDK1165: "}</note>
       </trans-unit>
       <trans-unit id="MissingTypeLibraryId">
         <source>NETSDK1171: An integer ID less than 65536 must be provided for type library '{0}' because more than one type library is specified.</source>
-        <target state="translated">NETSDK1171: un ID intero inferiore a 65536 deve essere fornito per la libreria dei tipi '{0}' perché è specificata più di una libreria dei tipi.</target>
+        <target state="new">NETSDK1171: An integer ID less than 65536 must be provided for type library '{0}' because more than one type library is specified.</target>
         <note>{StrBegin="NETSDK1171: "}</note>
       </trans-unit>
       <trans-unit id="MultipleFilesResolved">
         <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: è stato trovato più di un file per {0}</target>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
         <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: questo progetto usa una libreria destinata a .NET Standard 1.5 o versione successiva ed è destinato a una versione di .NET Framework che non include il supporto predefinito per tale versione di .NET Standard. Per un serie di problemi noti, visitare https://aka.ms/net-standard-known-issues. Provare a impostare come destinazione .NET Framework 4.7.2.</target>
+        <target state="new">NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
         <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkWithoutUsingNETSdkDefaults">
         <source>NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</source>
-        <target state="translated">NETSDK1115: l'istanza corrente di .NET SDK non supporta .NET Framework senza usare le impostazioni predefinite di .NET SDK. Il problema dipende probabilmente da una mancata corrispondenza tra la proprietà CLRSupport del progetto C++/CLI e TargetFramework.</target>
+        <target state="new">NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
         <source>NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</source>
-        <target state="translated">NETSDK1182: la destinazione .NET 6.0 o versione successiva in Visual Studio 2019 non è supportata.</target>
+        <target state="new">NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="Net7NotCompatibleWithDev173">
         <source>NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.</source>
-        <target state="translated">NETSDK1192: la destinazione .NET 7.0 o versione successiva in Visual Studio 2022 17.3 non è supportata.</target>
+        <target state="new">NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.</target>
         <note>{StrBegin="NETSDK1192: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="translated">NETSDK1084: non è disponibile alcun host applicazione per l'elemento RuntimeIdentifier specificato '{0}'.</target>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
       <trans-unit id="NoBuildRequested">
         <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
-        <target state="translated">NETSDK1085: non è stata impostata alcuna proprietà 'NoBuild' su true, ma è stata chiamata la destinazione 'Build'.</target>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
         <note>{StrBegin="NETSDK1085: "}</note>
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: il progetto '{0}' è destinato a '{2}'. Non può essere usato come riferimento in un progetto destinato a '{1}'.</target>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackAvailable">
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="translated">NETSDK1082: non è disponibile alcun pacchetto di runtime per {0} per l'elemento RuntimeIdentifier specificato '{1}'.</target>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackInformation">
         <source>NETSDK1132: No runtime pack information was available for {0}.</source>
-        <target state="translated">NETSDK1132: non sono disponibili informazioni sui pacchetti di runtime per {0}.</target>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
         <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
-        <target state="translated">NETSDK1128: l'hosting COM non supporta le distribuzioni complete.</target>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
         <note>{StrBegin="NETSDK1128: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
-        <target state="translated">NETSDK1119: i progetti C++/CLI destinati a .NET Core non possono usare EnableComHosting=true.</target>
+        <target state="new">NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</target>
         <note>{StrBegin="NETSDK1119: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppNonDynamicLibraryDotnetCore">
         <source>NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</source>
-        <target state="translated">NETSDK1116: i progetti C++/CLI destinati a .NET Core devono essere librerie dinamiche.</target>
+        <target state="new">NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</target>
         <note>{StrBegin="NETSDK1116: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPackDotnetCore">
         <source>NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</source>
-        <target state="translated">NETSDK1118: i progetti C++/CLI destinati a .NET Core non possono essere compressi.</target>
+        <target state="new">NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</target>
         <note>{StrBegin="NETSDK1118: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPublishDotnetCore">
         <source>NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</source>
-        <target state="translated">NETSDK1117: la pubblicazione di progetti C++/CLI destinati a .NET Core non è supportata.</target>
+        <target state="new">NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</target>
         <note>{StrBegin="NETSDK1117: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppSelfContained">
         <source>NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</source>
-        <target state="translated">NETSDK1121: i progetti C++/CLI destinati a .NET Core non possono usare SelfContained=true.</target>
+        <target state="new">NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
       <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
         <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</source>
-        <target state="translated">NETSDK1151: il progetto '{0}' a cui viene fatto riferimento è un eseguibile autonomo. Non è possibile fare riferimento a un eseguibile autonomo da un eseguibile non autonomo. Per altre informazioni, vedere https://aka.ms/netsdk1151</target>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</target>
         <note>{StrBegin="NETSDK1151: "}</note>
       </trans-unit>
       <trans-unit id="PDBGeneratorInputExecutableNotFound">
         <source>NETSDK1162: PDB generation: R2R executable '{0}' not found.</source>
-        <target state="translated">NETSDK1162: generazione PDB: l'eseguibile '{0}' di R2R non è stato trovato.</target>
+        <target state="new">NETSDK1162: PDB generation: R2R executable '{0}' not found.</target>
         <note>{StrBegin="NETSDK1162: "}</note>
       </trans-unit>
       <trans-unit id="PReleaseRequiresEnvVarOnSln">
         <source>NETSDK1190: To use '{0}' in solution projects, you must set the environment variable '{1}' (to true). This will increase the time to complete the operation.</source>
-        <target state="translated">NETSDK1190: per usare '{0}' nei progetti di soluzione, è necessario impostare la variabile di ambiente '{1}' (su true). Ciò aumenterà il tempo necessario per completare l'operazione.</target>
+        <target state="new">NETSDK1190: To use '{0}' in solution projects, you must set the environment variable '{1}' (to true). This will increase the time to complete the operation.</target>
         <note>{StrBegin="NETSDK1190: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: la creazione di pacchetti come strumenti non prevede elementi autonomi.</target>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
         <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
-        <target state="translated">NETSDK1146: PackAsTool non supporta l'impostazione di TargetPlatformIdentifier. Ad esempio, TargetFramework non può essere essere impostato su net5.0-windows, ma solo su net5.0. PackAsTool non supporta neanche UseWPF o UseWindowsForms quando la destinazione è .NET 5 e versioni successive.</target>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageContainsIncorrectlyCasedLocale">
         <source>NETSDK1187: Package {0} {1} has a resource with the locale '{2}'. This locale has been normalized to the standard format '{3}' to prevent casing issues in the build. Consider notifying the package author about this casing issue.</source>
-        <target state="translated">NETSDK1187: il pacchetto {0} {1} include una risorsa con le impostazioni locali '{2}'. Queste impostazioni locali sono state normalizzate nel formato standard '{3}' per evitare problemi di maiuscole e minuscole nella compilazione. È consigliabile informare l'autore del pacchetto in merito a questo problema di maiuscole e minuscole.</target>
+        <target state="new">NETSDK1187: Package {0} {1} has a resource with the locale '{2}'. This locale has been normalized to the standard format '{3}' to prevent casing issues in the build. Consider notifying the package author about this casing issue.</target>
         <note>Error code is NETSDK1187. 0 is a package name, 1 is a package version, 2 is the incorrect locale string, and 3 is the correct locale string.</note>
       </trans-unit>
       <trans-unit id="PackageContainsUnknownLocale">
         <source>NETSDK1188: Package {0} {1} has a resource with the locale '{2}'. This locale is not recognized by .NET. Consider notifying the package author that it appears to be using an invalid locale.</source>
-        <target state="translated">NETSDK1188: il pacchetto {0} {1} include una risorsa con le impostazioni locali '{2}'. Queste impostazioni locali non sono riconosciute da .NET. È consigliabile notificare all'autore del pacchetto che sembra usare impostazioni locali non valide.</target>
+        <target state="new">NETSDK1188: Package {0} {1} has a resource with the locale '{2}'. This locale is not recognized by .NET. Consider notifying the package author that it appears to be using an invalid locale.</target>
         <note>Error code is NETSDK1188. 0 is a package name, 1 is a package version, and 2 is the incorrect locale string</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="translated">NETSDK1064: il pacchetto {0} versione {1} non è stato trovato. Potrebbe essere stato eliminato dopo il ripristino di NuGet. In caso contrario, il ripristino di NuGet potrebbe essere stato completato solo parzialmente, a causa delle restrizioni relative alla lunghezza massima del percorso.</target>
+        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceOverrideWarning">
         <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: nel progetto è stato incluso un riferimento al pacchetto per '{0}'. Questo pacchetto viene usato come riferimento implicito da .NET SDK e non è in genere necessario farvi riferimento dal progetto. Per altre informazioni, vedere {1}</target>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
         <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceVersionNotRecommended">
         <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: in un elemento PackageReference che fa riferimento a '{0}' è specificata la versione di `{1}`. È consigliabile non specificare la versione di questo pacchetto. Per altre informazioni, vedere https://aka.ms/sdkimplicitrefs</target>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
         <source>NETSDK1174: Placeholder</source>
-        <target state="translated">NETSDK1174: Placeholder</target>
+        <target state="new">NETSDK1174: Placeholder</target>
         <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
       </trans-unit>
       <trans-unit id="Prefer32BitIgnoredForNetCoreApp">
         <source>NETSDK1189: Prefer32Bit is not supported and has no effect for netcoreapp target.</source>
-        <target state="translated">NETSDK1189: Prefer32Bit non è supportato e non ha alcun effetto per la destinazione netcoreapp.</target>
+        <target state="new">NETSDK1189: Prefer32Bit is not supported and has no effect for netcoreapp target.</target>
         <note>{StrBegin="NETSDK1189: "}</note>
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: le risorse vengono utilizzate dal progetto '{0}', ma non è stato trovato alcun percorso di progetto MSBuild corrispondente in '{1}'.</target>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
         <note>{StrBegin="NETSDK1011: "}</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
         <source>NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: lo strumento '{0}' è ora incluso in .NET SDK. Per informazioni sulla risoluzione di questo avviso, vedere (https://aka.ms/dotnetclitools-in-box).</target>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
         <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: gli strumenti del progetto (DotnetCliTool) supportano come destinazione solo .NET Core 2.2 e versioni precedenti.</target>
+        <target state="new">NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1122: la compilazione eseguita con ReadyToRun verrà ignorata perché è supportata solo per .NET Core 3.0 o versioni successive.</target>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
         <note>{StrBegin="NETSDK1122: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedMustBeBool">
         <source>NETSDK1193: If PublishSelfContained is set, it must be either true or false. The value given was '{0}'.</source>
-        <target state="translated">NETSDK1193: se PublishSelfContained è impostato, deve essere true o false. Il valore specificato è '{0}'.</target>
+        <target state="new">NETSDK1193: If PublishSelfContained is set, it must be either true or false. The value given was '{0}'.</target>
         <note>{StrBegin="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1123: per la pubblicazione di un'applicazione in un file singolo è richiesto .NET Core 3.0 o versioni successive.</target>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
         <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="PublishTrimmedRequiresVersion30">
         <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1124: per il trimming degli assembly è richiesto .NET Core 3.0 o versioni successive.</target>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
         <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="PublishUnsupportedWithoutTargetFramework">
         <source>NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</source>
-        <target state="translated">NETSDK1129: la destinazione 'Publish' non è supportata se non viene specificato un framework di destinazione. Il progetto corrente è destinato a più framework, di conseguenza è necessario specificare il framework per l'applicazione pubblicata.</target>
+        <target state="new">NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</target>
         <note>{StrBegin="NETSDK1129: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>
-        <target state="translated">NETSDK1096: l'ottimizzazione degli assembly per le prestazioni non è riuscita. È possibile escludere gli assembly in errore dall'ottimizzazione oppure impostare la proprietà PublishReadyToRun su false.</target>
+        <target state="new">NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
         <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
-        <target state="translated">Alcune compilazioni eseguite con la proprietà ReadyToRun hanno restituito avvisi per indicare potenziali dipendenze mancanti. Le dipendenze mancanti potrebbero causare errori di runtime. Per visualizzare gli avvisi, impostare la proprietà PublishReadyToRunShowWarnings su true.</target>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing. When targeting .NET 6 or higher, make sure to restore packages with the PublishReadyToRun property set to true.</source>
-        <target state="translated">NETSDK1094: non è possibile ottimizzare gli assembly per le prestazioni perché non è stato trovato alcun pacchetto di runtime valido. Impostare la proprietà PublishReadyToRun su false oppure usare un identificatore di runtime supportato durante la pubblicazione. Quando si usa .NET 6 o versioni successive, assicurarsi di ripristinare i pacchetti con la proprietà PublishReadyToRun impostata su true.</target>
+        <target state="new">NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing. When targeting .NET 6 or higher, make sure to restore packages with the PublishReadyToRun property set to true.</target>
         <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunTargetNotSupportedError">
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
-        <target state="translated">NETSDK1095: l'ottimizzazione degli assembly per le prestazioni non è supportata per la piattaforma o l'architettura di destinazione selezionata. Verificare di usare un identificatore di runtime supportato oppure impostare la proprietà PublishReadyToRun su false.</target>
+        <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
       </trans-unit>
       <trans-unit id="RollForwardRequiresVersion30">
         <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1103: l'impostazione RollForward è supportata solo in .NET Core 3.0 o versione successiva.</target>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
         <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="translated">NETSDK1083: l'elemento RuntimeIdentifier '{0}' specificato non è riconosciuto.</target>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
         <note>{StrBegin="NETSDK1083: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: specificare un elemento RuntimeIdentifier</target>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
         <note>{StrBegin="NETSDK1028: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeListNotFound">
         <source>NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="translated">NETSDK1109: il file di elenco di runtime '{0}' non è stato trovato. Segnalare questo errore al team di .NET all'indirizzo: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="new">NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</target>
         <note>{StrBegin="NETSDK1109: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotDownloaded">
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
-        <target state="translated">NETSDK1112: il pacchetto di runtime per {0} non è stato scaricato. Provare a eseguire un ripristino NuGet con RuntimeIdentifier '{1}'.</target>
+        <target state="new">NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
         <source>NETSDK1185: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="translated">NETSDK1185: il Runtime Pack per FrameworkReference '{0}' non è disponibile. È possibile che DisableTransitiveFrameworkReferenceDownloads sia stato impostato su true.</target>
+        <target state="new">NETSDK1185: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
-        <target state="translated">NETSDK1150: il progetto '{0}' a cui viene fatto riferimento è un eseguibile non autonomo. Non è possibile fare riferimento a un eseguibile non autonomo da un eseguibile autonomo. Per altre informazioni, vedere https://aka.ms/netsdk1150</target>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</target>
         <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionShouldBeUsedWithRuntime">
         <source>NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</source>
-        <target state="translated">NETSDK1179: quando si usa '--runtime' è necessaria una delle opzioni '--self-contained' o '--no-self-contained'.</target>
+        <target state="new">NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</target>
         <note>{StrBegin="NETSDK1179: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: per GenerateRuntimeConfigurationFiles è stato specificato 'AdditionalProbingPaths', ma questo valore verrà ignorato perché 'RuntimeConfigDevPath' è vuoto.</target>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
         <note>{StrBegin="NETSDK1048: "}</note>
       </trans-unit>
       <trans-unit id="TargetFrameworkIsEol">
         <source>NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
-        <target state="translated">NETSDK1138: il framework di destinazione '{0}' non è più supportato e non riceverà aggiornamenti della sicurezza in futuro. Per altre informazioni sui criteri di supporto, vedere {1}.</target>
+        <target state="new">NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
         <note>{StrBegin="NETSDK1138: "}</note>
       </trans-unit>
       <trans-unit id="TargetFrameworkWithSemicolon">
         <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: il valore '{0}' di TargetFramework non è valido. Per impostare più destinazioni, usare la proprietà 'TargetFrameworks'.</target>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
       <trans-unit id="TargetingApphostPackMissingCannotRestore">
         <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
-        <target state="translated">NETSDK1145: il pacchetto {0} non è installato e il ripristino del pacchetto NuGet non è supportato. Aggiornare Visual Studio, rimuovere global.json se specifica una determinata versione dell'SDK e disinstallare l'SDK più recente. Per altre opzioni, vedere https://aka.ms/targeting-apphost-pack-missing. Tipo del pacchetto: {0}. Directory del pacchetto: {1}. Framework di destinazione: {2}. ID pacchetto: {3}. Versione del pacchetto: {4}</target>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
         <note>{StrBegin="NETSDK1145: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
-        <target state="translated">NETSDK1127: il Targeting Pack {0} non è installato. Ripristinare e riprovare.</target>
+        <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
         <source>NETSDK1184: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="translated">NETSDK1184: il Targeting Pack per FrameworkReference '{0}' non è disponibile. È possibile che DisableTransitiveFrameworkReferenceDownloads sia stato impostato su true.</target>
+        <target state="new">NETSDK1184: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>
-        <target state="translated">NETSDK1175: quando il trimming è abilitato, Windows Form non è supportato o consigliato. Per altre informazioni, vedere https://aka.ms/dotnet-illink/windows-forms.</target>
+        <target state="new">NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</target>
         <note>{StrBegin="NETSDK1175: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWpfIsNotSupported">
         <source>NETSDK1168: WPF is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/wpf for more details.</source>
-        <target state="translated">NETSDK1168: quando il trimming è abilitato, il WPF non è supportato o consigliato. Per altre informazioni, visitare https://aka.ms/dotnet-illink/wpf.</target>
+        <target state="new">NETSDK1168: WPF is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/wpf for more details.</target>
         <note>{StrBegin="NETSDK1168: "}</note>
       </trans-unit>
       <trans-unit id="TypeLibraryDoesNotExist">
         <source>NETSDK1172: The provided type library '{0}' does not exist.</source>
-        <target state="translated">NETSDK1172: la libreria dei tipi specificata '{0}' non esiste.</target>
+        <target state="new">NETSDK1172: The provided type library '{0}' does not exist.</target>
         <note>{StrBegin="NETSDK1172: "}</note>
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: il percorso risolto per '{0}' non è stato trovato.</target>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
         <note>{StrBegin="NETSDK1016: "}</note>
       </trans-unit>
       <trans-unit id="UnableToUsePackageAssetsCache_Info">
         <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">Non è possibile usare la cache delle risorse del pacchetto a causa dell'errore di I/O. Questo problema può verificarsi quando lo stesso progetto viene compilato più volte in parallelo. Può influire sulle prestazioni, ma non sul risultato della compilazione.</target>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedFileType">
         <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: tipo di file imprevisto per '{0}'. Il tipo è sia '{1}' che '{2}'.</target>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
         <note>{StrBegin="NETSDK1012: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference">
         <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: l'elemento FrameworkReference '{0}' non è stato riconosciuto</target>
+        <target state="new">NETSDK1073: The FrameworkReference '{0}' was not recognized</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
         <source>NETSDK1186: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="translated">NETSDK1186: questo progetto dipende da Maui Essentials tramite un riferimento al progetto o al pacchetto NuGet, ma non dichiara questa dipendenza in modo esplicito. Per compilare questo progetto, è necessario impostare la proprietà UseMauiEssentials su true e, se necessario, installare il carico di lavoro Maui.</target>
+        <target state="new">NETSDK1186: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
         <note>{StrBegin="NETSDK1186: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
-        <target state="translated">NETSDK1137: non è più necessario usare Microsoft.NET.Sdk.WindowsDesktop SDK. Provare a modificare l'attributo Sdk dell'elemento Project radice in 'Microsoft.NET.Sdk'.</target>
+        <target state="new">NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</target>
         <note>{StrBegin="NETSDK1137: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: token di preprocessore '{0}' non riconosciuto in '{1}'.</target>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
         <note>{StrBegin="NETSDK1009: "}</note>
       </trans-unit>
       <trans-unit id="UnresolvedTargetingPack">
         <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="translated">NETSDK1081: il pacchetto di destinazione per {0} non è stato trovato. Per risolvere il problema, eseguire un ripristino NuGet sul progetto.</target>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
         <note>{StrBegin="NETSDK1081: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} è un framework non supportato.</target>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: il progetto è destinato al runtime '{0}' ma non ha risolto pacchetti specifici del runtime. È possibile che questo runtime non sia supportato dal framework di destinazione.</target>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">
         <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: la versione di Microsoft.NET.Sdk usata da questo progetto non è sufficiente per supportare i riferimenti alle librerie destinate a .NET Standard 1.5 o versione successiva. Installare la versione 2.0 o successiva di .NET Core SDK.</target>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
         <note>{StrBegin="NETSDK1050: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetFrameworkVersion">
         <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: la versione corrente di .NET SDK non supporta {0} {1} come destinazione. Impostare come destinazione {0} {2} o una versione precedente oppure usare una versione di .NET SDK che supporta {0} {1}.</target>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifier">
         <source>NETSDK1139: The target platform identifier {0} was not recognized.</source>
-        <target state="translated">NETSDK1139: l'identificatore di piattaforma di destinazione {0} non è stato riconosciuto.</target>
+        <target state="new">NETSDK1139: The target platform identifier {0} was not recognized.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
-        <target state="translated">NETSDK1107: per compilare applicazioni desktop di Windows, è necessario Microsoft.NET.Sdk.WindowsDesktop. 'UseWpf' e 'UseWindowsForms' non sono supportati dall'SDK corrente.</target>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
         <note>{StrBegin="NETSDK1107: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdk_Info">
         <source>NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy</source>
-        <target state="translated">NETSDK1057: si sta usando una versione in anteprima di .NET. Vedere https://aka.ms/dotnet-support-policy</target>
+        <target state="new">NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy</target>
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
-        <target state="translated">NETSDK1131: la produzione di un componente Metadati Windows gestito con WinMDExp non è supportata quando la destinazione è {0}.</target>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
         <source>NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</source>
-        <target state="translated">NETSDK1130: non è possibile fare riferimento a {1}. Il riferimento diretto a un componente di Metadati Windows quando la destinazione è .NET 5 o versione successiva non è supportato. Per altre informazioni, vedere https://aka.ms/netsdk1130</target>
+        <target state="new">NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WinMDTransitiveReferenceNotSupported">
         <source>NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</source>
-        <target state="translated">NETSDK1149: non è possibile fare riferimento a {0} perché usa il supporto incorporato per WinRT, che non è più supportato in .NET 5 e versioni successive. È necessaria una versione aggiornata del componente che supporta .NET 5. Per altre informazioni, vedere https://aka.ms/netsdk1149</target>
+        <target state="new">NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</target>
         <note>{StrBegin="NETSDK1149: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
-        <target state="translated">NETSDK1106: con Microsoft.NET.Sdk.WindowsDesktop 'UseWpf' o 'UseWindowsForms' deve essere impostato su 'true'</target>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
         <note>{StrBegin="NETSDK1106: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
         <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
-        <target state="translated">NETSDK1105: le applicazioni desktop di Windows sono supportate solo in .NET Core 3.0 o versioni successive.</target>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
-        <target state="translated">NETSDK1100: per compilare un progetto destinato a Windows in questo sistema operativo, impostare la proprietà EnableWindowsTargeting su true.</target>
+        <target state="new">NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">
         <source>NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</source>
-        <target state="translated">NETSDK1136: la piattaforma di destinazione deve essere impostata su Windows, in genere includendo '-windows ' nella proprietà TargetFramework, quando si usa Windows Forms o WPF oppure si fa riferimento a progetti o pacchetti che lo usano.</target>
+        <target state="new">NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</target>
         <note>{StrBegin="NETSDK1136: "}</note>
       </trans-unit>
       <trans-unit id="WindowsSDKVersionConflicts">
         <source>NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</source>
-        <target state="translated">NETSDK1148: un assembly di riferimento è stato compilato con una versione più recente di Microsoft.Windows.SDK.NET.dll. Eseguire l'aggiornamento a un SDK .NET più recente per fare riferimento a questo assembly.</target>
+        <target state="new">NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>
-        <target state="translated">NETSDK1178: il progetto dipende dai pacchetti di carico di lavoro seguenti che non esistono in nessuno dei carichi di lavoro disponibili in questa installazione: {0}
-Potrebbe essere necessario compilare il progetto in un altro sistema operativo o architettura oppure aggiornare .NET SDK.</target>
+        <target state="new">NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
+You may need to build the project on another operating system or architecture, or update the .NET SDK.</target>
         <note>{StrBegin="NETSDK1178: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotInstalled">
         <source>NETSDK1147: To build this project, the following workloads must be installed: {0}
 To install these workloads, run the following command: dotnet workload restore</source>
-        <target state="translated">NETSDK1147: per compilare questo progetto devono essere installati i seguenti carichi di lavoro: {0}
-Per installare questi carichi di lavoro, eseguire il seguente comando: dotnet workload restore</target>
+        <target state="new">NETSDK1147: To build this project, the following workloads must be installed: {0}
+To install these workloads, run the following command: dotnet workload restore</target>
         <note>{StrBegin="NETSDK1147: "} LOCALIZATION: Do not localize "dotnet workload restore"</note>
       </trans-unit>
     </body>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: プロジェクト ツール (DotnetCliTool) は、ターゲットが .NET Core 2.2 以下の場合のみサポートされます。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: ReadyToRun コンパイルは、.NET Core 3.0 以降でのみサポートされているため、スキップされます。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: 프로젝트 도구(DotnetCliTool)는 .NET Core 2.2 이하를 대상으로 하는 경우만 지원합니다.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: ReadyToRun 컴파일은 .NET Core 3.0 이상에서만 지원되므로 건너뜁니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Narzędzia projektu (DotnetCliTool) obsługują tylko ukierunkowanie na program .NET Core w wersji 2.2 lub niższej.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: Kompilacja ReadyToRun zostanie pominięta, ponieważ jest obsługiwana tylko w przypadku platformy .NET Core 3.0 lub nowszej.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: as ferramentas do projeto (DotnetCliTool) dão suporte somente para o direcionamento ao .NET Core 2.2 e inferior.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: a compilação de ReadyToRun será ignorada porque ela é compatível apenas com o .NET Core 3.0 ou superior.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: средства проекта (DotnetCliTool) поддерживают только целевую платформу .NET Core 2.2 и более ранних версий.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: компиляция ReadyToRun будет пропущена, так как она поддерживается только для .NET Core 3.0 или более поздних версий.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Proje araçları (DotnetCliTool) yalnızca .NET Core 2.2 veya daha düşük sürümünü hedeflemeyi destekliyor.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: ReadyToRun derlemesi, yalnızca .NET Core 3.0 veya üzeri için desteklendiğinden atlanacak.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: NETSDK1093: 项目工具(DotnetCliTool)仅支持面向 .NET Core 2.2 及更低版本。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: 将跳过 ReadyToRun 编译，因为只有 .NET Core 3.0 或更高版本才支持该编译。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -725,6 +725,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: 專案工具 (DotnetCliTool) 僅支援以 .NET Core 2.2 或更低版本作為目標。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PublishProfileNotPresent">
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <note>{StrBegin="NETSDK1198: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: 將跳過 ReadyToRun 編譯，原因是只有 .NET Core 3.0 或更高版本支援此作業。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -726,8 +726,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
-        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</source>
-        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name</target>
+        <source>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</source>
+        <target state="new">NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</target>
         <note>{StrBegin="NETSDK1198: "}</note>
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -114,6 +114,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(PublishAot)' == 'true' and '$(PublishAotSupported)' != 'true'"
                 ResourceName="AotNotSupported" />
 
+    <NETSdkWarning Condition="'$(PublishProfileImported)' != 'true' and '$(PublishProfile)' != ''"
+                ResourceName="PublishProfileNotPresent" 
+                FormatArguments="$(PublishProfile)"/>    
+                               
     <!-- Enable warning for trying to use PublishRelease or PackRelease with a solution if env-var is not set.-->
     <NETSdkWarning Condition="'$(PublishRelease)' != '' and '$(SolutionExt)' == '.sln' and '$(DOTNET_CLI_ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS)' == ''"
                    ResourceName="PReleaseRequiresEnvVarOnSln" 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -1076,11 +1076,12 @@ public static class Program
         [InlineData("invalidProfile", true)]
         [InlineData("invalidProfile.pubxml", true)]
         [InlineData("..\\Properties\\PublishProfiles\\invalidProfile.pubxml", true)]
+        [InlineData("invalidProfile.txt", true)]
         [InlineData("testProfile", false)]
         [InlineData("testProfile.pubxml", false)]
         [InlineData("..\\Properties\\PublishProfiles\\testProfile.pubxml", false)]
         [InlineData("", false)]
-        public void It_warns_with_an_invalid_publish_profile(string publishProfile, bool shouldWarn)
+        public void It_warns_with_an_invalid_publish_profile_NetSdk(string publishProfile, bool shouldWarn)
         {
             var tfm = ToolsetInfo.CurrentTargetFramework;
 
@@ -1088,11 +1089,68 @@ public static class Program
             {
                 Name = "ConsoleWithPublishProfile",
                 TargetFrameworks = tfm,
-                ProjectSdk = "Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish",
+                ProjectSdk = "Microsoft.NET.Sdk",
                 IsExe = true,
             };
 
-            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, identifier: $"PublishProfile{publishProfile.Length}");
+
+            var projectDirectory = Path.Combine(testProjectInstance.Path, testProject.Name);
+            var publishProfilesDirectory = Path.Combine(projectDirectory, "Properties", "PublishProfiles");
+            Directory.CreateDirectory(publishProfilesDirectory);
+
+            File.WriteAllText(Path.Combine(publishProfilesDirectory, "testProfile.pubxml"), $@"
+<Project>
+  <PropertyGroup>
+    <msbuildProperty>value</msbuildProperty>
+  </PropertyGroup>
+</Project>
+");
+
+            var command = new PublishCommand(testProjectInstance);
+            if (shouldWarn)
+            {
+                command
+                    .Execute($"/p:PublishProfile={publishProfile}")
+                    .Should()
+                    .Pass()
+                    .And
+                    .HaveStdOutContaining("NETSDK1198");
+            }
+            else
+            {
+                command
+                    .Execute($"/p:PublishProfile={publishProfile}")
+                    .Should()
+                    .Pass()
+                    .And
+                    .NotHaveStdOutContaining("NETSDK1198");
+            }
+        }
+
+        [Theory]
+        [InlineData("invalidProfile", true)]
+        [InlineData("invalidProfile.pubxml", true)]
+        [InlineData("..\\Properties\\PublishProfiles\\invalidProfile.pubxml", true)]
+        [InlineData("invalidProfile.txt", true)]
+        [InlineData("testProfile", false)]
+        [InlineData("testProfile.pubxml", false)]
+        [InlineData("..\\Properties\\PublishProfiles\\testProfile.pubxml", false)]
+        [InlineData("Default", false)]
+        [InlineData("", false)]
+        public void It_warns_with_an_invalid_publish_profile_WebSdk(string publishProfile, bool shouldWarn)
+        {
+            var tfm = ToolsetInfo.CurrentTargetFramework;
+
+            var testProject = new TestProject()
+            {
+                Name = "WebWithPublishProfile",
+                TargetFrameworks = tfm,
+                ProjectSdk = "Microsoft.NET.Sdk.Web",
+                IsExe = true,
+            };
+
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, identifier: $"PublishProfile{publishProfile.Length}");
 
             var projectDirectory = Path.Combine(testProjectInstance.Path, testProject.Name);
             var publishProfilesDirectory = Path.Combine(projectDirectory, "Properties", "PublishProfiles");

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -1073,6 +1073,61 @@ public static class Program
         }
 
         [Theory]
+        [InlineData("invalidProfile", true)]
+        [InlineData("invalidProfile.pubxml", true)]
+        [InlineData("..\\Properties\\PublishProfiles\\invalidProfile.pubxml", true)]
+        [InlineData("testProfile", false)]
+        [InlineData("testProfile.pubxml", false)]
+        [InlineData("..\\Properties\\PublishProfiles\\testProfile.pubxml", false)]
+        [InlineData("", false)]
+        public void It_warns_with_an_invalid_publish_profile(string publishProfile, bool shouldWarn)
+        {
+            var tfm = ToolsetInfo.CurrentTargetFramework;
+
+            var testProject = new TestProject()
+            {
+                Name = "ConsoleWithPublishProfile",
+                TargetFrameworks = tfm,
+                ProjectSdk = "Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish",
+                IsExe = true,
+            };
+
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
+
+            var projectDirectory = Path.Combine(testProjectInstance.Path, testProject.Name);
+            var publishProfilesDirectory = Path.Combine(projectDirectory, "Properties", "PublishProfiles");
+            Directory.CreateDirectory(publishProfilesDirectory);
+
+            File.WriteAllText(Path.Combine(publishProfilesDirectory, "testProfile.pubxml"), $@"
+<Project>
+  <PropertyGroup>
+    <msbuildProperty>value</msbuildProperty>
+  </PropertyGroup>
+</Project>
+");
+
+            var command = new PublishCommand(testProjectInstance);
+            if (shouldWarn)
+            {
+                command
+                    .Execute($"/p:PublishProfile={publishProfile}")
+                    .Should()
+                    .Pass()
+                    .And
+                    .HaveStdOutContaining("NETSDK1198");
+            }
+            else
+            {
+                command
+                    .Execute($"/p:PublishProfile={publishProfile}")
+                    .Should()
+                    .Pass()
+                    .And
+                    .NotHaveStdOutContaining("NETSDK1198");
+            }
+        }
+
+        [Theory]
         [InlineData("--p:PublishReadyToRun=true")]
         [InlineData("-p:PublishSingleFile=true")]
         [InlineData("-p:PublishSelfContained=true")]

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -49,6 +49,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
  -->
   <PropertyGroup Condition="'$(PublishProfileImported)' != 'true'">
     <PublishProfile Condition="'$(PublishProfile)' ==''">Default</PublishProfile>
+    <PublishProfileImported Condition="'$(PublishProfile)' == 'Default'">true</PublishProfileImported>
     <PublishProfileName Condition="'$(PublishProfileName)' == ''">$([System.IO.Path]::GetFileNameWithoutExtension($(PublishProfile)))</PublishProfileName>
   </PropertyGroup>
 

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -49,11 +49,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
  -->
   <PropertyGroup Condition="'$(PublishProfileImported)' != 'true'">
     <PublishProfile Condition="'$(PublishProfile)' ==''">Default</PublishProfile>
-    <PublishProfileImported Condition="'$(PublishProfile)' == 'Default'">true</PublishProfileImported>
     <PublishProfileName Condition="'$(PublishProfileName)' == ''">$([System.IO.Path]::GetFileNameWithoutExtension($(PublishProfile)))</PublishProfileName>
   </PropertyGroup>
 
   <Import Project="$(_PublishProfilesDir)$(PublishProfileName).pubxml" Condition="Exists('$(_PublishProfilesDir)$(PublishProfileName).pubxml') And '$(PublishProfileImported)' != 'true'" />
+
+  <!-- Mark the PublishProfile as imported if the default profile shipped with WebSDK is imported -->
+  <PropertyGroup Condition="'$(PublishProfileImported)' != 'true'">
+    <PublishProfileImported Condition="Exists('$(_PublishProfilesDir)$(PublishProfileName).pubxml')">true</PublishProfileImported>
+  </PropertyGroup>
+
 
   <!--
   ***********************************************************************************************


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/28370

Fix: 
Adds a warning if the publish profile is provided but is not imported and is not present in the project.
The fix also makes sure that websdk will mark the profile as imported if the default profile is imported.

Why this fix? 
With publish profiles getting more and more popular and most projects now onboarding to this profile concept, it is important that we warn the user if their provided profile is not imported for any reason.

why warning and not an error?
PublishProfile property is just an msbuild property that the sdk handles in a specific way. It would be aggressive to fail the build just because the user passed an arbitrary msbuild property. Also, having shipped this way for the last various versions, it is probably safer to warn than to error in this scenario.

Tests: 
Added tests for both the success and failure scenarios.

@baronfel / @noahfalk - Let me know if you have any concerns with the approach/fix here. 