### PR TITLE
Only enable scoped CSS when using Razor SDK

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Sdk.StaticWebAssets.CurrentVersion.targets
+++ b/src/StaticWebAssetsSdk/Targets/Sdk.StaticWebAssets.CurrentVersion.targets
@@ -124,8 +124,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Import Project="Microsoft.NET.Sdk.StaticWebAssets.Pack.CrossTargeting.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
 
-  <Import Project="Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.5_0.targets" Condition="'$(UseStaticWebAssetsV2)' != 'true' And '$(ScopedCssEnabled)' == 'true'" />
-  <Import Project="Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets" Condition="'$(UseStaticWebAssetsV2)' == 'true' And '$(ScopedCssEnabled)' == 'true'" />
+  <Import Project="Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.5_0.targets" Condition="'$(UsingMicrosoftNETSdkRazor)' == 'true' And '$(UseStaticWebAssetsV2)' != 'true' And '$(ScopedCssEnabled)' == 'true'" />
+  <Import Project="Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets" Condition="'$(UsingMicrosoftNETSdkRazor)' == 'true' And '$(UseStaticWebAssetsV2)' == 'true' And '$(ScopedCssEnabled)' == 'true'" />
 
   <Import Project="Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets" Condition="'$(JSModulesEnabled)' == 'true'" />
 


### PR DESCRIPTION
## Only enable scoped CSS when using Razor SDK

The scoped CSS feature has a dependency on targets defined in the Razor SDK. In order to allow the StaticWebAssets SDK to be used without the Razor SDK, this PR enables scoped CSS only when the Razor SDK is used.

Fixes https://github.com/dotnet/aspnetcore/issues/47314