### PR TITLE
Bump dependencies Verify.Xunit and Verify.DiffPlex to same versions as dotnet/templating

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -4,8 +4,8 @@
 
   <ItemGroup>
     <!--Test dependencies-->
-    <PackageReference Update="Verify.Xunit" Version="19.8.0" />
-    <PackageReference Update="Verify.DiffPlex" Version="2.1.0" />
+    <PackageReference Update="Verify.Xunit" Version="19.9.2" />
+    <PackageReference Update="Verify.DiffPlex" Version="2.2.0" />
     <PackageReference Update="FakeItEasy" Version="7.3.1" />
     <PackageReference Update="Wcwidth.Sources" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
### Problem
The version of Verify.Xunit and Verify.DiffPlex is lower than the ones in dotnet/templating. It causes `Detected package downgrade` error during building.

### Solution
Keep the version same as dotnet/templating.