### PR TITLE
Allow hashtag in response files

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -118,17 +118,8 @@ namespace Microsoft.DotNet.Cli
                 var lines = File.ReadAllLines(filePath);
                 var trimmedLines =
                     lines
-                        // Remove content in the lines that contain #, starting from the point of the #
-                        .Select(line => {
-                            var hashPos = line.IndexOf('#');
-                            if (hashPos == -1) {
-                                return line;
-                            } else if (hashPos == 0) {
-                                return "";
-                            } else {
-                                return line.Substring(0, hashPos).Trim();
-                            }
-                        })
+                        // Remove content in the lines that start with # after trimmer leading whitespace
+                        .Select(line => line.TrimStart().StartsWith('#') ? string.Empty : line)
                         // trim leading/trailing whitespace to not pass along dead spaces
                         .Select(x => x.Trim())
                         // Remove empty lines

--- a/src/Tests/dotnet.Tests/ParserTests/ResponseFileTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ResponseFileTests.cs
@@ -56,7 +56,8 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var lines = new[] {
                 "build",
                 "",
-                "run# but skip this",
+                "  #skip this",
+                "run #but don't skip this",
                 "# and this"
             };
             File.WriteAllLines(tempFilePath, lines);
@@ -66,7 +67,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var tokens = parseResult.Tokens.Select(t => t.Value);
             var tokenized = new [] {
                 "build",
-                "run"
+                "run #but don't skip this"
             };
 
             tokens.Skip(1).Should().BeEquivalentTo(tokenized);


### PR DESCRIPTION
## Description
Fixes #30759 by allowing response files to contain `#`. Only lines where the first non-whitespace character is a `#` will be treated as a comment. This is consistent with msbuild where response files can be used to pass properties that contain a `#`.