### PR TITLE
GenAPI: Filter out generic base interfaces if type argument/s are filtered out.

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Simplification;
@@ -144,7 +145,9 @@ namespace Microsoft.DotNet.GenAPI
                 // If the method is ExplicitInterfaceImplementation and is derived from an interface that was filtered out, we must filter out it either.
                 if (member is IMethodSymbol method &&
                     method.MethodKind == MethodKind.ExplicitInterfaceImplementation &&
-                    method.ExplicitInterfaceImplementations.Any(m => !_symbolFilter.Include(m.ContainingSymbol)))
+                    method.ExplicitInterfaceImplementations.Any(m => !_symbolFilter.Include(m.ContainingSymbol) ||
+                        // if explicit interface implementation method has inaccessible type argument
+                        m.ContainingType.HasInaccessibleTypeArgument(_symbolFilter)))
                 {
                     continue;
                 }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 
 namespace Microsoft.DotNet.GenAPI
@@ -165,6 +164,15 @@ namespace Microsoft.DotNet.GenAPI
 
             return true;
         }
+
+        /// <summary>
+        /// Detects if a generic type contains inaccessible type arguments.
+        /// </summary>
+        /// <param name="namedType">A loaded named type symbol <see cref="INamedTypeSymbol"/>.</param>
+        /// <param name="symbolFilter">Assembly symbol filter <see cref="ISymbolFilter"/>.</param>
+        /// <returns>Boolean</returns>
+        public static bool HasInaccessibleTypeArgument(this INamedTypeSymbol namedType, ISymbolFilter symbolFilter)
+            => namedType.IsGenericType && namedType.TypeArguments.Any(a => !symbolFilter.Include(a));
 
         /// <summary>
         /// Synthesize an internal default constructor for the type with implicit default constructor and the base type without.

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -9,6 +9,8 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
+using System.Security.AccessControl;
+using Microsoft.VisualBasic;
 
 namespace Microsoft.DotNet.GenAPI
 {
@@ -107,8 +109,10 @@ namespace Microsoft.DotNet.GenAPI
                 baseTypes.Add(SyntaxFactory.SimpleBaseType((TypeSyntax)syntaxGenerator.TypeExpression(type.BaseType)));
             }
 
-            // includes only interfaces that were not filtered out by the given <see cref="ISymbolFilter"/>.
-            baseTypes.AddRange(type.Interfaces.Where(symbolFilter.Include).Select(i => SyntaxFactory.SimpleBaseType((TypeSyntax)syntaxGenerator.TypeExpression(i))));
+            // includes only interfaces that were not filtered out by the given <see cref="ISymbolFilter"/> or none of TypeParameters were filtered out.
+            baseTypes.AddRange(type.Interfaces
+                .Where(i => symbolFilter.Include(i) && !i.HasInaccessibleTypeArgument(symbolFilter))
+                .Select(i => SyntaxFactory.SimpleBaseType((TypeSyntax)syntaxGenerator.TypeExpression(i))));
             return baseTypes.Count > 0 ?
                 SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(baseTypes)) :
                 null;

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1685,8 +1685,53 @@ namespace Microsoft.DotNet.GenAPI.Tests
                         {
                             public Bar() { }
                         }
-                    
+
                         public partial class Foo : Bar
+                        {
+                        }
+                    }
+                    """,
+                includeInternalSymbols: false);
+        }
+
+        [Fact]
+        public void TestGenericBaseInterfaceWithInaccessibleTypeArguments()
+        {
+            RunTest(original: """
+                    namespace A
+                    {
+                        internal class IOption2
+                        {
+                        }
+
+                        public interface IOption
+                        {
+                        }
+
+                        public interface AreEqual<T>
+                        {
+                            bool Compare(T other);
+                        }
+
+                        public class PerLanguageOption : AreEqual<IOption2>, IOption
+                        {
+                            bool AreEqual<IOption2>.Compare(IOption2 other) => false;
+                        }
+                    }
+                    """,
+                expected: """
+                    namespace A
+                    {
+                        public partial interface AreEqual<T>
+                        {
+                            bool Compare(T other);
+                        }
+
+                        public partial interface IOption
+                        {
+                        }
+                    
+                        public partial class PerLanguageOption : IOption
                         {
                         }
                     }
@@ -1695,3 +1740,4 @@ namespace Microsoft.DotNet.GenAPI.Tests
         }
     }
 }
+


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/30805