### PR TITLE
[Breaking Backport] Fix Encoding On Non EN Languages

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -11,6 +13,7 @@ namespace Microsoft.DotNet.Cli.Utils
         internal const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
         private const string VSLANG = nameof(VSLANG);
         private const string PreferredUILang = nameof(PreferredUILang);
+        private static Encoding DefaultMultilingualEncoding = Encoding.UTF8; // We choose UTF8 as the default encoding as opposed to specific language encodings because it supports emojis & other chars in .NET.
 
         public static void Setup()
         {
@@ -20,11 +23,23 @@ namespace Microsoft.DotNet.Cli.Utils
                 ApplyOverrideToCurrentProcess(language);
                 FlowOverrideToChildProcesses(language);
             }
+
+            if (
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && // Encoding is only an issue on Windows
+                !CultureInfo.CurrentUICulture.TwoLetterISOLanguageName.Equals("en", StringComparison.InvariantCultureIgnoreCase) &&
+                Environment.OSVersion.Version.Major >= 10 // UTF-8 is only officially supported on 10+.
+                )
+            {
+                Console.OutputEncoding = DefaultMultilingualEncoding;
+                Console.InputEncoding = DefaultMultilingualEncoding; // Setting both encodings causes a change in the CHCP, making it so we dont need to P-Invoke ourselves.
+                // If the InputEncoding is not set, the encoding will work in CMD but not in Powershell, as the raw CHCP page won't be changed.
+            }
         }
 
         private static void ApplyOverrideToCurrentProcess(CultureInfo language)
         {
             CultureInfo.DefaultThreadCurrentUICulture = language;
+            // We don't need to change CurrentUICulture, as it will be changed by DefaultThreadCurrentUICulture on NET Core (but not Framework) apps. 
         }
 
         private static void FlowOverrideToChildProcesses(CultureInfo language)
@@ -35,6 +50,11 @@ namespace Microsoft.DotNet.Cli.Utils
             SetIfNotAlreadySet(PreferredUILang, language.Name); // for C#/VB targets that pass $(PreferredUILang) to compiler
         }
 
+        /// <summary>
+        /// Look first at UI Language Overrides. (DOTNET_CLI_UI_LANGUAGE and VSLANG). Does NOT check System Locale or OS Display Language.
+        /// </summary>
+        /// <returns>The custom language that was set by the user.
+        /// DOTNET_CLI_UI_LANGUAGE > VSLANG. Returns null if none are set.</returns>
         private static CultureInfo GetOverriddenUILanguage()
         {
             // DOTNET_CLI_UI_LANGUAGE=<culture name> is the main way for users to customize the CLI's UI language.


### PR DESCRIPTION
## Description:
Backport of: https://github.com/dotnet/sdk/pull/29755

## Customer Impact

Using the `DOTNET_CLI_UI_LANGUAGE` environment variable in languages such as German, Japanese, Russian, and more, will actually work properly, as the CLI will be able to display characters in the correct encoding. Before as shown in the above PR it would show garbage characters.

This is a breaking change because, while the fix is only applied to windows 10+, previews or older bits of windows 10 may not fully support UTF 8. Customers may have relied on console output to not be in the UTF 8 encoding. In addition, there is/was an existing bug where the SDK leaves its encoding behind and can affect the encoding of other commands/programs called in the same command prompt after it's finished execution. (https://github.com/dotnet/sdk/issues/30170).

Because of this, we should likely take the change only in 7.0.300 and not in 7.0.200. It is already in preview 1 of 8.0.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [X] Medium
- [ ] Low

## Verification

- [x] Manual (required)
- [ ] Automated