### PR TITLE
Add the test that verifies generated join symbol with Ref to derived symbol can be evaluated correctly

### DIFF
--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol/.template.config/template.json
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol/.template.config/template.json
@@ -1,0 +1,43 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol",
+  "shortName": "TestAssets.TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol",
+  "symbols": {
+    "NugetToolName": {
+      "type": "parameter",
+      "datatype": "text",
+      "isRequired": true,
+      "description": "client name"
+    },
+    "ToolNameCapitalCase": {
+      "type": "derived",
+      "datatype": "text",
+      "valueSource": "NugetToolName",
+      "valueTransform": "firstUpperCase",
+      "FileRename": "Tool"
+    },
+    "PackageName": {
+      "type": "generated",
+      "generator": "join",
+      "replaces": "PackageName_SpaceHolder",
+      "parameters": {
+        "symbols": [
+          {
+            "type": "ref",
+            "value": "ToolNameCapitalCase"
+          },
+          {
+            "type": "const",
+            "value": "Frameworks"
+          }
+        ],
+        "separator": "."
+      }
+    }
+  }
+}

--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol/MyProject.Helper.csproj
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol/MyProject.Helper.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="PackageName_SpaceHolder" Version="6.0.*" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol/Tool.cs
+++ b/src/Assets/TestPackages/dotnet-new/test_templates/TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol/Tool.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MyProject.Con
+{
+    class ToolHelper
+    {
+    }
+}

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanEvaluateGeneratedJoinSymbolWithRefToDerivedSymbolCorrectly.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewInstantiateTests.CanEvaluateGeneratedJoinSymbolWithRefToDerivedSymbolCorrectly.verified.txt
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nuget.Frameworks" Version="6.0.*" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.Approval.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewInstantiateTests.Approval.cs
@@ -752,5 +752,34 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             return Verify(commandResult.FormatOutputStreams())
                 .UseParameters(setName);
         }
+
+        [Fact]
+        public Task CanEvaluateGeneratedJoinSymbolWithRefToDerivedSymbolCorrectly()
+        {
+            string workingDirectory = CreateTemporaryFolder();
+            string homeDirectory = CreateTemporaryFolder();
+            InstallTestTemplate("TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol", _log, homeDirectory, workingDirectory);
+
+            string toolName = "nuget";
+            string toolName_FirstUpperCase = toolName.First().ToString().ToUpper() + toolName.Substring(1);
+            CommandResult commandResult = new DotnetNewCommand(_log, "TestAssets.TemplateWithGeneratedJoinSymbolWithRefToDerivedSymbol", "--NugetToolName", toolName)
+                .WithCustomHive(homeDirectory)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute();
+
+            commandResult
+                .Should()
+                .Pass();
+
+            // Verify file name is renamed using the value of derived symbol
+            string originalFileName = "Tool";
+            string renameFilePath = Path.Combine(workingDirectory, $"{toolName_FirstUpperCase}.cs");
+            Assert.True(File.Exists(renameFilePath));
+            Assert.True(!File.Exists(Path.Combine(workingDirectory, $"{originalFileName}.cs")));
+
+            // Verify generated join symbol with ref to derived symbol has correct value that replaces target text
+            string projectFilePath = Path.Combine(workingDirectory, "MyProject.Helper.csproj");
+            return Verify(File.ReadAllText(projectFilePath));
+        }
     }
 }


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/6291 - lacks test for generated symbol with ref to computed symbol.

### Solution
Add the test.