### PR TITLE
Refactor command line options parsing, add/improve imp of --launch-profile and --no-launch-profile options.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -186,6 +186,7 @@
     <FluentAssertionsJsonVersion>6.1.0</FluentAssertionsJsonVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.23120.1</MicrosoftDotNetXUnitExtensionsVersion>
     <MoqPackageVersion>4.8.2</MoqPackageVersion>
+    <XunitCombinatorialVersion>1.3.2</XunitCombinatorialVersion>
     <MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>6.0.0-beta.22262.1</MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Assets/TestProjects/WatchAppWithLaunchSettings/Program.cs
+++ b/src/Assets/TestProjects/WatchAppWithLaunchSettings/Program.cs
@@ -1,5 +1,6 @@
 ﻿Console.WriteLine("Started");
 Console.WriteLine($"Environment: {Environment.GetEnvironmentVariable("EnvironmentFromProfile")}");
+Console.WriteLine($"Arguments: {string.Join(",", args)}");
 
 if (Environment.GetEnvironmentVariable("READ_INPUT") != null)
 {

--- a/src/Assets/TestProjects/WatchAppWithLaunchSettings/Properties/launchSettings.json
+++ b/src/Assets/TestProjects/WatchAppWithLaunchSettings/Properties/launchSettings.json
@@ -5,6 +5,18 @@
         "environmentVariables": {
           "EnvironmentFromProfile": "Development"
         }
+      },
+      "P1": {
+        "commandName": "Project",
+        "commandLineArgs": "argP1"
+      },
+      "P2": {
+        "commandName": "Project",
+        "commandLineArgs": "argP2"
+      },
+      "P and Q and \"R\"": {
+        "commandName": "Project",
+        "commandLineArgs": "argPQR"
       }
     }
   }

