### PR TITLE
Allow multiple loggers for VSTest command

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option<string> TestFrameworkOption = new Option<string>("--Framework");
 
-        public static readonly Option<string> TestLoggerOption = new Option<string>("--logger");
+        public static readonly Option<string[]> TestLoggerOption = new Option<string[]>("--logger");
 
         public static bool VerbosityIsDetailedOrDiagnostic(this VerbosityOptions verbosity)
         {

--- a/src/Cli/dotnet/Telemetry/TopLevelCommandNameAndOptionToLog.cs
+++ b/src/Cli/dotnet/Telemetry/TopLevelCommandNameAndOptionToLog.cs
@@ -35,12 +35,34 @@ namespace Microsoft.DotNet.Cli.Telemetry
                         new Dictionary<string, string>
                         {
                             { "verb", topLevelCommandName},
-                            { option.Name, parseResult.GetValueForOption(option)?.ToString() }
+                            { option.Name, Stringify(parseResult.GetValueForOption(option)) }
                         },
                         measurements));
                 }
             }
             return result;
+        }
+
+        /// <summary>
+        /// We're dealing with untyped payloads here, so we need to handle arrays vs non-array values
+        /// </summary>
+        private static string Stringify(object value)
+        {
+            if (value is null) {
+                return null;
+            }
+            if (value is IEnumerable<string> enumerable)
+            {
+                return string.Join(";", enumerable);
+            }
+            if (value is IEnumerable<object> enumerableOfObjects)
+            {
+                return string.Join(";", enumerableOfObjects);
+            }
+            if (value is object[] arr) {
+                return string.Join(";", arr);
+            }
+            return value.ToString();
         }
     }
 }

