### PR TITLE
Revert MSBuild to match VS 17.5.0 GA

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,7 +9,7 @@
     <add key="darc-int-dotnet-aspnetcore-febee99-1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-aspnetcore-febee99d-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from DotNet-msbuild-Trusted -->
-    <add key="darc-pub-DotNet-msbuild-Trusted-81ac935-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-81ac9354-1/nuget/v3/index.json" />
+    <add key="darc-pub-DotNet-msbuild-Trusted-6f08c67-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-6f08c67f-1/nuget/v3/index.json" />
     <!--  End: Package sources from DotNet-msbuild-Trusted -->
     <!--  Begin: Package sources from dotnet-roslyn-analyzers -->
     <!--  End: Package sources from dotnet-roslyn-analyzers -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -48,11 +48,11 @@
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="17.5.0">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>81ac93548ee1044f03d0ac363712bb778920ef8c</Sha>
+      <Sha>6f08c67f3ed838dccfbcdab91e6bebc54a26fd94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.5.0-preview-23112-02">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.5.0-preview-23107-06">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>81ac93548ee1044f03d0ac363712bb778920ef8c</Sha>
+      <Sha>6f08c67f3ed838dccfbcdab91e6bebc54a26fd94</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.5.0-beta.23069.2">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -115,7 +115,7 @@
     <MicrosoftBuildPackageVersion Condition="exists('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion') and '$(DotNetBuildFromSource)' != 'true'">$([System.IO.File]::ReadAllText('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion').Trim())</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.5.0-preview-23112-02</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.5.0-preview-23107-06</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>


### PR DESCRIPTION
**Description**

Automated merges of 17.5 builds done since the final 17.5.0 GA (but with no meaningful content) moved MSBuild in the SDK ahead of the one shipped with VS, which is not necessary or meaningful. Revert to match what's in VS ([internal link](https://dev.azure.com/devdiv/DevDiv/_git/VS?path=/.corext/Configs/components.json&version=GBrel/d17.5&line=39&lineEnd=39&lineStartColumn=19&lineEndColumn=83&lineStyle=plain&_a=contents)).

The reverted commits are: 
https://github.com/dotnet/msbuild/compare/6f08c67f3ed838dccfbcdab91e6bebc54a26fd94...81ac93548ee1044f03d0ac363712bb778920ef8c

**Customer Impact**
None, engineering change to align the shipped version in VS and .NET SDK.

**Regression?**
yes

**Risk** 
very low