### PR TITLE
Disable analyzers for dotnet-watch when running source-build.

### DIFF
--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -9,6 +9,7 @@
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <UseAppHost>false</UseAppHost>
     <RuntimeIdentifier />
+    <RunAnalyzers Condition="'$(DotNetBuildFromSource)' == 'true'">false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Source-build-specific temporary fix for https://github.com/dotnet/sdk/issues/30786.