### PR TITLE
Make SdkFeatureBand internal (sometimes)

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -13,6 +13,7 @@
 
     <UseSystemTextJson Condition="'$(TargetFramework)'!='netstandard2.0' And '$(TargetFramework)'!='net472'">True</UseSystemTextJson>
     <DefineConstants Condition="'$(UseSystemTextJson)'=='True'">$(DefineConstants);USE_SYSTEM_TEXT_JSON</DefineConstants>
+    <DefineConstants>$(DefineConstants);SDK_FEATURE_BAND_INTERNAL</DefineConstants>
 
     <!-- Create FileDefinitions items for ResolveHostfxrCopyLocalContent target -->
     <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkFeatureBand.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkFeatureBand.cs
@@ -7,7 +7,11 @@ using Microsoft.Deployment.DotNet.Releases;
 #nullable disable
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
+#if SDK_FEATURE_BAND_INTERNAL
+    internal struct SdkFeatureBand : IEquatable<SdkFeatureBand>, IComparable<SdkFeatureBand>
+#else
     public struct SdkFeatureBand : IEquatable<SdkFeatureBand>, IComparable<SdkFeatureBand>
+#endif
     {
         private ReleaseVersion _featureBand;
 


### PR DESCRIPTION
## Description

This change fixes a performance regression in Visual Studio. MSBuild uses reflection to locate SDK resolvers. It uses [`GetTypeInfo`](https://github.com/dotnet/msbuild/blob/56087a97257fab6a67d110a7b2c4116f707325ee/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs#L231) that trigger assembly loads. The `SdkFeatureBand` struct is public and uses a private backing field that depends on the `ReleaseVersion` type. This causes an additional load operation for Microsoft.Deployment.DotNet.Releases that trips the module count performance regression.