### PR TITLE
GenAPI: do not synthesize generic fields of inaccessible type

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.GenAPI
                 // Collect generic excluded fields
                 IEnumerable<IFieldSymbol> genericTypedFields = excludedFields.Where(f => {
                     if (f.Type is INamedTypeSymbol ty) {
-                        return !ty.IsBoundGenericType();
+                        return !ty.IsBoundGenericType() && symbolFilter.Include(ty);
                     }
                     return f.Type is ITypeParameterSymbol;
                 });

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1112,7 +1112,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 {
                     internal class Bar<T> {}
 
-                    public struct Foo<T> where T : notnull
+                    public struct Foo<T>
                     {
                         #pragma warning disable 0169
                         // as the includeInternalSymbols field is set to false and the Bar<> class is internal -

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1105,6 +1105,36 @@ namespace Microsoft.DotNet.GenAPI.Tests
         }
 
         [Fact]
+        void TestSynthesizePrivateFieldsForInaccessibleNestedGenericTypes()
+        {
+            RunTest(original: """
+                namespace A
+                {
+                    internal class Bar<T> {}
+
+                    public struct Foo<T> where T : notnull
+                    {
+                        #pragma warning disable 0169
+                        // as the includeInternalSymbols field is set to false and the Bar<> class is internal -
+                        //   we must skip generation of the `_field` private field.
+                        private Bar<T> _field;
+                    }
+                }
+                """,
+            expected: """
+                namespace A
+                {
+                    public partial struct Foo<T>
+                    {
+                        private object _dummy;
+                        private int _dummyPrimitive;
+                    }
+                }
+                """,
+                includeInternalSymbols: false);
+        }
+
+        [Fact]
         public void TestBaseTypeWithoutExplicitDefaultConstructor()
         {
             RunTest(original: """


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/30627