### PR TITLE
Use latest dogfood version

### DIFF
--- a/eng/dogfood.ps1
+++ b/eng/dogfood.ps1
@@ -39,7 +39,7 @@ try {
 
   $TestDotnetRoot = Join-Path $ArtifactsDir "bin\redist\$configuration\dotnet"
 
-  $testDotnetVersion = (Get-Childitem -Directory "$TestDotnetRoot\sdk")[0]
+  $testDotnetVersion = (Get-Childitem -Directory "$TestDotnetRoot\sdk")[-1]
   $env:DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR = Join-Path $TestDotnetRoot "sdk\$testDotnetVersion\Sdks"
   $env:MicrosoftNETBuildExtensionsTargets = Join-Path $ArtifactsDir "bin\$configuration\Sdks\Microsoft.NET.Build.Extensions\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\Microsoft.NET.Build.Extensions.targets"
 


### PR DESCRIPTION
I don't necessarily clean before every build, so I had multiple versions in the sdk folder, and it took the 5.0 one because it's "earlier" in this list. This should change it to take the last one in the list.