### PR TITLE
Move RDG omission to ResolveTargetingPackAssets target

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -427,7 +427,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <AnalyzerToRemove Include="@(OffByDefaultAnalyzer)"
-                        Path="%(Analyzer.FullPath)"
+                        Path="%(Analyzer.Identity)"
                         Condition="'%(Analyzer.Filename)' == '@(OffByDefaultAnalyzer)'" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -30,7 +30,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <KnownFrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref" />
     </ItemGroup>
-    
+
     <!-- Generate KnownFrameworkReference items for the Windows SDK pack -->
     <CreateWindowsSdkKnownFrameworkReferences
       UseWindowsSDKPreview="$(UseWindowsSDKPreview)"
@@ -42,7 +42,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       WindowsSdkSupportedTargetPlatformVersions="@(WindowsSdkSupportedTargetPlatformVersion)">
 
       <Output TaskParameter="KnownFrameworkReferences" ItemName="KnownFrameworkReference" />
-      
+
     </CreateWindowsSdkKnownFrameworkReferences>
   </Target>
 
@@ -415,6 +415,24 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <RuntimeFramework Remove="@(RuntimeFramework)" />
       <RuntimeFramework Include="@(_UsedRuntimeFramework)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ResolveOffByDefaultAnalyzers" AfterTargets="ResolveTargetingPackAssets"
+          Condition="'@(FrameworkReference)' != ''">
+    <ItemGroup>
+      <OffByDefaultAnalyzer Include="Microsoft.AspNetCore.Http.Generators"
+                            IsEnabled="$(EnableRequestDelegateGenerator)"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <AnalyzerToRemove Include="@(OffByDefaultAnalyzer)"
+                        Path="%(Analyzer.FullPath)"
+                        Condition="'%(Analyzer.Filename)' == '@(OffByDefaultAnalyzer)'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Analyzer Remove="%(AnalyzerToRemove.Path)" Condition="'%(AnalyzerToRemove.IsEnabled)' != 'true'"/>
     </ItemGroup>
   </Target>
 

--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -61,19 +61,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <!--  The RequestDelegateGenerator is bundled into the Microsoft.AspNetCore.App ref pack.-->
-  <!--  We want this generator to be disabled by default so we remove it from the list of-->
-  <!--  analyzers here. Since this depends on the analyzer having already been added to the-->
-  <!--  `Analyzer` item group by previous tasks in the build, we must wrap this work in a-->
-  <!--  target that executes right before the compilation loop.-->
-  <Target Name="RemoveRequestDelegateGenerator" BeforeTargets="CoreCompile">
-    <ItemGroup>
-      <Analyzer
-        Remove="@(Analyzer->HasMetadata('FileName')->WithMetadataValue('FileName', 'Microsoft.AspNetCore.Http.Generators'))"
-        Condition="'$(Language)'=='C#' AND '$(EnableRequestDelegateGenerator)' != 'true'"/>
-    </ItemGroup>
-  </Target>
-
   <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
     <Using Include="System.Net.Http.Json" />
     <Using Include="Microsoft.AspNetCore.Builder" />


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/issues/30872.

Centralize the configuration for off-by-default analyzers/generators into a new build target that runs after `ResolveTargetingPackAssets`. The idea is that we roll out new generators that need to be off-by-default, we would add new items to the `OffByDefaultAnalyzer` item group.