### PR TITLE
changes to containers tests and `ComputeDotnetBaseImageTag` 

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageTag.cs
@@ -97,6 +97,14 @@ public sealed class ComputeDotnetBaseImageTag : Microsoft.Build.Utilities.Task
                     return null;
                 }
             }
+            else if (channel == "alpha")
+            {
+                return $"{major}.{minor}-preview.1";
+            }
+            else if (channel == "dev" || channel == "ci")
+            {
+                return $"{major}.{minor}-preview";
+            }
             else
             {
                 Log.LogError(Resources.Strings.InvalidSdkPrereleaseVersion, channel);

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -9,6 +9,7 @@ using Microsoft.NET.Build.Containers.IntegrationTests;
 using Microsoft.NET.Build.Containers.UnitTests;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework;
 
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
@@ -34,7 +35,7 @@ public class CreateNewImageTests
 
         newProjectDir.Create();
 
-        new DotnetCommand(_testOutput, "new", "console", "-f", "net7.0")
+        new DotnetCommand(_testOutput, "new", "console", "-f", ToolsetInfo.CurrentTargetFramework)
             .WithWorkingDirectory(newProjectDir.FullName)
             .Execute()
             .Should().Pass();
@@ -50,7 +51,7 @@ public class CreateNewImageTests
         task.BaseImageTag = "7.0";
 
         task.OutputRegistry = "localhost:5010";
-        task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", "net7.0", "linux-arm64", "publish");
+        task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-arm64", "publish");
         task.ImageName = "dotnet/testimage";
         task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";
@@ -74,7 +75,7 @@ public class CreateNewImageTests
 
         newProjectDir.Create();
 
-        new DotnetCommand(_testOutput, "new", "console", "-f", "net7.0")
+        new DotnetCommand(_testOutput, "new", "console", "-f", ToolsetInfo.CurrentTargetFramework)
             .WithWorkingDirectory(newProjectDir.FullName)
             .Execute()
             .Should().Pass();
@@ -104,7 +105,7 @@ public class CreateNewImageTests
         cni.BaseImageTag = pcp.ParsedContainerTag;
         cni.ImageName = pcp.NewContainerImageName;
         cni.OutputRegistry = "localhost:5010";
-        cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", "net7.0");
+        cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.CurrentTargetFramework);
         cni.WorkingDirectory = "app/";
         cni.Entrypoint = new TaskItem[] { new("ParseContainerProperties_EndToEnd") };
         cni.ImageTags = pcp.NewContainerTags;
@@ -130,7 +131,7 @@ public class CreateNewImageTests
 
         newProjectDir.Create();
 
-        new DotnetCommand(_testOutput, "new", "console", "-f", "net7.0")
+        new DotnetCommand(_testOutput, "new", "console", "-f", ToolsetInfo.CurrentTargetFramework)
             .WithWorkingDirectory(newProjectDir.FullName)
             .Execute()
             .Should().Pass();
@@ -169,7 +170,7 @@ public class CreateNewImageTests
         cni.BaseImageTag = pcp.ParsedContainerTag;
         cni.ImageName = pcp.NewContainerImageName;
         cni.OutputRegistry = pcp.NewContainerRegistry;
-        cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", "net7.0", "linux-x64");
+        cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.CurrentTargetFramework, "linux-x64");
         cni.WorkingDirectory = "/app";
         cni.Entrypoint = new TaskItem[] { new("/app/Tasks_EndToEnd_With_EnvironmentVariable_Validation") };
         cni.ImageTags = pcp.NewContainerTags;

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -140,6 +140,10 @@ public class TargetsTests
     [InlineData("8.0.200-preview3", "v8.0", "8.0")]
     [InlineData("6.0.100", "v6.0", "6.0")]
     [InlineData("6.0.100-preview.1", "v6.0", "6.0")]
+    [InlineData("8.0.100-dev", "v8.0", "8.0-preview")]
+    [InlineData("8.0.100-ci", "v8.0", "8.0-preview")]
+    [InlineData("8.0.100-alpha.12345", "v8.0", "8.0-preview.1")]
+    [InlineData("9.0.100-alpha.12345", "v9.0", "9.0-preview.1")]
     [Theory]
     public void CanComputeTagsForSupportedSDKVersions(string sdkVersion, string tfm, string expectedTag)
     {

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Microsoft.NET.TestFramework;
 
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
@@ -23,7 +24,7 @@ internal static class TestSettings
                 {
                     if(_testArtifactsDir == null)
                     {
-                        string tmpDir = Path.Combine(Path.GetTempPath(), "ContainersTests", DateTime.Now.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture));
+                        string tmpDir = Path.Combine(TestContext.Current.TestExecutionDirectory, "ContainersTests", DateTime.Now.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture));
                         if (!Directory.Exists(tmpDir))
                         {
                             Directory.CreateDirectory(tmpDir);


### PR DESCRIPTION
Changes are cherry-picked from https://github.com/dotnet/sdk/pull/31511