### PR TITLE
Refactor allowEmptyTelemetry to use Items and support hashing

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAAllowEmptyTelemetry.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAAllowEmptyTelemetry.cs
@@ -8,16 +8,24 @@ using System.Text;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
+using Microsoft.Build.Utilities;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     public class GivenAAllowEmptyTelemetry
     {
-        [Theory]
-        [InlineData("Property1")]
-        [InlineData("Property1=")]
-        public void WhenInvokeWithoutValueItSendValueAsNull(string eventData)
+        private static ITaskItem CreateHashItem(string key, string value = null, Nullable<bool> hash = null) {
+            var item = new TaskItem(key);
+            item.SetMetadata("Value", value);
+            if(hash.HasValue) {
+                item.SetMetadata("Hash", hash.Value.ToString());
+            }
+            return item;
+        }
+
+        [Fact]
+        public void WhenInvokeWithoutValueItSendValueAsNull()
         {
             var engine = new MockBuildEngine5();
 
@@ -25,12 +33,16 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 BuildEngine = engine,
                 EventName = "My event name",
-                EventData = eventData
+                EventData = new ITaskItem[] {
+                    CreateHashItem("Property1"),
+                    CreateHashItem("Property2", "")
+                }
             };
 
             telemetryTask.Execute();
 
             engine.Log.Should().Contain("'Property1' = 'null'");
+            engine.Log.Should().Contain("'Property2' = 'null'");
         }
 
         [Fact]
@@ -42,7 +54,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 BuildEngine = engine,
                 EventName = "My event name",
-                EventData = "Property1=EE2493A167D24F00996DE7C8E769EAE6;Property1=4ADE3D2622CA400B8B95A039DF540037"
+                EventData = new ITaskItem[] {
+                    CreateHashItem("Property1", "EE2493A167D24F00996DE7C8E769EAE6"),
+                    CreateHashItem("Property1", "4ADE3D2622CA400B8B95A039DF540037")
+                }
             };
 
             bool retVal = telemetryTask.Execute();
@@ -51,23 +66,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             engine.Log.Should().NotContain("EE2493A167D24F00996DE7C8E769EAE6");
             engine.Log.Should().Contain("4ADE3D2622CA400B8B95A039DF540037");
-        }
-
-        [Fact]
-        public void WhenInvokeWithInvalidEventDataItThrows()
-        {
-            var engine = new MockBuildEngine5();
-
-            AllowEmptyTelemetry telemetryTask = new AllowEmptyTelemetry
-            {
-                BuildEngine = engine,
-                EventName = "My event name",
-                EventData = "Property1=Value1;=Value2"
-            };
-
-            Action a = () => telemetryTask.Execute();
-
-            a.Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -85,6 +83,27 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             retVal.Should().BeTrue();
             engine.Log.Should().Contain(telemetryTask.EventName);
+        }
+
+        [Fact]
+        public void WhenHashIsRequestedValueIsHashed()
+        {
+            var engine = new MockBuildEngine5();
+
+            AllowEmptyTelemetry telemetryTask = new AllowEmptyTelemetry
+            {
+                BuildEngine = engine,
+                EventName = "My event name",
+                EventData = new ITaskItem[] {
+                    CreateHashItem("Property1", "hi", true),
+                    CreateHashItem("Property2", "hello", false)
+                }
+            };
+
+            telemetryTask.Execute();
+            // first property should be hashed
+            engine.Log.Should().Contain("'Property1' = 'cd6f6854353f68f47c9c93217c5084bc66ea1af918ae1518a2d715a1885e1fcb'");
+            engine.Log.Should().Contain("'Property2' = 'hello'");
         }
 
         /// <summary>
