### PR TITLE
Produce reference assembly when target is .NET Standard

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -240,6 +240,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
+    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' and '$(TargetFrameworkIdentifier)' == '.NETStandard' and ('$(ProduceOnlyReferenceAssembly)' != 'true') and '$(MSBuildProjectExtension)' != '.fsproj'" >true</ProduceReferenceAssembly>
     <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and ('$(ProduceOnlyReferenceAssembly)' != 'true') and '$(MSBuildProjectExtension)' != '.fsproj'" >true</ProduceReferenceAssembly>
     <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 7.0)) and ('$(ProduceOnlyReferenceAssembly)' != 'true') and '$(MSBuildProjectExtension)' == '.fsproj'" >true</ProduceReferenceAssembly>
   </PropertyGroup>


### PR DESCRIPTION
In general we want to produce reference assemblies whenever possible, as they improve incremental build performance.

Making them work end-to-end requires support from other components, such as the fast up-to-date check in VS. While support was originally added for SDK-style projects, it was not present for legacy `.csproj` files. Accordingly, `ProduceReferenceAssemblies` was set `true` only when the target framework was `net5.0` or later (and `net7.0` for F#).

VS 17.5 ships the new Build Acceleration feature, which works best when used in conjunction with reference assemblies. A customer reported in https://github.com/dotnet/project-system/issues/8865 that builds in their .NET Standard projects were not accelerated. Investigation shows this is because reference assemblies are not produced for such projects.

This change enables the production of reference assemblies for all (non-F#) projects targeting .NET Standard.