### PR TITLE
Fix bug with `dotnet publish -p:Foo` 

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
@@ -10,6 +10,10 @@ using System.Text;
 
 namespace Microsoft.DotNet.Cli.Utils;
 
+/// <summary>
+/// Parses property key value pairs that have already been forwarded through the PropertiesOption class.
+/// Does not parse -p and etc. formats, (this is done by PropertiesOption) but does parse property values separated by =, ;, and using quotes.
+/// </summary>
 public static class MSBuildPropertyParser {
     public static IEnumerable<(string key, string value)> ParseProperties(string input) {
         var currentPos = 0;

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -282,23 +282,10 @@ namespace Microsoft.DotNet.Cli
 
             foreach (var keyEqValString in globalPropEnumerable)
             {
-                foreach (var keyEqVal in keyEqValString.Split(";"))
+                var propertyPairs = MSBuildPropertyParser.ParseProperties(keyEqValString);
+                foreach (var propertyKeyValue in propertyPairs)
                 {
-                    string[] keyValuePair = keyEqVal.Split("=", 2);
-                    if (keyValuePair.Count() == 0)
-                    {
-                        // The user provided an empty value after ;. e.g. -p:Foo=Bar;
-                        continue;
-                    }
-                    else if (keyValuePair.Count() == 1)
-                    {
-                        // The user provided a property such as -p:Foo without giving a value. Undefine the property.
-                        // Note that MSBuild will fail if given -p:Foo; but we can ignore this situation because of this and let MsBuild fail, or, assuming it comes to parity with ';', behave the same as if ; was not present.
-                        // The same can be said for -p:Foo=bar;-p:Bar=Foo, which is also invalid syntax to MSBuild.
-                        globalProperties[keyValuePair[0]] = "";
-                        continue;
-                    }
-                    globalProperties[keyValuePair[0]] = keyValuePair[1];
+                    globalProperties[propertyKeyValue.key] = propertyKeyValue.value;
                 }
             }
             return globalProperties;

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -283,6 +283,11 @@ namespace Microsoft.DotNet.Cli
             foreach (var keyEqVal in globalPropEnumerable)
             {
                 string[] keyValuePair = keyEqVal.Split("=", 2);
+                if (keyValuePair.Count() != 2)
+                {
+                    // The user provided a property such as -p:Foo without giving a value. Ignore the property.
+                    continue;
+                }
                 globalProperties[keyValuePair[0]] = keyValuePair[1];
             }
             return globalProperties;

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -280,15 +280,26 @@ namespace Microsoft.DotNet.Cli
 
             string[] globalPropEnumerable = _parseResult.GetValue(CommonOptions.PropertiesOption);
 
-            foreach (var keyEqVal in globalPropEnumerable)
+            foreach (var keyEqValString in globalPropEnumerable)
             {
-                string[] keyValuePair = keyEqVal.Split("=", 2);
-                if (keyValuePair.Count() != 2)
+                foreach (var keyEqVal in keyEqValString.Split(";"))
                 {
-                    // The user provided a property such as -p:Foo without giving a value. Ignore the property.
-                    continue;
+                    string[] keyValuePair = keyEqVal.Split("=", 2);
+                    if (keyValuePair.Count() == 0)
+                    {
+                        // The user provided an empty value after ;. e.g. -p:Foo=Bar;
+                        continue;
+                    }
+                    else if (keyValuePair.Count() == 1)
+                    {
+                        // The user provided a property such as -p:Foo without giving a value. Undefine the property.
+                        // Note that MSBuild will fail if given -p:Foo; but we can ignore this situation because of this and let MsBuild fail, or, assuming it comes to parity with ';', behave the same as if ; was not present.
+                        // The same can be said for -p:Foo=bar;-p:Bar=Foo, which is also invalid syntax to MSBuild.
+                        globalProperties[keyValuePair[0]] = "";
+                        continue;
+                    }
+                    globalProperties[keyValuePair[0]] = keyValuePair[1];
                 }
-                globalProperties[keyValuePair[0]] = keyValuePair[1];
             }
             return globalProperties;
         }

--- a/src/Cli/dotnet/commands/dotnet-pack/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-pack/LocalizableStrings.resx
@@ -148,7 +148,7 @@
     <value>The project to pack, defaults to the project file in the current directory. Can be a path to any project file</value>
   </data>
   <data name="ConfigurationOptionDescription" xml:space="preserve">
-    <value>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</value>
+    <value>The configuration to use for building the package. The default is 'Release'.</value>
   </data>
   <data name="CmdNoLogo" xml:space="preserve">
     <value>Do not display the startup banner or the copyright message.</value>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.cs.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Konfigurace, která se má použít k sestavení balíčku. Výchozí hodnota je Debug. Pomocí vlastnosti PackRelease nastavte release jako výchozí pro tento příkaz.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">Konfigurace, která se má použít k sestavení balíčku. Výchozí hodnota je Debug. Pomocí vlastnosti PackRelease nastavte release jako výchozí pro tento příkaz.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.de.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Die Konfiguration, die zum Erstellen des Pakets verwendet werden soll. Der Standardwert ist „Debuggen“. Verwenden Sie die „PackRelease“-Eigenschaft, um „Release“ als Standard für diesen Befehl zu verwenden.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">Die Konfiguration, die zum Erstellen des Pakets verwendet werden soll. Der Standardwert ist „Debuggen“. Verwenden Sie die „PackRelease“-Eigenschaft, um „Release“ als Standard für diesen Befehl zu verwenden.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.es.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Configuración que se va a usar para compilar el paquete. El valor predeterminado es "Debug". Use la propiedad "PackRelease" para que "Release" sea el valor predeterminado para este comando.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">Configuración que se va a usar para compilar el paquete. El valor predeterminado es "Debug". Use la propiedad "PackRelease" para que "Release" sea el valor predeterminado para este comando.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.fr.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">La configuration à utiliser pour construire le package. La valeur par défaut est 'Débogage'. Utilisez la propriété `PackRelease` pour faire de 'Release' la valeur par défaut pour cette commande.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">La configuration à utiliser pour construire le package. La valeur par défaut est 'Débogage'. Utilisez la propriété `PackRelease` pour faire de 'Release' la valeur par défaut pour cette commande.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.it.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Configurazione da usare per compilare il pacchetto. L'impostazione predefinita è 'Debug'. Usare la proprietà 'PackRelease' per rendere 'Release' il valore predefinito per questo comando.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">Configurazione da usare per compilare il pacchetto. L'impostazione predefinita è 'Debug'. Usare la proprietà 'PackRelease' per rendere 'Release' il valore predefinito per questo comando.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ja.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">パッケージのビルドに使用する構成。既定値は 'Debug' です。'Release' をこのコマンドの既定値にするには、'PackRelease' プロパティを使用します。</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">パッケージのビルドに使用する構成。既定値は 'Debug' です。'Release' をこのコマンドの既定値にするには、'PackRelease' プロパティを使用します。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ko.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">패키지를 빌드하는 데 사용할 구성입니다. 기본값은 '디버그'입니다. `PackRelease` 속성을 사용하여 'Release'를 이 명령의 기본값으로 설정합니다.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">패키지를 빌드하는 데 사용할 구성입니다. 기본값은 '디버그'입니다. `PackRelease` 속성을 사용하여 'Release'를 이 명령의 기본값으로 설정합니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pl.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Konfiguracja używana do kompilowania pakietu. Wartość domyślna to „Debug”. Użyj właściwości „PackRelease”, aby ustawienie „Release” było domyślne dla tego polecenia.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">Konfiguracja używana do kompilowania pakietu. Wartość domyślna to „Debug”. Użyj właściwości „PackRelease”, aby ustawienie „Release” było domyślne dla tego polecenia.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pt-BR.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">A configuração a ser usada para compilar o pacote. O padrão é 'Depurar'. Use a propriedade `PackRelease` para tornar 'Release' o padrão para este comando.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">A configuração a ser usada para compilar o pacote. O padrão é 'Depurar'. Use a propriedade `PackRelease` para tornar 'Release' o padrão para este comando.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ru.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Конфигурация для сборки пакета. По умолчанию используется Debug. Используйте свойство PackRelease, чтобы сделать Release стандартом для этой команды.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">Конфигурация для сборки пакета. По умолчанию используется Debug. Используйте свойство PackRelease, чтобы сделать Release стандартом для этой команды.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.tr.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Paket derlemede kullanmak için yapılandırma. Varsayılan değer: 'Debug'. Bu komutta, 'Release' komutunu varsayılan yapmak için 'PackRelease' özelliğini kullanın.</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">Paket derlemede kullanmak için yapılandırma. Varsayılan değer: 'Debug'. Bu komutta, 'Release' komutunu varsayılan yapmak için 'PackRelease' özelliğini kullanın.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hans.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">用于生成包的配置。默认值为 “Debug”。使用 `PackRelease` 属性将 “Release” 作为此命令的默认值。</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">用于生成包的配置。默认值为 “Debug”。使用 `PackRelease` 属性将 “Release” 作为此命令的默认值。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hant.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to use for building the package. The default is 'Debug'. Use the `PackRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">將用以組建套件的設定。預設值為 'Debug'。使用 'PackRelease' 屬性將 'Release' 設定為此命令的預設值。</target>
+        <source>The configuration to use for building the package. The default is 'Release'.</source>
+        <target state="needs-review-translation">將用以組建套件的設定。預設值為 'Debug'。使用 'PackRelease' 屬性將 'Release' 設定為此命令的預設值。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-publish/LocalizableStrings.resx
@@ -146,7 +146,7 @@
 The default is to publish a framework-dependent application.</value>
   </data>
   <data name="ConfigurationOptionDescription" xml:space="preserve">
-    <value>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</value>
+    <value>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</value>
   </data>
   <data name="CmdNoLogo" xml:space="preserve">
     <value>Do not display the startup banner or the copyright message.</value>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.cs.xlf
@@ -55,8 +55,8 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Konfigurace, pro kterou se má publikovat. Výchozí hodnota je Debug. Pomocí vlastnosti PublishRelease nastavte release jako výchozí pro tento příkaz.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">Konfigurace, pro kterou se má publikovat. Výchozí hodnota je Debug. Pomocí vlastnosti PublishRelease nastavte release jako výchozí pro tento příkaz.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.de.xlf
@@ -55,8 +55,8 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Die Konfiguration, für die veröffentlicht werden soll. Der Standardwert ist „Debuggen“. Verwenden Sie die „PublishRelease“-Eigenschaft, um „Release“ als Standard für diesen Befehl zu verwenden.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">Die Konfiguration, für die veröffentlicht werden soll. Der Standardwert ist „Debuggen“. Verwenden Sie die „PublishRelease“-Eigenschaft, um „Release“ als Standard für diesen Befehl zu verwenden.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.es.xlf
@@ -55,8 +55,8 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Configuración para la que se va a publicar. El valor predeterminado es "Debug". Use la propiedad "PublishRelease" para que "Release" sea el valor predeterminado para este comando.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">Configuración para la que se va a publicar. El valor predeterminado es "Debug". Use la propiedad "PublishRelease" para que "Release" sea el valor predeterminado para este comando.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.fr.xlf
@@ -55,8 +55,8 @@ La valeur par défaut est de publier une application dépendante du framework.</
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">La configuration pour laquelle publier. La valeur par défaut est 'Débogage'. Utilisez la propriété `PublishRelease` pour faire de 'Release' la valeur par défaut pour cette commande.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">La configuration pour laquelle publier. La valeur par défaut est 'Débogage'. Utilisez la propriété `PublishRelease` pour faire de 'Release' la valeur par défaut pour cette commande.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.it.xlf
@@ -55,8 +55,8 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Configurazione per cui eseguire la pubblicazione. L'impostazione predefinita è 'Debug'. Usare la proprietà 'PublishRelease' per rendere 'Release' il valore predefinito per questo comando.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">Configurazione per cui eseguire la pubblicazione. L'impostazione predefinita è 'Debug'. Usare la proprietà 'PublishRelease' per rendere 'Release' il valore predefinito per questo comando.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ja.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">公開する構成。既定値は 'Debug' です。'Release' をこのコマンドの既定値にするには、'PublishRelease' プロパティを使用します。</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">公開する構成。既定値は 'Debug' です。'Release' をこのコマンドの既定値にするには、'PublishRelease' プロパティを使用します。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ko.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">게시할 구성입니다. 기본값은 '디버그'입니다. 'PublishRelease' 속성을 사용하여 'Release'를 이 명령의 기본값으로 설정합니다.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">게시할 구성입니다. 기본값은 '디버그'입니다. 'PublishRelease' 속성을 사용하여 'Release'를 이 명령의 기본값으로 설정합니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pl.xlf
@@ -55,8 +55,8 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Konfiguracja do opublikowania. Wartość domyślna to „Debug”. Użyj właściwości „PublishRelease”, aby ustawienie „Release” było ustawieniem domyślnym dla tego polecenia.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">Konfiguracja do opublikowania. Wartość domyślna to „Debug”. Użyj właściwości „PublishRelease”, aby ustawienie „Release” było ustawieniem domyślnym dla tego polecenia.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pt-BR.xlf
@@ -55,8 +55,8 @@ O padrão é publicar uma aplicação dependente de framework.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">A configuração para a qual publicar. O padrão é 'Depurar'. Use a propriedade `PublishRelease` para tornar 'Release' o padrão para este comando.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">A configuração para a qual publicar. O padrão é 'Depurar'. Use a propriedade `PublishRelease` para tornar 'Release' o padrão para este comando.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ru.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Конфигурация для публикации. По умолчанию используется Debug. Используйте свойство PublishRelease, чтобы сделать Release стандартом для этой команды.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">Конфигурация для публикации. По умолчанию используется Debug. Используйте свойство PublishRelease, чтобы сделать Release стандартом для этой команды.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.tr.xlf
@@ -55,8 +55,8 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">Yayımlama için yapılandırma. Varsayılan değer: 'Debug'. Bu komutta, 'Release' komutunu varsayılan yapmak için 'PublishRelease' özelliğini kullanın.</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">Yayımlama için yapılandırma. Varsayılan değer: 'Debug'. Bu komutta, 'Release' komutunu varsayılan yapmak için 'PublishRelease' özelliğini kullanın.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hans.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">要发布的配置。默认值为 “Debug”。使用 `PublishRelease` 属性将 “Release” 作为此命令的默认值。</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">要发布的配置。默认值为 “Debug”。使用 `PublishRelease` 属性将 “Release” 作为此命令的默认值。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hant.xlf
@@ -55,8 +55,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
-        <source>The configuration to publish for. The default is 'Debug'. Use the `PublishRelease` property to make 'Release' the default for this command.</source>
-        <target state="translated">將發佈的設定。預設值為 'Debug'。使用 'PublishRelease' 屬性將 'Release' 設定為此命令的預設值。</target>
+        <source>The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.</source>
+        <target state="needs-review-translation">將發佈的設定。預設值為 'Debug'。使用 'PublishRelease' 屬性將 'Release' 設定為此命令的預設值。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Policy;
@@ -584,6 +585,7 @@ public static class Program
         [InlineData("-property:Configuration=Debug")]
         [InlineData("--property:Configuration=Debug")]
         [InlineData("/p:Configuration=Debug")]
+        [InlineData("_IsPublishing=true;Configuration=Debug")]
         [InlineData("/property:Configuration=Debug")]
         public void PublishRelease_does_not_override_Configuration_property_across_formats(string configOpt)
         {
@@ -608,6 +610,35 @@ public static class Program
             Assert.True(File.Exists(expectedAssetPath));
             var releaseAssetPath = Path.Combine(helloWorldAsset.Path, "bin", "Release", tfm, "HelloWorld.dll");
             Assert.False(File.Exists(releaseAssetPath)); // build will produce a debug asset, need to make sure this doesn't exist either.
+        }
+
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("=")]
+        public void PublishRelease_does_recognize_undefined_property(string propertySuffix)
+        {
+            string tfm = ToolsetInfo.CurrentTargetFramework;
+            var testProject = new TestProject()
+            {
+                IsExe = true,
+                TargetFrameworks = tfm
+            };
+
+            testProject.RecordProperties("SelfContained");
+            testProject.RecordProperties("PublishAot");
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            new DotnetPublishCommand(Log)
+                .WithWorkingDirectory(Path.Combine(testAsset.TestRoot, MethodBase.GetCurrentMethod().Name))
+                .Execute(("-p:SelfContained" + propertySuffix))
+                .Should()
+                .Pass();
+
+            var properties = testProject.GetPropertyValues(testAsset.TestRoot, configuration: "Release", targetFramework: tfm);
+
+            Assert.Equal("", properties["SelfContained"]);
+            Assert.Equal("", properties["PublishAot"]);
         }
 
         [Theory]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -585,7 +585,8 @@ public static class Program
         [InlineData("-property:Configuration=Debug")]
         [InlineData("--property:Configuration=Debug")]
         [InlineData("/p:Configuration=Debug")]
-        [InlineData("_IsPublishing=true;Configuration=Debug")]
+        [InlineData("-p:_IsPublishing=true;Configuration=Debug")]
+        [InlineData("-p:_IsPublishing=true;Configuration=Debug;")]
         [InlineData("/property:Configuration=Debug")]
         public void PublishRelease_does_not_override_Configuration_property_across_formats(string configOpt)
         {


### PR DESCRIPTION
Just discovered this on my own testing ... since NET 7 there has been a invalid index exception which occurs when you `pack` or `publish` and give an incomplete property key value pair, such as `dotnet publish -p:Foo`. This fixes said error.  In NET 6 it was a no op to do this.