### PR TITLE
[GenAPI] generate forwarded type assembly attributes.

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
@@ -49,6 +49,11 @@ namespace Microsoft.DotNet.GenAPI.Task
         /// </summary>
         public bool IncludeVisibleOutsideOfAssembly { get; set; }
 
+        /// <summary>
+        /// Includes assembly attributes which are values that provide information about an assembly.
+        /// </summary>
+        public bool IncludeAssemblyAttributes { get; }
+
         protected override void ExecuteCore()
         {
             GenAPIApp.Run(new MSBuildLog(Log), new GenAPIApp.Context(
@@ -58,7 +63,8 @@ namespace Microsoft.DotNet.GenAPI.Task
                 HeaderFile,
                 ExceptionMessage,
                 ExcludeAttributesFiles,
-                IncludeVisibleOutsideOfAssembly
+                IncludeVisibleOutsideOfAssembly,
+                IncludeAssemblyAttributes
             ));
         }
     }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -48,7 +48,8 @@
       HeaderFile="$(GenAPIHeaderFile)"
       ExceptionMessage="$(GenAPIExceptionMessage)"
       ExcludeAttributesFiles="@(GenAPIExcludeAttributesList)"
-      IncludeVisibleOutsideOfAssembly="$(GenAPIIncludeVisibleOutsideOfAssembly)" />
+      IncludeVisibleOutsideOfAssembly="$(GenAPIIncludeVisibleOutsideOfAssembly)"
+      IncludeAssemblyAttributes="$(GenAPIIncludeAssemblyAttributes)" />
 
     <Message Text="Generated reference assembly source code: $(GenAPITargetPath)" Importance="$(GenAPIVerbosity)" />
   </Target>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
@@ -52,6 +52,9 @@ namespace Microsoft.DotNet.GenAPI.Tool
             Option<bool> includeVisibleOutsideOfAssemblyOption = new("--include-visible-outside",
                 "Include internal API's. Default is false.");
 
+            Option<bool> includeAssemblyAttributesOption = new("--include-assembly-attributes",
+                "Includes assembly attributes which are values that provide information about an assembly. Default is false.");
+
             RootCommand rootCommand = new("Microsoft.DotNet.GenAPI")
             {
                 TreatUnmatchedTokensAsErrors = true
@@ -63,6 +66,7 @@ namespace Microsoft.DotNet.GenAPI.Tool
             rootCommand.AddGlobalOption(headerFileOption);
             rootCommand.AddGlobalOption(exceptionMessageOption);
             rootCommand.AddGlobalOption(includeVisibleOutsideOfAssemblyOption);
+            rootCommand.AddGlobalOption(includeAssemblyAttributesOption);
 
             rootCommand.SetHandler((InvocationContext context) =>
             {
@@ -73,7 +77,8 @@ namespace Microsoft.DotNet.GenAPI.Tool
                     context.ParseResult.GetValue(headerFileOption),
                     context.ParseResult.GetValue(exceptionMessageOption),
                     context.ParseResult.GetValue(excludeAttributesFilesOption),
-                    context.ParseResult.GetValue(includeVisibleOutsideOfAssemblyOption)
+                    context.ParseResult.GetValue(includeVisibleOutsideOfAssemblyOption),
+                    context.ParseResult.GetValue(includeAssemblyAttributesOption)
                 ));
             });
 

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.GenAPI
                 {
                     _logger.LogWarning(string.Format(
                         "Could not resolve type '{0}' in containing assembly '{1}' via type forward. Make sure that the assembly is provided as a reference and contains the type.",
-                        symbol.ToString(),
+                        symbol.ToDisplayString(),
                         $"{symbol.ContainingAssembly.Name}.dll"));
                 }
             }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -82,23 +82,21 @@ namespace Microsoft.DotNet.GenAPI
                 .Rewrite(new BodyBlockCSharpSyntaxRewriter(_exceptionMessage))
                 .NormalizeWhitespace();
 
+            if (_includeAssemblyAttributes)
+            {
+                compilationUnit = GenerateAssemblyAttributes(assembly, compilationUnit);
+            }
+
+            compilationUnit = GenerateForwardedTypeAssemblyAttributes(assembly, compilationUnit);
+
             Document document = project.AddDocument(assembly.Name, compilationUnit);
 
             document = Simplifier.ReduceAsync(document).Result;
             document = Formatter.FormatAsync(document, DefineFormattingOptions()).Result;
 
