### PR TITLE
Respond to ProduceReferenceAssembly default changing to true

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -46,17 +46,17 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>0a396acafe9a7d46bce11f4338dbb3dd0d99b1b4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.7.0-preview-23212-01">
+    <Dependency Name="Microsoft.Build" Version="17.7.0-preview-23212-02">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>073c84ec2bb2de1e709eb1326402a8760d5651d3</Sha>
+      <Sha>cb5e760644d04def33c0cafcaef2a6f496fc68cc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Localization" Version="17.7.0-preview-23212-01">
+    <Dependency Name="Microsoft.Build.Localization" Version="17.7.0-preview-23212-02">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>073c84ec2bb2de1e709eb1326402a8760d5651d3</Sha>
+      <Sha>cb5e760644d04def33c0cafcaef2a6f496fc68cc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.7.0-preview-23212-01">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.7.0-preview-23212-02">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>073c84ec2bb2de1e709eb1326402a8760d5651d3</Sha>
+      <Sha>cb5e760644d04def33c0cafcaef2a6f496fc68cc</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="12.5.0-beta.23211.2">
       <Uri>https://github.com/dotnet/fsharp</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -106,7 +106,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>17.7.0-preview-23212-01</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.7.0-preview-23212-02</MicrosoftBuildPackageVersion>
     <MicrosoftBuildCurrentPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildCurrentPackageVersion>
     <!-- Some tasks and the resolver will need to run in an MSBuild that is older than the very latest,
           so target one that matches the version in minimumMSBuildVersion.
@@ -115,7 +115,7 @@
     <MicrosoftBuildPackageVersion Condition="exists('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion') and '$(DotNetBuildFromSource)' != 'true'">$([System.IO.File]::ReadAllText('$(RepoRoot)\src\Layout\redist\minimumMSBuildVersion').Trim())</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildLocalizationPackageVersion>17.7.0-preview-23212-01</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildLocalizationPackageVersion>17.7.0-preview-23212-02</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -239,11 +239,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <AppendTargetFrameworkToOutputPath Condition="'$(AppendTargetFrameworkToOutputPath)' == ''">true</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and ('$(ProduceOnlyReferenceAssembly)' != 'true') and '$(MSBuildProjectExtension)' != '.fsproj'" >true</ProduceReferenceAssembly>
-    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 7.0)) and ('$(ProduceOnlyReferenceAssembly)' != 'true') and '$(MSBuildProjectExtension)' == '.fsproj'" >true</ProduceReferenceAssembly>
-  </PropertyGroup>
-
   <!--
     Append $(TargetFramework) directory to output and intermediate paths to prevent bin clashes between
     targets.

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -868,7 +868,7 @@ class Program
                 .Pass();
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("17.7.0")]
         [InlineData(true)]
         [InlineData(false)]
         public void It_builds_the_project_successfully_with_only_reference_assembly_set(bool produceOnlyReferenceAssembly)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToProduceReferenceAssembly.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToProduceReferenceAssembly.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = targetFramework
             };
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework, targetExtension: extension);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework + extension, targetExtension: extension);
 
             var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToProduceReferenceAssembly.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToProduceReferenceAssembly.cs
@@ -9,7 +9,6 @@ using Xunit;
 using Xunit.Abstractions;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.ProjectConstruction;
-using System.Collections.Generic;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -18,26 +17,35 @@ namespace Microsoft.NET.Build.Tests
         public GivenThatWeWantToProduceReferenceAssembly(ITestOutputHelper log) : base(log)
         {}
 
-        [RequiresMSBuildVersionTheory("16.8.0")]
-        [InlineData("netcoreapp3.1", false)]
-        [InlineData(ToolsetInfo.CurrentTargetFramework, true)]
-        public void It_produces_ref_assembly_for_appropriate_frameworks(string targetFramework, bool expectedExists)
+        [RequiresMSBuildVersionTheory("17.7.0")]
+        [InlineData("netcoreapp3.1", ".csproj")]
+        [InlineData("net5.0", ".csproj")]
+        [InlineData("net5.0", ".fsproj")]
+        [InlineData("net6.0", ".csproj")]
+        [InlineData("net6.0", ".fsproj")]
+        [InlineData("net7.0", ".csproj")]
+        [InlineData("net7.0", ".fsproj")]
+#pragma warning disable xUnit1025 // InlineData duplicates
+        [InlineData(ToolsetInfo.CurrentTargetFramework, ".csproj")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, ".fsproj")]
+#pragma warning restore xUnit1025 // InlineData duplicates
+        public void It_produces_ref_assembly_for_appropriate_frameworks(string targetFramework, string extension)
         {
-            TestProject testProject = new TestProject()
+            TestProject testProject = new()
             {
                 Name = "ProduceRefAssembly",
                 IsExe = true,
                 TargetFrameworks = targetFramework
             };
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework, targetExtension: extension);
 
             var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute()
                 .Should()
                 .Pass();
             var filePath = Path.Combine(testAsset.Path, testProject.Name, "obj", "Debug", targetFramework, "ref", $"{testProject.Name}.dll");
-            File.Exists(filePath).Should().Be(expectedExists);
+            File.Exists(filePath).Should().Be(true);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToProduceReferenceAssembly.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToProduceReferenceAssembly.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
             var filePath = Path.Combine(testAsset.Path, testProject.Name, "obj", "Debug", targetFramework, "ref", $"{testProject.Name}.dll");
-            File.Exists(filePath).Should().Be(true);
+            File.Exists(filePath).Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/8133
Relates to https://github.com/dotnet/msbuild/pull/8571 

We have changed the default for all .NET projects such that `ProduceReferenceAssembly` is `true` by default. This change requires updates to the SDK, which are included in this PR.