### PR TITLE
Bump up dependencies and make them fit for Dependabot

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
+  <Import Project="$(RepositoryEngineeringDir)Packages.props" />
   <ItemGroup>
     <SupportedPlatform Remove="Android" />
     <SupportedPlatform Remove="iOS" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,0 +1,12 @@
+<Project>
+  <Import Project="dependabot\Packages.props" />
+  <!-- Override package versions in dependabot\Packages.props for source build -->
+  <!-- Packages must be set to their package version property if it exists (ex. BenchmarkDotNetVersion) since source-build uses
+  these properties to override package versions if necessary. -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnitVersion)' != ''" Version="$(VerifyXUnitVersion)" />
+    <PackageReference Update="Verify.DiffPlex" Condition="'$(VerifyDiffPlexVersion)' != ''" Version="$(VerifyDiffPlexVersion)" />
+    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasyVersion)' != ''" Version="$(FakeItEasyVersion)" />
+    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSourcesVersion)' != ''" Version="$(WcwidthSourcesVersion)" />
+  </ItemGroup>
+</Project>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <!-- Packages in this file have versions updated periodically by Dependabot. Versions managed by Darc/Maestro should be in ..\Packages.props. -->
+
+  <ItemGroup>
+    <!--Test dependencies-->
+    <PackageReference Update="Verify.Xunit" Version="19.9.2" />
+    <PackageReference Update="Verify.DiffPlex" Version="2.2.0" />
+    <PackageReference Update="FakeItEasy" Version="7.3.1" />
+    <PackageReference Update="Wcwidth.Sources" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/eng/dependabot/dependabot.csproj
+++ b/eng/dependabot/dependabot.csproj
@@ -1,0 +1,4 @@
+<!-- This isn't a real project, but Dependabot requires a project. If one
+     exists, it'll update stuff in Packages.props as well, which is all we
+     really want here. -->
+<Project />

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="$(MicrosoftTemplateEngineEdgePackageVersion)" />
     <PackageReference Include="Microsoft.TemplateSearch.Common" Version="$(MicrosoftTemplateSearchCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
-    <PackageReference Include="Wcwidth.Sources" Version="0.6.0" ExcludeAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Wcwidth.Sources" ExcludeAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 
@@ -61,7 +61,7 @@
 
   <Target Name="CopyExternalSourceFilesIntoProject" BeforeTargets="BeforeBuild">
     <ItemGroup>
-      <WcwidthFiles Include="$(PkgWcwidth_Sources)\contentFiles\cs\net5.0\External\**\*" />
+      <WcwidthFiles Include="$(PkgWcwidth_Sources)\contentFiles\cs\net6.0\External\**\*" />
     </ItemGroup>
     <Copy SourceFiles="@(WcwidthFiles)" DestinationFolder="$(BaseIntermediateOutputPath)/External/%(RecursiveDir)" />
     <ItemGroup>

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.3.1" />
-    <PackageReference Include="Verify.XUnit" Version="19.8.0" />
-    <PackageReference Include="Verify.DiffPlex" Version="2.1.0" />
+    <PackageReference Include="FakeItEasy" />
+    <PackageReference Include="Verify.XUnit" />
+    <PackageReference Include="Verify.DiffPlex" />
     <PackageReference Include="Microsoft.TemplateEngine.Mocks" Version="$(MicrosoftTemplateEngineMocksPackageVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.TestHelper" Version="$(MicrosoftTemplateEngineTestHelperPackageVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="$(MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion)" />

--- a/src/Tests/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
+++ b/src/Tests/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
@@ -15,8 +15,8 @@
     <ProjectReference Include="..\..\Cli\dotnet-new3\dotnet-new3.csproj" />
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-    <PackageReference Include="Verify.Xunit" Version="19.8.0" />
-    <PackageReference Include="Verify.DiffPlex" Version="2.1.0" />
+    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="Verify.DiffPlex" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.TestHelper" Version="$(MicrosoftTemplateEngineTestHelperPackageVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Authoring.TemplateVerifier" Version="$(MicrosoftTemplateEngineAuthoringTemplateVerifierVersion)" />


### PR DESCRIPTION
### Problem
The version of Verify.Xunit and Verify.DiffPlex is lower than the ones in dotnet/templating. It causes Detected package downgrade error during building.

### Solution
Keep the version same as dotnet/templating. And make change for utilizing Dependabot.