### PR TITLE
[GenAPI] Add abstract modifier for an abstract event.

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -66,13 +66,22 @@ namespace Microsoft.DotNet.GenAPI
                 }
             }
 
-            if (symbol is IEventSymbol eventSymbol && !eventSymbol.IsAbstract)
+            if (symbol is IEventSymbol eventSymbol)
             {
-                // adds generation of add & remove accessors for the non abstract events.
-                return syntaxGenerator.CustomEventDeclaration(eventSymbol.Name,
-                    syntaxGenerator.TypeExpression(eventSymbol.Type),
-                    eventSymbol.DeclaredAccessibility,
-                    DeclarationModifiers.From(eventSymbol));
+                if (eventSymbol.IsAbstract)
+                {
+                    // adds abstract keyword.
+                    EventFieldDeclarationSyntax eventDeclaration = (EventFieldDeclarationSyntax)syntaxGenerator.Declaration(symbol);
+                    return eventDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
+                }
+                else
+                {
+                    // adds generation of add & remove accessors for the non abstract events.
+                    return syntaxGenerator.CustomEventDeclaration(eventSymbol.Name,
+                        syntaxGenerator.TypeExpression(eventSymbol.Type),
+                        eventSymbol.DeclaredAccessibility,
+                        DeclarationModifiers.From(eventSymbol));
+                }
             }
 
             try

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeForwardAttributeCSharpSyntaxRewriter.cs
@@ -28,9 +28,16 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
             TypeArgumentListSyntax typeArgumentList = node.TypeArgumentList;
             SeparatedSyntaxList<TypeSyntax> newArguments = new();
 
-            foreach (IdentifierNameSyntax argument in typeArgumentList.Arguments)
+            foreach (TypeSyntax argument in typeArgumentList.Arguments)
             {
-                newArguments = newArguments.Add(argument.WithIdentifier(SyntaxFactory.Identifier(string.Empty)));
+                if (argument is IdentifierNameSyntax identifier)
+                {
+                    newArguments = newArguments.Add(identifier.WithIdentifier(SyntaxFactory.Identifier(string.Empty)));
+                }
+                else
+                {
+                    newArguments = newArguments.Add(argument);
+                }
             }
 
             typeArgumentList = typeArgumentList.WithArguments(newArguments);

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -447,7 +447,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 {
                     public abstract partial class AbstractEvents
                     {
-                        public event System.EventHandler<bool> TextChanged;
+                        public abstract event System.EventHandler<bool> TextChanged;
                     }
 
                     public partial class Events


### PR DESCRIPTION
* If a symbol is an abstract event - add an abstract modifier to event declaration.
* Attribute list for the `GenericNameSyntax` could contains value of types: `IdentifierNameSyntax`, `OmittedTypeArgumentSyntax` and other. We need to handle `IdentifierNameSyntax` use case.

Fixes: https://github.com/dotnet/arcade/issues/12609