### PR TITLE
fix displaying column when param is specified

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/TabularOutput/TemplateGroupDisplay.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TabularOutput/TemplateGroupDisplay.cs
@@ -161,8 +161,8 @@ namespace Microsoft.TemplateEngine.Cli.TabularOutput
                     .DefineColumn(t => t.ShortNames, LocalizableStrings.ColumnNameShortName, showAlways: true)
                     .DefineColumn(t => t.Languages, out object? languageColumn, LocalizableStrings.ColumnNameLanguage, TabularOutputSettings.ColumnNames.Language, defaultColumn: true)
                     .DefineColumn(t => t.Type, LocalizableStrings.ColumnNameType, TabularOutputSettings.ColumnNames.Type, defaultColumn: false)
-                    .DefineColumn(t => t.Author, LocalizableStrings.ColumnNameAuthor, TabularOutputSettings.ColumnNames.Tags, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
-                    .DefineColumn(t => t.Classifications, out object? tagsColumn, LocalizableStrings.ColumnNameTags, TabularOutputSettings.ColumnNames.Author, defaultColumn: true)
+                    .DefineColumn(t => t.Author, LocalizableStrings.ColumnNameAuthor, TabularOutputSettings.ColumnNames.Author, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
+                    .DefineColumn(t => t.Classifications, out object? tagsColumn, LocalizableStrings.ColumnNameTags, TabularOutputSettings.ColumnNames.Tags, defaultColumn: true)
                     .OrderBy(nameColumn, StringComparer.OrdinalIgnoreCase);
             reporter.WriteLine(formatter.Layout());
         }

--- a/src/Tests/dotnet-new.Tests/DotnetNewListTests.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewListTests.cs
@@ -542,6 +542,34 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         }
 
         [Theory]
+        [InlineData("author", "Author", "Microsoft")]
+        [InlineData("type", "Type", "")]
+        [InlineData("tags", "Tags", "Solution")]
+        [InlineData("language", "Language", "")]
+        public void TemplateWithSpecifiedColumnOutput(string columnName, string columnHeader, string columnValue)
+        {
+            string home = CreateTemporaryFolder(folderName: "Home");
+            string workingDirectory = CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "--install", "Microsoft.DotNet.Web.ProjectTemplates.5.0")
+                  .WithCustomHive(home)
+                  .WithWorkingDirectory(workingDirectory)
+                  .Execute()
+                  .Should()
+                  .ExitWith(0);
+
+            new DotnetNewCommand(_log, "list", "--columns", columnName)
+                .WithCustomHive(home)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("These templates matched your input:")
+                .And.HaveStdOutMatching($"Template Name                                 Short Name                  {columnHeader}")
+                .And.HaveStdOutMatching($"Solution File                                 sln,solution                {columnValue}");
+        }
+
+        [Theory]
         [InlineData("c --list", "--list c")]
         [InlineData("c --list --language F#", "--list c --language F#")]
         [InlineData("c --list --columns-all", "--list c --columns-all")]


### PR DESCRIPTION
## Problem
Fixes #https://github.com/dotnet/templating/issues/6212
When either "tag" or "author" parameter is specified it returns an invalid column.

## Solution 
Fix passed parameters to TemplateGroupDisplay.DisplayColumn

## Checks
Covered with tests