### PR TITLE
EnableRequestDelegateGenerator by default for PublishAot

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -41,6 +41,26 @@ namespace Microsoft.NET.Build.Tests
                     }
                 });
 
+            VerifyRequestDelegateGeneratorIsUsed(asset, isEnabled);
+        }
+
+        [Fact]
+        public void It_enables_requestdelegategenerator_for_PublishAot()
+        {
+            var asset = _testAssetsManager
+                .CopyTestAsset("WebApp")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    project.Root.Add(new XElement(ns + "PropertyGroup", new XElement("PublishAot", "true")));
+                });
+
+            VerifyRequestDelegateGeneratorIsUsed(asset, expectEnabled: true);
+        }
+
+        private void VerifyRequestDelegateGeneratorIsUsed(TestAsset asset, bool? expectEnabled)
+        {
             var command = new GetValuesCommand(
                 Log,
                 asset.Path,
@@ -55,7 +75,7 @@ namespace Microsoft.NET.Build.Tests
 
             var analyzers = command.GetValues();
 
-            Assert.Equal(isEnabled ?? false, analyzers.Any(analyzer => analyzer.Contains("Microsoft.AspNetCore.Http.Generators.dll")));
+            Assert.Equal(expectEnabled ?? false, analyzers.Any(analyzer => analyzer.Contains("Microsoft.AspNetCore.Http.Generators.dll")));
         }
 
         [Theory]

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -46,10 +46,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == ''">false</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
-
   <PropertyGroup Condition="'$(PublishTrimmed)' == 'true' Or '$(PublishAot)' == 'true'">
     <!-- Runtime feature defaults to trim unnecessary code -->
     <EnsureAspNetCoreJsonTrimmability Condition="'$(EnsureAspNetCoreJsonTrimmability)' == ''">true</EnsureAspNetCoreJsonTrimmability>
+  </PropertyGroup>
+
+  <!--
+    Enable the RequestDelegateGenerator by default for NativeAot apps.
+    This will be enabled for all PublishTrimmed apps once the RequestDelegateGenerator supports all MinimalApi features.
+   -->
+  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <EnableRequestDelegateGenerator Condition="'$(EnableRequestDelegateGenerator)' == ''">true</EnableRequestDelegateGenerator>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
The source generator allows develoeprs to publish a Minimal API NativeAOT app without warnings. It should be enabled by default when users opt into NativeAOT.