### PR TITLE
[Forward Port] Restore Encoding for the .NET SDK upon Exit

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Text;
+using Microsoft.Win32;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -27,7 +29,7 @@ namespace Microsoft.DotNet.Cli.Utils
             if (
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && // Encoding is only an issue on Windows
                 !CultureInfo.CurrentUICulture.TwoLetterISOLanguageName.Equals("en", StringComparison.InvariantCultureIgnoreCase) &&
-                Environment.OSVersion.Version.Major >= 10 // UTF-8 is only officially supported on 10+.
+                CurrentWindowsVersionOfficiallySupportsUTF8Encoding()
                 )
             {
                 Console.OutputEncoding = DefaultMultilingualEncoding;
@@ -96,6 +98,27 @@ namespace Microsoft.DotNet.Cli.Utils
         private static void SetIfNotAlreadySet(string environmentVariableName, int value)
         {
             SetIfNotAlreadySet(environmentVariableName, value.ToString());
+        }
+
+        private static bool CurrentWindowsVersionOfficiallySupportsUTF8Encoding()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version.Major >= 10) // UTF-8 is only officially supported on 10+.
+            {
+                try
+                {
+                    RegistryKey windowsVersionRegistry = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+                    var buildNumber = windowsVersionRegistry.GetValue("CurrentBuildNumber").ToString();
+                    const int buildNumberThatOfficialySupportsUTF8 = 18363;
+                    return int.Parse(buildNumber) >= buildNumberThatOfficialySupportsUTF8;
+                }
+                catch (Exception ex) when (ex is SecurityException || ex is ObjectDisposedException)
+                {
+                    // We don't want to break those in VS on older versions of Windows with a non-en language.
+                    // Allow those without registry permissions to force the encoding, however.
+                    return String.Equals(Environment.GetEnvironmentVariable("DOTNET_CLI_FORCE_UTF8_ENCODING"), "true", StringComparison.OrdinalIgnoreCase);
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
@@ -109,16 +109,21 @@ namespace Microsoft.DotNet.Cli.Utils
                     RegistryKey windowsVersionRegistry = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
                     var buildNumber = windowsVersionRegistry.GetValue("CurrentBuildNumber").ToString();
                     const int buildNumberThatOfficialySupportsUTF8 = 18363;
-                    return int.Parse(buildNumber) >= buildNumberThatOfficialySupportsUTF8;
+                    return int.Parse(buildNumber) >= buildNumberThatOfficialySupportsUTF8 || ForceUniversalEncodingOptInEnabled();
                 }
                 catch (Exception ex) when (ex is SecurityException || ex is ObjectDisposedException)
                 {
                     // We don't want to break those in VS on older versions of Windows with a non-en language.
                     // Allow those without registry permissions to force the encoding, however.
-                    return String.Equals(Environment.GetEnvironmentVariable("DOTNET_CLI_FORCE_UTF8_ENCODING"), "true", StringComparison.OrdinalIgnoreCase);
+                    return ForceUniversalEncodingOptInEnabled();
                 }
             }
             return false;
