### PR TITLE
(for discussion only) Add support for `DOTNET_WATCH_AUTO_RELOAD_WS_ENDPOINT` to `dotnet watch`

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshServer.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshServer.cs
@@ -146,8 +146,8 @@ namespace Microsoft.DotNet.Watcher.Tools
                 }
             }
 
-            // Only attempt to use DOTNET_WATCH_AUTO_RELOAD_WS_HOSTNAME environment variable
-            // if DOTNET_WATCH_AUTO_RELOAD_WS_ENDPOINT environment variable is not specified.
+            // Only attempt to use the DOTNET_WATCH_AUTO_RELOAD_WS_HOSTNAME environment variable
+            // when the DOTNET_WATCH_AUTO_RELOAD_WS_ENDPOINT environment variable is not specified.
             if (endpointSecure == null && endpoint == null)
             {
                 var envHostName = Environment.GetEnvironmentVariable(wsHostnameKey);


### PR DESCRIPTION
**Disclaimer:** I'm new here, so please let me know if I'm doing anything at all wrong and I'll fix it. 😄 

Hi `dotnet/sdk`,

This PR is to start the discussion (with some code) on adding support for environment variable `DOTNET_WATCH_AUTO_RELOAD_WS_ENDPOINT` to `dotnet watch`.

cc: @tmat, @arkalyanms as per [https://github.com/dotnet/sdk/blob/main/CODEOWNERS#L75](https://github.com/dotnet/sdk/blob/main/CODEOWNERS#L75).

This PR addresses the suggestion contained in [https://github.com/dotnet/aspnetcore/issues/39608](https://github.com/dotnet/aspnetcore/issues/39608).

A similar suggestion was also floated [https://github.com/dotnet/aspnetcore/issues/33823](https://github.com/dotnet/aspnetcore/issues/33823).

The original feature discussion (as implemented): [https://github.com/dotnet/aspnetcore/issues/23412](https://github.com/dotnet/aspnetcore/issues/23412).

My original plan was to PR this into a point release of .NET SDK 7.0.202+ (the next 7.x release), but for the life of me, I can't work out how to do that (i.e. I presume there's a branch somewhere for that, but I couldn't find it, and I tried and failed to find that documented, sorry).

**Edit:** Is this the place for .NET SDK 7.x patches [https://github.com/dotnet/source-build](https://github.com/dotnet/source-build)?

**Edit 2:** I've found branches `release/7.0.2xx`, `release/7.0.3xx`, and `release/7.0.4xx`, which all compile to produce v7 of the SDK, but apologies, I'm not sure if I'm supposed to raise PRs against one/many of those, or some other upstream 7.x branch?

I've tried to write this so it's backwards compatible and maintains support with `DOTNET_WATCH_AUTO_RELOAD_WS_HOSTNAME`, so that both can run in parallel for a time. I suspect this would replace that eventually, but in order to not break people's development environments, we can run with both.

I don't have any tests (yet), primarily because I didn't want to go too far down this rabbit hole if this feature isn't something the .NET team is interested in. Also, the current implementation has no tests AFAICS. That being said, I'm more than happy to write a suite of tests for the original method (and this change), presuming there's general interest in / agreement that this is a good feature (and therefore I should keep going).

We'd also need to adjust the behaviour of `aspnetcore-browser-refresh.js` slightly so that it will e.g. `window.location.reload()` when it detects a subsequent drop and reconnection of the WebSocket(s), but at this stage, I'm just focussed on seeing if this change to static ports is one that's amenable to the team.

Cheers,

Tod.