### PR TITLE
[7.0.2xx Servicing] Fix Property Parsing in `publish` and `pack`

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildPropertyParser.cs
@@ -10,6 +10,10 @@ using System.Text;
 
 namespace Microsoft.DotNet.Cli.Utils;
 
+/// <summary>
+/// Parses property key value pairs that have already been forwarded through the PropertiesOption class.
+/// Does not parse -p and etc. formats, (this is done by PropertiesOption) but does parse property values separated by =, ;, and using quotes.
+/// </summary>
 public static class MSBuildPropertyParser {
     public static IEnumerable<(string key, string value)> ParseProperties(string input) {
         var currentPos = 0;

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -188,13 +188,15 @@ namespace Microsoft.DotNet.Cli
         private Dictionary<string, string> GetGlobalPropertiesFromUserArgs(ParseResult parseResult)
         {
             Dictionary<string, string> globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
             string[] globalPropEnumerable = parseResult.GetValueForOption(CommonOptions.PropertiesOption);
 
-            foreach (var keyEqVal in globalPropEnumerable)
+            foreach (var keyEqValString in globalPropEnumerable)
             {
-                string[] keyValuePair = keyEqVal.Split("=", 2);
-                globalProperties[keyValuePair[0]] = keyValuePair[1];
+                var propertyPairs = MSBuildPropertyParser.ParseProperties(keyEqValString);
+                foreach (var propertyKeyValue in propertyPairs)
+                {
+                    globalProperties[propertyKeyValue.key] = propertyKeyValue.value;
+                }
             }
             return globalProperties;
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -688,6 +689,8 @@ public static class Program
         [InlineData("-property:Configuration=Debug")]
         [InlineData("--property:Configuration=Debug")]
         [InlineData("/p:Configuration=Debug")]
+        [InlineData("-p:_IsPublishing=true;Configuration=Debug")]
+        [InlineData("-p:_IsPublishing=true;Configuration=Debug;")]
         [InlineData("/property:Configuration=Debug")]
         public void PublishRelease_does_not_override_Configuration_property_across_formats(string configOpt)
         {
@@ -718,6 +721,34 @@ public static class Program
             Assert.True(File.Exists(expectedAssetPath));
             var releaseAssetPath = System.IO.Path.Combine(helloWorldAsset.Path, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "HelloWorld.dll");
             Assert.False(File.Exists(releaseAssetPath)); // build will produce a debug asset, need to make sure this doesn't exist either.
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("=")]
+        public void PublishRelease_does_recognize_undefined_property(string propertySuffix)
+        {
+            string tfm = ToolsetInfo.CurrentTargetFramework;
+            var testProject = new TestProject()
+            {
+                IsExe = true,
+                TargetFrameworks = tfm
+            };
+
+            testProject.RecordProperties("SelfContained");
+            testProject.RecordProperties("PublishAot");
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            new DotnetPublishCommand(Log)
+                .WithWorkingDirectory(Path.Combine(testAsset.TestRoot, MethodBase.GetCurrentMethod().Name))
+                .Execute(("-p:SelfContained" + propertySuffix))
+                .Should()
+                .Pass();
+
+            var properties = testProject.GetPropertyValues(testAsset.TestRoot, configuration: "Release", targetFramework: tfm);
+
+            Assert.Equal("", properties["SelfContained"]);
+            Assert.Equal("", properties["PublishAot"]);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -745,7 +745,7 @@ public static class Program
                 .Should()
                 .Pass();
 
-            var properties = testProject.GetPropertyValues(testAsset.TestRoot, configuration: "Release", targetFramework: tfm);
+            var properties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework: tfm);
 
             Assert.Equal("", properties["SelfContained"]);
             Assert.Equal("", properties["PublishAot"]);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -695,7 +695,7 @@ public static class Program
         public void PublishRelease_does_not_override_Configuration_property_across_formats(string configOpt)
         {
             var helloWorldAsset = _testAssetsManager
-               .CopyTestAsset("HelloWorld", $"PublishReleaseHelloWorldCsProjConfigPropOverride{configOpt}")
+               .CopyTestAsset("HelloWorld", identifier: configOpt)
                .WithSource()
                .WithTargetFramework(ToolsetInfo.CurrentTargetFramework)
                .WithProjectChanges(project =>
@@ -705,21 +705,14 @@ public static class Program
                    propertyGroup.Add(new XElement(ns + "PublishRelease", "true"));
                });
 
-            new BuildCommand(helloWorldAsset)
-           .Execute(configOpt)
-           .Should()
-           .Pass();
+            new DotnetPublishCommand(Log, helloWorldAsset.TestRoot)
+               .Execute(configOpt)
+               .Should()
+               .Pass().And.NotHaveStdErr();
 
-            var publishCommand = new DotnetPublishCommand(Log, helloWorldAsset.TestRoot);
-
-            publishCommand
-            .Execute(configOpt)
-            .Should()
-            .Pass().And.NotHaveStdErr();
-
-            var expectedAssetPath = System.IO.Path.Combine(helloWorldAsset.Path, "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "HelloWorld.dll");
+            var expectedAssetPath = Path.Combine(helloWorldAsset.Path, "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "HelloWorld.dll");
             Assert.True(File.Exists(expectedAssetPath));
-            var releaseAssetPath = System.IO.Path.Combine(helloWorldAsset.Path, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "HelloWorld.dll");
+            var releaseAssetPath = Path.Combine(helloWorldAsset.Path, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "HelloWorld.dll");
             Assert.False(File.Exists(releaseAssetPath)); // build will produce a debug asset, need to make sure this doesn't exist either.
         }
 


### PR DESCRIPTION
## Description:
Backport of part of: https://github.com/dotnet/sdk/pull/30265.
Will let this flow into 7.0.3xx automagically.

## Customer Impact

Using the undefine property syntax `dotnet publish --property:Foo`, properties delimited by ;, like `dotnet publish -p:'Foo;Bar=Baz'`, or invalid properties such as `dotnet publish --property:Foo=` without a value will now either work (successfully undefine the property with the `--property:Foo` syntax) or fail elegantly and ignore. In 6.0 this would be OK or elegantly fail, in 7.0 we added a change (https://github.com/dotnet/sdk/pull/25991) which broke this old behavior `pack` and `publish`. (Example of a customer reporting this: https://github.com/dotnet/sdk/issues/30758). In Net 7.0, customers would see a KeyValueError when incorrect syntax is used, and the undefine property syntax would not work for `pack` and `publish`.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [X] Medium
- [ ] Low

## Verification

- [x] Manual (required)
- [X] Automated  (see added tests.)