### PR TITLE
Delete regex timeout

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/RegexStringTransformer.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/RegexStringTransformer.cs
@@ -12,8 +12,6 @@ namespace Microsoft.DotNet.ApiCompat
     internal class RegexStringTransformer
     {
         private readonly (Regex Regex, string ReplacementString)[] _patterns;
-        // Define a timeout for regex matches to guard against malicious user inputs.
-        private static readonly TimeSpan s_regexTimeout = TimeSpan.FromSeconds(2);
 
         /// <summary>
         /// Initializes the regex string transformer with a given capture group and replacement patterns.
@@ -34,7 +32,7 @@ namespace Microsoft.DotNet.ApiCompat
             _patterns = new (Regex Regex, string ReplacementString)[rawPatterns.Length];
             for (int i = 0; i < rawPatterns.Length; i++)
             {
-                _patterns[i] = (new Regex(rawPatterns[i].CaptureGroupPattern, RegexOptions.Compiled, s_regexTimeout), rawPatterns[i].ReplacementString);
+                _patterns[i] = (new Regex(rawPatterns[i].CaptureGroupPattern, RegexOptions.Compiled), rawPatterns[i].ReplacementString);
             }
         }
 

--- a/src/Tests/Microsoft.DotNet.ApiCompat.Tests/RegexStringTransformerTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompat.Tests/RegexStringTransformerTests.cs
@@ -74,15 +74,5 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
 
             Assert.Equal("runtimes/android/lib/net7.0/System.Linq.dll", output);
         }
-
-        [Fact]
-        public void Transform_SinglePatternWithBacktracking_ThrowsRegexMatchTimeoutException()
-        {
-            const string TransformInput = "An input string that takes a very very very very very very very very very very very long time!";
-
-            RegexStringTransformer regexStringTransformer = new(@"^(\w+\s?)*$", "lib");
-
-            Assert.Throws<RegexMatchTimeoutException>(() => regexStringTransformer.Transform(TransformInput));
-        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/81543

As discussed in dotnet/runtime, a regex timeout isn't necessary as the tool currently doesn't run in a security sensitive environment in our core stack repositories and customers aren't expected to be using this functionality in such an environment either.

When ApiCompat upgrades and targets .NET 7+, we should also leverage the `RegexOptions.NonBacktracking` mode.