### PR TITLE
Remove reference to the VS preview flag in the developer guide

### DIFF
--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -33,12 +33,6 @@ As part of the build, some intermediate files will get generated which may run i
 
 To open the solution in Visual Studio, be sure to build with `build.cmd` and run the generated environment for your shell. If you're using `cmd`, then run `artifacts\sdk-build-env.bat`. If you're using powershell, you need to 'dot source' `artifacts/sdk-build-env.ps1`. Finally, open Visual Studio with `devenv sdk.sln`.
 
-In addition, Visual Studio must have the following option set:
-
-![image](https://user-images.githubusercontent.com/23152278/211684116-923ed37e-6d56-42bf-befe-a5ef66758000.png)
-
-Go to `Tools` -> `Options` to make sure "Use previews of the .NET SDK (requires restart)" is checked and restart VS.
-
 ### Linux and macOS
 
 Run the following command from the root of the repository:


### PR DESCRIPTION
The "Use previews of the .NET SDK" feature flag no longer seems to be in VS (based on my recent internal build, Version 17.6.0 Preview 3.0 [33529.503.main]).

This removes the section in red:

![image](https://user-images.githubusercontent.com/350947/229689171-91e63b0f-153c-4abd-bc57-2bd9a93f7172.png)
