### PR TITLE
Add tests for Nuget restore post action with the argument files

### DIFF
--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/.template.config/template.json
@@ -1,0 +1,30 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.PostActions.RestoreNuGet.Files_MatchSpecifiedFiles",
+    "generatorVersions": "[1.0.0.0-*)",
+    "groupIdentity": "TestAssets.PostActions.RestoreNuGet.Files_MatchSpecifiedFiles",
+    "precedence": "100",
+    "identity": "TestAssets.PostActions.RestoreNuGet.Files_MatchSpecifiedFiles",
+    "shortName": "TestAssets.PostActions.RestoreNuGet.Files_MatchSpecifiedFiles",
+    "sourceName": "Tool",
+    "primaryOutputs": [
+        { "path": "Tool/Tool.csproj" }
+    ],
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                { "text": "Run 'dotnet restore'" }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true,
+            "args": {
+                "files": [
+                    "./Tool.Library/Tool.Library.csproj",
+                    "./Tool.Test/Tool.Test.csproj"
+                ]
+            }
+        }
+    ]
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Library/Tool.Library.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Library/Tool.Library.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Library/Utils.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Library/Utils.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Tool.Library
+{
+    public class Utils
+    {
+        public static object Deserialize(string value)
+        {
+            return JsonConvert.DeserializeObject(value);
+        }
+
+        public static string Serialize(object value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Test/Tool.Test.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Test/Tool.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Test/UnitTest1.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Test/UnitTest1.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool.Test
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+            Assert.Contains(filed, result);
+            Assert.Contains(frequence, result);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Test/Usings.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool/Program.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool/Program.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool/Tool.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MatchSpecifiedFiles/Tool/Tool.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/.template.config/template.json
@@ -1,0 +1,28 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.PostActions.RestoreNuGet.Files_MismatchSpecifiedFiles",
+    "generatorVersions": "[1.0.0.0-*)",
+    "groupIdentity": "TestAssets.PostActions.RestoreNuGet.Files_MismatchSpecifiedFiles",
+    "precedence": "100",
+    "identity": "TestAssets.PostActions.RestoreNuGet.Files_MismatchSpecifiedFiles",
+    "shortName": "TestAssets.PostActions.RestoreNuGet.Files_MismatchSpecifiedFiles",
+    "sourceName": "Tool",
+    "primaryOutputs": [
+        { "path": "Tool.Library/Tool.Library.csproj" },
+        { "path": "Tool/Tool.csproj" }
+    ],
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                { "text": "Run 'dotnet restore'" }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true,
+            "args": {
+                "files": [ "Tool.Test/Tool.Test.csproj" ] // Relative source path starts with "./". This pattern should mismatch.
+            }
+        }
+    ]
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Library/Tool.Library.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Library/Tool.Library.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Library/Utils.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Library/Utils.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Tool.Library
+{
+    public class Utils
+    {
+        public static object Deserialize(string value)
+        {
+            return JsonConvert.DeserializeObject(value);
+        }
+
+        public static string Serialize(object value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Test/Tool.Test.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Test/Tool.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Test/UnitTest1.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Test/UnitTest1.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool.Test
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+            Assert.Contains(filed, result);
+            Assert.Contains(frequence, result);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Test/Usings.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool/Program.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool/Program.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool/Tool.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_MismatchSpecifiedFiles/Tool/Tool.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/.template.config/template.json
@@ -1,0 +1,30 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithFileName",
+    "generatorVersions": "[1.0.0.0-*)",
+    "groupIdentity": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithFileName",
+    "precedence": "100",
+    "identity": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithFileName",
+    "shortName": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithFileName",
+    "sourceName": "Tool",
+    "primaryOutputs": [
+        { "path": "Tool.Test/Tool.Test.csproj" }
+    ],
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                { "text": "Run 'dotnet restore'" }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true,
+            "args": {
+                "files": [
+                    "Tool.Lib*.csproj",
+                    "Tool.csproj"
+                ]
+            }
+        }
+    ]
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Library/Tool.Library.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Library/Tool.Library.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Library/Utils.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Library/Utils.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Tool.Library
+{
+    public class Utils
+    {
+        public static object Deserialize(string value)
+        {
+            return JsonConvert.DeserializeObject(value);
+        }
+
+        public static string Serialize(object value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Test/Tool.Test.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Test/Tool.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Test/UnitTest1.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Test/UnitTest1.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool.Test
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+            Assert.Contains(filed, result);
+            Assert.Contains(frequence, result);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Test/Usings.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool/Program.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool/Program.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool/Tool.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithFileName/Tool/Tool.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/.template.config/template.json
@@ -1,0 +1,28 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithGlobstar",
+    "generatorVersions": "[1.0.0.0-*)",
+    "groupIdentity": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithGlobstar",
+    "precedence": "100",
+    "identity": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithGlobstar",
+    "shortName": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithGlobstar",
+    "sourceName": "Tool",
+    "primaryOutputs": [
+        { "path": "Tool/Tool.csproj" },
+        { "path": "Tool.Test/Tool.Test.csproj" }
+    ],
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                { "text": "Run 'dotnet restore'" }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true,
+            "args": {
+                "files": [ "**/Tool.Library.csproj" ]
+            }
+        }
+    ]
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Library/Tool.Library.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Library/Tool.Library.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Library/Utils.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Library/Utils.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Tool.Library
+{
+    public class Utils
+    {
+        public static object Deserialize(string value)
+        {
+            return JsonConvert.DeserializeObject(value);
+        }
+
+        public static string Serialize(object value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Test/Tool.Test.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Test/Tool.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Test/UnitTest1.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Test/UnitTest1.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool.Test
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+            Assert.Contains(filed, result);
+            Assert.Contains(frequence, result);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Test/Usings.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool/Program.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool/Program.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool/Tool.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithGlobstar/Tool/Tool.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/.template.config/template.json
@@ -1,0 +1,27 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithWildcard",
+    "generatorVersions": "[1.0.0.0-*)",
+    "groupIdentity": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithWildcard",
+    "precedence": "100",
+    "identity": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithWildcard",
+    "shortName": "TestAssets.PostActions.RestoreNuGet.Files_PatternWithWildcard",
+    "sourceName": "Tool",
+    "primaryOutputs": [
+        { "path": "Tool/Tool.csproj" }
+    ],
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                { "text": "Run 'dotnet restore'" }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true,
+            "args": {
+                "files": [ "*/Tool.*/Tool.*.csproj" ]
+            }
+        }
+    ]
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Library/Tool.Library.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Library/Tool.Library.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Library/Utils.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Library/Utils.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Tool.Library
+{
+    public class Utils
+    {
+        public static object Deserialize(string value)
+        {
+            return JsonConvert.DeserializeObject(value);
+        }
+
+        public static string Serialize(object value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Test/Tool.Test.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Test/Tool.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Test/UnitTest1.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Test/UnitTest1.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool.Test
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+            Assert.Contains(filed, result);
+            Assert.Contains(frequence, result);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Test/Usings.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool/Program.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool/Program.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool/Tool.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_PatternWithWildcard/Tool/Tool.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/.template.config/template.json
@@ -1,0 +1,27 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "name": "TestAssets.PostActions.RestoreNuGet.Files_SupportSemicolonDelimitedList",
+    "generatorVersions": "[1.0.0.0-*)",
+    "groupIdentity": "TestAssets.PostActions.RestoreNuGet.Files_SupportSemicolonDelimitedList",
+    "precedence": "100",
+    "identity": "TestAssets.PostActions.RestoreNuGet.Files_SupportSemicolonDelimitedList",
+    "shortName": "TestAssets.PostActions.RestoreNuGet.Files_SupportSemicolonDelimitedList",
+    "sourceName": "Tool",
+    "primaryOutputs": [
+        { "path": "Tool.Test/Tool.Test.csproj" }
+    ],
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                { "text": "Run 'dotnet restore'" }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true,
+            "args": {
+                "files": "./Tool.Library/Tool.Library.csproj;./Tool/Tool.csproj"
+            }
+        }
+    ]
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Library/Tool.Library.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Library/Tool.Library.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Library/Utils.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Library/Utils.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Tool.Library
+{
+    public class Utils
+    {
+        public static object Deserialize(string value)
+        {
+            return JsonConvert.DeserializeObject(value);
+        }
+
+        public static string Serialize(object value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Test/Tool.Test.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Test/Tool.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Test/UnitTest1.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Test/UnitTest1.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool.Test
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+            Assert.Contains(filed, result);
+            Assert.Contains(frequence, result);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Test/Usings.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool/Program.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool/Program.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Tool.Library;
+
+namespace Tool
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+
+            string filed = "Schedule";
+            string frequence = "Daily";
+            string value = $"{{\"{filed}\": \"{frequence}\"}}";
+            var schedule = Utils.Deserialize(value);
+            var result = JsonConvert.SerializeObject(schedule);
+        }
+    }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool/Tool.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/PostActions/RestoreNuGet/Files_SupportSemicolonDelimitedList/Tool/Tool.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <ProjectReference Include="..\Tool.Library\Tool.Library.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/5922 - Nuget restore post action lacks tests on argument `files`.

### Solution
Add tests for the cases of argument `files`.