### PR TITLE
[GenAPI] Add DocIdSymbolFilter for doc-id API exclusion.

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.ApiCompat
 
                 if (excludeAttributesFiles != null)
                 {
-                    compositeSymbolFilter.Add(new DocIdExcludeListSymbolFilter(excludeAttributesFiles));
+                    compositeSymbolFilter.Add(new DocIdSymbolFilter(excludeAttributesFiles));
                 }
 
                 SymbolEqualityComparer symbolEqualityComparer = new();

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.ApiCompat
 
                 if (excludeAttributesFiles != null)
                 {
-                    compositeSymbolFilter.Add(new AttributeSymbolFilter(excludeAttributesFiles));
+                    compositeSymbolFilter.Add(new DocIdExcludeListSymbolFilter(excludeAttributesFiles));
                 }
 
                 SymbolEqualityComparer symbolEqualityComparer = new();

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
@@ -40,6 +40,11 @@ namespace Microsoft.DotNet.GenAPI.Task
         public string? ExceptionMessage { get; set; }
 
         /// <summary>
+        /// The path to one or more api exclusion files with types in DocId format.
+        /// </summary>
+        public string[]? ExcludeApiFiles { get; set; }
+
+        /// <summary>
         /// The path to one or more attribute exclusion files with types in DocId format.
         /// </summary>
         public string[]? ExcludeAttributesFiles { get; set; }
@@ -62,6 +67,7 @@ namespace Microsoft.DotNet.GenAPI.Task
                 OutputPath,
                 HeaderFile,
                 ExceptionMessage,
+                ExcludeApiFiles,
                 ExcludeAttributesFiles,
                 IncludeVisibleOutsideOfAssembly,
                 IncludeAssemblyAttributes

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -47,7 +47,7 @@
       OutputPath="$(GenAPITargetPath)"
       HeaderFile="$(GenAPIHeaderFile)"
       ExceptionMessage="$(GenAPIExceptionMessage)"
-      ExcludeApiFiles="$(GenAPIExcludeApiList)"
+      ExcludeApiFiles="@(GenAPIExcludeApiList)"
       ExcludeAttributesFiles="@(GenAPIExcludeAttributesList)"
       IncludeVisibleOutsideOfAssembly="$(GenAPIIncludeVisibleOutsideOfAssembly)"
       IncludeAssemblyAttributes="$(GenAPIIncludeAssemblyAttributes)" />

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -47,6 +47,7 @@
       OutputPath="$(GenAPITargetPath)"
       HeaderFile="$(GenAPIHeaderFile)"
       ExceptionMessage="$(GenAPIExceptionMessage)"
+      ExcludeApiFiles="$(GenAPIExcludeApiFiles)"
       ExcludeAttributesFiles="@(GenAPIExcludeAttributesList)"
       IncludeVisibleOutsideOfAssembly="$(GenAPIIncludeVisibleOutsideOfAssembly)"
       IncludeAssemblyAttributes="$(GenAPIIncludeAssemblyAttributes)" />

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -47,7 +47,7 @@
       OutputPath="$(GenAPITargetPath)"
       HeaderFile="$(GenAPIHeaderFile)"
       ExceptionMessage="$(GenAPIExceptionMessage)"
-      ExcludeApiFiles="$(GenAPIExcludeApiFiles)"
+      ExcludeApiFiles="$(GenAPIExcludeApiList)"
       ExcludeAttributesFiles="@(GenAPIExcludeAttributesList)"
       IncludeVisibleOutsideOfAssembly="$(GenAPIIncludeVisibleOutsideOfAssembly)"
       IncludeAssemblyAttributes="$(GenAPIIncludeAssemblyAttributes)" />

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
@@ -32,6 +32,13 @@ namespace Microsoft.DotNet.GenAPI.Tool
                 Arity = ArgumentArity.ZeroOrMore
             };
 
+            Option<string[]?> excludeApiFilesOption = new("--exclude-api-file",
+                description: "The path to one or more api exclusion files with types in DocId format.",
+                parseArgument: ParseAssemblyArgument)
+            {
+                Arity = ArgumentArity.ZeroOrMore
+            };
+
             Option<string[]?> excludeAttributesFilesOption = new("--exclude-attributes-file",
                 description: "The path to one or more attribute exclusion files with types in DocId format.",
                 parseArgument: ParseAssemblyArgument)
@@ -61,6 +68,7 @@ namespace Microsoft.DotNet.GenAPI.Tool
             };
             rootCommand.AddGlobalOption(assembliesOption);
             rootCommand.AddGlobalOption(assemblyReferencesOption);
