### PR TITLE
Downgrade errors for specifying `--output` for solutions to warnings

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option<string> OutputOption = new ForwardedOption<string>(new string[] { "-o", "--output" }, LocalizableStrings.CmdOutputDirDescription)
         {
             ArgumentHelpName = LocalizableStrings.CmdOutputDir
-        }.ForwardAsOutputPath("PackageOutputPath");
+        }.ForwardAsSingle(o => $"-property:PackageOutputPath={CommandDirectoryContext.GetFullPath(o)}");
 
         public static readonly Option<bool> NoBuildOption = new ForwardedOption<bool>("--no-build", LocalizableStrings.CmdNoBuildOptionDescription)
             .ForwardAs("-property:NoBuild=true");

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -880,7 +880,7 @@ You may need to build the project on another operating system or architecture, o
     <comment>{StrBegin="NETSDK1193: "}</comment>
   </data>
   <data name="CannotHaveSolutionLevelOutputPath" xml:space="preserve">
-    <value>NETSDK1194: The "--output" option isn't supported when building a solution.</value>
+    <value>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</value>
     <comment>{StrBegin="NETSDK1194: "}</comment>
   </data>
   <data name="AotNotSupported" xml:space="preserve">

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: Možnost „--output“ se při sestavování řešení nepodporuje.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: Možnost „--output“ se při sestavování řešení nepodporuje.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: Die Option "--output" wird beim Erstellen einer Lösung nicht unterstützt.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: Die Option "--output" wird beim Erstellen einer Lösung nicht unterstützt.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: La opción "--output" no es permitida mientras se crea una solución.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: La opción "--output" no es permitida mientras se crea una solución.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: l’option «--output» n’est pas prise en charge lors de la génération d’une solution.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: l’option «--output» n’est pas prise en charge lors de la génération d’une solution.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: l'opzione "--output" non è supportata durante la compilazione di una soluzione.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: l'opzione "--output" non è supportata durante la compilazione di una soluzione.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: ソリューションのビルド時に "--output" オプションはサポートされていません。</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: ソリューションのビルド時に "--output" オプションはサポートされていません。</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: 솔루션을 빌드할 때는 "--output" 옵션이 지원되지 않습니다.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: 솔루션을 빌드할 때는 "--output" 옵션이 지원되지 않습니다.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: opcja „--output” nie jest obsługiwana podczas tworzenia rozwiązania.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: opcja „--output” nie jest obsługiwana podczas tworzenia rozwiązania.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: a opção "--output" não é suportada ao criar uma solução.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: a opção "--output" não é suportada ao criar uma solução.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: параметр "--output" не поддерживается при создании решения.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: параметр "--output" не поддерживается при создании решения.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: Çözüm oluşturulurken "--output" seçeneği desteklenmez.</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: Çözüm oluşturulurken "--output" seçeneği desteklenmez.</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: 生成解决方案时不支持 “--output” 选项。</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: 生成解决方案时不支持 “--output” 选项。</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -148,8 +148,8 @@
         <note>{StrBegin="NETSDK1099: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
-        <source>NETSDK1194: The "--output" option isn't supported when building a solution.</source>
-        <target state="translated">NETSDK1194: 建置解決方案時不支援 "--output" 選項。</target>
+        <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
+        <target state="needs-review-translation">NETSDK1194: 建置解決方案時不支援 "--output" 選項。</target>
         <note>{StrBegin="NETSDK1194: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelRuntimeIdentifier">

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions-ver/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions-ver/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets
@@ -33,7 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           BeforeTargets="Build;Publish;Clean;Store;VSTest"
           Condition="'$(_CommandLineDefinedOutputPath)' == 'true'">
 
-    <NETSdkError ResourceName="CannotHaveSolutionLevelOutputPath" />
+    <NetSdkWarning ResourceName="CannotHaveSolutionLevelOutputPath" />
 
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions-ver/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions-ver/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets
@@ -30,7 +30,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 
   <Target Name="_CheckForSolutionLevelOutputPath"
-          BeforeTargets="Build;Publish;Clean;Pack;Store;VSTest"
+          BeforeTargets="Build;Publish;Clean;Store;VSTest"
           Condition="'$(_CommandLineDefinedOutputPath)' == 'true'">
 
     <NETSdkError ResourceName="CannotHaveSolutionLevelOutputPath" />

--- a/src/Tests/Microsoft.NET.Pack.Tests/SolutionPackTests.cs
+++ b/src/Tests/Microsoft.NET.Pack.Tests/SolutionPackTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+
+using FluentAssertions;
+using Xunit.Abstractions;
+using System.IO;
+
+namespace Microsoft.NET.Pack.Tests
+{
+    public class SolutionPackTests : SdkTest
+    {
+        public SolutionPackTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void ItCanPackASolutionWithOutputPath()
+        {
+            var testProject1 = new TestProject()
+            {
+                Name = "Project1",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework
+            };
+
+            var testProject2 = new TestProject()
+            {
+                Name = "Project2",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProjects(new[] { testProject1, testProject2 });
+
+            string packageOutputPath = Path.Combine(testAsset.Path, "output", "packages");
+
+            new DotnetCommand(Log, "pack", "--output", packageOutputPath)
+                .WithWorkingDirectory(testAsset.Path)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new FileInfo(Path.Combine(packageOutputPath, testProject1.Name + ".1.0.0.nupkg")).Should().Exist();
+            new FileInfo(Path.Combine(packageOutputPath, testProject1.Name + ".1.0.0.nupkg")).Should().Exist();
+
+        }
+    }
+}

--- a/src/Tests/dotnet.Tests/OutputPathOptionTests.cs
+++ b/src/Tests/dotnet.Tests/OutputPathOptionTests.cs
@@ -26,14 +26,14 @@ namespace dotnet.Tests
         }
 
         [Theory]
-        [InlineData("build")]
-        [InlineData("clean")]
-        [InlineData("pack")]
-        [InlineData("publish")]
-        [InlineData("test")]
-        public void OutputOptionGeneratesErrorsWithSolutionFiles(string command)
+        [InlineData("build", true)]
+        [InlineData("clean", true)]
+        [InlineData("pack", false)]
+        [InlineData("publish", true)]
+        [InlineData("test", true)]
+        public void OutputOptionGeneratesWarningsWithSolutionFiles(string command, bool shouldWarn)
         {
-            TestOutputWithSolution(command, true);
+            TestOutputWithSolution(command, useOption: true, shouldWarn: shouldWarn);
         }
 
         [Theory]
@@ -42,12 +42,12 @@ namespace dotnet.Tests
         [InlineData("pack")]
         [InlineData("publish")]
         [InlineData("test")]
-        public void OutputPathPropertyDoesNotGenerateErrorsWithSolutionFiles(string command)
+        public void OutputPathPropertyDoesNotGenerateWarningsWithSolutionFiles(string command)
         {
-            TestOutputWithSolution(command, false);
+            TestOutputWithSolution(command, useOption: false, shouldWarn: false);
         }
 
-        void TestOutputWithSolution(string command, bool useOption, [CallerMemberName] string callingMethod = "")
+        void TestOutputWithSolution(string command, bool useOption, bool shouldWarn, [CallerMemberName] string callingMethod = "")
         {
             var testProject = new TestProject()
             {
@@ -73,24 +73,27 @@ namespace dotnet.Tests
                 .Should().Pass();
 
             string outputDirectory = Path.Combine(slnDirectory, "bin");
-
+            Microsoft.DotNet.Cli.Utils.CommandResult commandResult;
             if (useOption)
             {
-                new DotnetCommand(Log)
+                commandResult = new DotnetCommand(Log)
                     .WithWorkingDirectory(slnDirectory)
-                    .Execute(command, "--output", outputDirectory)
-                    .Should()
-                    .Fail()
-                    .And
-                    .HaveStdOutContaining("NETSDK1194");
+                    .Execute(command, "--output", outputDirectory);
             }
             else
             {
-                new DotnetCommand(Log)
+                commandResult = new DotnetCommand(Log)
                     .WithWorkingDirectory(slnDirectory)
-                    .Execute(command, $"--property:OutputPath={outputDirectory}")
-                    .Should()
-                    .Pass();
+                    .Execute(command, $"--property:OutputPath={outputDirectory}");
+            }
+            commandResult.Should().Pass();
+            if (shouldWarn)
+            {
+                commandResult.Should().HaveStdOutContaining("NETSDK1194");
+            }
+            else
+            {
+                commandResult.Should().NotHaveStdOutContaining("NETSDK1194");
             }
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
@@ -24,8 +24,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-o", "<packageoutputpath>" }, "-property:PackageOutputPath=<cwd><packageoutputpath> -property:_CommandLineDefinedOutputPath=true")]
-        [InlineData(new string[] { "--output", "<packageoutputpath>" }, "-property:PackageOutputPath=<cwd><packageoutputpath> -property:_CommandLineDefinedOutputPath=true")]
+        [InlineData(new string[] { "-o", "<packageoutputpath>" }, "-property:PackageOutputPath=<cwd><packageoutputpath>")]
+        [InlineData(new string[] { "--output", "<packageoutputpath>" }, "-property:PackageOutputPath=<cwd><packageoutputpath>")]
         [InlineData(new string[] { "--no-build" }, "-property:NoBuild=true")]
         [InlineData(new string[] { "--include-symbols" }, "-property:IncludeSymbols=true")]
         [InlineData(new string[] { "--include-source" }, "-property:IncludeSource=true")]


### PR DESCRIPTION
# Downgrade errors for specifying `--output` for solutions to warnings

## Description

In 7.0.200, we [added an error](https://github.com/dotnet/sdk/pull/29065) when the `--output` option was specified for a solution.  This was because this causes multiple projects to use the same output path, which can lead to hard-to-diagnose issues.  It can also result in build flakiness if there are different projects copying the same files to the output path.

However, it appears that this change broke a lot more people than expected, so we will downgrade this error to a warning.

Additionally, we are going to remove the error/warning entirely from the `dotnet pack` command.  The `--output` parameter for `dotnet pack` only affects the package output path, and since each project should be generating a different .nupkg file, there shouldn't be a risk of file collisions when multiple projects share the same package output path.

## Customer impact

We have [multiple](https://github.com/dotnet/sdk/issues/30624) [reports](https://github.com/dotnet/dotnet-docker/issues/4424) of this breaking CI builds.

## Regression?
* [x]  Yes
* [ ]  No

## Risk

Low

## Verification

* [x]  Manual (required)
* [x]  Automated
