### PR TITLE
fix repo build on non-ubuntu linux

### DIFF
--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -21,10 +21,6 @@ function InitializeCustomSDKToolset {
 
   InitializeDotNetCli true
   
-  if [[ "$DISTRO" != "ubuntu" || "$MAJOR_VERSION" -le 16 ]]; then
-    InstallDotNetSharedFramework "1.0.5"
-    InstallDotNetSharedFramework "1.1.2"
-  fi
   InstallDotNetSharedFramework "2.1.0"
   InstallDotNetSharedFramework "2.2.8"
   InstallDotNetSharedFramework "3.1.0"


### PR DESCRIPTION
`eng/restore-tools.{sh, ps1}` tries to fetch runtime versions 1.0.5 and 1.1.2 on
non-ubuntu linuxes. Since the web resource for those builds return 404, a
fresh build of the sdk can't succeed on non-ubuntu linuxes. These builds could
be made available again, but since they're manually installed for testing, it's
better to remove them from the restore script.