### PR TITLE
Issue 25536 enable -disable-build-servers for pack, clean, test, msbuild

### DIFF
--- a/src/Cli/dotnet/CommonLocalizableStrings.resx
+++ b/src/Cli/dotnet/CommonLocalizableStrings.resx
@@ -708,4 +708,7 @@ The default is 'true' if a runtime identifier is specified.</value>
   <data name="CorruptSolutionProjectFolderStructure" xml:space="preserve">
     <value>The solution file '{0}' is missing EndProject tags or has invalid child-parent project folder mappings around project GUID: '{1}'. Manually repair the solution or try to open and save it in Visual Studio."</value>
   </data>
+  <data name="MSBuildAdditionalOptionTitle" xml:space="preserve">
+    <value>.NET Cli Options:</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -281,6 +281,28 @@ namespace Microsoft.DotNet.Cli
                 }
             }
 
+            public void additionalOption(HelpContext context)
+            {
+                List<TwoColumnHelpRow> options = new();
+                HashSet<Option> uniqueOptions = new();
+                foreach (Option option in context.Command.Options)
+                {
+                    if (!option.IsHidden && uniqueOptions.Add(option))
+                    {
+                        options.Add(context.HelpBuilder.GetTwoColumnRow(option, context));
+                    }
+                }
+
+                if (options.Count <= 0)
+                {
+                    return;
+                }
+
+                context.Output.WriteLine(CommonLocalizableStrings.MSBuildAdditionalOptionTitle);
+                context.HelpBuilder.WriteColumns(options, context);
+                context.Output.WriteLine();
+            }
+
             public override void Write(HelpContext context)
             {
                 var command = context.Command;
@@ -296,6 +318,8 @@ namespace Microsoft.DotNet.Cli
                 else if (command.Name.Equals(MSBuildCommandParser.GetCommand().Name))
                 {
                     new MSBuildForwardingApp(helpArgs).Execute();
+                    context.Output.WriteLine();
+                    additionalOption(context);
                 }
                 else if (command.Name.Equals(VSTestCommandParser.GetCommand().Name))
                 {
@@ -342,6 +366,9 @@ namespace Microsoft.DotNet.Cli
                     base.Write(context);
                 }
             }
+
+
+
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-build/BuildCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-build/BuildCommand.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Cli;
 using System.CommandLine;
 using System.CommandLine.Parsing;
-using System;
+using Microsoft.DotNet.Cli;
 
 namespace Microsoft.DotNet.Tools.Build
 {

--- a/src/Cli/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
 using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.Build;
 using LocalizableStrings = Microsoft.DotNet.Tools.Build.LocalizableStrings;

--- a/src/Cli/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -52,6 +52,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(CommonOptions.VerbosityOption);
             command.AddOption(OutputOption);
             command.AddOption(NoLogoOption);
+            command.AddOption(CommonOptions.DisableBuildServersOption);
 
             command.SetHandler(CleanCommand.Run);
 

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildCommandParser.cs
@@ -29,7 +29,9 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 Arguments
             };
 
-            command.SetHandler((ParseResult parseResult) => MSBuildCommand.Run(parseResult.GetValue(Arguments)));
+            command.AddOption(CommonOptions.DisableBuildServersOption);
+
+            command.SetHandler(MSBuildCommand.Run);
 
             return command;
         }

--- a/src/Cli/dotnet/commands/dotnet-msbuild/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/Program.cs
@@ -29,8 +29,6 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
             msbuildArgs.AddRange(parseResult.GetValue(MSBuildCommandParser.Arguments));
 
-            //result.ShowHelpOrErrorIfAppropriate();
-
             msbuildArgs.AddRange(parseResult.OptionValuesToBeForwarded(MSBuildCommandParser.GetCommand()));
 
             MSBuildCommand command = new MSBuildCommand(
@@ -38,11 +36,6 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 msbuildPath);
             return command;
         }
