### PR TITLE
[release/7.0.3xx] fixed bug in `CreateTemporaryFolder` counter logic

### DIFF
--- a/src/Tests/dotnet-new.Tests/Utilities.cs
+++ b/src/Tests/dotnet-new.Tests/Utilities.cs
@@ -31,11 +31,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             lock (Locker[baseDir])
             {
                 string workingDir = Path.Combine(baseDir, DateTime.UtcNow.ToString("yyyyMMddHHmmssfff"));
-                if (!Directory.Exists(workingDir))
-                {
-                    Directory.CreateDirectory(workingDir);
-                }
-                else
+                if (Directory.Exists(workingDir))
                 {
                     //simple logic for counts if DateTime.UtcNow is not unique
                     int counter = 1;
@@ -47,8 +43,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                     {
                         throw new Exception("Failed to create temp directory after 100 attempts");
                     }
-                    Directory.CreateDirectory(workingDir + "_" + counter);
+                    workingDir = workingDir + "_" + counter;
                 }
+                Directory.CreateDirectory(workingDir);
                 return workingDir;
             }
         }


### PR DESCRIPTION
Bug in `CreateTemporaryFolder` method leads to flaky tests in template engine jobs.


Backport of fix from https://github.com/dotnet/sdk/pull/30320