### PR TITLE
Add new line to C# item templates with file-scoped namespaces

### DIFF
--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.class.langVersion=10.0.targetFramework=net6.0.verified/class/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.class.langVersion=10.0.targetFramework=net6.0.verified/class/TestItem1.cs
@@ -1,4 +1,5 @@
 ﻿namespace ClassLib;
+
 public class TestItem1
 {
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.class.langVersion=preview.targetFramework=net7.0.verified/class/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.class.langVersion=preview.targetFramework=net7.0.verified/class/TestItem1.cs
@@ -1,4 +1,5 @@
 ﻿namespace ClassLib;
+
 public class TestItem1
 {
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.langVersion=10.targetFramework=net6.0.verified/enum/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.langVersion=10.targetFramework=net6.0.verified/enum/TestItem1.cs
@@ -1,4 +1,5 @@
 ﻿namespace ClassLib;
+
 public enum TestItem1
 {
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.targetFramework=net7.0.verified/enum/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.targetFramework=net7.0.verified/enum/TestItem1.cs
@@ -1,4 +1,5 @@
 ﻿namespace ClassLib;
+
 public enum TestItem1
 {
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.interface.langVersion=10.0.targetFramework=net6.0.verified/interface/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.interface.langVersion=10.0.targetFramework=net6.0.verified/interface/TestItem1.cs
@@ -1,4 +1,5 @@
 ﻿namespace ClassLib;
+
 public interface TestItem1
 {
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.record.langVersion=10.targetFramework=net6.0.verified/record/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.record.langVersion=10.targetFramework=net6.0.verified/record/TestItem1.cs
@@ -1,4 +1,5 @@
 ﻿namespace ClassLib;
+
 public record class TestItem1
 {
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.struct.langVersion=10.targetFramework=net6.0.verified/struct/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.struct.langVersion=10.targetFramework=net6.0.verified/struct/TestItem1.cs
@@ -1,4 +1,5 @@
 ﻿namespace ClassLib;
+
 public struct TestItem1
 {
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.struct.langVersion=10.verified/struct/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.struct.langVersion=10.verified/struct/TestItem1.cs
@@ -1,4 +1,5 @@
 ﻿namespace ClassLib;
+
 public struct TestItem1
 {
 

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Class-CSharp/Class1.cs
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Class-CSharp/Class1.cs
@@ -4,6 +4,7 @@ using System;
 #endif
 #if (csharpFeature_FileScopedNamespaces)
 namespace Company.ClassLibrary1;
+
 public class Class1
 {
 

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Enum-CSharp/Enum1.cs
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Enum-CSharp/Enum1.cs
@@ -1,5 +1,6 @@
 ﻿#if (csharpFeature_FileScopedNamespaces)
 namespace Company.ClassLibrary1;
+
 public enum Enum1
 {
 

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Interface-CSharp/Interface1.cs
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Interface-CSharp/Interface1.cs
@@ -4,6 +4,7 @@ using System;
 #endif
 #if (csharpFeature_FileScopedNamespaces)
 namespace Company.ClassLibrary1;
+
 public interface Interface1
 {
 

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Record-CSharp/Record1.cs
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Record-CSharp/Record1.cs
@@ -1,5 +1,6 @@
 ﻿#if (csharpFeature_RecordClass)
 namespace Company.ClassLibrary1;
+
 public record class Record1
 {
 

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Struct-CSharp/Struct1.cs
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Struct-CSharp/Struct1.cs
@@ -4,6 +4,7 @@ using System;
 #endif
 #if (csharpFeature_FileScopedNamespaces)
 namespace Company.ClassLibrary1;
+
 public struct Struct1
 {
 


### PR DESCRIPTION
~~Fixes: https://github.com/dotnet/roslyn/issues/65921~~ (Does not fix that issue)

Started a new project recently and it was _extreamly annoying_ to add that additional line every single time I create an item. In all codebases I've seen there is always a line break between namespace and type declaration