### PR TITLE
Fix passing --interactive flag to nuget

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SharedOptions.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SharedOptions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         public static Option<FileInfo> ProjectPathOption { get; } = new Option<FileInfo>("--project", SymbolStrings.Option_ProjectPath).AcceptExistingOnly();
 
+        public static Option<bool> InteractiveOption { get; } = SharedOptionsFactory.CreateInteractiveOption();
+
         internal static Option<bool> ForceOption { get; } = SharedOptionsFactory.CreateForceOption();
 
         internal static Option<string> NameOption { get; } = new Option<string>(new string[] { "-n", "--name" })

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         internal static Option<bool> ForceOption { get; } = SharedOptionsFactory.CreateForceOption().WithDescription(SymbolStrings.Option_Install_Force);
 
-        internal virtual Option<bool> InteractiveOption { get; } = SharedOptionsFactory.CreateInteractiveOption();
+        internal virtual Option<bool> InteractiveOption { get; } = SharedOptions.InteractiveOption;
 
         internal virtual Option<string[]> AddSourceOption { get; } = SharedOptionsFactory.CreateAddSourceOption();
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -3,6 +3,7 @@
 //
 
 using System.CommandLine;
+using System.Diagnostics;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Constraints;
@@ -358,6 +359,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         private static void InitializeNuGetCredentialService(bool interactive)
         {
+            Debugger.Launch();
             try
             {
                 DefaultCredentialServiceUtility.SetupDefaultCredentialService(new CliNuGetLogger(), !interactive);

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -3,7 +3,6 @@
 //
 
 using System.CommandLine;
-using System.Diagnostics;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Constraints;
@@ -359,7 +358,6 @@ namespace Microsoft.TemplateEngine.Cli
 
         private static void InitializeNuGetCredentialService(bool interactive)
         {
-            Debugger.Launch();
             try
             {
                 DefaultCredentialServiceUtility.SetupDefaultCredentialService(new CliNuGetLogger(), !interactive);

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -46,7 +46,8 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
         private bool _verifySignatures;
 
-        public NuGetPackageDownloader(DirectoryPath packageInstallDir,
+        public NuGetPackageDownloader(
+            DirectoryPath packageInstallDir,
             IFilePermissionSetter filePermissionSetter = null,
             IFirstPartyNuGetPackageSigningVerifier firstPartyNuGetPackageSigningVerifier = null,
             ILogger verboseLogger = null,

--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.Cli
             }
 
             builtIns.Add((typeof(IWorkloadsInfoProvider), new WorkloadsInfoProvider(
-                    new Lazy<IWorkloadsRepositoryEnumerator>(() => new WorkloadInfoHelper(parseResult))))
+                    new Lazy<IWorkloadsRepositoryEnumerator>(() => new WorkloadInfoHelper(parseResult.HasOption(SharedOptions.InteractiveOption)))))
             );
             builtIns.Add((typeof(ISdkInfoProvider), new SdkInfoProvider()));
 

--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
@@ -119,11 +119,17 @@ namespace Microsoft.DotNet.Cli
                     verbosity = userSetVerbosity;
                 }
                 Reporter.Reset();
-                return CreateHost(disableSdkTemplates, disableProjectContext, projectPath, outputPath, verbosity.ToLogLevel());
+                return CreateHost(disableSdkTemplates, disableProjectContext, projectPath, outputPath, parseResult, verbosity.ToLogLevel());
             }
         }
 
-        private static CliTemplateEngineHost CreateHost(bool disableSdkTemplates, bool disableProjectContext, FileInfo? projectPath, FileInfo? outputPath, LogLevel logLevel)
+        private static CliTemplateEngineHost CreateHost(
+            bool disableSdkTemplates,
+            bool disableProjectContext,
+            FileInfo? projectPath,
+            FileInfo? outputPath,
+            ParseResult parseResult,
+            LogLevel logLevel)
         {
             var builtIns = new List<(Type InterfaceType, IIdentifiedComponent Instance)>();
             builtIns.AddRange(Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Components.AllComponents);
@@ -151,7 +157,7 @@ namespace Microsoft.DotNet.Cli
             }
 
             builtIns.Add((typeof(IWorkloadsInfoProvider), new WorkloadsInfoProvider(
-                    new Lazy<IWorkloadsRepositoryEnumerator>(() => new WorkloadInfoHelper())))
+                    new Lazy<IWorkloadsRepositoryEnumerator>(() => new WorkloadInfoHelper(parseResult))))
             );
             builtIns.Add((typeof(ISdkInfoProvider), new SdkInfoProvider()));
 

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
@@ -81,7 +81,8 @@ namespace Microsoft.DotNet.Workloads.Workload
         /// <param name="tempDirPath">The directory to use for volatile output. If no value is specified, the commandline
         /// option is used if present, otherwise the default temp directory used.</param>
         /// <param name="nugetPackageDownloader">The package downloader to use for acquiring NuGet packages.</param>
