### PR TITLE
[WIP] GenAPI: a work around for a generation an explicit interface implementation indexer.

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -92,6 +92,16 @@ namespace Microsoft.DotNet.GenAPI
                 }
             }
 
+            // TODO: a work around for the https://github.com/dotnet/sdk/issues/31570 issue.
+            // if the symbol is a property (not an indexer) and if it is an explicit interface implementation of an indexer property.
+            if (symbol is IPropertySymbol propertySymbol &&
+                !propertySymbol.IsIndexer && propertySymbol.ExplicitInterfaceImplementations.Length == 1 &&
+                propertySymbol.ExplicitInterfaceImplementations.ElementAt(0) is IPropertySymbol explicitProperty &&
+                explicitProperty.IsIndexer)
+            {
+                return syntaxGenerator.IndexerDeclaration(propertySymbol);
+            }
+
             try
             {
                 return syntaxGenerator.Declaration(symbol);


### PR DESCRIPTION
This is a work around solution for the https://github.com/dotnet/sdk/issues/31570 issue to unblock the A&D team.

Indexer properties is not resolved correctly for the scenario like:
```C#
public interface IFooList<T>
{
    T this[int index] { get; set; }
}

public struct Bar<T> : IFooList<T>
{
    // indexer №1
    public T this[int index] { get; set; }

    // indexer №2
    T IFooList<T>.this[int index] { get; set; }
}
```

Indexer №1 is generated correctly, but explicit interface implementation indexer (№2) is not. I double checked that the customer passes correct reference assemblies, and it seems, it could be a bug in the Roslyn API.

@ericstj could you please review this work around. Once @ViktorHofer returns from his vacation, I will communicate the problem with him.