### PR TITLE
Filter out default member attribute for types with indexer. Implement filtering out base type and interfaces.

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/AttributeDataExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/AttributeDataExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.GenAPI
@@ -37,6 +38,14 @@ namespace Microsoft.DotNet.GenAPI
             }
 
             return (bool)errorArgument.Value;
+        }
+
+        public static bool IsDefaultMemberAttribute(this AttributeData attribute)
+        {
+            INamedTypeSymbol? attributeClass = attribute.AttributeClass;
+            if (attributeClass == null) return false;
+
+            return attributeClass.ToDisplayString() == typeof(DefaultMemberAttribute).FullName;
         }
     }
 }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -105,7 +105,12 @@ namespace Microsoft.DotNet.GenAPI
                 foreach (AttributeData attribute in typeMember.GetAttributes()
                     .Where(a => a.AttributeClass != null && _symbolFilter.Include(a.AttributeClass)))
                 {
-                    typeDeclaration = _syntaxGenerator.AddAttributes(typeDeclaration, _syntaxGenerator.Attribute(attribute));
+                    // The C# compiler emits the DefaultMemberAttribute on any type containing an indexer.
+                    // In C# it is an error to manually attribute a type with the DefaultMemberAttribute if the type also declares an indexer.
+                    if (!attribute.IsDefaultMemberAttribute() || !typeMember.HasIndexer())
+                    {
+                        typeDeclaration = _syntaxGenerator.AddAttributes(typeDeclaration, _syntaxGenerator.Attribute(attribute));
+                    }
                 }
 
                 typeDeclaration = Visit(typeDeclaration, typeMember);
@@ -122,6 +127,20 @@ namespace Microsoft.DotNet.GenAPI
 
             foreach (ISymbol member in members.Order())
             {
+                // If the method is ExplicitInterfaceImplementation and is derived from an interface that was filtered out, we must filter out it either.
+                if (member is IMethodSymbol method &&
+                    method.MethodKind == MethodKind.ExplicitInterfaceImplementation &&
+                    method.ExplicitInterfaceImplementations.Any(m => !_symbolFilter.Include(m.ContainingSymbol)))
+                {
+                    continue;
+                }
+                // If the property is derived from an interface that was filter out, we must filtered out it either.
+                if (member is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsEmpty &&
+                    property.ExplicitInterfaceImplementations.Any(m => !_symbolFilter.Include(m.ContainingSymbol)))
+                {
+                    continue;
+                }
+
                 SyntaxNode memberDeclaration = _syntaxGenerator.DeclarationExt(member, _symbolFilter);
 
                 foreach (AttributeData attribute in member.GetAttributes()

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.GenAPI
     {
         public static bool HasIndexer(this INamedTypeSymbol type)
         {
-            return type.GetMembers().Where(m => m is IPropertySymbol).Select(m => (IPropertySymbol)m).Any(m => m.IsIndexer);
+            return type.GetMembers().Any(member => member is IPropertySymbol propertySymbol && propertySymbol.IsIndexer);
         }
     }
 }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.GenAPI
+{
+    internal static class INamedTypeSymbolExtension
+    {
+        public static bool HasIndexer(this INamedTypeSymbol type)
+        {
+            return type.GetMembers().Where(m => m is IPropertySymbol).Select(m => (IPropertySymbol)m).Any(m => m.IsIndexer);
+        }
+    }
+}

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -96,6 +96,7 @@ namespace Microsoft.DotNet.GenAPI
             return constructorInitializer;
         }
 
+        // Gets the list of base class and interfaces for a given symbol <see cref="INamedTypeSymbol"/>.
         private static BaseListSyntax? GetBaseTypeList(this SyntaxGenerator syntaxGenerator,
             INamedTypeSymbol type,
             ISymbolFilter symbolFilter)
@@ -107,8 +108,11 @@ namespace Microsoft.DotNet.GenAPI
                 baseTypes.Add(SyntaxFactory.SimpleBaseType((TypeSyntax)syntaxGenerator.TypeExpression(type.BaseType)));
             }
 
