### PR TITLE
Replace File.Move with copy/delete

### DIFF
--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -196,7 +196,11 @@ namespace Microsoft.DotNet.Installer.Windows
             if (!File.Exists(destinationFile))
             {
                 // See https://github.com/dotnet/sdk/issues/28450
-                FileAccessRetrier.RetryOnMoveAccessFailure(() => File.Move(sourceFile, destinationFile));
+                // Moving a file copies the ACE of the original owner and will not inherit the complete DACL from
+                // the containing directory. For example, the ACEs for Everyone and Built-in Users can be dropped
+                // while the original user retains full access.
+                FileAccessRetrier.RetryOnMoveAccessFailure(() => File.Copy(sourceFile, destinationFile));
+                FileAccessRetrier.RetryOnMoveAccessFailure(() => File.Delete(sourceFile));
                 Log?.LogMessage($"Moved '{sourceFile}' to '{destinationFile}'");
 
                 FileInfo fi = new(destinationFile);


### PR DESCRIPTION
`File.Move` does not retain the inherited ACEs while an explicit `Copy` does, so we manually move the file using a separate copy & delete instead.