--- a/src/Assets/TestProjects/WatchHotReloadAppMultiTfm/Program.cs
+++ b/src/Assets/TestProjects/WatchHotReloadAppMultiTfm/Program.cs
@@ -17,7 +17,7 @@ Console.WriteLine($"Process identifier = {Process.GetCurrentProcess().Id}, {Proc
 Console.WriteLine($"DOTNET_WATCH = {Environment.GetEnvironmentVariable("DOTNET_WATCH")}");
 Console.WriteLine($"DOTNET_WATCH_ITERATION = {Environment.GetEnvironmentVariable("DOTNET_WATCH_ITERATION")}");
 Console.WriteLine($"Arguments = {string.Join(",", args)}");
-Console.WriteLine($"Version = {assembly.GetCustomAttributes<AssemblyVersionAttribute>().FirstOrDefault()?.Version ?? "<unspecified>"}");
+Console.WriteLine($"AssemblyName = {assembly.GetName()}");
 Console.WriteLine($"TFM = {assembly.GetCustomAttributes<TargetFrameworkAttribute>().FirstOrDefault()?.FrameworkName ?? "<unspecified>"}");
 Console.WriteLine($"Configuration = {assembly.GetCustomAttributes<AssemblyConfigurationAttribute>().FirstOrDefault()?.Configuration ?? "<unspecified>"}");
 

--- a/src/Assets/TestProjects/WatchHotReloadAppMultiTfm/Program.cs
+++ b/src/Assets/TestProjects/WatchHotReloadAppMultiTfm/Program.cs
@@ -18,6 +18,7 @@ Console.WriteLine($"DOTNET_WATCH = {Environment.GetEnvironmentVariable("DOTNET_W
 Console.WriteLine($"DOTNET_WATCH_ITERATION = {Environment.GetEnvironmentVariable("DOTNET_WATCH_ITERATION")}");
 Console.WriteLine($"Arguments = {string.Join(",", args)}");
 Console.WriteLine($"AssemblyName = {assembly.GetName()}");
+Console.WriteLine($"AssemblyTitle = '{assembly.GetCustomAttributes<AssemblyTitleAttribute>().FirstOrDefault()?.Title ?? "<unspecified>"}'");
 Console.WriteLine($"TFM = {assembly.GetCustomAttributes<TargetFrameworkAttribute>().FirstOrDefault()?.FrameworkName ?? "<unspecified>"}");
 Console.WriteLine($"Configuration = {assembly.GetCustomAttributes<AssemblyConfigurationAttribute>().FirstOrDefault()?.Configuration ?? "<unspecified>"}");
 

--- a/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
@@ -1,32 +1,233 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
+#nullable enable
+
 using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
 
-namespace Microsoft.DotNet.Watcher
+using Microsoft.DotNet.Watcher.Tools;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher;
+
+internal sealed class RunCommandLineOptions
 {
-    internal class CommandLineOptions
+    public required bool NoLaunchProfile { get; init; }
+    public required string? LaunchProfileName { get; init; }
+    public required IReadOnlyList<string> RemainingArguments { get; init; }
+}
+
+internal sealed class CommandLineOptions
+{
+    private const string Description = @"
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+";
+
+    private const string NoLaunchProfileOptionName = "--no-launch-profile";
+    private const string LaunchProfileOptionName = "--launch-profile";
+
+    public string? Project { get; init; }
+    public string? LaunchProfileName { get; init; }
+    public bool NoLaunchProfile { get; init; }
+    public bool Quiet { get; init; }
+    public bool Verbose { get; init; }
+    public bool List { get; init; }
+    public bool NoHotReload { get; init; }
+    public bool NonInteractive { get; init; }
+    public required IReadOnlyList<string> RemainingArguments { get; init; }
+    public RunCommandLineOptions? RunOptions { get; init; }
+
+    public static CommandLineOptions? Parse(string[] args, IReporter reporter, out int errorCode, System.CommandLine.IConsole? console = null)
     {
-        public string Project { get; set; }
-        public string LaunchProfile { get; set; }
-        public bool Quiet { get; set; }
-        public bool Verbose { get; set; }
-        public bool List { get; set; }
-        public bool NoHotReload { get; set; }
+        var quietOption = new Option<bool>(new[] { "--quiet", "-q" }, "Suppresses all output except warnings and errors");
+        var verboseOption = new Option<bool>(new[] { "--verbose", "-v" }, "Show verbose output");
 
-        public bool NonInteractive { get; set; }
-        public IReadOnlyList<string> RemainingArguments { get; set; }
-
-        public static bool IsPollingEnabled
+        verboseOption.AddValidator(v =>
         {
-            get
+            if (v.FindResultFor(quietOption) is not null && v.FindResultFor(verboseOption) is not null)
             {
-                var envVar = Environment.GetEnvironmentVariable("DOTNET_USE_POLLING_FILE_WATCHER");
-                return envVar != null &&
-                    (envVar.Equals("1", StringComparison.OrdinalIgnoreCase) ||
-                     envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
+                v.ErrorMessage = Resources.Error_QuietAndVerboseSpecified;
+            }
+        });
+
+        var listOption = new Option<bool>("--list", "Lists all discovered files without starting the watcher.");
+        var shortProjectOption = new Option<string>("-p", "The project to watch.") { IsHidden = true };
+        var longProjectOption = new Option<string>("--project", "The project to watch");
+
+        // launch profile used by dotnet-watch
+        var launchProfileWatchOption = new Option<string>(new[] { "-lp", LaunchProfileOptionName }, "The launch profile to start the project with (case-sensitive).");
+        var noLaunchProfileWatchOption = new Option<bool>(new[] { NoLaunchProfileOptionName }, "Do not attempt to use launchSettings.json to configure the application.");
+
+        // launch profile used by dotnet-run
+        var launchProfileRunOption = new Option<string>(new[] { "-lp", LaunchProfileOptionName }) { IsHidden = true };
+        var noLaunchProfileRunOption = new Option<bool>(new[] { NoLaunchProfileOptionName }) { IsHidden = true };
+
+        var noHotReloadOption = new Option<bool>("--no-hot-reload", "Suppress hot reload for supported apps.");
+        var nonInteractiveOption = new Option<bool>(
+            "--non-interactive",
+            "Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled. " +
+            "Use this option to prevent console input from being captured.");
+
+        var remainingWatchArgs = new Argument<string[]>("forwardedArgs", "Arguments to pass to the child dotnet process.");
+        var remainingRunArgs = new Argument<string[]>(name: null);
+
+        var runCommand = new Command("run")
+        {
+            quietOption,
+            verboseOption,
+            noHotReloadOption,
+            nonInteractiveOption,
+            longProjectOption,
+            shortProjectOption,
+            launchProfileRunOption,
+            noLaunchProfileRunOption,
+            listOption,
+            remainingRunArgs,
+        };
+
+        runCommand.IsHidden = true;
+
+        var rootCommand = new RootCommand(Description)
+        {
+            quietOption,
+            verboseOption,
+            noHotReloadOption,
+            nonInteractiveOption,
+            longProjectOption,
+            shortProjectOption,
+            launchProfileWatchOption,
+            noLaunchProfileWatchOption,
+            listOption,
+            runCommand,
+            remainingWatchArgs
+        };
+
+        CommandLineOptions? options = null;
+
+        runCommand.SetHandler(context =>
+        {
+            RootHandler(context, new()
+            {
+                LaunchProfileName = context.ParseResult.GetValue(launchProfileRunOption),
+                NoLaunchProfile = context.ParseResult.GetValue(noLaunchProfileRunOption),
+                RemainingArguments = context.ParseResult.GetValue(remainingRunArgs),
+            });
+        });
+
+        rootCommand.SetHandler(context => RootHandler(context, runOptions: null));
+
+        void RootHandler(InvocationContext context, RunCommandLineOptions? runOptions)
+        {
+            var parseResults = context.ParseResult;
+            var projectValue = parseResults.GetValue(longProjectOption);
+            if (string.IsNullOrEmpty(projectValue))
+            {
+                var projectShortValue = parseResults.GetValue(shortProjectOption);
+                if (!string.IsNullOrEmpty(projectShortValue))
+                {
+                    reporter.Warn(Resources.Warning_ProjectAbbreviationDeprecated);
+                    projectValue = projectShortValue;
+                }
+            }
+
+            options = new()
+            {
+                Quiet = parseResults.GetValue(quietOption),
+                List = parseResults.GetValue(listOption),
+                NoHotReload = parseResults.GetValue(noHotReloadOption),
+                NonInteractive = parseResults.GetValue(nonInteractiveOption),
+                Verbose = parseResults.GetValue(verboseOption),
+                Project = projectValue,
+                LaunchProfileName = parseResults.GetValue(launchProfileWatchOption),
+                NoLaunchProfile = parseResults.GetValue(noLaunchProfileWatchOption),
+                RemainingArguments = parseResults.GetValue(remainingWatchArgs),
+                RunOptions = runOptions,
+            };
+        }
+
+        errorCode = rootCommand.Invoke(args, console);
+        return options;
+    }
+
+    public IReadOnlyList<string> GetLaunchProcessArguments(bool hotReload, IReporter reporter, out bool watchNoLaunchProfile, out string? watchLaunchProfileName)
+    {
+        var argsBuilder = new List<string>();
+        if (!hotReload)
+        {
+            // Arguments are passed to dotnet and the first argument is interpreted as a command.
+            argsBuilder.Add("run");
+        }
+
+        argsBuilder.AddRange(RemainingArguments);
+
+        // launch profile:
+        if (hotReload)
+        {
+            watchNoLaunchProfile = NoLaunchProfile || RunOptions?.NoLaunchProfile == true;
+            watchLaunchProfileName = LaunchProfileName ?? RunOptions?.LaunchProfileName;
+
+            if (LaunchProfileName != null && RunOptions?.LaunchProfileName != null)
+            {
+                reporter.Warn($"Using launch profile name '{LaunchProfileName}', ignoring '{RunOptions.LaunchProfileName}'.");
             }
         }
+        else
+        {
+            var runNoLaunchProfile = (RunOptions != null) ? RunOptions.NoLaunchProfile : NoLaunchProfile;
+            watchNoLaunchProfile = NoLaunchProfile;
+
+            var runLaunchProfileName = (RunOptions != null) ? RunOptions.LaunchProfileName : LaunchProfileName;
+            watchLaunchProfileName = LaunchProfileName;
+
+            if (runNoLaunchProfile)
+            {
+                argsBuilder.Add(NoLaunchProfileOptionName);
+            }
+
+            if (runLaunchProfileName != null)
+            {
+                argsBuilder.Add(LaunchProfileOptionName);
+                argsBuilder.Add(runLaunchProfileName);
+            }
+        }
+
+        if (RunOptions != null)
+        {
+            argsBuilder.AddRange(RunOptions.RemainingArguments);
+        }
+
+        return argsBuilder.ToArray();
     }
 }

--- a/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
@@ -3,6 +3,8 @@
 
 #nullable enable
 
+using System.Collections.Generic;
+
 using Microsoft.Build.Graph;
 using Microsoft.Extensions.Tools.Internal;
 
@@ -31,5 +33,9 @@ namespace Microsoft.DotNet.Watcher.Tools
         public LaunchSettingsProfile LaunchSettingsProfile { get; init; } = default!;
 
         public ProjectGraph? ProjectGraph { get; set; }
+
+        public string? TargetFramework { get; init; }
+
+        public IReadOnlyList<(string name, string value)>? BuildProperties { get; init; }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -321,7 +321,7 @@ namespace Microsoft.DotNet.Watcher
                 processSpec.EnvironmentVariables[rootVariableName] = Path.GetDirectoryName(_muxerPath);
             }
 
-            if (context.LaunchSettingsProfile.EnvironmentVariables is IDictionary<string, string> envVariables)
+            if (context.LaunchSettingsProfile.EnvironmentVariables is { } envVariables)
             {
                 foreach (var entry in envVariables)
                 {

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/FileWatcherFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/FileWatcherFactory.cs
@@ -7,8 +7,13 @@ namespace Microsoft.DotNet.Watcher.Internal
 {
     internal static class FileWatcherFactory
     {
+        public static bool IsPollingEnabled
+            => Environment.GetEnvironmentVariable("DOTNET_USE_POLLING_FILE_WATCHER") is { } value &&
+               (value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                value.Equals("true", StringComparison.OrdinalIgnoreCase));
+
         public static IFileSystemWatcher CreateWatcher(string watchedDirectory)
-            => CreateWatcher(watchedDirectory, CommandLineOptions.IsPollingEnabled);
+            => CreateWatcher(watchedDirectory, IsPollingEnabled);
 
         public static IFileSystemWatcher CreateWatcher(string watchedDirectory, bool usePollingWatcher)
         {

--- a/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,8 +12,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Cli;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
 using IReporter = Microsoft.Extensions.Tools.Internal.IReporter;
 
 namespace Microsoft.DotNet.Watcher.Internal
@@ -31,42 +31,28 @@ namespace Microsoft.DotNet.Watcher.Internal
         private readonly IReadOnlyList<string> _buildFlags;
 
         public MsBuildFileSetFactory(
-            IReporter reporter,
-            DotNetWatchOptions dotNetWatchOptions,
-            string muxerPath,
-            string projectFile,
-            bool waitOnError,
-            bool trace)
-            : this(dotNetWatchOptions, reporter, muxerPath, projectFile, new OutputSink(), waitOnError, trace)
-        {
-        }
-
-        // output sink is for testing
-        internal MsBuildFileSetFactory(
             DotNetWatchOptions dotNetWatchOptions,
             IReporter reporter,
             string muxerPath,
             string projectFile,
-            OutputSink outputSink,
+            string? targetFramework,
+            IReadOnlyList<(string, string)>? buildProperties,
+            OutputSink? outputSink,
             bool waitOnError,
             bool trace)
         {
-            Ensure.NotNull(reporter, nameof(reporter));
-            Ensure.NotNullOrEmpty(projectFile, nameof(projectFile));
-            Ensure.NotNull(outputSink, nameof(outputSink));
-
             _reporter = reporter;
             _dotNetWatchOptions = dotNetWatchOptions;
             _muxerPath = muxerPath;
             _projectFile = projectFile;
-            _outputSink = outputSink;
+            _outputSink = outputSink ?? new OutputSink();
             _processRunner = new ProcessRunner(reporter);
-            _buildFlags = InitializeArgs(FindTargetsFile(), trace);
+            _buildFlags = InitializeArgs(FindTargetsFile(), targetFramework, buildProperties, trace);
 
             _waitOnError = waitOnError;
         }
 
-        public async Task<FileSet> CreateAsync(CancellationToken cancellationToken)
+        public async Task<FileSet?> CreateAsync(CancellationToken cancellationToken)
         {
             var watchList = Path.GetTempFileName();
             try
@@ -109,6 +95,7 @@ namespace Microsoft.DotNet.Watcher.Internal
                     {
                         using var watchFile = File.OpenRead(watchList);
                         var result = await JsonSerializer.DeserializeAsync<MSBuildFileSetResult>(watchFile, cancellationToken: cancellationToken);
+                        Debug.Assert(result != null);
 
                         var fileItems = new List<FileItem>();
                         foreach (var project in result.Projects)
@@ -203,7 +190,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             }
         }
 
-        private IReadOnlyList<string> InitializeArgs(string watchTargetsFile, bool trace)
+        private IReadOnlyList<string> InitializeArgs(string watchTargetsFile, string? targetFramework, IReadOnlyList<(string name, string value)>? buildProperties, bool trace)
         {
             var args = new List<string>
             {
@@ -215,6 +202,16 @@ namespace Microsoft.DotNet.Watcher.Internal
                 "/p:CustomAfterMicrosoftCommonTargets=" + watchTargetsFile,
                 "/p:CustomAfterMicrosoftCommonCrossTargetingTargets=" + watchTargetsFile,
             };
+
+            if (targetFramework != null)
+            {
+                args.Add("/p:TargetFramework=" + targetFramework);
+            }
+
+            if (buildProperties != null)
+            {
+                args.AddRange(buildProperties.Select(p => $"/p:{p.name}={p.value}"));
+            }
 
             if (trace)
             {
@@ -228,6 +225,8 @@ namespace Microsoft.DotNet.Watcher.Internal
         private string FindTargetsFile()
         {
             var assemblyDir = Path.GetDirectoryName(typeof(MsBuildFileSetFactory).Assembly.Location);
+            Debug.Assert(assemblyDir != null);
+
             var searchPaths = new[]
             {
                 Path.Combine(AppContext.BaseDirectory, "assets"),
@@ -237,12 +236,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             };
 
             var targetPath = searchPaths.Select(p => Path.Combine(p, WatchTargetsFileName)).FirstOrDefault(File.Exists);
-            if (targetPath == null)
-            {
-                _reporter.Error("Fatal error: could not find DotNetWatch.targets");
-                return null;
-            }
-            return targetPath;
+            return targetPath ?? throw new FileNotFoundException("Fatal error: could not find DotNetWatch.targets");
         }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
@@ -14,15 +14,12 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     internal sealed class LaunchSettingsProfile
     {
-        public string? ApplicationUrl { get; set; }
-
-        public string? CommandName { get; set; }
-
-        public bool LaunchBrowser { get; set; }
-
-        public string? LaunchUrl { get; set; }
-
-        public IDictionary<string, string>? EnvironmentVariables { get; set; }
+        public string? ApplicationUrl { get; init; }
+        public string? CommandName { get; init; }
+        public bool LaunchBrowser { get; init; }
+        public string? LaunchUrl { get; init; }
+        public string? CommandLineArgs { get; init; }
+        public IReadOnlyDictionary<string, string>? EnvironmentVariables { get; init; }
 
         internal static LaunchSettingsProfile? ReadLaunchProfile(string projectDirectory, string? launchProfileName, IReporter reporter)
         {

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -1,15 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
-using System.Runtime.Loader;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Binding;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Graph;
@@ -19,48 +21,11 @@ using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.Extensions.Tools.Internal;
 using IConsole = Microsoft.Extensions.Tools.Internal.IConsole;
 using Resources = Microsoft.DotNet.Watcher.Tools.Resources;
-using System.Diagnostics;
 
 namespace Microsoft.DotNet.Watcher
 {
     internal sealed class Program : IDisposable
     {
-        private const string Description = @"
-Environment variables:
-
-  DOTNET_USE_POLLING_FILE_WATCHER
-  When set to '1' or 'true', dotnet-watch will poll the file system for
-  changes. This is required for some file systems, such as network shares,
-  Docker mounted volumes, and other virtual file systems.
-
-  DOTNET_WATCH
-  dotnet-watch sets this variable to '1' on all child processes launched.
-
-  DOTNET_WATCH_ITERATION
-  dotnet-watch sets this variable to '1' and increments by one each time
-  a file is changed and the command is restarted.
-
-  DOTNET_WATCH_SUPPRESS_EMOJIS
-  When set to '1' or 'true', dotnet-watch will not show emojis in the 
-  console output.
-
-Remarks:
-  The special option '--' is used to delimit the end of the options and
-  the beginning of arguments that will be passed to the child dotnet process.
-  Its use is optional. When the special option '--' is not used,
-  dotnet-watch will use the first unrecognized argument as the beginning
-  of all arguments passed into the child dotnet process.
-
-  For example: dotnet watch -- --verbose run
-
-  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
-  indicates that '--verbose' should be treated instead as an argument for
-  dotnet-run.
-
-Examples:
-  dotnet watch run
-  dotnet watch test
-";
         private readonly IConsole _console;
         private readonly string _workingDirectory;
         private readonly string _muxerPath;
@@ -89,6 +54,7 @@ Examples:
             try
             {
                 var muxerPath = Environment.ProcessPath;
+                Debug.Assert(muxerPath != null);
                 Debug.Assert(Path.GetFileNameWithoutExtension(muxerPath) == "dotnet", $"Invalid muxer path {muxerPath}");
 
 #if DEBUG
@@ -124,60 +90,14 @@ Examples:
 
         internal async Task<int> RunAsync(string[] args)
         {
-            var rootCommand = CreateRootCommand(HandleWatch, _reporter);
-            return await rootCommand.InvokeAsync(args);
-        }
+            var options = CommandLineOptions.Parse(args, _reporter, out var errorCode);
 
-        internal static RootCommand CreateRootCommand(Func<CommandLineOptions, Task<int>> handler, IReporter reporter)
-        {
-            var quiet = new Option<bool>(
-                new[] { "--quiet", "-q" },
-                "Suppresses all output except warnings and errors");
-
-            var verbose = new Option<bool>(
-                new[] { "--verbose", "-v" },
-                "Show verbose output");
-
-            verbose.AddValidator(v =>
+            // an error reported or help printed:
+            if (options == null)
             {
-                if (v.FindResultFor(quiet) is not null && v.FindResultFor(verbose) is not null)
-                {
-                    v.ErrorMessage = Resources.Error_QuietAndVerboseSpecified;
-                }
-            });
+                return errorCode;
+            }
 
-            var listOption = new Option<bool>("--list", "Lists all discovered files without starting the watcher.");
-            var shortProjectOption = new Option<string>("-p", "The project to watch.") { IsHidden = true };
-            var longProjectOption = new Option<string>("--project","The project to watch");
-            var launchProfileOption = new Option<string>(new[] { "-lp", "--launch-profile" }, "The launch profile to start the project with (case-sensitive). " +
-                "This option is only supported when running 'dotnet watch' or 'dotnet watch run'.");
-            var noHotReloadOption = new Option<bool>("--no-hot-reload", "Suppress hot reload for supported apps.");
-            var nonInteractiveOption = new Option<bool>(
-                "--non-interactive",
-                "Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled. " +
-                "Use this option to prevent console input from being captured.");
-            var forwardedArguments = new Argument<string[]>("forwardedArgs", "Arguments to pass to the child dotnet process.");
-
-            var root = new RootCommand(Description)
-            {
-                 quiet,
-                 verbose,
-                 noHotReloadOption,
-                 nonInteractiveOption,
-                 longProjectOption,
-                 shortProjectOption,
-                 launchProfileOption,
-                 listOption,
-                 forwardedArguments
-            };
-
-            var binder = new CommandLineOptionsBinder(longProjectOption, shortProjectOption, launchProfileOption, quiet, listOption, noHotReloadOption, nonInteractiveOption, verbose, forwardedArguments, reporter);
-            root.SetHandler((CommandLineOptions options) => handler(options), binder);
-            return root;
-        }
-
-        private async Task<int> HandleWatch(CommandLineOptions options)
-        {
             // update reporter as configured by options
             var suppressEmojis = ShouldSuppressEmojis();
             _reporter = CreateReporter(options.Verbose, options.Quiet, _console, suppressEmojis);
@@ -192,13 +112,11 @@ Examples:
 
                 if (options.List)
                 {
-                    return await ListFilesAsync(_reporter,
-                        options.Project,
-                        _cts.Token);
+                    return await ListFilesAsync(_reporter, options.Project, _cts.Token);
                 }
                 else
                 {
-                    return await MainInternalAsync(options, _cts.Token);
+                    return await RunAsync(options, _cts.Token);
                 }
             }
             catch (Exception ex)
@@ -215,7 +133,7 @@ Examples:
             }
         }
 
-        private void OnCancelKeyPress(object sender, ConsoleCancelEventArgs args)
+        private void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs args)
         {
             // suppress CTRL+C on the first press
             args.Cancel = !_cts.IsCancellationRequested;
@@ -228,7 +146,7 @@ Examples:
             _cts.Cancel();
         }
 
-        private async Task<int> MainInternalAsync(CommandLineOptions options, CancellationToken cancellationToken)
+        private async Task<int> RunAsync(CommandLineOptions options, CancellationToken cancellationToken)
         {
             // TODO multiple projects should be easy enough to add here
             string projectFile;
@@ -253,24 +171,20 @@ Examples:
                 waitOnError: true,
                 trace: false);
 
-            if (CommandLineOptions.IsPollingEnabled)
+            if (FileWatcherFactory.IsPollingEnabled)
             {
                 _reporter.Output("Polling file watcher is enabled");
             }
 
-            var workingDirectory = Path.GetDirectoryName(projectFile);
-            var launchProfile = LaunchSettingsProfile.ReadLaunchProfile(workingDirectory, options.LaunchProfile, _reporter) ?? new();
+            var projectDirectory = Path.GetDirectoryName(projectFile);
+            Debug.Assert(projectDirectory != null);
+
             var projectGraph = TryReadProject(projectFile);
 
             bool enableHotReload;
             if (options.NoHotReload)
             {
                 _reporter.Verbose("Hot Reload disabled by command line switch.");
-                enableHotReload = false;
-            }
-            else if (options.RemainingArguments is not ([] or ["run", ..]))
-            {
-                _reporter.Error("Only 'run' command supports Hot Reload");
                 enableHotReload = false;
             }
             else if (projectGraph is null || !IsHotReloadSupported(projectGraph))
@@ -284,30 +198,20 @@ Examples:
                 enableHotReload = true;
             }
 
-            var args = options.RemainingArguments;
-            if (enableHotReload)
-            {
-                // Arguments are passed directly to the application .exe, so we need to make sure they do NOT start with the "run" command name.
-                if (args is not [])
-                {
-                    Debug.Assert(args is ["run", ..]);
-                    args = args.Skip(1).ToArray();
-                }
-            }
-            else if (args is [])
-            {
-                // Arguments are passed to dotnet and the first argument is interpreted as a command.
-                // If there is none, add "run".
-                args = new[] { "run" };
-            }
+            var args = options.GetLaunchProcessArguments(enableHotReload, _reporter, out var noLaunchProfile, out var launchProfileName);
+            var launchProfile = (noLaunchProfile ? null : LaunchSettingsProfile.ReadLaunchProfile(projectDirectory, launchProfileName, _reporter)) ?? new();
+
+            // If no args forwarded to the app were specified use the ones in the profile.
+            var escapedArgs = (enableHotReload && args is []) ? launchProfile.CommandLineArgs : null;
 
             var context = new DotNetWatchContext
             {
                 HotReloadEnabled = enableHotReload,
                 ProcessSpec = new ProcessSpec
                 {
-                    WorkingDirectory = workingDirectory,
+                    WorkingDirectory = projectDirectory,
                     Arguments = args,
+                    EscapedArguments = escapedArgs,
                     EnvironmentVariables =
                     {
                         ["DOTNET_WATCH"] = "1"
@@ -333,7 +237,7 @@ Examples:
             return 0;
         }
 
-        private ProjectGraph TryReadProject(string project)
+        private ProjectGraph? TryReadProject(string project)
         {
             try
             {
@@ -369,7 +273,7 @@ Examples:
 
         private async Task<int> ListFilesAsync(
             IReporter reporter,
-            string project,
+            string? project,
             CancellationToken cancellationToken)
         {
             // TODO multiple projects should be easy enough to add here
@@ -448,74 +352,5 @@ Examples:
                 return null;
             };
         }
-        private sealed class CommandLineOptionsBinder : BinderBase<CommandLineOptions>
-        {
-            private readonly Option<string> _longProjectOption;
-            private readonly Option<string> _shortProjectOption;
-            private readonly Option<string> _launchProfileOption;
-            private readonly Option<bool> _quietOption;
-            private readonly Option<bool> _listOption;
-            private readonly Option<bool> _noHotReloadOption;
-            private readonly Option<bool> _nonInteractiveOption;
-            private readonly Option<bool> _verboseOption;
-
-            private readonly Argument<string[]> _argumentsToForward;
-            private readonly IReporter _reporter;
-
-            internal CommandLineOptionsBinder(
-                Option<string> longProjectOption,
-                Option<string> shortProjectOption,
-                Option<string> launchProfileOption,
-                Option<bool> quietOption,
-                Option<bool> listOption,
-                Option<bool> noHotReloadOption,
-                Option<bool> nonInteractiveOption,
-                Option<bool> verboseOption,
-                Argument<string[]> argumentsToForward,
-                IReporter reporter)
-            {
-                _longProjectOption = longProjectOption;
-                _shortProjectOption = shortProjectOption;
-                _launchProfileOption = launchProfileOption;
-                _quietOption = quietOption;
-                _listOption = listOption;
-                _noHotReloadOption = noHotReloadOption;
-                _nonInteractiveOption = nonInteractiveOption;
-                _verboseOption = verboseOption;
-                _argumentsToForward = argumentsToForward;
-                _reporter = reporter;
-            }
-
-            protected override CommandLineOptions GetBoundValue(BindingContext bindingContext)
-            {
-                var parseResults = bindingContext.ParseResult;
-                var projectValue = parseResults.GetValue(_longProjectOption);
-                if (string.IsNullOrEmpty(projectValue))
-                {
-#pragma warning disable CS0618 // Type or member is obsolete
-                    var projectShortValue = parseResults.GetValue(_shortProjectOption);
-#pragma warning restore CS0618 // Type or member is obsolete
-                    if (!string.IsNullOrEmpty(projectShortValue))
-                    {
-                        _reporter.Warn(Resources.Warning_ProjectAbbreviationDeprecated);
-                        projectValue = projectShortValue;
-                    }
-                }
-
-                var options = new CommandLineOptions
-                {
-                    Quiet = parseResults.GetValue(_quietOption),
-                    List = parseResults.GetValue(_listOption),
-                    NoHotReload = parseResults.GetValue(_noHotReloadOption),
-                    NonInteractive = parseResults.GetValue(_nonInteractiveOption),
-                    Verbose = parseResults.GetValue(_verboseOption),
-                    Project = projectValue,
-                    LaunchProfile = parseResults.GetValue(_launchProfileOption),
-                    RemainingArguments = parseResults.GetValue(_argumentsToForward),
-                };
-                return options;
-            }
-        }
     }
-
 }

--- a/src/Tests/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/src/Tests/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -5,22 +5,14 @@ using System;
 using System.CommandLine.IO;
 using System.Linq;
 
-using Moq;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Watcher.Tools
 {
     public class CommandLineOptionsTests
     {
-        private readonly Extensions.Tools.Internal.TestReporter _testReporter;
-        private readonly TestConsole _console;
-
-        public CommandLineOptionsTests(ITestOutputHelper output)
-        {
-            _console = new();
-            _testReporter = new(output);
-        }
+        private readonly MockReporter _testReporter = new();
+        private readonly TestConsole _console = new();
 
         [Theory]
         [InlineData(new object[] { new[] { "-h" } })]
@@ -32,7 +24,35 @@ namespace Microsoft.DotNet.Watcher.Tools
             Assert.Null(CommandLineOptions.Parse(args, _testReporter, out var errorCode, _console));
             Assert.Equal(0, errorCode);
 
+            Assert.Empty(_testReporter.Messages);
             Assert.Contains("Usage:", _console.Out.ToString());
+        }
+
+        [Theory]
+        [InlineData("P=V", "P", "V")]
+        [InlineData("P==", "P", "=")]
+        [InlineData("P=A=B", "P", "A=B")]
+        [InlineData(" P\t = V ", "P", " V ")]
+        public void BuildProperties_Valid(string argValue, string name, string value)
+        {
+            var args = new[] { "--property", argValue };
+            var options = CommandLineOptions.Parse(args, _testReporter, out var errorCode, _console);
+            Assert.Equal(new[] { (name, value) }, options.BuildProperties);
+            Assert.Equal(0, errorCode);
+            Assert.Equal("", _console.Error.ToString());
+        }
+
+        [Theory]
+        [InlineData("P2=")]
+        [InlineData("=P3")]
+        [InlineData("=")]
+        [InlineData("==")]
+        public void BuildProperties_Invalid(string value)
+        {
+            var args = new[] { "--property", value };
+            CommandLineOptions.Parse(args, _testReporter, out var errorCode, _console);
+            Assert.Equal(1, errorCode);
+            Assert.Equal($"Invalid property format: '{value}'. Expected 'name=value'.", _console.Error.ToString().Trim());
         }
 
         [Fact]
@@ -133,12 +153,10 @@ namespace Microsoft.DotNet.Watcher.Tools
             Assert.Equal(new[] { "run", "--launch-profile", "P2" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
             Assert.Equal("P1", watchProfileName);
 
-            var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
-            reporter.Setup(r => r.Warn($"Using launch profile name 'P1', ignoring 'P2'.", It.IsAny<string>())).Verifiable();
-
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, reporter.Object, out _, out watchProfileName));
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out watchProfileName));
             Assert.Equal("P1", watchProfileName);
 
+            Assert.Equal(new[] { "warn ⌚ Using launch profile name 'P1', ignoring 'P2'." }, _testReporter.Messages);
             Assert.Empty(_console.Out.ToString());
         }
 
@@ -246,14 +264,20 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         [Theory]
         [CombinatorialData]
-        public void Project_BeforeOrAfterRun(bool afterRun)
+        public void OptionsSpecifiedBeforeOrAfterRun(bool afterRun)
         {
-            var args = new[] { "--project", "abc" };
+            var args = new[] { "--project", "P", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2" };
             args = afterRun ? args.Prepend("run").ToArray() : args.Append("run").ToArray();
 
             var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
 
-            Assert.Equal("abc", options.Project);
+            Assert.Equal("P", options.Project);
+            Assert.Equal("F", options.TargetFramework);
+            Assert.Equal(new[] { ("P1", "V1"), ("P2", "V2") }, options.BuildProperties);
+
+            Assert.Equal(new[] { "run", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
+
             Assert.Empty(_console.Out.ToString());
         }
 
@@ -266,15 +290,15 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         [Theory]
         [CombinatorialData]
-        public void OptionDuplicates_Allowed(
+        public void OptionDuplicates_Allowed_Bool(
             ArgPosition position,
             [CombinatorialValues(
                 "--verbose",
                 "--quiet",
                 "--list",
                 "--no-hot-reload",
-                "--non-interactive"
-            )] string arg)
+                "--non-interactive")]
+            string arg)
         {
             var args = new[] { arg };
 
@@ -302,7 +326,26 @@ namespace Microsoft.DotNet.Watcher.Tools
         }
 
         [Theory]
+        [InlineData("--property", "P1=V1", "P2=V2")]
+        public void OptionDuplicates_Allowed_Strings(string argName, string argValue1, string argValue2)
+        {
+            var args = new[] { argName, argValue1, "run", argName, argValue2 };
+
+            var options = CommandLineOptions.Parse(args, _testReporter, out var errorCode, _console);
+
+            Assert.Equal(new[] { argValue1, argValue2 }, argName switch
+            {
+                "--property" => options.BuildProperties.Select(p => $"{p.name}={p.value}"),
+                _ => null,
+            });
+
+            Assert.Equal(0, errorCode);
+            Assert.Equal("", _console.Out.ToString());
+        }
+
+        [Theory]
         [InlineData(new object[] { new[] { "--project", "abc" } })]
+        [InlineData(new object[] { new[] { "--framework", "abc" } })]
         public void OptionDuplicates_NotAllowed(string[] args)
         {
             args = args.Concat(new[] { "run" }).Concat(args).ToArray();
@@ -346,13 +389,10 @@ namespace Microsoft.DotNet.Watcher.Tools
         [Fact]
         public void ShortFormForProjectArgumentPrintsWarning()
         {
-            var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
-            reporter.Setup(r => r.Warn(Resources.Warning_ProjectAbbreviationDeprecated, It.IsAny<string>())).Verifiable();
-
             var args = new[] { "-p", "MyProject.csproj" };
-            var options = CommandLineOptions.Parse(args, reporter.Object, out _, _console);
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
 
-            reporter.Verify();
+            Assert.Equal(new[] { $"warn ⌚ {Resources.Warning_ProjectAbbreviationDeprecated}" }, _testReporter.Messages);
             Assert.NotNull(options);
             Assert.Equal("MyProject.csproj", options.Project);
         }
@@ -360,12 +400,10 @@ namespace Microsoft.DotNet.Watcher.Tools
         [Fact]
         public void LongFormForProjectArgumentWorks()
         {
-            var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
-
             var args = new[] { "--project", "MyProject.csproj" };
-            var options = CommandLineOptions.Parse(args, reporter.Object, out _, _console);
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
 
-            reporter.Verify(r => r.Warn(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            Assert.Empty(_testReporter.Messages);
             Assert.NotNull(options);
             Assert.Equal("MyProject.csproj", options.Project);
         }
@@ -373,12 +411,10 @@ namespace Microsoft.DotNet.Watcher.Tools
         [Fact]
         public void LongFormForLaunchProfileArgumentWorks()
         {
-            var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
-
             var args = new[] { "--launch-profile", "CustomLaunchProfile" };
-            var options = CommandLineOptions.Parse(args, reporter.Object, out _, _console);
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
 
-            reporter.Verify(r => r.Warn(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            Assert.Empty(_testReporter.Messages);
             Assert.NotNull(options);
             Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
         }
@@ -386,12 +422,10 @@ namespace Microsoft.DotNet.Watcher.Tools
         [Fact]
         public void ShortFormForLaunchProfileArgumentWorks()
         {
-            var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
-
             var args = new[] { "-lp", "CustomLaunchProfile" };
-            var options = CommandLineOptions.Parse(args, reporter.Object, out _, _console);
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
 
-            reporter.Verify(r => r.Warn(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            Assert.Empty(_testReporter.Messages);
             Assert.NotNull(options);
             Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
         }

--- a/src/Tests/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/src/Tests/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.CommandLine;
+using System;
 using System.CommandLine.IO;
-using System.CommandLine.Parsing;
-using System.Threading.Tasks;
+using System.Linq;
+
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,57 +27,330 @@ namespace Microsoft.DotNet.Watcher.Tools
         [InlineData(new object[] { new[] { "-?" } })]
         [InlineData(new object[] { new[] { "--help" } })]
         [InlineData(new object[] { new[] { "--help", "--bogus" } })]
-        public async Task HelpArgs(string[] args)
+        public void HelpArgs(string[] args)
         {
-            var rootCommand = Program.CreateRootCommand(c => Task.FromResult(0), _testReporter);
-
-            await rootCommand.InvokeAsync(args, _console);
+            Assert.Null(CommandLineOptions.Parse(args, _testReporter, out var errorCode, _console));
+            Assert.Equal(0, errorCode);
 
             Assert.Contains("Usage:", _console.Out.ToString());
         }
 
-        [Theory]
-        [InlineData(new[] { "run" }, new[] { "run" })]
-        [InlineData(new[] { "run", "--", "subarg" }, new[] { "run", "subarg" })]
-        [InlineData(new[] { "--", "run", "--", "subarg" }, new[] { "run", "--", "subarg" })]
-        [InlineData(new[] { "--unrecognized-arg" }, new[] { "--unrecognized-arg" })]
-        public async Task ParsesRemainingArgs(string[] args, string[] expected)
+        [Fact]
+        public void RunOptions_NoRun()
         {
-            CommandLineOptions options = null;
+            var args = new[] { "--verbose" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
 
-            var rootCommand = Program.CreateRootCommand(c =>
-            {
-                options = c;
-                return Task.FromResult(0);
-            }, _testReporter);
+            Assert.True(options.Verbose);
+            Assert.False(options.NoLaunchProfile);
+            Assert.Null(options.LaunchProfileName);
+            Assert.Empty(options.RemainingArguments);
 
-            await rootCommand.InvokeAsync(args, _console);
+            Assert.Null(options.RunOptions);
 
-            Assert.NotNull(options);
+            Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoProfile, out var watchProfileName));
+            Assert.False(watchNoProfile);
+            Assert.Null(watchProfileName);
 
-            Assert.Equal(expected, options.RemainingArguments);
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoProfile, out watchProfileName));
+            Assert.False(watchNoProfile);
+            Assert.Null(watchProfileName);
+
             Assert.Empty(_console.Out.ToString());
         }
 
         [Fact]
-        public async Task CannotHaveQuietAndVerbose()
+        public void RunOptions_Run()
         {
-            var rootCommand = Program.CreateRootCommand(c => Task.FromResult(0), _testReporter);
+            var args = new[] { "--verbose", "run" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
 
-            await rootCommand.InvokeAsync(new[] { "--quiet", "--verbose" }, _console);
+            Assert.True(options.Verbose);
+            Assert.False(options.NoLaunchProfile);
+            Assert.Null(options.LaunchProfileName);
+            Assert.Empty(options.RemainingArguments);
+
+            Assert.False(options.RunOptions.NoLaunchProfile);
+            Assert.Null(options.RunOptions.LaunchProfileName);
+            Assert.Empty(options.RunOptions.RemainingArguments);
+
+            Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoProfile, out var watchProfileName));
+            Assert.False(watchNoProfile);
+            Assert.Null(watchProfileName);
+
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoProfile, out watchProfileName));
+            Assert.False(watchNoProfile);
+            Assert.Null(watchProfileName);
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void RunOptions_LaunchProfile_Watch()
+        {
+            var args = new[] { "-lp", "P", "run" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.Equal("P", options.LaunchProfileName);
+            Assert.Null(options.RunOptions.LaunchProfileName);
+
+            Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
+            Assert.Equal("P", watchProfileName);
+
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out watchProfileName));
+            Assert.Equal("P", watchProfileName);
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void RunOptions_LaunchProfile_Run()
+        {
+            var args = new[] { "run", "-lp", "P" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.Null(options.LaunchProfileName);
+            Assert.Equal("P", options.RunOptions.LaunchProfileName);
+
+            Assert.Equal(new[] { "run", "--launch-profile", "P" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
+            Assert.Null(watchProfileName);
+
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out watchProfileName));
+            Assert.Equal("P", watchProfileName);
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void RunOptions_LaunchProfile_Both()
+        {
+            var args = new[] { "-lp", "P1", "run", "-lp", "P2" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.Equal("P1", options.LaunchProfileName);
+            Assert.Equal("P2", options.RunOptions.LaunchProfileName);
+
+            Assert.Equal(new[] { "run", "--launch-profile", "P2" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
+            Assert.Equal("P1", watchProfileName);
+
+            var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
+            reporter.Setup(r => r.Warn($"Using launch profile name 'P1', ignoring 'P2'.", It.IsAny<string>())).Verifiable();
+
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, reporter.Object, out _, out watchProfileName));
+            Assert.Equal("P1", watchProfileName);
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void RunOptions_NoProfile_Watch()
+        {
+            var args = new[] { "--no-launch-profile", "run" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.True(options.NoLaunchProfile);
+            Assert.False(options.RunOptions.NoLaunchProfile);
+
+            Assert.Equal(new[] { "run", }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoLaunchProfile, out _));
+            Assert.True(watchNoLaunchProfile);
+
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoLaunchProfile, out _));
+            Assert.True(watchNoLaunchProfile);
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void RunOptions_NoProfile_Run()
+        {
+            var args = new[] { "run", "--no-launch-profile" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.False(options.NoLaunchProfile);
+            Assert.True(options.RunOptions.NoLaunchProfile);
+
+            Assert.Equal(new[] { "run", "--no-launch-profile" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoLaunchProfile, out _));
+            Assert.False(watchNoLaunchProfile);
+
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoLaunchProfile, out _));
+            Assert.True(watchNoLaunchProfile);
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void RunOptions_NoProfile_Both()
+        {
+            var args = new[] { "--no-launch-profile", "run", "--no-launch-profile" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.True(options.NoLaunchProfile);
+            Assert.True(options.RunOptions.NoLaunchProfile);
+
+            Assert.Equal(new[] { "run", "--no-launch-profile" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoLaunchProfile, out _));
+            Assert.True(watchNoLaunchProfile);
+
+            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoLaunchProfile, out _));
+            Assert.True(watchNoLaunchProfile);
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void RemainingOptions()
+        {
+            var args = new[] { "-watchArg", "--verbose", "run", "-runArg" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+            //dotnet watch -- --verbose run
+            Assert.True(options.Verbose);
+            Assert.Equal(new[] { "-watchArg" }, options.RemainingArguments);
+            Assert.Equal(new[] { "-runArg" }, options.RunOptions.RemainingArguments);
+
+            Assert.Equal(new[] { "run", "-watchArg", "-runArg" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
+            Assert.Equal(new[] { "-watchArg", "-runArg" }, options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void RemainingOptionsDashDash()
+        {
+            var args = new[] { "-watchArg", "--", "--verbose", "run", "-runArg" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.False(options.Verbose);
+            Assert.Equal(new[] { "-watchArg", "--verbose", "run", "-runArg" }, options.RemainingArguments);
+            Assert.Null(options.RunOptions);
+
+            Assert.Equal(new[] { "run", "-watchArg", "--verbose", "run", "-runArg" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
+            Assert.Equal(new[] { "-watchArg", "--verbose", "run", "-runArg" }, options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void RemainingOptionsDashDashRun()
+        {
+            var args = new[] { "--", "run" };
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.False(options.Verbose);
+            Assert.Equal(new[] { "run" }, options.RemainingArguments);
+            Assert.Null(options.RunOptions);
+
+            Assert.Equal(new[] { "run", "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
+            Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void Project_BeforeOrAfterRun(bool afterRun)
+        {
+            var args = new[] { "--project", "abc" };
+            args = afterRun ? args.Prepend("run").ToArray() : args.Append("run").ToArray();
+
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.Equal("abc", options.Project);
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        public enum ArgPosition
+        {
+            Before,
+            After,
+            Both
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void OptionDuplicates_Allowed(
+            ArgPosition position,
+            [CombinatorialValues(
+                "--verbose",
+                "--quiet",
+                "--list",
+                "--no-hot-reload",
+                "--non-interactive"
+            )] string arg)
+        {
+            var args = new[] { arg };
+
+            args = position switch
+            {
+                ArgPosition.Before => args.Prepend("run").ToArray(),
+                ArgPosition.Both => args.Concat(new[] { "run" }).Concat(args).ToArray(),
+                ArgPosition.After => args.Append("run").ToArray(),
+                _ => args,
+            };
+
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.True(arg switch
+            {
+                "--verbose" => options.Verbose,
+                "--quiet" => options.Quiet,
+                "--list" => options.List,
+                "--no-hot-reload" => options.NoHotReload,
+                "--non-interactive" => options.NonInteractive,
+                _ => false
+            });
+
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Theory]
+        [InlineData(new object[] { new[] { "--project", "abc" } })]
+        public void OptionDuplicates_NotAllowed(string[] args)
+        {
+            args = args.Concat(new[] { "run" }).Concat(args).ToArray();
+
+            var options = CommandLineOptions.Parse(args, _testReporter, out var errorCode, _console);
+            Assert.Null(options);
+            Assert.Equal(1, errorCode);
+
+            Assert.Equal("", _console.Out.ToString());
+        }
+
+        [Theory]
+        [InlineData(new[] { "--unrecognized-arg" }, new[] { "--unrecognized-arg" }, new string[0])]
+        [InlineData(new[] { "run" }, new string[0], new string[0])]
+        [InlineData(new[] { "run", "--", "runarg" }, new string[0], new[] { "runarg" })]
+        [InlineData(new[] { "-watcharg", "run", "runarg1", "-runarg2" }, new[] { "-watcharg" }, new[] { "runarg1", "-runarg2" })]
+        // run is after -- and therefore not parsed as a command:
+        [InlineData(new[] { "-watcharg", "--", "run", "--", "runarg" }, new[] { "-watcharg", "run", "--", "runarg" }, new string[0])]
+        // run is before -- and therefore parsed as a command:
+        [InlineData(new[] { "-watcharg", "run", "--", "--", "runarg" }, new[] { "-watcharg" }, new[] { "--", "runarg" })]
+        public void ParsesRemainingArgs(string[] args, string[] expectedWatch, string[] expectedRun)
+        {
+            var options = CommandLineOptions.Parse(args, _testReporter, out _, _console);
+
+            Assert.NotNull(options);
+
+            Assert.Equal(expectedWatch, options.RemainingArguments);
+            Assert.Equal(expectedRun, options.RunOptions?.RemainingArguments ?? Array.Empty<string>());
+            Assert.Empty(_console.Out.ToString());
+        }
+
+        [Fact]
+        public void CannotHaveQuietAndVerbose()
+        {
+            var args = new[] { "--quiet", "--verbose" };
+            _ = CommandLineOptions.Parse(args, _testReporter, out _, _console);
 
             Assert.Contains(Resources.Error_QuietAndVerboseSpecified, _console.Error.ToString());
         }
 
         [Fact]
-        public async Task ShortFormForProjectArgumentPrintsWarning()
+        public void ShortFormForProjectArgumentPrintsWarning()
         {
             var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
             reporter.Setup(r => r.Warn(Resources.Warning_ProjectAbbreviationDeprecated, It.IsAny<string>())).Verifiable();
-            CommandLineOptions options = null;
-            var rootCommand = Program.CreateRootCommand(c => { options = c; return Task.FromResult(0); }, reporter.Object);
 
-            await rootCommand.InvokeAsync(new[] { "-p", "MyProject.csproj" }, _console);
+            var args = new[] { "-p", "MyProject.csproj" };
+            var options = CommandLineOptions.Parse(args, reporter.Object, out _, _console);
 
             reporter.Verify();
             Assert.NotNull(options);
@@ -85,13 +358,12 @@ namespace Microsoft.DotNet.Watcher.Tools
         }
 
         [Fact]
-        public async Task LongFormForProjectArgumentWorks()
+        public void LongFormForProjectArgumentWorks()
         {
             var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
-            CommandLineOptions options = null;
-            var rootCommand = Program.CreateRootCommand(c => { options = c; return Task.FromResult(0); }, reporter.Object);
 
-            await rootCommand.InvokeAsync(new[] { "--project", "MyProject.csproj" }, _console);
+            var args = new[] { "--project", "MyProject.csproj" };
+            var options = CommandLineOptions.Parse(args, reporter.Object, out _, _console);
 
             reporter.Verify(r => r.Warn(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
             Assert.NotNull(options);
@@ -99,31 +371,29 @@ namespace Microsoft.DotNet.Watcher.Tools
         }
 
         [Fact]
-        public async Task LongFormForLaunchProfileArgumentWorks()
+        public void LongFormForLaunchProfileArgumentWorks()
         {
             var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
-            CommandLineOptions options = null;
-            var rootCommand = Program.CreateRootCommand(c => { options = c; return Task.FromResult(0); }, reporter.Object);
 
-            await rootCommand.InvokeAsync(new[] { "--launch-profile", "CustomLaunchProfile" }, _console);
+            var args = new[] { "--launch-profile", "CustomLaunchProfile" };
+            var options = CommandLineOptions.Parse(args, reporter.Object, out _, _console);
 
             reporter.Verify(r => r.Warn(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
             Assert.NotNull(options);
-            Assert.Equal("CustomLaunchProfile", options.LaunchProfile);
+            Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
         }
 
         [Fact]
-        public async Task ShortFormForLaunchProfileArgumentWorks()
+        public void ShortFormForLaunchProfileArgumentWorks()
         {
             var reporter = new Mock<Extensions.Tools.Internal.IReporter>();
-            CommandLineOptions options = null;
-            var rootCommand = Program.CreateRootCommand(c => { options = c; return Task.FromResult(0); }, reporter.Object);
 
-            await rootCommand.InvokeAsync(new[] { "-lp", "CustomLaunchProfile" }, _console);
+            var args = new[] { "-lp", "CustomLaunchProfile" };
+            var options = CommandLineOptions.Parse(args, reporter.Object, out _, _console);
 
             reporter.Verify(r => r.Warn(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
             Assert.NotNull(options);
-            Assert.Equal("CustomLaunchProfile", options.LaunchProfile);
+            Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
         }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
+++ b/src/Tests/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
@@ -328,7 +328,7 @@ $@"<ItemGroup>
 
             var output = new OutputSink();
             var options = GetWatchOptions();
-            var filesetFactory = new MsBuildFileSetFactory(options, _reporter, _muxerPath, projectA, output, waitOnError: false, trace: true);
+            var filesetFactory = new MsBuildFileSetFactory(options, _reporter, _muxerPath, projectA, targetFramework: null, buildProperties: null, output, waitOnError: false, trace: true);
 
             var fileset = await filesetFactory.CreateAsync(CancellationToken.None);
 
@@ -363,7 +363,7 @@ $@"<ItemGroup>
         private Task<FileSet> GetFileSet(string projectPath)
         {
             DotNetWatchOptions options = GetWatchOptions();
-            return new MsBuildFileSetFactory(options, _reporter, _muxerPath, projectPath, new OutputSink(), waitOnError: false, trace: false).CreateAsync(CancellationToken.None);
+            return new MsBuildFileSetFactory(options, _reporter, _muxerPath, projectPath, targetFramework: null, buildProperties: null, new OutputSink(), waitOnError: false, trace: false).CreateAsync(CancellationToken.None);
         }
 
         private static DotNetWatchOptions GetWatchOptions() => 

--- a/src/Tests/dotnet-watch.Tests/Utilities/MockReporter.cs
+++ b/src/Tests/dotnet-watch.Tests/Utilities/MockReporter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher.Tools;
+
+internal class MockReporter : IReporter
+{
+    public readonly List<string> Messages = new();
+
+    public void Verbose(string message, string emoji = "⌚")
+        => Messages.Add($"verbose {emoji} " + message);
+
+    public void Output(string message, string emoji = "⌚")
+        => Messages.Add($"output {emoji} " + message);
+    
+    public void Warn(string message, string emoji = "⌚")
+        => Messages.Add($"warn {emoji} " + message);
+
+    public void Error(string message, string emoji = "❌")
+        => Messages.Add($"error {emoji} " + message);
+}

--- a/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -61,18 +61,6 @@ namespace Microsoft.DotNet.Watcher.Tests
         }
 
         [Fact]
-        public async Task OnlyRunSupportsHotReload()
-        {
-            var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
-                .WithSource()
-                .Path;
-
-            App.Start(testAsset, new[] { "--verbose", "abc" });
-
-           await App.AssertOutputLineStartsWith("dotnet watch ❌ Only 'run' command supports Hot Reload");
-        }
-
-        [Fact]
         public async Task RunArguments()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppMultiTfm")

--- a/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -71,7 +71,8 @@ namespace Microsoft.DotNet.Watcher.Tests
             {
                 "run",
                 "-f",         // dotnet watch does not recognize this arg -> dotnet run arg
-                "net6.0",     
+                "net6.0",
+                "--property:AssemblyVersion=1.2.3.4",
                 "--",         // the following args are not dotnet watch args
                 "-v",         // dotnet run arg
                 "minimal",
@@ -80,6 +81,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             });
 
             Assert.Equal("-v", await App.AssertOutputLineStartsWith("Arguments = "));
+            Assert.Equal("WatchHotReloadAppMultiTfm, Version=1.2.3.4, Culture=neutral, PublicKeyToken=null", await App.AssertOutputLineStartsWith("AssemblyName = "));
             Assert.Equal(".NETCoreApp,Version=v6.0", await App.AssertOutputLineStartsWith("TFM = "));
 
             // expected output from build (-v minimal):

--- a/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -44,11 +44,11 @@ namespace Microsoft.DotNet.Watcher.Tests
         /// <summary>
         /// Asserts that the watched process outputs a line starting with <paramref name="expectedPrefix"/> and returns the remainder of that line.
         /// </summary>
-        public async Task<string> AssertOutputLineStartsWith(string expectedPrefix)
+        public async Task<string> AssertOutputLineStartsWith(string expectedPrefix, Predicate<string> failure = null)
         {
             var line = await Process.GetOutputLineAsync(
                 success: line => line.StartsWith(expectedPrefix, StringComparison.Ordinal),
-                failure: line => line.Contains(WatchErrorOutputEmoji, StringComparison.Ordinal));
+                failure: failure ?? new Predicate<string>(line => line.Contains(WatchErrorOutputEmoji, StringComparison.Ordinal)));
 
             Assert.StartsWith(expectedPrefix, line, StringComparison.Ordinal);
 

--- a/src/Tests/dotnet-watch.Tests/dotnet-watch.Tests.csproj
+++ b/src/Tests/dotnet-watch.Tests/dotnet-watch.Tests.csproj
@@ -12,5 +12,6 @@
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds support for `--framework` and `--property` command line options.

Fixes https://github.com/dotnet/aspnetcore/issues/45629
Fixes https://github.com/dotnet/aspnetcore/issues/38408
Fixes https://github.com/dotnet/aspnetcore/issues/39443
Fixes https://github.com/dotnet/aspnetcore/issues/38408
Fixes https://github.com/dotnet/aspnetcore/issues/40472
Fixes https://github.com/dotnet/aspnetcore/issues/33726

Might fix https://github.com/dotnet/aspnetcore/issues/37504 -- needs validation.