+            // includes only interfaces that were not filtered out by the given <see cref="ISymbolFilter"/>.
             baseTypes.AddRange(type.Interfaces.Where(symbolFilter.Include).Select(i => SyntaxFactory.SimpleBaseType((TypeSyntax)syntaxGenerator.TypeExpression(i))));
-            return baseTypes.Count == 0 ? null : SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(baseTypes));
+            return baseTypes.Count > 0 ?
+                SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(baseTypes)) :
+                null;
         }
     }
 }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/SingleLineStatementCSharpSyntaxRewriter.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/SingleLineStatementCSharpSyntaxRewriter.cs
@@ -21,6 +21,41 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
         /// <inheritdoc />
         public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
         {
+            return VisitBaseMethodDeclarationSyntax(node);
+        }
+
+        /// <inheritdoc />
+        public override SyntaxNode? VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            return VisitBaseMethodDeclarationSyntax(node);
+        }
+
+        /// <inheritdoc />
+        public override SyntaxNode? VisitOperatorDeclaration(OperatorDeclarationSyntax node)
+        {
+            return VisitBaseMethodDeclarationSyntax(node);
+        }
+
+        /// <inheritdoc />
+        public override SyntaxNode? VisitConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax node)
+        {
+            return VisitBaseMethodDeclarationSyntax(node);
+        }
+
+        /// <inheritdoc />
+        public override SyntaxNode? VisitIndexerDeclaration(IndexerDeclarationSyntax node)
+        {
+            return VisitBasePropertyDeclarationSyntax(node);
+        }
+
+        /// <inheritdoc />
+        public override SyntaxNode? VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            return VisitBasePropertyDeclarationSyntax(node);
+        }
+
+        private static SyntaxNode? VisitBaseMethodDeclarationSyntax(BaseMethodDeclarationSyntax node)
+        {
             BlockSyntax? body = node.Body;
             if (body != null)
             {
@@ -39,19 +74,7 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
             return node.WithBody(body);
         }
 
-        public override SyntaxNode? VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
-        {
-            BlockSyntax? body = node.Body;
-            if (body != null)
-            {
-                body = body
-                    .WithOpenBraceToken(body.OpenBraceToken.WithTrailingTrivia(SyntaxFactory.Space))
-                    .WithCloseBraceToken(body.CloseBraceToken.WithLeadingTrivia());
-            }
-            return node.WithBody(body);
-        }
-
-        public override SyntaxNode? VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        private static SyntaxNode? VisitBasePropertyDeclarationSyntax(BasePropertyDeclarationSyntax node)
         {
             AccessorListSyntax? accessorList = node.AccessorList;
 

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriterTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriterTests.cs
@@ -176,6 +176,60 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 }
                 """);
         }
+
+        [Fact]
+        public void TestOperatorPostProcessing()
+        {
+            Compare(new SingleLineStatementCSharpSyntaxRewriter(),
+                original: """
+                namespace A
+                {
+                    class B
+                    {
+                        public static bool operator ==(ChildSyntaxList list1, ChildSyntaxList list2) {
+                        throw null;
+                        }
+                    }
+                }
+                """,
+                expected: """
+                namespace A
+                {
+                    class B
+                    {
+                        public static bool operator ==(ChildSyntaxList list1, ChildSyntaxList list2) { throw null; }
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public void TestConversionOperatorPostProcessing()
+        {
+            Compare(new SingleLineStatementCSharpSyntaxRewriter(),
+                original: """
+                    namespace Foo
+                    {
+                        public readonly struct Digit
+                        {
+                            public static implicit operator byte(Digit d) {
+                            throw null;
+                            }
+                            public static explicit operator Digit(byte b) => throw null;
+                        }
+                    }
+                    """,
+                expected: """
+                    namespace Foo
+                    {
+                        public readonly struct Digit
+                        {
+                            public static implicit operator byte(Digit d) { throw null; }
+                            public static explicit operator Digit(byte b) => throw null;
+                        }
+                    }
+                    """);
+        }
     }
 
     public class TypeDeclarationSyntaxRewriterTests : SyntaxRewriterTests


### PR DESCRIPTION
Epic: https://github.com/dotnet/arcade/issues/10291
* Add filtering of `DefaultMember` attributes for types with indexer
* Implement filtering out base type and interfaces.