-
-        //public int Execute()
-        //{
-        //    return new MSBuildForwardingApp(_msbuildArgs, _msbuildPath).Execute();
-        //}
 
         public static int Run(ParseResult parseResult)
         {

--- a/src/Cli/dotnet/commands/dotnet-msbuild/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/Program.cs
@@ -1,17 +1,54 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using Microsoft.DotNet.Cli;
 
 namespace Microsoft.DotNet.Tools.MSBuild
 {
-    public class MSBuildCommand
+    public class MSBuildCommand : MSBuildForwardingApp
     {
-        public static int Run(string[] args)
+        public MSBuildCommand
+            (IEnumerable<string> msbuildArgs,
+            string msbuildPath = null) 
+             : base(msbuildArgs, msbuildPath)
         {
-            return new MSBuildForwardingApp(args).Execute();
+        }
+
+        public static MSBuildCommand FromArgs(string[] args, string msbuildPath = null)
+        { 
+            var parser = Cli.Parser.Instance;
+            var result = parser.ParseFrom("dotnet msbuild", args);
+            return FromParseResult(result, msbuildPath);
+        }
+
+        public static MSBuildCommand FromParseResult(ParseResult parseResult, string msbuildPath = null)
+        {
+            var msbuildArgs = new List<string>();
+
+            msbuildArgs.AddRange(parseResult.GetValue(MSBuildCommandParser.Arguments));
+
+            //result.ShowHelpOrErrorIfAppropriate();
+
+            msbuildArgs.AddRange(parseResult.OptionValuesToBeForwarded(MSBuildCommandParser.GetCommand()));
+
+            MSBuildCommand command = new MSBuildCommand(
+                msbuildArgs,
+                msbuildPath);
+            return command;
+        }
+
+        //public int Execute()
+        //{
+        //    return new MSBuildForwardingApp(_msbuildArgs, _msbuildPath).Execute();
+        //}
+
+        public static int Run(ParseResult parseResult)
+        {
+            parseResult.HandleDebugSwitch();
+
+            return FromParseResult(parseResult).Execute();
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
 using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.Pack;
 using LocalizableStrings = Microsoft.DotNet.Tools.Pack.LocalizableStrings;
@@ -68,6 +66,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(CommonOptions.VerbosityOption);
             command.AddOption(CommonOptions.VersionSuffixOption);
             command.AddOption(ConfigurationOption);
+            command.AddOption(CommonOptions.DisableBuildServersOption);
             RestoreCommandParser.AddImplicitRestoreOptions(command, includeRuntimeOption: true, includeNoDependenciesOption: true);
 
             command.SetHandler(PackCommand.Run);

--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -108,6 +108,21 @@ namespace Microsoft.DotNet.Tools.Test
             return exitCode;
         }
 
+        public static TestCommand FromArgs(string[] args, string testSessionCorrelationId = null, string msbuildPath = null)
+        {
+            var parser = Microsoft.DotNet.Cli.Parser.Instance;
+            var parseResult = parser.ParseFrom("dotnet test", args);
+
+            // settings parameters are after -- (including --), these should not be considered by the parser
+            string[] settings = args.SkipWhile(a => a != "--").ToArray();
+            if (string.IsNullOrEmpty(testSessionCorrelationId))
+            {
+                testSessionCorrelationId = $"{Environment.ProcessId}_{Guid.NewGuid()}";
+            }
+            
+            return FromParseResult(parseResult, settings, testSessionCorrelationId, msbuildPath);
+        }
+
         private static TestCommand FromParseResult(ParseResult result, string[] settings, string testSessionCorrelationId, string msbuildPath = null)
         {
             result.ShowHelpOrErrorIfAppropriate();

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -160,6 +160,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(CommonOptions.VerbosityOption);
             command.AddOption(CommonOptions.ArchitectureOption);
             command.AddOption(CommonOptions.OperatingSystemOption);
+            command.AddOption(CommonOptions.DisableBuildServersOption);
 
             command.SetHandler(TestCommand.Run);
 

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Publikujte svoji aplikaci jako aplikaci závislou na architektuře. Aby bylo možné vaši aplikaci spustit, musí být na cílovém počítači nainstalovaný kompatibilní modul runtime .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">V {0} se našlo několik projektů. Vyberte, který z nich chcete použít.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Veröffentlichen Sie Ihre Anwendung als eine von einem Framework abhängige Anwendung. Eine kompatible .NET-Runtime muss auf dem Zielcomputer installiert sein, um Ihre Anwendung ausführen zu können.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">In "{0}" wurden mehrere Projekte gefunden. Geben Sie an, welches davon verwendet werden soll.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Publique la aplicación como una aplicación dependiente del marco de trabajo. para ejecutar la aplicación debe instalarse un entorno de ejecución de .NET compatible en el equipo de destino.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Se han encontrado varios proyectos en "{0}". Especifique el que debe usarse.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Publiez votre application en tant qu'application dépendante du framework. Un runtime .NET compatible doit être installé sur la machine cible pour exécuter votre application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Plusieurs projets dans '{0}'. Spécifiez celui à utiliser.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Pubblicare l'applicazione come applicazione dipendente dal framework. Per eseguire l'applicazione, è necessario installare un runtime .NET compatibile nel computer di destinazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Sono stati trovati più progetti in `{0}`. Specificare quello da usare.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">アプリケーションをフレームワーク依存アプリケーションとして公開します。アプリケーションを実行するには、対象のコンピューターで互換性のある .NET ランタイムをインストールする必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">`{0}` に複数のプロジェクトが見つかりました。使用するプロジェクトを指定してください。</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">애플리케이션을 프레임워크 종속 애플리케이션으로 게시합니다. 애플리케이션을 실행하려면 호환되는 .NET 런타임이 대상 시스템에 설치되어 있어야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">'{0}'에서 프로젝트를 두 개 이상 찾았습니다. 사용할 프로젝트를 지정하세요.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Opublikuj aplikację jako aplikację zależną od frameworku. Aby można było uruchomić aplikację, na maszynie docelowej musi być zainstalowane zgodne środowisko uruchomieniowe platformy .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Znaleziono więcej niż jeden projekt w lokalizacji „{0}”. Określ, który ma zostać użyty.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Publique o seu aplicativo como um aplicativo dependente de estrutura. Um runtime do .NET compatível precisa ser instalado no computador de destino para executar o aplicativo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Foi encontrado mais de um projeto em ‘{0}’. Especifique qual deve ser usado.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Опубликуйте приложение как зависимое от платформы. Для запуска приложения на целевом компьютере должна быть установлена совместимая среда выполнения .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Найдено несколько проектов в "{0}". Выберите один.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">Uygulamanızı çerçeveye bağımlı bir uygulama olarak yayımlayın. Uygulamanızı çalıştırmak için hedef makineye uyumlu bir .NET çalışma zamanı yüklenmelidir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">`{0}` içinde birden fazla proje bulundu. Hangisinin kullanılacağını belirtin.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -110,6 +110,11 @@ EOF
         <target state="translated">将应用程序发布为依赖框架的应用程序。目标计算机上必须安装兼容的 .NET 运行时才能运行该应用程序。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">在“{0}”中找到多个项目。请指定使用哪一个。</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -110,6 +110,11 @@ export PATH="$PATH:{0}"
         <target state="translated">將您的應用程式發佈為架構相依的應用程式。必須在目標機器上安裝相容的 .NET 執行階段，才能執行您的應用程式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildAdditionalOptionTitle">
+        <source>.NET Cli Options:</source>
+        <target state="new">.NET Cli Options:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">在 `{0}` 中找到多個專案。請指定要使用的專案。</target>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Tools.Build;
 using FluentAssertions;
-using Xunit;
+using Microsoft.DotNet.Tools.Build;
 using Microsoft.NET.TestFramework;
+using Xunit;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Tools.Clean;
 using FluentAssertions;
-using Xunit;
-using System;
-using System.IO;
-using System.Runtime.InteropServices;
+using Microsoft.DotNet.Tools.Clean;
 using Microsoft.NET.TestFramework;
+using Xunit;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -37,6 +34,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--configuration", "<configuration>" }, "-property:Configuration=<configuration>")]
         [InlineData(new string[] { "-v", "diag" }, "-verbosity:diag")]
         [InlineData(new string[] { "--verbosity", "diag" }, "-verbosity:diag")]
+        [InlineData(new string[] { "--disable-build-servers" }, "-p:UseRazorBuildServer=false -p:UseSharedCompilation=false /nodeReuse:false")]
+
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetMSBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetMSBuildInvocation.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using FluentAssertions;
+using Microsoft.DotNet.Tools.MSBuild;
+using Microsoft.NET.TestFramework;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.MSBuild.Tests
+{
+    [Collection(TestConstants.UsesStaticTelemetryState)]
+
+    public class GivenDotnetMSBuildInvocation : IClassFixture<NullCurrentSessionIdFixture>
+    {
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m";
+       
+        private static readonly string WorkingDirectory =
+            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetPackInvocation));
+
+        [Theory]
+        [InlineData(new string[] { "--disable-build-servers" }, "-p:UseRazorBuildServer=false -p:UseSharedCompilation=false /nodeReuse:false")]
+
+        public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                expectedAdditionalArgs =
+                    (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")
+                    .Replace("<cwd>", WorkingDirectory);
+
+                var msbuildPath = "<msbuildpath>";
+                var command = MSBuildCommand.FromArgs(args, msbuildPath);
+                //var expectedPrefix = args.FirstOrDefault() == "--no-build" ? ExpectedNoBuildPrefix : ExpectedPrefix;
+
+                //command.SeparateRestoreCommand.Should().BeNull();
+                command.GetArgumentsToMSBuild().Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+            });
+        }
+    }
+}

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetMSBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetMSBuildInvocation.cs
@@ -31,9 +31,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 var msbuildPath = "<msbuildpath>";
                 var command = MSBuildCommand.FromArgs(args, msbuildPath);