-        public WorkloadCommandBase(ParseResult parseResult,
+        public WorkloadCommandBase(
+            ParseResult parseResult,
             Option<VerbosityOptions> verbosityOptions = null,
             IReporter reporter = null,
             string tempDirPath = null,

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -28,9 +28,9 @@ namespace Microsoft.DotNet.Cli
             return Command;
         }
 
-        internal static void ShowWorkloadsInfo(IWorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null)
+        internal static void ShowWorkloadsInfo(ParseResult parseResult, IWorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null)
         {
-            workloadInfoHelper ??= new WorkloadInfoHelper();
+            workloadInfoHelper ??= new WorkloadInfoHelper(parseResult);
             IEnumerable<WorkloadId> installedList = workloadInfoHelper.InstalledSdkWorkloadIds;
             InstalledWorkloadsCollection installedWorkloads = workloadInfoHelper.AddInstalledVsWorkloads(installedList);
             reporter ??= Cli.Utils.Reporter.Output;
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli
         {
             if (parseResult.HasOption(InfoOption) && parseResult.RootSubCommandResult() == "workload")
             {
-                ShowWorkloadsInfo();
+                ShowWorkloadsInfo(parseResult);
                 return 0;
             }
             return parseResult.HandleMissingCommand();

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.List;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.TemplateEngine.Cli.Commands;
 using CommonStrings = Microsoft.DotNet.Workloads.Workload.LocalizableStrings;
 using IReporter = Microsoft.DotNet.Cli.Utils.IReporter;
 
@@ -30,7 +31,7 @@ namespace Microsoft.DotNet.Cli
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult, IWorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null)
         {
-            workloadInfoHelper ??= new WorkloadInfoHelper(parseResult);
+            workloadInfoHelper ??= new WorkloadInfoHelper(parseResult.HasOption(SharedOptions.InteractiveOption));
             IEnumerable<WorkloadId> installedList = workloadInfoHelper.InstalledSdkWorkloadIds;
             InstalledWorkloadsCollection installedWorkloads = workloadInfoHelper.AddInstalledVsWorkloads(installedList);
             reporter ??= Cli.Utils.Reporter.Output;

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
@@ -12,7 +12,6 @@ using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
-using Microsoft.TemplateEngine.Cli.Commands;
 using Product = Microsoft.DotNet.Cli.Utils.Product;
 
 namespace Microsoft.DotNet.Workloads.Workload.List

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.Workloads.Workload.Install;
@@ -21,6 +22,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         private readonly string _targetSdkVersion;
 
         public WorkloadInfoHelper(
+            ParseResult parseResult,
             VerbosityOptions verbosity = VerbosityOptions.normal,
             string targetSdkVersion = null,
             bool? verifySignatures = null,
@@ -29,8 +31,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
             string currentSdkVersion = null,
             string dotnetDir = null,
             string userProfileDir = null,
-            IWorkloadResolver workloadResolver = null
-        )
+            IWorkloadResolver workloadResolver = null)
         {
             string dotnetPath = dotnetDir ?? Path.GetDirectoryName(Environment.ProcessPath);
             ReleaseVersion currentSdkReleaseVersion = new(currentSdkVersion ?? Product.Version);
@@ -38,20 +39,27 @@ namespace Microsoft.DotNet.Workloads.Workload.List
 
             _targetSdkVersion = targetSdkVersion;
             userProfileDir ??= CliFolderPathCalculator.DotnetUserProfileFolderPath;
-            var workloadManifestProvider =
-                new SdkDirectoryWorkloadManifestProvider(dotnetPath,
-                    string.IsNullOrWhiteSpace(_targetSdkVersion)
-                        ? currentSdkReleaseVersion.ToString()
-                        : _targetSdkVersion,
-                    userProfileDir);
+            var workloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(
+                dotnetPath,
+                string.IsNullOrWhiteSpace(_targetSdkVersion)
+                    ? currentSdkReleaseVersion.ToString()
+                    : _targetSdkVersion,
+                userProfileDir);
             WorkloadResolver = workloadResolver ?? NET.Sdk.WorkloadManifestReader.WorkloadResolver.Create(
                 workloadManifestProvider, dotnetPath,
                 currentSdkReleaseVersion.ToString(), userProfileDir);
 
-            Installer = WorkloadInstallerFactory.GetWorkloadInstaller(reporter, _currentSdkFeatureBand,
-                                     WorkloadResolver, verbosity, userProfileDir,
-                                     verifySignatures ?? !SignCheck.IsDotNetSigned(),
-                                     elevationRequired: false);
+            var restoreConfig = new RestoreActionConfig(Interactive: parseResult.HasOption(CommonOptions.InteractiveOption));
+
+            Installer = WorkloadInstallerFactory.GetWorkloadInstaller(
+                reporter,
+                _currentSdkFeatureBand,
+                WorkloadResolver,
+                verbosity,
+                userProfileDir,
+                verifySignatures ?? !SignCheck.IsDotNetSigned(),
+                restoreActionConfig: restoreConfig,
+                elevationRequired: false);
 
             WorkloadRecordRepo = workloadRecordRepo ?? Installer.GetWorkloadInstallationRecordRepository();
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.TemplateEngine.Cli.Commands;
 using Product = Microsoft.DotNet.Cli.Utils.Product;
 
 namespace Microsoft.DotNet.Workloads.Workload.List
@@ -49,7 +50,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 workloadManifestProvider, dotnetPath,
                 currentSdkReleaseVersion.ToString(), userProfileDir);
 
-            var restoreConfig = new RestoreActionConfig(Interactive: parseResult.HasOption(CommonOptions.InteractiveOption));
+            var restoreConfig = new RestoreActionConfig(Interactive: parseResult.HasOption(SharedOptions.InteractiveOption));
 
             Installer = WorkloadInstallerFactory.GetWorkloadInstaller(
                 reporter,

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         private readonly string _targetSdkVersion;
 
         public WorkloadInfoHelper(
-            ParseResult parseResult,
+            bool isInteractive,
             VerbosityOptions verbosity = VerbosityOptions.normal,
             string targetSdkVersion = null,
             bool? verifySignatures = null,
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 workloadManifestProvider, dotnetPath,
                 currentSdkReleaseVersion.ToString(), userProfileDir);
 
-            var restoreConfig = new RestoreActionConfig(Interactive: parseResult.HasOption(SharedOptions.InteractiveOption));
+            var restoreConfig = new RestoreActionConfig(Interactive: isInteractive);
 
             Installer = WorkloadInstallerFactory.GetWorkloadInstaller(
                 reporter,

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallerFactory.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallerFactory.cs
@@ -49,7 +49,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             userProfileDir ??= CliFolderPathCalculator.DotnetUserProfileFolderPath;
 
-            return new FileBasedInstaller(reporter,
+            return new FileBasedInstaller(
+                reporter,
                 sdkFeatureBand,
                 workloadResolver,
                 userProfileDir,

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.TemplateEngine.Cli.Commands;
 using InformationStrings = Microsoft.DotNet.Workloads.Workload.LocalizableStrings;
 
 namespace Microsoft.DotNet.Workloads.Workload.List
@@ -39,7 +40,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         ) : base(parseResult, CommonOptions.HiddenVerbosityOption, reporter, tempDirPath, nugetPackageDownloader)
         {
             _workloadListHelper = new WorkloadInfoHelper(
-                parseResult,
+                parseResult.HasOption(SharedOptions.InteractiveOption),
                 Verbosity,
                 parseResult?.GetValue(WorkloadListCommandParser.VersionOption) ?? null,
                 VerifySignatures,

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         private readonly IWorkloadInfoHelper _workloadListHelper;
 
         public WorkloadListCommand(
-            ParseResult result,
+            ParseResult parseResult,
             IReporter reporter = null,
             IWorkloadInstallationRecordRepository workloadRecordRepo = null,
             string currentSdkVersion = null,
@@ -36,11 +36,12 @@ namespace Microsoft.DotNet.Workloads.Workload.List
             INuGetPackageDownloader nugetPackageDownloader = null,
             IWorkloadManifestUpdater workloadManifestUpdater = null,
             IWorkloadResolver workloadResolver = null
-        ) : base(result, CommonOptions.HiddenVerbosityOption, reporter, tempDirPath, nugetPackageDownloader)
+        ) : base(parseResult, CommonOptions.HiddenVerbosityOption, reporter, tempDirPath, nugetPackageDownloader)
         {
             _workloadListHelper = new WorkloadInfoHelper(
+                parseResult,
                 Verbosity,
-                result?.GetValue(WorkloadListCommandParser.VersionOption) ?? null,
+                parseResult?.GetValue(WorkloadListCommandParser.VersionOption) ?? null,
                 VerifySignatures,
                 Reporter,
                 workloadRecordRepo,
@@ -50,9 +51,9 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 workloadResolver
             );
 
-            _machineReadableOption = result.GetValue(WorkloadListCommandParser.MachineReadableOption);
+            _machineReadableOption = parseResult.GetValue(WorkloadListCommandParser.MachineReadableOption);
 
-            _includePreviews = result.GetValue(WorkloadListCommandParser.IncludePreviewsOption);
+            _includePreviews = parseResult.GetValue(WorkloadListCommandParser.IncludePreviewsOption);
             string userProfileDir1 = userProfileDir ?? CliFolderPathCalculator.DotnetUserProfileFolderPath;
 
             _workloadManifestUpdater = workloadManifestUpdater ?? new WorkloadManifestUpdater(Reporter,

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -186,7 +186,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var workloadResolver = WorkloadResolver.CreateForTests(new MockManifestProvider(new[] { _manifestPath }), dotnetRoot);
             var parseResult = Parser.Instance.Parse(new string[] { "dotnet", "workload", "install", "xamarin-android"});
 
-            IWorkloadInfoHelper workloadInfoHelper = new WorkloadInfoHelper(parseResult, workloadResolver: workloadResolver);
+            IWorkloadInfoHelper workloadInfoHelper = new WorkloadInfoHelper(isInteractive: false, workloadResolver: workloadResolver);
             WorkloadCommandParser.ShowWorkloadsInfo(parseResult, workloadInfoHelper: workloadInfoHelper, reporter:_reporter);
             _reporter.Lines.Should().Contain("There are no installed workloads to display.");
         }

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -186,8 +186,8 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var workloadResolver = WorkloadResolver.CreateForTests(new MockManifestProvider(new[] { _manifestPath }), dotnetRoot);
             var parseResult = Parser.Instance.Parse(new string[] { "dotnet", "workload", "install", "xamarin-android"});
 
-            IWorkloadInfoHelper workloadInfoHelper = new WorkloadInfoHelper(workloadResolver: workloadResolver);
-            WorkloadCommandParser.ShowWorkloadsInfo(workloadInfoHelper: workloadInfoHelper, reporter:_reporter);
+            IWorkloadInfoHelper workloadInfoHelper = new WorkloadInfoHelper(parseResult, workloadResolver: workloadResolver);
+            WorkloadCommandParser.ShowWorkloadsInfo(parseResult, workloadInfoHelper: workloadInfoHelper, reporter:_reporter);
             _reporter.Lines.Should().Contain("There are no installed workloads to display.");
         }
 

--- a/src/Tests/dotnet.Tests/dotnet-new/WorkloadsInfoProviderTests.cs
+++ b/src/Tests/dotnet.Tests/dotnet-new/WorkloadsInfoProviderTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
 
             var parseResult = Parser.Instance.Parse(new string[] { "dotnet" });
             IWorkloadsRepositoryEnumerator workloadsEnumerator = new WorkloadInfoHelper(
-                parseResult,
+                isInteractive: false,
                 currentSdkVersion: "1.2.3",
                 workloadRecordRepo: repoMock.Object,
                 workloadResolver: resolverMock.Object);

--- a/src/Tests/dotnet.Tests/dotnet-new/WorkloadsInfoProviderTests.cs
+++ b/src/Tests/dotnet.Tests/dotnet-new/WorkloadsInfoProviderTests.cs
@@ -41,7 +41,9 @@ namespace Microsoft.DotNet.Cli.New.Tests
                 .Returns((IEnumerable<WorkloadId> workloadIds) => workloadIds.Select(w =>
                     new WorkloadResolver.WorkloadInfo(w, $"Description: {w.ToString()}")));
 
+            var parseResult = Parser.Instance.Parse(new string[] { "dotnet" });
             IWorkloadsRepositoryEnumerator workloadsEnumerator = new WorkloadInfoHelper(
+                parseResult,
                 currentSdkVersion: "1.2.3",
                 workloadRecordRepo: repoMock.Object,
                 workloadResolver: resolverMock.Object);


### PR DESCRIPTION
## Problem
Fixes https://github.com/dotnet/templating/issues/6020

## Solution
After major refactoring between net 6 and net 7 the logic of NuGetPackageDownloader instantiation,  passing `--interactive` flag was missed for the install command.


