### PR TITLE
Introduce `exp` prefix in PR to allow better PR review process

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -8,6 +8,7 @@ trigger:
     - internal/release/5.*
     - internal/release/6.*
     - internal/release/7.*
+    - exp/*
   paths:
     exclude:
     - "*.md"


### PR DESCRIPTION
MSBuild currenly does this.  https://github.com/dotnet/msbuild/blob/main/.vsts-dotnet.yml#L4 
I would like to do this to submit more digestible PRs to a copy of main. This way the changes don't go into main yet and PRs can be done in pieces. We need to add this so we can trigger CI/CD for this pattern.

Example of why I'd wanna do this: https://github.com/dotnet/sdk/pull/30266
Thanks @marcpopMSFT for the pointer.