### PR TITLE
syncing the logic in `CreateNewImage` and `ContainerBuilder`

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -1,19 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
 using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers;
 
 public static class ContainerBuilder
 {
-    public static async Task ContainerizeAsync(
-        DirectoryInfo folder,
+    public static async Task<int> ContainerizeAsync(
+        DirectoryInfo publishDirectory,
         string workingDir,
-        string registryName,
-        string baseName,
-        string baseTag,
+        string baseRegistry,
+        string baseImageName,
+        string baseImageTag,
         string[] entrypoint,
         string[]? entrypointArgs,
         string imageName,
@@ -29,107 +28,115 @@ public static class ContainerBuilder
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var isDaemonPull = String.IsNullOrEmpty(registryName);
-        if (isDaemonPull)
+        if (!publishDirectory.Exists)
+        {
+            throw new ArgumentException(string.Format(Resource.GetString(nameof(Strings.PublishDirectoryDoesntExist)), nameof(publishDirectory), publishDirectory.FullName));
+        }
+        bool isDaemonPull = string.IsNullOrEmpty(baseRegistry);
+        Registry? sourceRegistry = isDaemonPull ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(baseRegistry));
+        ImageReference sourceImageReference = new(sourceRegistry, baseImageName, baseImageTag);
+
+        bool isDaemonPush = string.IsNullOrEmpty(outputRegistry);
+        Registry? destinationRegistry = isDaemonPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(outputRegistry!));
+        IEnumerable<ImageReference> destinationImageReferences = imageTags.Select(t => new ImageReference(destinationRegistry, imageName, t));
+
+        ImageBuilder? imageBuilder;
+        if (sourceRegistry is { } registry)
+        {
+            imageBuilder = await registry.GetImageManifestAsync(
+                baseImageName,
+                baseImageTag,
+                containerRuntimeIdentifier,
+                ridGraphPath,
+                cancellationToken).ConfigureAwait(false);
+        }
+        else
         {
             throw new NotSupportedException(Resource.GetString(nameof(Strings.DontKnowHowToPullImages)));
         }
-
-        Registry baseRegistry = new Registry(ContainerHelpers.TryExpandRegistryToUri(registryName));
-        ImageReference sourceImageReference = new(baseRegistry, baseName, baseTag);
-        var isDockerPush = String.IsNullOrEmpty(outputRegistry);
-        var destinationImageReferences = imageTags.Select(t => new ImageReference(isDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(outputRegistry!)), imageName, t));
-
-        ImageBuilder imageBuilder = await baseRegistry.GetImageManifestAsync(baseName, baseTag, containerRuntimeIdentifier, ridGraphPath, cancellationToken).ConfigureAwait(false);
-
+        if (imageBuilder is null)
+        {
+            Console.WriteLine(Resource.GetString(nameof(Strings.BaseImageNotFound)), sourceImageReference.RepositoryAndTag, containerRuntimeIdentifier);
+            return 1;
+        }
+        Console.WriteLine("Containerize: building image '{0}' with tags {1} on top of base image {2}", imageName, string.Join(",", imageName), sourceImageReference);
         cancellationToken.ThrowIfCancellationRequested();
 
+        Layer newLayer = Layer.FromDirectory(publishDirectory.FullName, workingDir, imageBuilder.IsWindows);
+        imageBuilder.AddLayer(newLayer);
         imageBuilder.SetWorkingDirectory(workingDir);
-
-        JsonSerializerOptions options = new()
-        {
-            WriteIndented = true,
-        };
-
-        Layer l = Layer.FromDirectory(folder.FullName, workingDir, imageBuilder.IsWindows);
-
-        imageBuilder.AddLayer(l);
-
         imageBuilder.SetEntryPoint(entrypoint, entrypointArgs);
-
         foreach (KeyValuePair<string, string> label in labels)
         {
             // labels are validated by System.CommandLine API
             imageBuilder.AddLabel(label.Key, label.Value);
         }
-
         foreach (KeyValuePair<string, string> envVar in envVars)
         {
             imageBuilder.AddEnvironmentVariable(envVar.Key, envVar.Value);
         }
-
         foreach ((int number, PortType type) in exposedPorts ?? Array.Empty<Port>())
         {
             // ports are validated by System.CommandLine API
             imageBuilder.ExposePort(number, type);
         }
-
         if (containerUser is { } user)
         {
             imageBuilder.SetUser(user);
         }
-
         BuiltImage builtImage = imageBuilder.Build();
-
         cancellationToken.ThrowIfCancellationRequested();
 
-        foreach (var destinationImageReference in destinationImageReferences)
+        foreach (ImageReference destinationImageReference in destinationImageReferences)
         {
-            if (destinationImageReference.Registry is { } outReg)
+            if (isDaemonPush)
             {
-                try
-                {
-                    await outReg.PushAsync(
-                        builtImage,
-                        sourceImageReference,
-                        destinationImageReference,
-                        (message) => Console.WriteLine($"Containerize: {message}"),
-                        cancellationToken).ConfigureAwait(false);
-                    Console.WriteLine($"Containerize: Pushed container '{destinationImageReference.RepositoryAndTag}' to registry '{outputRegistry}'");
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.RegistryOutputPushFailed), e.Message));
-                    Environment.ExitCode = 1;
-                }
-            }
-            else
-            {
-
-                var localDaemon = GetLocalDaemon(localContainerDaemon, Console.WriteLine);
+                LocalDocker localDaemon = GetLocalDaemon(localContainerDaemon,Console.WriteLine);
                 if (!(await localDaemon.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
                 {
                     Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.LocalDaemondNotAvailable)));
-                    Environment.ExitCode = 7;
-                    return;
+                    return 7;
                 }