-            if (_includeAssemblyAttributes)
-            {
-                GenerateAssemblyAttributes(assembly, compilationUnit)
-                    .WriteTo(_textWriter);
-            }
-
-            GenerateForwardedTypeAssemblyAttributes(assembly, compilationUnit)
-                .Rewrite(new TypeForwardAttributeCSharpSyntaxRewriter())
-                .WriteTo(_textWriter);
-
             document.GetSyntaxRootAsync().Result!
                 .Rewrite(new SingleLineStatementCSharpSyntaxRewriter())
+                .Rewrite(new TypeForwardAttributeCSharpSyntaxRewriter())
                 .WriteTo(_textWriter);
         }
 

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -206,7 +206,10 @@ namespace Microsoft.DotNet.GenAPI
                 }
                 else
                 {
-                    _logger.LogWarning(string.Format("Could not find matching assembly: '{0}' in any of the search directories.", $"{symbol.ContainingAssembly.Name}.dll"));
+                    _logger.LogWarning(string.Format(
+                        "Could not resolve type '{0}' in containing assembly '{1}' via type forward. Make sure that the assembly is provided as a reference and contains the type.",
+                        symbol.ToString(),
+                        $"{symbol.ContainingAssembly.Name}.dll"));
                 }
             }
 

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -117,6 +117,7 @@ namespace Microsoft.DotNet.GenAPI
                 textWriter.Write(ReadHeaderFile(context.HeaderFile));
 
                 using CSharpFileBuilder fileBuilder = new(
+                    logger,
                     compositeSymbolFilter,
                     textWriter,
                     context.ExceptionMessage,

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -27,7 +27,8 @@ namespace Microsoft.DotNet.GenAPI
                 string? headerFile,
                 string? exceptionMessage,
                 string[]? excludeAttributesFiles,
-                bool includeVisibleOutsideOfAssembly)
+                bool includeVisibleOutsideOfAssembly,
+                bool includeAssemblyAttributes)
             {
                 Assemblies = assemblies;
                 AssemblyReferences = assemblyReferences;
@@ -36,6 +37,7 @@ namespace Microsoft.DotNet.GenAPI
                 ExceptionMessage = exceptionMessage;
                 ExcludeAttributesFiles = excludeAttributesFiles;
                 IncludeVisibleOutsideOfAssembly = includeVisibleOutsideOfAssembly;
+                IncludeAssemblyAttributes = includeAssemblyAttributes;
             }
 
             /// <summary>
@@ -73,6 +75,11 @@ namespace Microsoft.DotNet.GenAPI
             /// Include internal API's. Default is false.
             /// </summary>
             public bool IncludeVisibleOutsideOfAssembly { get; }
+
+            /// <summary>
+            /// Includes assembly attributes which are values that provide information about an assembly.
+            /// </summary>
+            public bool IncludeAssemblyAttributes { get; }
         }
 
         /// <summary>
@@ -113,6 +120,7 @@ namespace Microsoft.DotNet.GenAPI
                     compositeSymbolFilter,
                     textWriter,
                     context.ExceptionMessage,
