### PR TITLE
Add AfterPublish target to ClickOnce target dependencies

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets
@@ -63,6 +63,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       _DeploymentGenerateBootstrapper;
       ResolveKeySource;
       _DeploymentSignClickOnceDeployment;
+      AfterPublish
     </ClickOncePublishDependsOn>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes [AB#1730358](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1730358)

### Issue
Users add custom target to run after AfterPublish expecting to run custom tasks after ClickOnce publish is complete and don't see their custom target invoked.

### Fix
Add AfterPublish msbuild target to list of dependencies invoked during ClickOnce publish.