@@ -121,9 +140,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             public void LogTelemetry(string eventName, IDictionary<string, string> properties)
             {
                 string message = $"Received telemetry event '{eventName}'{Environment.NewLine}";
-                foreach (string key in properties?.Keys)
-                {
-                    message += $"  Property '{key}' = '{properties[key]}'{Environment.NewLine}";
+                if (properties is not null) {
+                    foreach (string key in properties.Keys)
+                    {
+                        message += $"  Property '{key}' = '{properties[key]}'{Environment.NewLine}";
+                    }
                 }
 
                 lock (_lockObj)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAAllowEmptyTelemetry.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAAllowEmptyTelemetry.cs
@@ -11,14 +11,16 @@ using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
 
+#nullable enable
+
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     public class GivenAAllowEmptyTelemetry
     {
-        private static ITaskItem CreateHashItem(string key, string value = null, Nullable<bool> hash = null) {
+        private static ITaskItem CreateHashItem(string key, string? value = null, bool? hash = null) {
             var item = new TaskItem(key);
             item.SetMetadata("Value", value);
-            if(hash.HasValue) {
+            if(hash is not null) {
                 item.SetMetadata("Hash", hash.Value.ToString());
             }
             return item;
@@ -83,6 +85,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             retVal.Should().BeTrue();
             engine.Log.Should().Contain(telemetryTask.EventName);
+            engine.Log.Should().NotContain("Property"); // shouldn't have any logged properties since none were supplied
         }
 
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Tasks
         private static string HashWithNormalizedCasing(string text){
             var utf8UpperBytes = System.Text.Encoding.UTF8.GetBytes(text.ToUpperInvariant());
 #if NETFRAMEWORK
-            var crypt = new System.Security.Cryptography.SHA256.Create();
+            var crypt = System.Security.Cryptography.SHA256.Create();
             var hash = new System.Text.StringBuilder();
             byte[] crypto = crypt.ComputeHash(utf8UpperBytes);
             foreach (byte theByte in crypto)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Build.Tasks;
 
@@ -10,41 +11,67 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public sealed class AllowEmptyTelemetry : TaskBase
     {
+        public AllowEmptyTelemetry() {
+            EventData = Array.Empty<ITaskItem>();
+            EventName = String.Empty;
+        }
+
         /// <summary>
-        /// Gets or sets a semi-colon delimited list of equal-sign separated key/value pairs.  An example would be &quot;Property1=Value1;Property2=Value2&quot;Property3=.
-        /// Property3's value will be "null"
+        /// Gets or sets an array of ITaskItems. The ItemSpec of the item will be the 'key' of the telemetry event property. The 'Value' metadata will be the value.
+        /// If the 'Hash' metadata is present and set to 'true', the value will be hashed before being logged.
         /// </summary>
-        public string EventData { get; set; }
+        public ITaskItem[] EventData { get; set; }
 
         [Required] public string EventName { get; set; }
 
         protected override void ExecuteCore()
         {
-            IDictionary<string, string> properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            if (!string.IsNullOrEmpty(EventData))
-            {
-                foreach (string pair in EventData.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries))
+            if (EventData == null) {
+                (BuildEngine as IBuildEngine5)?.LogTelemetry(EventName, null);
+            } else {
+                IDictionary<string, string> properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var item in EventData)
                 {
-                    var item = pair.Split(new[] {'='}, 2);
-
-                    if (string.IsNullOrWhiteSpace(item[0]))
-                    {
-                        throw new ArgumentException($"{pair} is invalid.");
+                    var key = item.ItemSpec;
+                    var availableNames = item.MetadataNames.Cast<string>();
+                    var hasValue = availableNames.Contains("Value");
+                    var value = hasValue ? item.GetMetadata("Value") : null;
+                    var hasHash = availableNames.Contains("Hash");
+                    var hash = hasHash ? bool.Parse(item.GetMetadata("Hash")) : false;
+                    if (hash && value != null) {
+                        value = HashWithNormalizedCasing(value);
                     }
-
-                    if (item.Length < 2 || string.IsNullOrWhiteSpace(item[1]))
+                    if (String.IsNullOrEmpty(value))
                     {
-                        properties[item[0]] = "null";
+                        properties[key] = "null";
                     }
                     else
                     {
-                        properties[item[0]] = item[1];
+                        properties[key] = value;
                     }
                 }
+                (BuildEngine as IBuildEngine5)?.LogTelemetry(EventName, properties);
             }
+        }
 
-            (BuildEngine as IBuildEngine5)?.LogTelemetry(EventName, properties);
+        // A local copy of Sha256Hasher.HashWithNormalizedCasing from the Microsoft.DotNet.Cli.Utils project.
+        // We don't want to introduce a project<->project dependency, and the logic is straightforward enough.
+        private static string HashWithNormalizedCasing(string text){
+            var utf8UpperBytes = System.Text.Encoding.UTF8.GetBytes(text.ToUpperInvariant());
+#if NETFRAMEWORK
+            var crypt = new System.Security.Cryptography.SHA256.Create();
+            var hash = new System.Text.StringBuilder();
+            byte[] crypto = crypt.ComputeHash(utf8UpperBytes);
+            foreach (byte theByte in crypto)
+            {
+                hash.Append(theByte.ToString("x2"));
+            }
+            return hash.ToString().ToLowerInvariant();
+#endif
+#if NET
+            byte[] hash = System.Security.Cryptography.SHA256.HashData(utf8UpperBytes);
+            return Convert.ToHexString(hash).ToLowerInvariant();
+#endif
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public sealed class AllowEmptyTelemetry : TaskBase
     {
-        public AllowEmptyTelemetry() {
+        public AllowEmptyTelemetry()
+        {
             EventData = Array.Empty<ITaskItem>();
             EventName = String.Empty;
         }
@@ -26,9 +27,12 @@ namespace Microsoft.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            if (EventData == null) {
+            if (EventData == null)
+            {
                 (BuildEngine as IBuildEngine5)?.LogTelemetry(EventName, null);
-            } else {
+            }
+            else
+            {
                 IDictionary<string, string> properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var item in EventData)
                 {
@@ -38,7 +42,8 @@ namespace Microsoft.Build.Tasks
                     var value = hasValue ? item.GetMetadata("Value") : null;
                     var hasHash = availableNames.Contains("Hash");
                     var hash = hasHash ? bool.Parse(item.GetMetadata("Hash")) : false;
-                    if (hash && value != null) {
+                    if (hash && value != null)
+                    {
                         value = HashWithNormalizedCasing(value);
                     }
                     if (String.IsNullOrEmpty(value))
@@ -56,7 +61,8 @@ namespace Microsoft.Build.Tasks
 
         // A local copy of Sha256Hasher.HashWithNormalizedCasing from the Microsoft.DotNet.Cli.Utils project.
         // We don't want to introduce a project<->project dependency, and the logic is straightforward enough.
-        private static string HashWithNormalizedCasing(string text){
+        private static string HashWithNormalizedCasing(string text)
+        {
             var utf8UpperBytes = System.Text.Encoding.UTF8.GetBytes(text.ToUpperInvariant());
 #if NETFRAMEWORK
             var crypt = System.Security.Cryptography.SHA256.Create();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -347,8 +347,13 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_PrepareForReadyToRunCompilation;
                             _CreateR2RImages;
                             _CreateR2RSymbols">
-
-    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="PublishReadyToRunUseCrossgen2=$(PublishReadyToRunUseCrossgen2);Crossgen2PackVersion=%(ResolvedCrossgen2Pack.NuGetPackageVersion);CompileListCount=@(_ReadyToRunCompileList->Count());FailedCount=@(_ReadyToRunCompilationFailures->Count())" />
+    <ItemGroup>
+      <R2RTelemetry Include="PublishReadyToRunUseCrossgen2" Value="$(PublishReadyToRunUseCrossgen2)" />
+      <R2RTelemetry Include="Crossgen2PackVersion" Value="%(ResolvedCrossgen2Pack.NuGetPackageVersion)" />
+      <R2RTelemetry Include="CompileListCount" Value="@(_ReadyToRunCompileList->Count())" />
+      <R2RTelemetry Include="FailedCount" Value="@(_ReadyToRunCompilationFailures->Count())" />
+    </ItemGroup>
+    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="@(R2RTelemetry)" />
 
     <NETSdkError Condition="'@(_ReadyToRunCompilationFailures)' != ''" ResourceName="ReadyToRunCompilationFailed" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -72,7 +72,14 @@ Copyright (c) .NET Foundation. All rights reserved.
          the published assets were copied. -->
     <Message Importance="High" Text="$(MSBuildProjectName) -> $([System.IO.Path]::GetFullPath('$(PublishDir)'))" />
 
-    <AllowEmptyTelemetry EventName="PublishProperties" EventData="PublishReadyToRun=$(PublishReadyToRun);PublishTrimmed=$(PublishTrimmed);PublishSingleFile=$(PublishSingleFile);PublishAot=$(PublishAot);PublishProtocol=$(PublishProtocol)" />
+    <ItemGroup>
+      <PublishTelemetry Include="PublishReadyToRun" Value="$(PublishReadyToRun)" />
+      <PublishTelemetry Include="PublishTrimmed" Value="$(PublishTrimmed)" />
+      <PublishTelemetry Include="PublishSingleFile" Value="$(PublishSingleFile)" />
+      <PublishTelemetry Include="PublishAot" Value="$(PublishAot)" />
+      <PublishTelemetry Include="PublishProtocol" Value="$(PublishProtocol)" />
+    </ItemGroup>
+    <AllowEmptyTelemetry EventName="PublishProperties" EventData="@(PublishTelemetry)" />
   </Target>
 
   <!-- Don't let project reference resolution build project references in NoBuild case. -->
@@ -116,7 +123,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Enable warning for trying to use PublishRelease or PackRelease with a solution if env-var is not set.-->
     <NETSdkWarning Condition="'$(PublishRelease)' != '' and '$(SolutionExt)' == '.sln' and '$(DOTNET_CLI_ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS)' == ''"
-                   ResourceName="PReleaseRequiresEnvVarOnSln" 
+                   ResourceName="PReleaseRequiresEnvVarOnSln"
                    FormatArguments="PublishRelease;DOTNET_CLI_ENABLE_PUBLISH_RELEASE_FOR_SOLUTIONS"
     />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -117,7 +117,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="AllowEmptyTelemetry" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <Target Name="_CollectTargetFrameworkForTelemetry" AfterTargets="_CheckForUnsupportedTargetFramework">
-    <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="TargetFrameworkVersion=$([MSBuild]::Escape('$(TargetFrameworkMoniker)'));RuntimeIdentifier=$(RuntimeIdentifier);SelfContained=$(SelfContained);UseApphost=$(UseApphost);OutputType=$(OutputType)" />
+    <ItemGroup>
+      <TFTelemetry Include="TargetFrameworkVersion" Value="$([MSBuild]::Escape('$(TargetFrameworkMoniker)'))" />
+      <TFTelemetry Include="RuntimeIdentifier" Value="$(RuntimeIdentifier)" />
+      <TFTelemetry Include="SelfContained" Value="$(SelfContained)" />
+      <TFTelemetry Include="UseApphost" Value="$(UseApphost)" />
+      <TFTelemetry Include="OutputType" Value="$(OutputType)" />
+    </ItemGroup>
+    <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="@(TFTelemetry)" />
   </Target>
 
   <!--


### PR DESCRIPTION
As part of reviewing #30239, I realized that we could answer some questions about the way devs use PublishProfiles from the CLI if we collected a little more telemetry - specifically the name of the profile that was imported (hashed of course), and if a Profile was imported at all. This would allow us to securely get usage rates for SDK-bundled profiles, as well as get data on how often users specify a Profile but there's not a matching profile (i.e. typos or deleted files, that kind of thing).

The Name of the profile would require hashing to comply with out privacy guidelines, since it could contain sensitive user data. The current AllowEmptyTelemetry implementation didn't really allow for specifying if a piece of data needed to be hashed or not, so we needed a new implementation that would allow for this.

The Task now takes in ITaskITems and reads metadata to determine how each one should be handled - `Include` is the key, `Value` is the value, and `Hash` is a boolean that says if the `Value` should be hashed in our standard way.

Tests were updated to ensure that we didn't regress behavior, I added a new one showing the hashing, and I updated existing callsites as part of this.
