### PR TITLE
Remove scrubbing the warning for furhter observation

### DIFF
--- a/src/Tests/dotnet-new.Tests/DotnetClassTemplateTests.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetClassTemplateTests.cs
@@ -90,10 +90,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                    if (path.Replace(Path.DirectorySeparatorChar, '/') == "std-streams/stdout.txt")
                    {
                        content
-                       .UnixifyNewlines()
-                       .ScrubAndReplace(
-                           "Warning: Failed to evaluate bind symbol \'langVersion\', it will be skipped.",
-                           string.Empty);
+                       .UnixifyNewlines();
 
                        content.ScrubAndReplace("\n", string.Empty);
                    }
@@ -163,10 +160,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                    if (path.Replace(Path.DirectorySeparatorChar, '/') == "std-streams/stdout.txt")
                    {
                        content
-                       .UnixifyNewlines()
-                       .ScrubAndReplace(
-                           "Warning: Failed to evaluate bind symbol \'langVersion\', it will be skipped.",
-                           string.Empty);
+                       .UnixifyNewlines();
 
                        content.ScrubAndReplace("\n", string.Empty);
                    }


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/6781

### Solution
It's not able to reproduce the problem after running tests many times locally or in the pipeline https://github.com/dotnet/sdk/pull/30732.
I think we can do further observation by removing scrubbing the warning and catch potential issue.