+
                 try
                 {
                     await localDaemon.LoadAsync(builtImage, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
                     Console.WriteLine("Containerize: Pushed container '{0}' to Docker daemon", destinationImageReference.RepositoryAndTag);
                 }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.RegistryOutputPushFailed), ex.Message));
+                    return 1;
+                }
+            }
+            else
+            {
+                try
+                {
+                    if (destinationImageReference.Registry is not null)
+                    {
+                        await (destinationImageReference.Registry.PushAsync(
+                            builtImage,
+                            sourceImageReference,
+                            destinationImageReference,
+                            message => Console.WriteLine($"Containerize: {message}"),
+                            cancellationToken)).ConfigureAwait(false);
+                        Console.WriteLine($"Containerize: Pushed container '{destinationImageReference.RepositoryAndTag}' to registry '{outputRegistry}'");
+                    }
+                }
                 catch (Exception e)
                 {
                     Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.RegistryOutputPushFailed), e.Message));
-                    Environment.ExitCode = 1;
+                    return 1;
                 }
             }
         }
+        return 0;
     }
 
     private static LocalDocker GetLocalDaemon(string localDaemonType, Action<string> logger)
     {
-        var daemon = localDaemonType switch
+        LocalDocker daemon = localDaemonType switch
         {
             KnownDaemonTypes.Docker => new LocalDocker(logger),
             _ => throw new ArgumentException(Resource.FormatString(nameof(Strings.UnknownDaemonType), localDaemonType, String.Join(",", KnownDaemonTypes.SupportedLocalDaemonTypes)), nameof(localDaemonType))

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -2,7 +2,7 @@
 Microsoft.NET.Build.Containers.BaseImageNotFoundException
 Microsoft.NET.Build.Containers.Constants
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ComputeDotnetBaseImageTag() -> void
-static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! folder, string! workingDir, string! registryName, string! baseName, string! baseTag, string![]! entrypoint, string![]? entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, System.Collections.Generic.Dictionary<string!, string!>! labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, System.Collections.Generic.Dictionary<string!, string!>! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, string? containerUser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! publishDirectory, string! workingDir, string! baseRegistry, string! baseImageName, string! baseImageTag, string![]! entrypoint, string![]? entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, System.Collections.Generic.Dictionary<string!, string!>! labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, System.Collections.Generic.Dictionary<string!, string!>! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, string? containerUser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>!
 static readonly Microsoft.NET.Build.Containers.Constants.Version -> string!
 Microsoft.NET.Build.Containers.ContainerBuilder
 Microsoft.NET.Build.Containers.ContainerHelpers

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -80,6 +80,11 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         SetPorts(imageBuilder, ExposedPorts);
 
+        if (ContainerUser is { } user)
+        {
+            imageBuilder.SetUser(user);
+        }
+
         // at the end of this step, if any failed then bail out.
         if (Log.HasLoggedErrors)
         {

--- a/src/Containers/containerize/ContainerizeCommand.cs
+++ b/src/Containers/containerize/ContainerizeCommand.cs
@@ -206,7 +206,7 @@ internal class ContainerizeCommand : RootCommand
             string _ridGraphPath = context.ParseResult.GetValueForOption(RidGraphPathOption)!;
             string _localContainerDaemon = context.ParseResult.GetValueForOption(LocalContainerDaemonOption)!;
             string? _containerUser = context.ParseResult.GetValueForOption(ContainerUserOption);
-            await ContainerBuilder.ContainerizeAsync(
+            context.ExitCode = await ContainerBuilder.ContainerizeAsync(
                 _publishDir,
                 _workingDir,
                 _baseReg,

--- a/src/Containers/packaging/package.csproj
+++ b/src/Containers/packaging/package.csproj
@@ -65,6 +65,7 @@
             <Content Include="$(OutDir)containerize.runtimeconfig.json" Pack="true" PackagePath="containerize/" />
             <Content Include="$(OutDir)Newtonsoft.Json.dll" Pack="true" PackagePath="containerize/" />
             <Content Include="$(OutDir)NuGet.*.dll" Pack="true" PackagePath="containerize/" />
+            <Content Include="$(OutDir)Microsoft.DotNet.Cli.Utils.dll" Pack="true" PackagePath="containerize/" />
             <Content Include="$(OutDir)System.CommandLine.dll" Pack="true" PackagePath="containerize/" />
             <Content Include="$(OutDir)Valleysoft.DockerCredsProvider.dll" Pack="true" PackagePath="containerize/" />
             <Content Include="@(ContainerLibraryOutput)" Pack="true" PackagePath="containerize/" />


### PR DESCRIPTION
- `Microsoft.DotNet.Cli.Utils.dll` should have been added to `package` as included to nuget package
- `CreateNewImage` and `ContainerBuilder` is identical but diverged in some cases (user, some other). Synced it now

https://github.com/dotnet/sdk-container-builds/issues/404 should fix the 2nd issue entirely.