+            rootCommand.AddGlobalOption(excludeApiFilesOption);
             rootCommand.AddGlobalOption(excludeAttributesFilesOption);
             rootCommand.AddGlobalOption(outputPathOption);
             rootCommand.AddGlobalOption(headerFileOption);
@@ -76,6 +84,7 @@ namespace Microsoft.DotNet.GenAPI.Tool
                     context.ParseResult.GetValue(outputPathOption),
                     context.ParseResult.GetValue(headerFileOption),
                     context.ParseResult.GetValue(exceptionMessageOption),
+                    context.ParseResult.GetValue(excludeApiFilesOption),
                     context.ParseResult.GetValue(excludeAttributesFilesOption),
                     context.ParseResult.GetValue(includeVisibleOutsideOfAssemblyOption),
                     context.ParseResult.GetValue(includeAssemblyAttributesOption)

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.GenAPI
                 string? outputPath,
                 string? headerFile,
                 string? exceptionMessage,
+                string[]? excludeApiFiles,
                 string[]? excludeAttributesFiles,
                 bool includeVisibleOutsideOfAssembly,
                 bool includeAssemblyAttributes)
@@ -35,6 +36,7 @@ namespace Microsoft.DotNet.GenAPI
                 OutputPath = outputPath;
                 HeaderFile = headerFile;
                 ExceptionMessage = exceptionMessage;
+                ExcludeApiFiles = excludeApiFiles;
                 ExcludeAttributesFiles = excludeAttributesFiles;
                 IncludeVisibleOutsideOfAssembly = includeVisibleOutsideOfAssembly;
                 IncludeAssemblyAttributes = includeAssemblyAttributes;
@@ -65,6 +67,11 @@ namespace Microsoft.DotNet.GenAPI
             /// Method bodies should throw PlatformNotSupportedException.
             /// </summary>
             public string? ExceptionMessage { get; }
+
+            /// <summary>
+            /// The path to one or more api exclusion files with types in DocId format.
+            /// </summary>
+            public string[]? ExcludeApiFiles { get; }
 
             /// <summary>
             /// The path to one or more attribute exclusion files with types in DocId format.
