### PR TITLE
GenAPI: add support for reference parameters in constructors.

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/BodyBlockCSharpSyntaxRewriter.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/BodyBlockCSharpSyntaxRewriter.cs
@@ -25,9 +25,21 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
         /// <inheritdoc />
         public override SyntaxNode? VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
         {
-            node = node.WithBody(GetEmptyBody())
-                       .WithParameterList(node.ParameterList.WithTrailingTrivia(SyntaxFactory.Space));
-            return base.VisitConstructorDeclaration(node);
+            // visit subtree first to normalize type names.
+            ConstructorDeclarationSyntax? rs = (ConstructorDeclarationSyntax?)base.VisitConstructorDeclaration(node);
+            if (rs is null) return rs;
+
+            // if there is at least one reference parameter - generate non empty body.
+            if (node.ParameterList.Parameters.Any(p => p.Modifiers.Any(m => m.IsKind(SyntaxKind.OutKeyword))))
+            {
+                rs = rs.WithBody(GetThrowNullBody());
+            }
+            else
+            {
+                rs = rs.WithBody(GetEmptyBody());
+            }
+
+            return rs;
         }
 
         /// <inheritdoc />
@@ -47,8 +59,7 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
                 rs = rs.WithExpressionBody(null);
             }
 
-            string returnType = rs.ReturnType.ToString();
-            if ((returnType != "void" && returnType != "System.Void") ||
+            if (!(rs.ReturnType is PredefinedTypeSyntax predefined && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword)) ||
                 // if there is at least one reference parameter - generate non empty body.
                 node.ParameterList.Parameters.Any(p => p.Modifiers.Any(m => m.IsKind(SyntaxKind.OutKeyword))))
             {

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriterTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriterTests.cs
@@ -462,6 +462,30 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 }
                 """);
         }
+
+        [Fact]
+        public void TestConstructorWithReferenceParameters()
+        {
+            CompareSyntaxTree(new BodyBlockCSharpSyntaxRewriter("Not implemented"),
+                original: """
+                namespace A
+                {
+                    public class Foo
+                    {
+                        public Foo(int a, out int b) { b = 1; }
+                    }
+                }
+                """,
+                expected: """
+                namespace A
+                {
+                    public class Foo
+                    {
+                        public Foo(int a, out int b) { throw new PlatformNotSupportedException("Not implemented"); }
+                    }
+                }
+                """);
+        }
     }
 
     public class TypeForwardAttributeCSharpSyntaxRewriterTests : SyntaxRewriterTests

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriterTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriterTests.cs
@@ -472,6 +472,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 {
                     public class Foo
                     {
+                        public Foo(int a) { }
                         public Foo(int a, out int b) { b = 1; }
                     }
                 }
@@ -481,6 +482,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 {
                     public class Foo
                     {
+                        public Foo(int a) { }
                         public Foo(int a, out int b) { throw new PlatformNotSupportedException("Not implemented"); }
                     }
                 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/31006