### PR TITLE
Remove ILLink version override workaround

### DIFF
--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -62,7 +62,6 @@
     <OverrideAndCreateBundledNETCoreAppPackageVersion
       Stage0MicrosoftNETCoreAppRefPackageVersionPath="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/Microsoft.NETCoreSdk.BundledVersions.props"
       MicrosoftNETCoreAppRefPackageVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-      MicrosoftNETILLinkTasksPackageVersion="$(MicrosoftNETILLinkTasksPackageVersion)"
       NewSDKVersion="$(Version)"
       OutputPath="$(SdkOutputDirectory)/Microsoft.NETCoreSdk.BundledVersions.props"/>
 

--- a/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
+++ b/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -36,10 +36,6 @@ namespace Microsoft.DotNet.Build.Tasks
 
         [Required] public string MicrosoftNETCoreAppRefPackageVersion { get; set; }
 
-        // TODO: remove this once linker packages are produced from dotnet/runtime
-        // and replace it with MicrosoftNETCoreAppRefPackageVersion.
-        [Required] public string MicrosoftNETILLinkTasksPackageVersion { get; set; }
-
         [Required] public string NewSDKVersion { get; set; }
 
         [Required] public string OutputPath { get; set; }
@@ -50,7 +46,6 @@ namespace Microsoft.DotNet.Build.Tasks
                 ExecuteInternal(
                     File.ReadAllText(Stage0MicrosoftNETCoreAppRefPackageVersionPath),
                     MicrosoftNETCoreAppRefPackageVersion,
-                    MicrosoftNETILLinkTasksPackageVersion,
                     NewSDKVersion));
             return true;
         }
@@ -58,7 +53,6 @@ namespace Microsoft.DotNet.Build.Tasks
         public static string ExecuteInternal(
             string stage0MicrosoftNETCoreAppRefPackageVersionContent,
             string microsoftNETCoreAppRefPackageVersion,
-            string microsoftNETILLinkTasksPackageVersion,
             string newSDKVersion)
         {
             var projectXml = XDocument.Parse(stage0MicrosoftNETCoreAppRefPackageVersionContent);
@@ -123,9 +117,8 @@ namespace Microsoft.DotNet.Build.Tasks
                 .Elements(ns + "KnownCrossgen2Pack").First().Attribute("Crossgen2PackVersion"));
             CheckAndReplaceAttribute(itemGroup
                 .Elements(ns + "KnownILCompilerPack").First().Attribute("ILCompilerPackVersion"));
-
-            // TODO: replace this with CheckAndReplaceAttribute once linker packages are produced from dotnet/runtime.
-            itemGroup.Elements(ns + "KnownILLinkPack").First().Attribute("ILLinkPackVersion").Value = microsoftNETILLinkTasksPackageVersion;
+            CheckAndReplaceAttribute(itemGroup
+                .Elements(ns + "KnownILLinkPack").First().Attribute("ILLinkPackVersion"));
 
             CheckAndReplaceAttribute(itemGroup
                 .Elements(ns + "KnownRuntimePack").First().Attribute("LatestRuntimeFrameworkVersion"));


### PR DESCRIPTION
Now that we consume ILLink packages from dotnet/runtime, and sdk got a stage0 update with this change (https://github.com/dotnet/sdk/pull/31460), we can use the existing version override logic that we use for other runtime packs.