### PR TITLE
Fix GenAPI invocation with IncludeAssemblyAttributes

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.GenAPI.Task
         /// <summary>
         /// Includes assembly attributes which are values that provide information about an assembly.
         /// </summary>
-        public bool IncludeAssemblyAttributes { get; }
+        public bool IncludeAssemblyAttributes { get; set; }
 
         protected override void ExecuteCore()
         {


### PR DESCRIPTION
The setter was missing and caused the following error:

error MSB4026: The "IncludeAssemblyAttributes=$(GenAPIIncludeAssemblyAttributes)" parameter for the "Microsoft.DotNet.GenAPI.Task.GenAPITask" task is invalid.