@@ -105,7 +112,12 @@ namespace Microsoft.DotNet.GenAPI
 
             if (context.ExcludeAttributesFiles != null)
             {
-                compositeSymbolFilter.Add(new AttributeSymbolFilter(context.ExcludeAttributesFiles));
+                compositeSymbolFilter.Add(new DocIdExcludeListSymbolFilter(context.ExcludeAttributesFiles));
+            }
+
+            if (context.ExcludeApiFiles != null)
+            {
+                compositeSymbolFilter.Add(new DocIdExcludeListSymbolFilter(context.ExcludeApiFiles));
             }
 
             IReadOnlyList<IAssemblySymbol?> assemblySymbols = loader.LoadAssemblies(context.Assemblies);

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -112,12 +112,12 @@ namespace Microsoft.DotNet.GenAPI
 
             if (context.ExcludeAttributesFiles != null)
             {
-                compositeSymbolFilter.Add(new DocIdExcludeListSymbolFilter(context.ExcludeAttributesFiles));
+                compositeSymbolFilter.Add(new DocIdSymbolFilter(context.ExcludeAttributesFiles));
             }
 
             if (context.ExcludeApiFiles != null)
             {
-                compositeSymbolFilter.Add(new DocIdExcludeListSymbolFilter(context.ExcludeApiFiles));
+                compositeSymbolFilter.Add(new DocIdSymbolFilter(context.ExcludeApiFiles));
             }
 
             IReadOnlyList<IAssemblySymbol?> assemblySymbols = loader.LoadAssemblies(context.Assemblies);

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.GenAPI
             {
                 if (eventSymbol.IsAbstract)
                 {
-                    // adds abstract keyword.
+                    // TODO: remove a work around solution after the Roslyn issue https://github.com/dotnet/roslyn/issues/66966 is fixed
                     EventFieldDeclarationSyntax eventDeclaration = (EventFieldDeclarationSyntax)syntaxGenerator.Declaration(symbol);
                     return eventDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
                 }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxNodeExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxNodeExtensions.cs
@@ -1,13 +1,34 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 
 namespace Microsoft.DotNet.GenAPI
 {
     internal static class SyntaxNodeExtensions
     {
-        public static SyntaxNode Rewrite(this SyntaxNode node, CodeAnalysis.CSharp.CSharpSyntaxRewriter rewriter) => rewriter.Visit(node);
+        public static SyntaxNode Rewrite(this SyntaxNode node, CSharpSyntaxRewriter rewriter) => rewriter.Visit(node);
+
+        public static SyntaxNode AddMemberAttributes(this SyntaxNode node, SyntaxGenerator syntaxGenerator, ISymbolFilter symbolFilter, ISymbol member)
+        {
+            foreach (AttributeData attribute in member.GetAttributes()
+                .Where(a => a.AttributeClass != null && symbolFilter.Include(a.AttributeClass)))
+            {
+                // The C# compiler emits the DefaultMemberAttribute on any type containing an indexer.
+                // In C# it is an error to manually attribute a type with the DefaultMemberAttribute if the type also declares an indexer.
+                if (member is INamedTypeSymbol typeMember && typeMember.HasIndexer() && attribute.IsDefaultMemberAttribute())
+                {
+                    continue;
+                }
+                node = syntaxGenerator.AddAttributes(node, syntaxGenerator.Attribute(attribute));
+
+            }
+            return node;
+        }
     }
 }

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdExcludeListSymbolFilter.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdExcludeListSymbolFilter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
@@ -8,31 +8,29 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
 {
     /// <summary>
-    /// Implements the logic of filtering out attribute symbols. Reads the file with the list of attributes in DocId format.
+    /// Implements the logic of filtering out api.
+    /// Reads the file with the list of attributes, types, members in DocId format.
     /// </summary>
-    public class AttributeSymbolFilter : ISymbolFilter
+    public class DocIdExcludeListSymbolFilter : ISymbolFilter
     {
-        private readonly HashSet<string> _attributesToExclude;
+        private readonly HashSet<string> _docIdsToExclude;
 
-        public AttributeSymbolFilter(string[] excludeAttributesFiles)
+        public DocIdExcludeListSymbolFilter(string[] docIdsToExcludeFiles)
         {
-            _attributesToExclude = new HashSet<string>(ReadDocIdsAttributes(excludeAttributesFiles));
+            _docIdsToExclude = new HashSet<string>(ReadDocIdsAttributes(docIdsToExcludeFiles));
         }
 
         /// <summary>
-        ///  Determines whether the attribute <see cref="ISymbol"/> should be included.
+        ///  Determines whether the <see cref="ISymbol"/> should be included.
         /// </summary>
         /// <param name="symbol"><see cref="ISymbol"/> to evaluate.</param>
         /// <returns>True to include the <paramref name="symbol"/> or false to filter it out.</returns>
         public bool Include(ISymbol symbol)
         {
-            if (symbol is INamedTypeSymbol namedType)
+            string? docId = symbol.GetDocumentationCommentId();
+            if (docId != null && _docIdsToExclude.Contains(docId))
             {
-                string? docId = namedType.GetDocumentationCommentId();
-                if (docId != null && _attributesToExclude.Contains(docId))
-                {
-                    return false;
-                }
+                return false;
             }
 
             return true;

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
@@ -11,11 +11,11 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
     /// Implements the logic of filtering out api.
     /// Reads the file with the list of attributes, types, members in DocId format.
     /// </summary>
-    public class DocIdExcludeListSymbolFilter : ISymbolFilter
+    public class DocIdSymbolFilter : ISymbolFilter
     {
         private readonly HashSet<string> _docIdsToExclude;
 
-        public DocIdExcludeListSymbolFilter(string[] docIdsToExcludeFiles)
+        public DocIdSymbolFilter(string[] docIdsToExcludeFiles)
         {
             _docIdsToExclude = new HashSet<string>(ReadDocIdsAttributes(docIdsToExcludeFiles));
         }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
          */
 
         private static ISymbolFilter GetAccessibilityAndAttributeSymbolFiltersAsComposite(params string[] excludeAttributeFiles) =>
-            new CompositeSymbolFilter().Add(new AccessibilitySymbolFilter(false)).Add(new AttributeSymbolFilter(excludeAttributeFiles));
+            new CompositeSymbolFilter().Add(new AccessibilitySymbolFilter(false)).Add(new DocIdExcludeListSymbolFilter(excludeAttributeFiles));
 
         public static TheoryData<string, string, CompatDifference[]> TypesCases => new()
         {

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
          */
 
         private static ISymbolFilter GetAccessibilityAndAttributeSymbolFiltersAsComposite(params string[] excludeAttributeFiles) =>
-            new CompositeSymbolFilter().Add(new AccessibilitySymbolFilter(false)).Add(new DocIdExcludeListSymbolFilter(excludeAttributeFiles));
+            new CompositeSymbolFilter().Add(new AccessibilitySymbolFilter(false)).Add(new DocIdSymbolFilter(excludeAttributeFiles));
 
         public static TheoryData<string, string, CompatDifference[]> TypesCases => new()
         {


### PR DESCRIPTION
* Filter out the `DefaultMember` attribute for inner types with indexer.
* Refactor the `AttributeSymbolFilter` class and rename to a more generic name `DocIdSymbolFilter`

Fixes: https://github.com/dotnet/arcade/issues/12657