### PR TITLE
[release/8.0.1xx-preview1] Port introducing NamedMonitor from main for fixing floating tests

### DIFF
--- a/src/Tests/dotnet-new.Tests/Utilities.cs
+++ b/src/Tests/dotnet-new.Tests/Utilities.cs
@@ -31,11 +31,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             lock (Locker[baseDir])
             {
                 string workingDir = Path.Combine(baseDir, DateTime.UtcNow.ToString("yyyyMMddHHmmssfff"));
-                if (!Directory.Exists(workingDir))
-                {
-                    Directory.CreateDirectory(workingDir);
-                }
-                else
+                if (Directory.Exists(workingDir))
                 {
                     //simple logic for counts if DateTime.UtcNow is not unique
                     int counter = 1;
@@ -47,8 +43,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                     {
                         throw new Exception("Failed to create temp directory after 100 attempts");
                     }
-                    Directory.CreateDirectory(workingDir + "_" + counter);
+                    workingDir = workingDir + "_" + counter;
                 }
+                Directory.CreateDirectory(workingDir);
                 return workingDir;
             }
         }

--- a/src/Tests/dotnet-new.Tests/Utilities.cs
+++ b/src/Tests/dotnet-new.Tests/Utilities.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Microsoft.NET.TestFramework;
 
@@ -9,6 +10,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
     internal static class Utilities
     {
+        private static readonly NamedMonitor Locker = new NamedMonitor();
+
         /// <summary>
         /// Gets a folder that dotnet-new.IntegrationTests tests can use for temp files.
         /// </summary>
@@ -24,7 +27,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         internal static string CreateTemporaryFolder([CallerMemberName] string caller = "Unnamed", string customName = "")
         {
             string baseDir = Path.Combine(GetTestExecutionTempFolder(), caller, customName);
-            lock (string.Intern(baseDir.ToLowerInvariant()))
+
+            lock (Locker[baseDir])
             {
                 string workingDir = Path.Combine(baseDir, DateTime.UtcNow.ToString("yyyyMMddHHmmssfff"));
                 if (!Directory.Exists(workingDir))
@@ -47,6 +51,14 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 }
                 return workingDir;
             }
+        }
+
+        // Provides a thread safe Dictionary for creating critical section
+        internal class NamedMonitor
+        {
+            private readonly ConcurrentDictionary<string, object> _dictionary = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+            public object this[string name] => _dictionary.GetOrAdd(name, _ => new object());
         }
     }
 }


### PR DESCRIPTION
Porting form https://github.com/dotnet/sdk/pull/30138

Fixes race condition:
`
 System.AggregateException : One or more errors occurred. (Expected command to exit with 0 but it did not.\r\nFile Name: D:\a\_work\1\s\artifacts\bin\redist\Release\dotnet\dotnet.exe\r\nArguments: new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --debug:custom-hive D:\a\_work\1\s\artifacts\tmp\Release\dotnet-new.IntegrationTests\SharedHomeDirectory\20230125013446370\r\nExit Code: 106\r\nStdOut:\r\nThe following template packages will be installed:\r\n   D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405\r\nStdErr:\r\nD:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 is already installed.\r\nTo reinstall the same version of the template package, use '--force' option:\r\n   dotnet new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --force\r\n\r\nFor details on the exit code, refer to https://aka.ms/templating-exit-codes#106\r\n) (The following constructor parameters did not have matching fixture data: WebProjectsFixture fixture)\r\n---- Expected command to exit with 0 but it did not.\r\nFile Name: D:\a\_work\1\s\artifacts\bin\redist\Release\dotnet\dotnet.exe\r\nArguments: new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --debug:custom-hive D:\a\_work\1\s\artifacts\tmp\Release\dotnet-new.IntegrationTests\SharedHomeDirectory\20230125013446370\r\nExit Code: 106\r\nStdOut:\r\nThe following template packages will be installed:\r\n   D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405\r\nStdErr:\r\nD:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 is already installed.\r\nTo reinstall the same version of the template package, use '--force' option:\r\n   dotnet new install D:\a\_work\1\s\.packages\microsoft.dotnet.common.projecttemplates.6.0\6.0.405 --force\r\n\r\nFor details on the exit code, refer to https://aka.ms/templating-exit-codes#106\r\n\r\n---- The following constructor parameters did not have matching fixture data: WebProjectsFixture fixture`