### PR TITLE
Better fix for the OSX issues in installer repo

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -66,10 +66,16 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Theory]
+        [InlineData("netcoreapp1.1")]
         [InlineData("netcoreapp2.0")]
         [InlineData("netcoreapp3.0")]
         public void It_publishes_self_contained_apps_to_the_publish_folder_and_the_app_should_run(string targetFramework)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
             var helloWorldAsset = _testAssetsManager

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -127,7 +127,7 @@ namespace Microsoft.NET.TestFramework
                 string ubuntuVersionString = restOfRid.Split('-')[0];
                 if (float.TryParse(ubuntuVersionString, out float ubuntuVersion))
                 {
-                    if (ubuntuVersion > 16.04)
+                    if (ubuntuVersion > 16.04f)
                     {
                         if (nugetFramework.Version < new Version(2, 0, 0, 0))
                         {
@@ -144,31 +144,54 @@ namespace Microsoft.NET.TestFramework
             {
                 string restOfRid = currentRid.Substring(ridOS.Length + 1);
                 string osxVersionString = restOfRid.Split('-')[0];
-                //  From a string such as "10.14", get the second part, e.g. "14"
-                string osxVersionString2 = osxVersionString.Split('.')[1];
-                if (int.TryParse(osxVersionString2, out int osxVersion))
+                if (float.TryParse(osxVersionString, out float osxVersion))
                 {
                     //  .NET Core 1.1 - 10.11, 10.12
                     //  .NET Core 2.0 - 10.12+
-                    if (osxVersion <= 11)
+                    //  .NET Core 2.1 - 10.12-10.15
+                    //  .NET 5 <= 11.0
+                    //  .NET 6 <= 12
+                    //  .NET 7 <= 13
+                    if (osxVersion <= 10.11f)
                     {
                         if (nugetFramework.Version >= new Version(2, 0, 0, 0))
                         {
                             return false;
                         }
                     }
-                    else if (osxVersion == 12)
+                    else if (osxVersion == 10.12f)
                     {
                         if (nugetFramework.Version < new Version(2, 0, 0, 0))
                         {
                             return false;
                         }
                     }
-                    else if (osxVersion > 12)
+                    else if (osxVersion > 10.12f && osxVersion <= 10.15f)
                     {
                         //  .NET Core 2.0 is out of support, and doesn't seem to work with OS X 10.14
                         //  (it finds no assets for the RID), even though the support page says "10.12+"
                         if (nugetFramework.Version < new Version(2, 1, 0, 0))
+                        {
+                            return false;
+                        }
+                    }
+                    else if (osxVersion == 11.0f)
+                    {
+                        if (nugetFramework.Version < new Version(5, 0, 0, 0))
+                        {
+                            return false;
+                        }
+                    }
+                    else if (osxVersion == 12.0f)
+                    {
+                        if (nugetFramework.Version < new Version(6, 0, 0, 0))
+                        {
+                            return false;
+                        }
+                    }
+                    else if (osxVersion > 12.0f)
+                    {
+                        if (nugetFramework.Version < new Version(7, 0, 0, 0))
                         {
                             return false;
                         }


### PR DESCRIPTION
Revert #29916 as this is causing linux failures in installer now
Port fix for environmentinfo.
Realize that the fix won't work for 11.0
Modify the fix to work better following the idea of the other fix that almost worked

https://github.com/dotnet/sdk/pull/29916
https://github.com/dotnet/sdk/pull/29083

I manually tested various combinations of 10.12, 10.14, 10.15, 11.0, and 12