### PR TITLE
[WIP do no review yet] Use MSBuild Server in interactive mode only

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -68,7 +68,14 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             // We want to use MSBuild server only in inner loop development.
             // We use Console.IsOutputRedirected as simple heuristics detection of possible non-inner-loop usage (Azure CI/CD, GitHub Actions, ...)
-            return UseMSBuildServerEnvVarConfig && !Console.IsOutputRedirected;
+            // when there is no explicitly defined user intent.
+
+            bool isInteractiveExplicit = !string.IsNullOrEmpty(Env.GetEnvironmentVariable("DOTNET_CLI_MSBUILD_INTERACTIVE"));
+
+            return UseMSBuildServerEnvVarConfig &&
+                   (isInteractiveExplicit ?
+                       Env.GetEnvironmentVariableAsBool("DOTNET_CLI_MSBUILD_INTERACTIVE", false) :
+                       !Console.IsOutputRedirected);
         }
 
         private void InitializeForOutOfProcForwarding()

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -129,7 +129,11 @@ namespace Microsoft.DotNet.Cli
             new ForwardedOption<bool>(
                 "--interactive",
                 CommonLocalizableStrings.CommandInteractiveOptionDescription)
-            .ForwardAs("-property:NuGetInteractive=true");
+            .SetForwardingFunction((enabled) =>
+            {
+                Environment.SetEnvironmentVariable("DOTNET_CLI_MSBUILD_INTERACTIVE", enabled.ToString());
+                return "-property:NuGetInteractive=true";
+            });
 
         public static Option<bool> InteractiveOption =
             new Option<bool>(


### PR DESCRIPTION
Addresses https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1676390

Context
It has been decided that MSBuild server will be used only in interactive mode, i.e. when output of CLI is console, and user is expecting to be in inner dev loop.
So for example in CI/CD pipelines it will not be used as it does bring advantages only in short repeat builds loops.

Changes Made
We consider it as non interactive mode when output is redirected.

Testing
Local, and unit tests...