### PR TITLE
#28518: Stop generating NETSDK1138 warning when OutputType is Library.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
@@ -12,7 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- Default the check to true, but allow developers to turn the warning off. -->
-    <CheckEolTargetFramework Condition="'$(CheckEolTargetFramework)' == ''">true</CheckEolTargetFramework>
+    <CheckEolTargetFramework Condition="'$(CheckEolTargetFramework)' == '' and '$(OutputType)' != 'Library'">true</CheckEolTargetFramework>
   </PropertyGroup>
 
   <!--

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetEolFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetEolFrameworks.cs
@@ -55,6 +55,7 @@ namespace Microsoft.NET.Build.Tests
             {
                 Name = $"EolOnlyNetCore",
                 TargetFrameworks = $"netcoreapp1.0;{ToolsetInfo.CurrentTargetFramework};net472",
+                IsExe = true,
             };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -83,6 +84,29 @@ namespace Microsoft.NET.Build.Tests
             };
 
             testProject.AdditionalProperties["CheckEolTargetFramework"] = "false";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            var result = buildCommand
+                .Execute();
+
+            result
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("NETSDK1138");
+        }
+
+        [Fact]
+        public void It_does_not_warn_when_target_library()
+        {
+            var testProject = new TestProject()
+            {
+                Name = $"EolNoWarning",
+                TargetFrameworks = "netcoreapp1.0",
+            };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 


### PR DESCRIPTION
Issue #28518:

NETSDK1138 is raised to notify users of EOL frameworks being targeted. 
Stop generating NETSDK1138 warning when OutputType is Library.