### PR TITLE
Using built-in package for package reference to `Microsoft.NET.Build.Containers`

### DIFF
--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -46,16 +46,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Containers\packaging\package.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
     <ProjectReference Include="..\tool_msbuild\tool_msbuild.csproj" />
     <ProjectReference Include="..\tool_nuget\tool_nuget.csproj" />
     <ProjectReference Include="..\..\Cli\dotnet\dotnet.csproj" />
-    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj"
-                      ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
-    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Extensions.Tasks\Microsoft.NET.Build.Extensions.Tasks.csproj"
-                      ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Extensions.Tasks\Microsoft.NET.Build.Extensions.Tasks.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
     <ProjectReference Include="..\..\Resolvers\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj" />
-    <ProjectReference Include="$(RepoRoot)src\BuiltInTools\dotnet-watch\dotnet-watch.csproj"
-                      ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
+    <ProjectReference Include="$(RepoRoot)src\BuiltInTools\dotnet-watch\dotnet-watch.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -155,6 +155,11 @@
     </ItemGroup>
     <Copy SourceFiles="@(NETSdksContent)"
       DestinationFiles="@(NETSdksContent->'$(OutputPath)\%(DeploymentSubpath)\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <!-- adding Microsoft.NET.Build.Containers nuget package to library packs for Microsoft.NET.Sdk.Web to be able to implicitly reference package as required by VS-->
+    <!-- for now adding as part of Microsoft.NET.Sdk.Web as it is only used there -->
+    <Copy SourceFiles="$(ArtifactsDir)packages\$(Configuration)\Shipping\Microsoft.NET.Build.Containers.$(Version).nupkg"
+            DestinationFiles="$(OutputPath)\Sdks\Microsoft.NET.Sdk.Web\library-packs\Microsoft.NET.Build.Containers.$(Version).nupkg" />
   </Target>
 
   <Target Name="PublishTestCli"

--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -73,11 +73,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Using Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
+  <!--Built in Microsoft.NET.Build.Containers version is same as SDK version-->
   <PropertyGroup>
-    <SdkContainerSupportPackageVersion>0.4.0</SdkContainerSupportPackageVersion>
+    <SdkContainerSupportPackageVersion Condition="'$(SdkContainerSupportPackageVersion)' == ''">$(NETCoreSdkVersion)</SdkContainerSupportPackageVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(EnableSdkContainerSupport)' == 'true'">
+  <!--Implicit package references don't work well with central package management, so disable it. -->
+  <!--In this case the package reference should be added explicitly. -->
+  <PropertyGroup Condition=" '$(ManagePackageVersionsCentrally)' == 'true' ">
+    <DisableImplicitMicrosoftNETBuildContainersReference Condition="'$(DisableImplicitMicrosoftNETBuildContainersReference)' == ''">true</DisableImplicitMicrosoftNETBuildContainersReference>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(EnableSdkContainerSupport)' == 'true' AND '$(DisableImplicitMicrosoftNETBuildContainersReference)' != 'true'">
     <PackageReference Include="Microsoft.NET.Build.Containers" Version="$(SdkContainerSupportPackageVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 

--- a/src/WebSdk/Web/Sdk/Sdk.targets
+++ b/src/WebSdk/Web/Sdk/Sdk.targets
@@ -31,7 +31,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
 
   <!-- include library-packs folder as additional source for the restore -->
-  <PropertyGroup Condition=" '$(DisableImplicitLibraryPacksFolder)' != 'true' ">
+  <PropertyGroup Condition=" '$(DisableImplicitMicrosoftNETBuildContainersReference)' != 'true' ">
     <_WebLibraryPacksFolder Condition="'$(WebLibraryPacksFolder)' == ''">$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))../library-packs</_WebLibraryPacksFolder>
     <RestoreAdditionalProjectSources Condition="Exists('$(_WebLibraryPacksFolder)')">$(RestoreAdditionalProjectSources);$(_WebLibraryPacksFolder)</RestoreAdditionalProjectSources>
   </PropertyGroup>

--- a/src/WebSdk/Web/Sdk/Sdk.targets
+++ b/src/WebSdk/Web/Sdk/Sdk.targets
@@ -30,4 +30,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
 
+  <!-- include library-packs folder as additional source for the restore -->
+  <PropertyGroup Condition=" '$(DisableImplicitLibraryPacksFolder)' != 'true' ">
+    <_WebLibraryPacksFolder Condition="'$(WebLibraryPacksFolder)' == ''">$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))../library-packs</_WebLibraryPacksFolder>
+    <RestoreAdditionalProjectSources Condition="Exists('$(_WebLibraryPacksFolder)')">$(RestoreAdditionalProjectSources);$(_WebLibraryPacksFolder)</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/sdk-container-builds/issues/370

- included `Microsoft.NET.Build.Containers` nupkg as part of sdk layout. For time being, added it as part of `Microsoft.NET.Sdk.Web` as it is only place where it is used. For next version we are aiming to include tasks instead, so it's temporary anyway.

- updated `SdkContainerSupportPackageVersion` to built-in version

Existing end-to-end tests are covering this change.