--- a/src/Cli/dotnet/Telemetry/TopLevelCommandNameAndOptionToLog.cs
+++ b/src/Cli/dotnet/Telemetry/TopLevelCommandNameAndOptionToLog.cs
@@ -48,7 +48,8 @@ namespace Microsoft.DotNet.Cli.Telemetry
         /// </summary>
         private static string Stringify(object value)
         {
-            if (value is null) {
+            if (value is null)
+            {
                 return null;
             }
             if (value is IEnumerable<string> enumerable)
@@ -59,7 +60,8 @@ namespace Microsoft.DotNet.Cli.Telemetry
             {
                 return string.Join(";", enumerableOfObjects);
             }
-            if (value is object[] arr) {
+            if (value is object[] arr)
+            {
                 return string.Join(";", arr);
             }
             return value.ToString();

--- a/src/Cli/dotnet/commands/dotnet-vstest/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-vstest/Program.cs
@@ -28,9 +28,10 @@ namespace Microsoft.DotNet.Tools.VSTest
             if (parseResult.HasOption(CommonOptions.TestLoggerOption))
             {
                 // System command line might have mutated the options, reformat test logger option so vstest recognizes it
-                var loggerValue = parseResult.GetValueForOption(CommonOptions.TestLoggerOption);
-                args = args.Where(a => !a.Equals(loggerValue) && !CommonOptions.TestLoggerOption.Aliases.Contains(a));
-                args = args.Prepend($"{CommonOptions.TestLoggerOption.Aliases.First()}:{loggerValue}");
+                var loggerValues = parseResult.GetValueForOption(CommonOptions.TestLoggerOption);
+                var loggerArgs = loggerValues.Select(loggerValue => $"{CommonOptions.TestLoggerOption.Aliases.First()}:{loggerValue}");
+                args = args.Where(a => !loggerValues.Contains(a) && !CommonOptions.TestLoggerOption.Aliases.Contains(a));
+                args = loggerArgs.Concat(args);
             }
 
             return args.ToArray();

--- a/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
+++ b/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
@@ -124,6 +124,30 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
             result.StartInfo.EnvironmentVariables[dotnetRoot].Should().Be(Path.GetDirectoryName(dotnet));
         }
 
+        [Fact]
+        public void ItShouldAcceptMultipleLoggers() {
+            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp();
+
+            var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
+
+            new BuildCommand(Log, testProjectDirectory)
+                .Execute()
+                .Should().Pass();
+
+            var outputDll = Path.Combine(testProjectDirectory, "bin", configuration, ToolsetInfo.CurrentTargetFramework, "VSTestTestRunParameters.dll");
+
+            // Call test
+            CommandResult result = new DotnetVSTestCommand(Log)
+                                        .Execute(new[] {
+                                            outputDll,
+                                            "--logger:console;verbosity=normal",
+                                            "--logger:trx"
+                                        });
+
+            // Verify
+            result.ExitCode.Should().Be(0);
+        }
+
         private string CopyAndRestoreVSTestDotNetCoreTestApp([CallerMemberName] string callingMethod = "")
         {
             // Copy VSTestCore project in output directory of project dotnet-vstest.Tests

--- a/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
+++ b/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
@@ -141,11 +141,18 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
                                         .Execute(new[] {
                                             outputDll,
                                             "--logger:console;verbosity=normal",
-                                            "--logger:trx"
+                                            "--logger:trx",
+                                            "--",
+                                            "TestRunParameters.Parameter(name=\"myParam\",",
+                                            "value=\"value\")",
+                                            "TestRunParameters.Parameter(name=\"myParam2\",",
+                                            "value=\"value",
+                                            "with",
+                                            "space\")"
                                         });
 
             // Verify
-            result.ExitCode.Should().Be(0);
+            result.ExitCode.Should().Be(0, $"Should have executed successfully, but got: {result.StdOut}");
         }
 
         private string CopyAndRestoreVSTestDotNetCoreTestApp([CallerMemberName] string callingMethod = "")

--- a/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
+++ b/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
@@ -125,7 +125,8 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
         }
 
         [Fact]
-        public void ItShouldAcceptMultipleLoggers() {
+        public void ItShouldAcceptMultipleLoggers()
+        {
             var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
@@ -167,7 +168,8 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
         }
 
         [Fact]
-        public void ItShouldAcceptNoLoggers() {
+        public void ItShouldAcceptNoLoggers()
+        {
             var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";

--- a/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
+++ b/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
@@ -192,14 +192,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
                                         });
 
             //Verify
-            // Verify
-            if (!TestContext.IsLocalized())
-            {
-                result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
-                result.StdOut.Should().Contain("Total tests: 1");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Passed VSTestTestRunParameters");
-            }
+            // since there are no loggers, all we have to go on it the exit code
             result.ExitCode.Should().Be(0, $"Should have executed successfully, but got: {result.StdOut}");
         }
 

--- a/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
+++ b/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
@@ -192,7 +192,14 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
                                         });
 
             //Verify
-            // since there are no loggers, all we have to go on it the exit code
+            // Verify
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
+                result.StdOut.Should().Contain("Total tests: 1");
+                result.StdOut.Should().Contain("Passed: 1");
+                result.StdOut.Should().Contain("Passed VSTestTestRunParameters");
+            }
             result.ExitCode.Should().Be(0, $"Should have executed successfully, but got: {result.StdOut}");
         }
 


### PR DESCRIPTION
## Description

Allows users to specify the `--logger` option multiple times to the `vstest` command, restoring parity with the 6.0.2xx version of this command. This was introduced more than a year ago, but due to encouraging folks to move to the `test` command instead (where this problem isn't apparent) it wasn't seen until now.

## Customer Impact

This was reported by a user in #30034, and impacts users that use multiple loggers, e.g. to to both report console results of tests, as well as get a `trx` file for coverage reports.

## Regression?
* [x] Yes, from the 6.0.2xx series of SDKs
* [ ] No

## Risk
* [ ] High
* [ ] Medium
* [x] Low

The change itself is well-understood and used in multiple other locations in the CLI, and many new automated tests were added to verify that multiple loggers are allowed by the vstest command.

## Verification

* [x] manual
* [x] automated tests

Closes https://github.com/dotnet/sdk/issues/30034
