### PR TITLE
Enable Dependabot for branch release/7.0.3xx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,17 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
+    target-branch: "main"
+    labels:
+      - "dependencies"
+      - "dependabot: main"
+
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    target-branch: "release/7.0.3xx"
+    labels:
+      - "dependencies"
+      - "dependabot: 7.0.3xx"


### PR DESCRIPTION
Enable Dependabot for branch release/7.0.3xx.

@YuliiaKovalova  This needs to add the following additional labels to distinguish PRs targeting to different branches. Can you help to add them?

- dependabot: main
- dependabot: 7.0.3xx