### PR TITLE
Emit AssemblyVersion and ReferenceAssembly assembly attributes

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -296,8 +296,8 @@ namespace Microsoft.DotNet.GenAPI
             if (attributes.All(attribute => attribute.AttributeClass?.ToDisplayString() != typeof(AssemblyFlagsAttribute).FullName))
             {
                 attributeSyntaxNodes.Add(_syntaxGenerator.Attribute(typeof(AssemblyFlagsAttribute).FullName!,
-                SyntaxFactory.AttributeArgument(SyntaxFactory.IdentifierName("(System.Reflection.AssemblyNameFlags)0x70")))
-                .WithTrailingTrivia(SyntaxFactory.LineFeed));
+                    SyntaxFactory.AttributeArgument(SyntaxFactory.IdentifierName("(System.Reflection.AssemblyNameFlags)0x70")))
+                    .WithTrailingTrivia(SyntaxFactory.LineFeed));
             }
 
             return _syntaxGenerator.AddAttributes(compilationUnit, attributeSyntaxNodes);

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Formatting;

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -166,8 +166,8 @@ namespace Microsoft.DotNet.GenAPI
 
         // Name hiding through inheritance occurs when classes or structs redeclare names that were inherited from base classes.This type of name hiding takes one of the following forms:
         // - A constant, field, property, event, or type introduced in a class or struct hides all base class members with the same name.
-        // - A method introduced in a class or struct hides all non-method base class members with the same name, and all base class methods with the same signature(ง7.6).
-        // - An indexer introduced in a class or struct hides all base class indexers with the same signature(ง7.6) .
+        // - A method introduced in a class or struct hides all non-method base class members with the same name, and all base class methods with the same signature(ยง7.6).
+        // - An indexer introduced in a class or struct hides all base class indexers with the same signature(ยง7.6) .
         private bool HidesBaseMember(ISymbol member)
         {
             if (member.IsOverride)
@@ -266,12 +266,38 @@ namespace Microsoft.DotNet.GenAPI
 
         private SyntaxNode GenerateAssemblyAttributes(IAssemblySymbol assembly, SyntaxNode compilationUnit)
         {
-            foreach (AttributeData? attribute in assembly.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(_symbolFilter))
+            // When assembly references aren't available, assembly attributes with foreign types won't be resolved.
+            ImmutableArray<AttributeData> attributes = assembly.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(_symbolFilter);
+
+            // Emit assembly attributes from the IAssemblySymbol
+            List<SyntaxNode> attributeSyntaxNodes = attributes.Select(attribute => _syntaxGenerator.Attribute(attribute)
+                .WithTrailingTrivia(SyntaxFactory.LineFeed))
+                .ToList();
+
+            // [assembly: System.Reflection.AssemblyVersion("x.x.x.x")]
+            if (attributes.All(attribute => attribute.AttributeClass?.ToDisplayString() != typeof(AssemblyVersionAttribute).FullName))
             {
-                compilationUnit = _syntaxGenerator.AddAttributes(compilationUnit, _syntaxGenerator.Attribute(attribute)
+                attributeSyntaxNodes.Add(_syntaxGenerator.Attribute(typeof(AssemblyVersionAttribute).FullName!,
+                    SyntaxFactory.AttributeArgument(SyntaxFactory.IdentifierName($"\"{assembly.Identity.Version}\"")))
                     .WithTrailingTrivia(SyntaxFactory.LineFeed));
             }
-            return compilationUnit;
+
+            // [assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+            if (attributes.All(attribute => attribute.AttributeClass?.ToDisplayString() != typeof(ReferenceAssemblyAttribute).FullName))
+            {
+                attributeSyntaxNodes.Add(_syntaxGenerator.Attribute(typeof(ReferenceAssemblyAttribute).FullName!)
+                    .WithTrailingTrivia(SyntaxFactory.LineFeed));
+            }
+
+            // [assembly: System.Reflection.AssemblyFlags((System.Reflection.AssemblyNameFlags)0x70)]
+            if (attributes.All(attribute => attribute.AttributeClass?.ToDisplayString() != typeof(AssemblyFlagsAttribute).FullName))
+            {
+                attributeSyntaxNodes.Add(_syntaxGenerator.Attribute(typeof(AssemblyFlagsAttribute).FullName!,
+                SyntaxFactory.AttributeArgument(SyntaxFactory.IdentifierName("(System.Reflection.AssemblyNameFlags)0x70")))
+                .WithTrailingTrivia(SyntaxFactory.LineFeed));
+            }
+
+            return _syntaxGenerator.AddAttributes(compilationUnit, attributeSyntaxNodes);
         }
 
         private SyntaxNode GenerateForwardedTypeAssemblyAttributes(IAssemblySymbol assembly, SyntaxNode compilationUnit)
@@ -282,7 +308,7 @@ namespace Microsoft.DotNet.GenAPI
                 {
                     TypeSyntax typeSyntaxNode = (TypeSyntax)_syntaxGenerator.TypeExpression(symbol);
                     compilationUnit = _syntaxGenerator.AddAttributes(compilationUnit,
-                        _syntaxGenerator.Attribute("System.Runtime.CompilerServices.TypeForwardedToAttribute",
+                        _syntaxGenerator.Attribute(typeof(TypeForwardedToAttribute).FullName!,
                             SyntaxFactory.TypeOfExpression(typeSyntaxNode)).WithTrailingTrivia(SyntaxFactory.LineFeed));
                 }
                 else


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3328

GenAPI should emit the `ReferenceAssembly` and "0x70 assembly flags" attributes which prevents them from being loaded. Also emit the AssemblyVersion attribute to the output which seems generally useful and which was lost during the migration to the new tooling in SBRP.