-                //var expectedPrefix = args.FirstOrDefault() == "--no-build" ? ExpectedNoBuildPrefix : ExpectedPrefix;
-
-                //command.SeparateRestoreCommand.Should().BeNull();
+ 
                 command.GetArgumentsToMSBuild().Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
             });
         }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
@@ -37,6 +37,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "-v", "diag" }, "-verbosity:diag")]
         [InlineData(new string[] { "--verbosity", "diag" }, "-verbosity:diag")]
         [InlineData(new string[] { "<project>" }, "<project>")]
+        [InlineData(new string[] { "--disable-build-servers" }, "-p:UseRazorBuildServer=false -p:UseSharedCompilation=false /nodeReuse:false")]
+
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetTestInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetTestInvocation.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test;
+using Microsoft.NET.TestFramework;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.MSBuild.Tests
+{
+    [Collection(TestConstants.UsesStaticTelemetryState)]
+    public class GivenDotnetTestInvocation : IClassFixture<NullCurrentSessionIdFixture>
+    {
+        private const string ExpectedPrefix =
+            "-maxcpucount -verbosity:m -restore -target:VSTest -nodereuse:false -nologo";
+        private static readonly string WorkingDirectory =
+            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetTestInvocation));
+
+        [Theory]
+        [InlineData(new string[] { "--disable-build-servers" }, "-p:UseRazorBuildServer=false -p:UseSharedCompilation=false /nodeReuse:false -property:VSTestArtifactsProcessingMode=collect -property:VSTestSessionCorrelationId=<testSessionCorrelationId>")]
+        public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                Telemetry.Telemetry.DisableForTests();
+
+                expectedAdditionalArgs =
+                    (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")
+                    .Replace("<cwd>", WorkingDirectory);
+
+                var testSessionCorrelationId = "<testSessionCorrelationId>";
+                var msbuildPath = "<msbuildpath>";
+               
+                TestCommand.FromArgs(args, testSessionCorrelationId, msbuildPath)
+                    .GetArgumentsToMSBuild()
+                    .Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+            });
+        }
+    }
+}


### PR DESCRIPTION
Regarding the [issue](https://github.com/dotnet/sdk/issues/25536) 

Fixes #25536: enable -disable-build-servers for pack, clean, test, and msbuild. Added -disable-build-servers feature to pack, clean, test, and msbuild. Added options in --help for pack, clean, and test; 

Not changed the --help for msbuild