### PR TITLE
Disable BinaryFormatter across most .NET 8 project types

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
@@ -44,7 +44,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     When https://github.com/Microsoft/visualfsharp/issues/3207 is fixed,
     remove the block below and move it into the shared .targets file.
   -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0'))">
-    <WarningsAsErrors Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != 'true'">$(WarningsAsErrors);SYSLIB0011</WarningsAsErrors>
+  <PropertyGroup>
+    <WarningsAsErrors Condition="'$(_BinaryFormatterObsoleteAsError)' == 'true'">$(WarningsAsErrors);SYSLIB0011</WarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -130,8 +130,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     When https://github.com/Microsoft/visualfsharp/issues/3207 is fixed,
     remove the block below and move it into the shared .targets file.
   -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0'))">
-    <WarningsAsErrors Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != 'true'">$(WarningsAsErrors);SYSLIB0011</WarningsAsErrors>
+  <PropertyGroup>
+    <WarningsAsErrors Condition="'$(_BinaryFormatterObsoleteAsError)' == 'true'">$(WarningsAsErrors);SYSLIB0011</WarningsAsErrors>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -130,6 +130,44 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IncludeProjectsNotInAssetsFileInDepsFile Condition="'$(IncludeProjectsNotInAssetsFileInDepsFile)' == ''">true</IncludeProjectsNotInAssetsFileInDepsFile>
   </PropertyGroup>
 
+  <!--
+    BinaryFormatter killbitting
+    ===========================
+
+    The EnableUnsafeBinaryFormatterSerialization setting controls both runtime and compile-time behavior.
+    The behavior is slightly different depending on the project type and target runtime.
+
+    If the property is explicitly set to TRUE:
+      - The APIs are obsolete as warning, and calls to the APIs will succeed at runtime.
+    
+    If the property is explicitly set to FALSE:
+      - On .NET 5 & 6, the APIs are obsolete as warning, and calls to the APIs will fail at runtime.
+      - On .NET 7+, the APIs are obsolete as error, and calls to the APIs will fail at runtime.
+
+    If the property is not explicitly TRUE or FALSE:
+      - On .NET 5 & 6, the APIs are obsolete as warning, and calls to the APIs will succeed at runtime.
+      - On .NET 7, the APIs are obsolete as error, but calls to the APIs will succeed at runtime.
+      - On .NET 8+, the APIs are obsolete as error, and calls to the APIs will fail at runtime
+        unless the SDK has opted in to keeping legacy BinaryFormatter behavior around.
+    
+    n.b. The APIs are already marked obsolete (as warning) in .NET 5, so we don't need to special-case
+    them unless we want to upgrade them to warn-as-error.
+  -->
+
+  <PropertyGroup Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != 'true' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0'))">
+    <!--
+      Certain project types need to re-enable BinaryFormatter by default; it will still be warn-as-error but will work at runtime.
+      WinForms: enabled through 8.0 (but not after)
+      WPF: enabled through 8.0 (but not after)
+    -->
+    <_ProjectTypeRequiresBinaryFormatter Condition="'$(UseWindowsForms)' == 'true' AND $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), '8.0'))">true</_ProjectTypeRequiresBinaryFormatter>
+    <_ProjectTypeRequiresBinaryFormatter Condition="'$(UseWPF)' == 'true' AND $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), '8.0'))">true</_ProjectTypeRequiresBinaryFormatter>
+    <!-- controls warn as error -->
+    <_BinaryFormatterObsoleteAsError>true</_BinaryFormatterObsoleteAsError>
+    <!-- controls runtime behavior (AppContext & trimming) -->
+    <EnableUnsafeBinaryFormatterSerialization Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) AND '$(_ProjectTypeRequiresBinaryFormatter)' != 'true'">false</EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
+
   <PropertyGroup>
     <CoreBuildDependsOn>
       _CheckForBuildWithNoBuild;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -131,7 +131,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!--
-    BinaryFormatter killbitting
+    BinaryFormatter Disabling
     ===========================
 
     The EnableUnsafeBinaryFormatterSerialization setting controls both runtime and compile-time behavior.

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -37,11 +37,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <!--
-      ASP.NET 5.0 explicitly disables this functionality by default, requiring the app author
+      ASP.NET 5.0+ explicitly disables this functionality by default, requiring the app author
       to opt-in to re-enabling the feature. The way to opt back in is to specify the below
-      element with the value "true". It is anticipated that future releases of .NET will
-      disable this functionality by default across all project types, at which point this logic
-      can be removed from the ASP.NET-specific SDK.
+      element with the value "true". This functionality is disabled across most project types
+      by default in .NET 8; however, we need to keep the line below since it's not conditioned
+      on a version check like the normal SDK targets logic is.
     -->
     <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == ''">false</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>


### PR DESCRIPTION
Ref: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md

In .NET 7, we obsoleted (as error) the BinaryFormatter APIs, but existing compiled code could still call it and it would work. There was no runtime block except in certain project types like aspnet, Blazor, and MAUI.

In .NET 8, we're flipping this so that BinaryFormatter is now disabled across all project types except WinForms and WPF, which need a little bit more time to work on removal. If you retarget a .NET 7 console application to .NET 8 and that app was using BinaryFormatter under the covers, calls to BF will now fail at runtime.

Just like in .NET 7, applications can continue to use the `<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>` compat switch to opt back in to restoring BinaryFormatter behavior. Setting that compat switch suppresses _both_ the compile-time error (same as .NET 7) _and_ the .NET 8 runtime disablement.

For more information on the matrix, see the comment in **Microsoft.NET.Sdk.targets** within this PR.