+                    context.IncludeAssemblyAttributes,
                     loader.MetadataReferences);
 
                 fileBuilder.WriteAssembly(assemblySymbol);

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
+{
+    /// <summary>
+    /// Handles type forward assembly attributes and removes generic type arguments:
+    ///     [assembly:TypeForwardedToAttribute(typeof(System.Collections.Generic.IAsyncEnumerable<A, B, C>))] ->
+    ///     [assembly:TypeForwardedToAttribute(typeof(System.Collections.Generic.IAsyncEnumerable<,,>))] ->
+    /// </summary>
+    public class TypeForwardAttributeCSharpSyntaxRewriter : CSharpSyntaxRewriter
+    {
+        public override SyntaxNode? VisitGenericName(GenericNameSyntax node)
+        {
+            GenericNameSyntax? rs = (GenericNameSyntax?)base.VisitGenericName(node);
+
+            TypeArgumentListSyntax typeArgumentList = node.TypeArgumentList;
+            SeparatedSyntaxList<TypeSyntax> newArguments = new();
+
+            foreach (IdentifierNameSyntax argument in typeArgumentList.Arguments)
+            {
+                newArguments = newArguments.Add(argument.WithIdentifier(SyntaxFactory.Identifier("")));
+            }
+
+            typeArgumentList = typeArgumentList.WithArguments(newArguments);
+            return node.WithTypeArgumentList(typeArgumentList);
+        }
+    }
+}

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
 
             foreach (IdentifierNameSyntax argument in typeArgumentList.Arguments)
             {
-                newArguments = newArguments.Add(argument.WithIdentifier(SyntaxFactory.Identifier("")));
+                newArguments = newArguments.Add(argument.WithIdentifier(SyntaxFactory.Identifier(string.Empty)));
             }
 
             typeArgumentList = typeArgumentList.WithArguments(newArguments);

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
@@ -19,6 +19,12 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
     {
         public override SyntaxNode? VisitGenericName(GenericNameSyntax node)
         {
+            // skip if not of `typeof(Type<A,B,C>)` format
+            if (node.Parent == null || node.Parent.Parent == null || node.Parent.Parent is not TypeOfExpressionSyntax)
+            {
+                return node;
+            }
+
             TypeArgumentListSyntax typeArgumentList = node.TypeArgumentList;
             SeparatedSyntaxList<TypeSyntax> newArguments = new();
 

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
@@ -19,8 +19,6 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
     {
         public override SyntaxNode? VisitGenericName(GenericNameSyntax node)
         {
-            GenericNameSyntax? rs = (GenericNameSyntax?)base.VisitGenericName(node);
-
             TypeArgumentListSyntax typeArgumentList = node.TypeArgumentList;
             SeparatedSyntaxList<TypeSyntax> newArguments = new();
 

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 using Microsoft.DotNet.GenAPI.Filtering;
+using Microsoft.DotNet.ApiSymbolExtensions.Logging;
 
 namespace Microsoft.DotNet.GenAPI.Tests
 {
@@ -42,8 +43,8 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 .Add<ImplicitSymbolFilter>()
                 .Add(new AccessibilitySymbolFilter(includeInternalSymbols,
                     includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols));
-            IAssemblySymbolWriter csharpFileBuilder = new CSharpFileBuilder(compositeFilter,
-                stringWriter, null, false, MetadataReferences);
+            IAssemblySymbolWriter csharpFileBuilder = new CSharpFileBuilder(new ConsoleLog(MessageImportance.Low),
+                compositeFilter, stringWriter, null, false, MetadataReferences);
 
             IAssemblySymbol assemblySymbol = SymbolFactory.GetAssemblyFromSyntax(original, enableNullable: true);
             csharpFileBuilder.WriteAssembly(assemblySymbol);

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -42,7 +42,8 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 .Add<ImplicitSymbolFilter>()
                 .Add(new AccessibilitySymbolFilter(includeInternalSymbols,
                     includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols));
-            IAssemblySymbolWriter csharpFileBuilder = new CSharpFileBuilder(compositeFilter, stringWriter, null, MetadataReferences);
+            IAssemblySymbolWriter csharpFileBuilder = new CSharpFileBuilder(compositeFilter,
+                stringWriter, null, false, MetadataReferences);
 
             IAssemblySymbol assemblySymbol = SymbolFactory.GetAssemblyFromSyntax(original, enableNullable: true);
             csharpFileBuilder.WriteAssembly(assemblySymbol);

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriterTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriterTests.cs
@@ -463,4 +463,21 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 """);
         }
     }
+
+    public class TypeForwardAttributeCSharpSyntaxRewriterTests : SyntaxRewriterTests
+    {
+        [Fact]
+        public void TypeForwardAttributeDeclaration()
+        {
+            CompareSyntaxTree(new TypeForwardAttributeCSharpSyntaxRewriter(),
+                original: """
+                [assembly:System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(global::System.Collections.Generic.IAsyncEnumerable<T>))]
+                [assembly:System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(global::System.Collections.Generic.IAsyncEnumerable<A, B, C>))]
+                """,
+                expected: """
+                [assembly:System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(global::System.Collections.Generic.IAsyncEnumerable<>))]
+                [assembly:System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(global::System.Collections.Generic.IAsyncEnumerable<,,>))]
+                """);
+        }
+    }
 }


### PR DESCRIPTION
* Adds the `IncludeAssemblyAttributes` parameter that controls generation of assembly attributes.
* Adds support for generation of forwarded type assembly attributes

Fixes: https://github.com/dotnet/arcade/issues/12555