### PR TITLE
Fix package cache group SID

### DIFF
--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -79,16 +79,6 @@ namespace Microsoft.DotNet.Installer.Windows
         /// </summary>
         public readonly string PackageCacheRoot;
 
-        /// <summary>
-        /// SDDL string for files inside the package cache. The owner is set to built-in administrators (O:BA), the group is domain users (G:DU).
-        /// DACL is auto-inherit with the following ACE definitions: Full control for NT AUTHORITY\SYSTEM (A;ID;FA;;;SY),
-        /// full control for BUILTIN\Administators (A;ID;FA;;;BA), read and execute for BUILTIN\Users (A;ID;0x1200a9;;;BU) and
-        /// and Everyone (A;ID;0x1200a9;;;WD).
-        /// </summary>
-        /// <remarks>See <see href="https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-definition-language">SDDL</see>
-        /// documentation for details.</remarks>
-        private const string FileSecurityDescriptor = "O:BAG:DUD:AI(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU)(A;ID;0x1200a9;;;WD)";
-
         public MsiPackageCache(InstallElevationContextBase elevationContext, ISetupLogger logger,
             bool verifySignatures, string packageCacheRoot = null) : base(elevationContext, logger, verifySignatures)
         {
@@ -119,10 +109,20 @@ namespace Microsoft.DotNet.Installer.Windows
                 CreateSecureDirectory(Directory.GetParent(path).FullName);
 
                 DirectorySecurity directorySecurity = new();
+
+                // Only set the owner and use its default group. If the machine is domain joined, this should create
+                // a descriptor like O:BAG:DU by selecting SDDL_DOMAIN_USERS. On non-domain joined machines and Windows Sandbox,
+                // the group SID will be different and the descriptor will end up as O:BAG:S-1-5-21-2047949552-857980807-821054962-513.
+                directorySecurity.SetOwner(s_AdministratorsSid);
                 directorySecurity.SetAccessRule(s_AdministratorRule);
-                directorySecurity.SetGroup(s_LocalSystemSid);
+                directorySecurity.SetAccessRule(s_LocalSystemRule);
+                directorySecurity.SetAccessRule(s_UsersRule);
+                directorySecurity.SetAccessRule(s_EveryoneRule);
+
+                // Don't use Directory.CreateDirectory as that can cause problems with inherited ACEs from
+                // the parent folders as access rules become cumulative. The acccess rules for the directory should all have
+                // object and container inheritance set to ensure access rights are inherited when creating files.
                 directorySecurity.CreateDirectory(path);
-                SecureDirectory(path);
             }
         }
 
@@ -201,7 +201,13 @@ namespace Microsoft.DotNet.Installer.Windows
 
                 FileInfo fi = new(destinationFile);
                 FileSecurity fs = new();
-                fs.SetSecurityDescriptorSddlForm(FileSecurityDescriptor);
+
+                // Only set the owner, everything else should be inherited. Assuming the parent folder was not
+                // modified externally, the file's descriptor should either be
+                // O:BAG:DUD:(A;ID;0x1200a9;;;WD)(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU) or
+                // O:BAG:S-1-5-21-2047949552-857980807-821054962-513D:(A;ID;0x1200a9;;;WD)(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU)
+                // Note that all the access entries include the ID flag indicating they were inherited from the container.
+                fs.SetOwner(s_AdministratorsSid);
                 fi.SetAccessControl(fs);
             }
         }
@@ -317,22 +323,6 @@ namespace Microsoft.DotNet.Installer.Windows
             {
                 Log?.LogMessage($"Skipping signature verification for {msiPath}.");
             }
-        }
-
-        /// <summary>
-        /// Secures the target directory by applying multiple ACLs. Administrators and local SYSTEM
-        /// receive full control. Users and Everyone receive read and execute permissions.
-        /// </summary>
-        /// <param name="path">The directory to secure.</param>
-        private void SecureDirectory(string path)
-        {
-            DirectoryInfo directoryInfo = new DirectoryInfo(path);
-            DirectorySecurity directorySecurity = directoryInfo.GetAccessControl();
-            directorySecurity.SetAccessRule(s_AdministratorRule);
-            directorySecurity.SetAccessRule(s_EveryoneRule);
-            directorySecurity.SetAccessRule(s_LocalSystemRule);
-            directorySecurity.SetAccessRule(s_UsersRule);
-            directoryInfo.SetAccessControl(directorySecurity);
         }
     }
 }


### PR DESCRIPTION
## Description

Previously, the permissions on files in the workload package cache under `ProgramData` were too restrictive (see [28450](https://github.com/dotnet/sdk/issues/28450)) when another user tried to perform a workload action. To fix this, the group SID in the file's security descriptor was explicitly set to domain users (descriptor value `G:DU`).

The domain users SID does not always exist, for example, non-domain joined machines and Windows Sandbox will show an error when trying to cache a package: `The SDDL string contains an invalid sid or a sid that cannot be translated. (Parameter 'sddlForm')`

## Impact
While the issue was discovered on Windows Sandbox, we've had internal reports from users that are on non-domain joined devices. This would likely impact any external users trying out the preview SDK on their own devices.

## Workaround
None

## Fix
All folders in the cache are created with object and container inheritance and files inherit these permissions when moved to the cache. Instead of setting the group explicitly, we simply set the owner as built-in administrator (`O:BA`) and let the inheritance mechanism provide the rest of the information.

## Testing
All testing is manual since the actual usage requires the non-elevated client process to download the workload installers to a local user folder before the elevated server process moves and secures the file inside the package cache. This makes it difficult to verify with a unit test.

Manual verification was performed as follows:
1. Create a file locally and have the elevated process cache the file and verify the descriptor of the parent folder and file. This can be done from PowerShell, e.g. `get-acl <path-to-file-or-directory> | format-list -property sddl`. On a domain joined machine the descriptor for the directory should be `O:BAG:DUD:(A;OICIID;0x1200a9;;;WD)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;0x1200a9;;;BU)` and the file should be set to `O:BAG:DUD:(A;ID;0x1200a9;;;WD)(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU)`
2. Provide another user with standard permissions access to the machine from step 1 and verify that they can access the file. This validates that we did not regress the previous fix for multiple users accessing the cache.
3. Verify on Windows Sandbox that files are successfully cached and verify the descriptors. The parent directory should be set to `O:BAG:S-1-5-21-2047949552-857980807-821054962-513D:(A;OICIID;0x1200a9;;;WD)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;0x1200a9;;;BU)` and the file to `O:BAG:S-1-5-21-2047949552-857980807-821054962-513D:(A;ID;0x1200a9;;;WD)(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU)`