+        }
+
+        private static bool ForceUniversalEncodingOptInEnabled()
+        {
+            return String.Equals(Environment.GetEnvironmentVariable("DOTNET_CLI_FORCE_UTF8_ENCODING"), "true", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
@@ -27,9 +27,8 @@ namespace Microsoft.DotNet.Cli.Utils
             }
 
             if (
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && // Encoding is only an issue on Windows
                 !CultureInfo.CurrentUICulture.TwoLetterISOLanguageName.Equals("en", StringComparison.InvariantCultureIgnoreCase) &&
-                CurrentWindowsVersionOfficiallySupportsUTF8Encoding()
+                CurrentPlatformIsWindowsAndOfficiallySupportsUTF8Encoding()
                 )
             {
                 Console.OutputEncoding = DefaultMultilingualEncoding;
@@ -100,13 +99,13 @@ namespace Microsoft.DotNet.Cli.Utils
             SetIfNotAlreadySet(environmentVariableName, value.ToString());
         }
 
-        private static bool CurrentWindowsVersionOfficiallySupportsUTF8Encoding()
+        private static bool CurrentPlatformIsWindowsAndOfficiallySupportsUTF8Encoding()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version.Major >= 10) // UTF-8 is only officially supported on 10+.
             {
                 try
                 {
-                    RegistryKey windowsVersionRegistry = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+                    using RegistryKey windowsVersionRegistry = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
                     var buildNumber = windowsVersionRegistry.GetValue("CurrentBuildNumber").ToString();
                     const int buildNumberThatOfficialySupportsUTF8 = 18363;
                     return int.Parse(buildNumber) >= buildNumberThatOfficialySupportsUTF8 || ForceUniversalEncodingOptInEnabled();

--- a/src/Cli/dotnet/AutomaticEncodingRestorer.cs
+++ b/src/Cli/dotnet/AutomaticEncodingRestorer.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.IO;
+using System.Security;
+using System.Text;
+
+namespace Microsoft.DotNet.Cli
+{
+    /// <summary>
+    /// A program can change the encoding of the console which would affect other programs.
+    /// We would prefer to have a pattern where the program does not affect encoding of other programs.
+    /// Create this class in a function akin to Main and let it manage the console encoding resources to return it to the state before execution upon destruction.
+    /// </summary>
+    internal class AutomaticEncodingRestorer : IDisposable
+    {
+        Encoding _originalOutputEncoding = null;
+        Encoding _originalInputEncoding = null;
+
+        bool outputEncodingAccessible = false;
+        bool inputEncodingAccessible = false;
+
+        public AutomaticEncodingRestorer()
+        {
+            try
+            {
+                if (!OperatingSystem.IsIOS() && !OperatingSystem.IsAndroid() && !OperatingSystem.IsTvOS()) // Output + Input Encoding are unavailable on these platforms per docs.
+                {
+                    _originalOutputEncoding = Console.OutputEncoding;
+                    outputEncodingAccessible = true;
+                    if (!OperatingSystem.IsBrowser()) // Input Encoding is also unavailable in this platform.
+                    {
+                        _originalInputEncoding = Console.InputEncoding;
+                        inputEncodingAccessible = true;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException || ex is SecurityException)
+            {
+                // The encoding is unavailable. Do nothing.
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (outputEncodingAccessible)
+                {
+                    Console.OutputEncoding = _originalOutputEncoding;
+                }
+                if (inputEncodingAccessible)
+                {
+                    Console.InputEncoding = _originalInputEncoding;
+                }
+            }
+            catch (Exception ex) when (ex is IOException || ex is SecurityException)
+            {
+                // The encoding is unavailable. Do nothing.
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -27,6 +27,8 @@ namespace Microsoft.DotNet.Cli
 
         public static int Main(string[] args)
         {
+            using AutomaticEncodingRestorer _ = new();
+
             // Setting output encoding is not available on those platforms
             if (!OperatingSystem.IsIOS() && !OperatingSystem.IsAndroid() && !OperatingSystem.IsTvOS() && !OperatingSystem.IsBrowser())
             {
@@ -39,7 +41,6 @@ namespace Microsoft.DotNet.Cli
             }
 
             DebugHelper.HandleDebugSwitch(ref args);
-            using AutomaticEncodingRestorer _ = new();
 
             // Capture the current timestamp to calculate the host overhead.
             DateTime mainTimeStamp = DateTime.Now;

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -27,8 +27,8 @@ namespace Microsoft.DotNet.Cli
 
         public static int Main(string[] args)
         {
-            //setting output encoding is not available on those platforms
-            if (!OperatingSystem.IsIOS() && !OperatingSystem.IsAndroid() && !OperatingSystem.IsTvOS())
+            // Setting output encoding is not available on those platforms
+            if (!OperatingSystem.IsIOS() && !OperatingSystem.IsAndroid() && !OperatingSystem.IsTvOS() && !OperatingSystem.IsBrowser())
             {
                 //if output is redirected, force encoding to utf-8;
                 //otherwise the caller may not decode it correctly
@@ -39,6 +39,7 @@ namespace Microsoft.DotNet.Cli
             }
 
             DebugHelper.HandleDebugSwitch(ref args);
+            using AutomaticEncodingRestorer _ = new();
 
             // Capture the current timestamp to calculate the host overhead.
             DateTime mainTimeStamp = DateTime.Now;
@@ -105,19 +106,19 @@ namespace Microsoft.DotNet.Cli
             }
             finally
             {
-                if(perLogEventListener != null)
+                if (perLogEventListener != null)
                 {
                     perLogEventListener.Dispose();
                 }
             }
         }
 
-        internal static int ProcessArgs(string[] args, ITelemetry telemetryClient = null )
+        internal static int ProcessArgs(string[] args, ITelemetry telemetryClient = null)
         {
             return ProcessArgs(args, new TimeSpan(0), telemetryClient);
         }
 
-        internal static int ProcessArgs(string[] args, TimeSpan startupTime, ITelemetry telemetryClient = null )
+        internal static int ProcessArgs(string[] args, TimeSpan startupTime, ITelemetry telemetryClient = null)
         {
             Dictionary<string, double> performanceData = new Dictionary<string, double>();
 

--- a/src/Common/EnvironmentVariableNames.cs
+++ b/src/Common/EnvironmentVariableNames.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Cli
         public static readonly string WORKLOAD_DISABLE_PACK_GROUPS = "DOTNET_CLI_WORKLOAD_DISABLE_PACK_GROUPS";
         public static readonly string DISABLE_PUBLISH_AND_PACK_RELEASE = "DOTNET_CLI_DISABLE_PUBLISH_AND_PACK_RELEASE";
         public static readonly string DOTNET_CLI_LAZY_PUBLISH_AND_PACK_RELEASE_FOR_SOLUTIONS = "DOTNET_CLI_LAZY_PUBLISH_AND_PACK_RELEASE_FOR_SOLUTIONS";
+        public static readonly string DOTNET_CLI_FORCE_UTF8_ENCODING = nameof(DOTNET_CLI_FORCE_UTF8_ENCODING);
         public static readonly string TELEMETRY_OPTOUT = "DOTNET_CLI_TELEMETRY_OPTOUT";
         public static readonly string DOTNET_ROOT = "DOTNET_ROOT";
 


### PR DESCRIPTION
Didn't realize preview branches were treated differently when I first made this PR https://github.com/dotnet/sdk/pull/30963/so essentially that PR did nothing because it was a closed branch. This ports said pr forward to preview 3.