### PR TITLE
GenAPI: add workaround for IFieldSymbol.Name that has angle brackets

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -113,17 +113,9 @@ namespace Microsoft.DotNet.GenAPI
                 // Add a dummy field for each generic excluded field
                 foreach(IFieldSymbol genericField in genericTypedFields)
                 {
-                    String fieldName = genericField.Name;
-                    int i = fieldName.LastIndexOf('>');
-
-                    if (i >= 0)
-                    {
-                        fieldName = fieldName.Remove(0, i+1);
-                    }
-
                     yield return CreateDummyField(
                         genericField.Type.ToDisplayString(),
-                        fieldName,
+                        genericField.Name.Replace('<', '_').Replace('>', '_'),
                         FromAttributeData(genericField.GetAttributes()),
                         namedType.IsReadOnly);
                 }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -113,9 +113,17 @@ namespace Microsoft.DotNet.GenAPI
                 // Add a dummy field for each generic excluded field
                 foreach(IFieldSymbol genericField in genericTypedFields)
                 {
+                    String fieldName = genericField.Name;
+                    int i = fieldName.LastIndexOf('>');
+
+                    if (i >= 0)
+                    {
+                        fieldName = fieldName.Remove(0, i+1);
+                    }
+
                     yield return CreateDummyField(
                         genericField.Type.ToDisplayString(),
-                        genericField.Name,
+                        fieldName,
                         FromAttributeData(genericField.GetAttributes()),
                         namedType.IsReadOnly);
                 }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -88,6 +88,11 @@ namespace Microsoft.DotNet.GenAPI
             return declaration;
         }
 
+        // Sometimes the metadata can contain names that are not valid C# identifiers. For example,
+        // to express a set of type parameters, they can be prefixed with angle brackets.
+        // Normalize them by replacing these special characters with '_'.
+        private static string NormalizeIdentifier(string s) => s.Replace('<', '_').Replace('>', '_');
+
         // SynthesizeDummyFields yields private fields for the namedType, because they can be part of the API contract.
         // - A struct containing a field that is a reference type cannot be used as a reference.
         // - A struct containing nonempty fields needs to be fully initialized. (See "definite assignment" rules)
@@ -115,7 +120,7 @@ namespace Microsoft.DotNet.GenAPI
                 {
                     yield return CreateDummyField(
                         genericField.Type.ToDisplayString(),
-                        genericField.Name.Replace('<', '_').Replace('>', '_'),
+                        NormalizeIdentifier(genericField.Name),
                         FromAttributeData(genericField.GetAttributes()),
                         namedType.IsReadOnly);
                 }

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1074,6 +1074,34 @@ namespace Microsoft.DotNet.GenAPI.Tests
         }
 
         [Fact]
+        void TestSynthesizePrivateFieldsAngleBrackets()
+        {
+            RunTest(original: """
+                using System.Collections.Generic;
+
+                namespace Foo
+                {
+                    public readonly struct Bar<T> where T : notnull
+                    {
+                        public List<Bar<T>> Baz { get; }
+                    }
+                }
+                """,
+            expected: """
+                namespace Foo
+                {
+                    public readonly partial struct Bar<T>
+                    {
+                        private readonly System.Collections.Generic.List<Bar<T>> k__BackingField;
+                        private readonly object _dummy;
+                        private readonly int _dummyPrimitive;
+                        public System.Collections.Generic.List<Bar<T>> Baz { get { throw null; } }
+                    }
+                }
+                """);
+        }
+
+        [Fact]
         public void TestBaseTypeWithoutExplicitDefaultConstructor()
         {
             RunTest(original: """

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1092,7 +1092,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 {
                     public readonly partial struct Bar<T>
                     {
-                        private readonly System.Collections.Generic.List<Bar<T>> k__BackingField;
+                        private readonly System.Collections.Generic.List<Bar<T>> _Baz_k__BackingField;
                         private readonly object _dummy;
                         private readonly int _dummyPrimitive;
                         public System.Collections.Generic.List<Bar<T>> Baz { get { throw null; } }


### PR DESCRIPTION
Roslyn can (surprisingly?) return IFieldSymbols whose names are prefixed with `<T>` type parameters. For now, replace angle brackets with underscores before emitting a synthesized field.