### PR TITLE
GenAPI: Add unsafe keyword if the calls of the base constructor is unsafe

### DIFF
--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1566,6 +1566,76 @@ namespace Microsoft.DotNet.GenAPI.Tests
         }
 
         [Fact]
+        public void TestUnsafeConstructorGeneration()
+        {
+            RunTest(original: """
+                    namespace A
+                    {
+                        public class Bar
+                        {
+                            public unsafe Bar(char* f) { }
+                        }
+
+                        public class Foo : Bar
+                        {
+                            public unsafe Foo(char* f) : base(f) { }
+                        }
+                    }
+                    """,
+                expected: """
+                    namespace A
+                    {
+                        public partial class Bar
+                        {
+                            public unsafe Bar(char* f) { }
+                        }
+                    
+                        public partial class Foo : Bar
+                        {
+                            public unsafe Foo(char* f) : base(default) { }
+                        }
+                    }
+                    """,
+                includeInternalSymbols: false,
+                allowUnsafe: true);
+        }
+
+        [Fact]
+        public void TestUnsafeBaseConstructorGeneration()
+        {
+            RunTest(original: """
+                    namespace A
+                    {
+                        public class Bar
+                        {
+                            public unsafe Bar(char* f) { }
+                        }
+
+                        public class Foo : Bar
+                        {
+                            public unsafe Foo() : base(default) { }
+                        }
+                    }
+                    """,
+                expected: """
+                    namespace A
+                    {
+                        public partial class Bar
+                        {
+                            public unsafe Bar(char* f) { }
+                        }
+
+                        public partial class Foo : Bar
+                        {
+                            public unsafe Foo() : base(default) { }
+                        }
+                    }
+                    """,
+                includeInternalSymbols: false,
+                allowUnsafe: true);
+        }
+
+        [Fact]
         public void TestInternalDefaultConstructorGeneration()
         {
             RunTest(original: """


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/30640