### PR TITLE
Bundle Source Link packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -274,6 +274,31 @@
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
       <Sha>b60c95e1ce736630d17e16626c59e3dd85ebae2b</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Build.Tasks.Git" Version="8.0.0-beta.23210.3">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>759f344923a0859f3fae83431d0ba1cc62108118</Sha>
+      <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.Common" Version="8.0.0-beta.23210.3">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>759f344923a0859f3fae83431d0ba1cc62108118</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0-beta.23210.3">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>759f344923a0859f3fae83431d0ba1cc62108118</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="8.0.0-beta.23210.3">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>759f344923a0859f3fae83431d0ba1cc62108118</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.GitLab" Version="8.0.0-beta.23210.3">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>759f344923a0859f3fae83431d0ba1cc62108118</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.BitBucket.Git" Version="8.0.0-beta.23210.3">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>759f344923a0859f3fae83431d0ba1cc62108118</Sha>
+    </Dependency>
     <!-- Explicit dependency because Microsoft.Deployment.DotNet.Releases has different versioning
          than the SB intermediate -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.deployment-tools" Version="8.0.0-preview.1.23159.4">
@@ -287,11 +312,6 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>17d9eee32f20a6af0ebb620254a22f601d159578</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.SourceLink.GitHub" Version="8.0.0-beta.23210.3" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
-      <Uri>https://github.com/dotnet/sourcelink</Uri>
-      <Sha>759f344923a0859f3fae83431d0ba1cc62108118</Sha>
-      <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23211.8">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -176,12 +176,12 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sourcelink -->
-    <MicrosoftBuildTasksGitVersion>1.2.0-beta-23207-01</MicrosoftBuildTasksGitVersion>
-    <MicrosoftSourceLinkCommonVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkCommonVersion>
-    <MicrosoftSourceLinkAzureReposGitVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkAzureReposGitVersion>
-    <MicrosoftSourceLinkGitHubVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkGitHubVersion>
-    <MicrosoftSourceLinkGitLabVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkGitLabVersion>
-    <MicrosoftSourceLinkBitBucketVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkBitBucketVersion>
+    <MicrosoftBuildTasksGitVersion>8.0.0-beta.23210.3</MicrosoftBuildTasksGitVersion>
+    <MicrosoftSourceLinkCommonVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkCommonVersion>
+    <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkAzureReposGitVersion>
+    <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkGitHubVersion>
+    <MicrosoftSourceLinkGitLabVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkGitLabVersion>
+    <MicrosoftSourceLinkBitBucketVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkBitBucketVersion>
   </PropertyGroup>
   <!-- Get .NET Framework reference assemblies from NuGet packages -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -174,6 +174,15 @@
     <!-- Dependencies from https://github.com/dotnet/xliff-tasks -->
     <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.23206.1</MicrosoftDotNetXliffTasksVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Dependencies from https://github.com/dotnet/sourcelink -->
+    <MicrosoftBuildTasksGitVersion>1.2.0-beta-23207-01</MicrosoftBuildTasksGitVersion>
+    <MicrosoftSourceLinkCommonVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkCommonVersion>
+    <MicrosoftSourceLinkAzureReposGitVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkAzureReposGitVersion>
+    <MicrosoftSourceLinkGitHubVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkGitHubVersion>
+    <MicrosoftSourceLinkGitLabVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkGitLabVersion>
+    <MicrosoftSourceLinkBitBucketVersion>1.2.0-beta-23207-01</MicrosoftSourceLinkBitBucketVersion>
+  </PropertyGroup>
   <!-- Get .NET Framework reference assemblies from NuGet packages -->
   <PropertyGroup>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>

--- a/src/Assets/TestProjects/SourceLinkTestApp/Directory.Build.props
+++ b/src/Assets/TestProjects/SourceLinkTestApp/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/src/Assets/TestProjects/SourceLinkTestApp/Directory.Build.targets
+++ b/src/Assets/TestProjects/SourceLinkTestApp/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/src/Assets/TestProjects/SourceLinkTestApp/Program.cs
+++ b/src/Assets/TestProjects/SourceLinkTestApp/Program.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+Console.WriteLine("Hello World!");

--- a/src/Assets/TestProjects/SourceLinkTestApp/Program.cs
+++ b/src/Assets/TestProjects/SourceLinkTestApp/Program.cs
@@ -3,4 +3,10 @@
 
 using System;
 
-Console.WriteLine("Hello World!");
+class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine("Hello World!");
+    }
+}

--- a/src/Assets/TestProjects/SourceLinkTestApp/SourceLinkTestApp.csproj
+++ b/src/Assets/TestProjects/SourceLinkTestApp/SourceLinkTestApp.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RestorePackagesPath Condition=" '$(RestorePackagesPath)' == '' ">$(MSBuildThisFileDirectory)..\..\..\artifacts\.nuget\packages</RestorePackagesPath>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/src/Assets/TestProjects/SourceLinkTestApp/SourceLinkTestApp.csproj
+++ b/src/Assets/TestProjects/SourceLinkTestApp/SourceLinkTestApp.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RestorePackagesPath Condition=" '$(RestorePackagesPath)' == '' ">$(MSBuildThisFileDirectory)..\..\..\artifacts\.nuget\packages</RestorePackagesPath>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>

--- a/src/Layout/redist/targets/BundledSdks.targets
+++ b/src/Layout/redist/targets/BundledSdks.targets
@@ -4,5 +4,12 @@
     <BundledSdk Include="Microsoft.NET.Sdk.WindowsDesktop" Version="$(MicrosoftNETSdkWindowsDesktopPackageVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.4-bundled-0100" />
     <BundledSdk Include="Microsoft.Docker.Sdk" Version="1.1.0" />
+
+    <BundledSdk Include="Microsoft.Build.Tasks.Git" Version="$(MicrosoftBuildTasksGitVersion)" />
+    <BundledSdk Include="Microsoft.SourceLink.Common" Version="$(MicrosoftSourceLinkCommonVersion)" />
+    <BundledSdk Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(MicrosoftSourceLinkAzureReposGitVersion)" />
+    <BundledSdk Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" />
+    <BundledSdk Include="Microsoft.SourceLink.GitLab" Version="$(MicrosoftSourceLinkGitLabVersion)" />
+    <BundledSdk Include="Microsoft.SourceLink.Bitbucket.Git" Version="$(MicrosoftSourceLinkBitBucketVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Layout/redist/targets/RestoreDependency.proj
+++ b/src/Layout/redist/targets/RestoreDependency.proj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0" DefaultTargets="EnsureDependencyRestored;CopySdkToOutput">
+﻿<Project ToolsVersion="15.0" DefaultTargets="PrepareBundledDependencyProps;EnsureDependencyRestored;CopySdkToOutput">
 <!--
 
   Note that the CopySdkToOutput target explicitly does NOT have Inputs and Outputs declared.
@@ -24,24 +24,29 @@
 
   <Target Name="GetSdkItemsToCopy">
     <ItemGroup>
-      <SdkContent Include="$(DependencyNuPkgPath)/**/*"
-                  Exclude="$(DependencyNuPkgPath)/$(DependencyPackageName).nuspec;
-                           $(DependencyNuPkgPath)/$(DependencyPackageName).$(DependencyPackageVersion).nupkg;
-                           $(DependencyNuPkgPath)/$(DependencyPackageName).$(DependencyPackageVersion).nupkg.sha512" />
+      <SdkContent Include="$(DependencyNuPkgPath)**\*"
+                  Exclude="$(DependencyNuPkgPath)Icon.png;
+                           $(DependencyNuPkgPath)$(DependencyPackageName).nuspec;
+                           $(DependencyNuPkgPath)$(DependencyPackageName).$(DependencyPackageVersion).nupkg;
+                           $(DependencyNuPkgPath)$(DependencyPackageName).$(DependencyPackageVersion).nupkg.sha512" />
     </ItemGroup>
   </Target>
 
   <Target Name="EnsureDependencyRestored"
-          Condition="!Exists('$(DependencyNuPkgPath)/$(DependencyPackageName.ToLower()).nuspec')">
+          DependsOnTargets="PrepareBundledDependencyProps"
+          Condition="!Exists('$(DependencyNuPkgPath)$(DependencyPackageName.ToLower()).nuspec')">
+
+    <Message Text="Dependency has not been restored yet: '$(DependencyNuPkgPath)$(DependencyPackageName.ToLower()).nuspec'"/>
+
     <MSbuild
-      Projects="$(MSBuildThisFileDirectory)/sdks/sdks.csproj"
+      Projects="$(MSBuildThisFileDirectory)sdks\sdks.csproj"
       Properties="DependencyPackageName=$(DependencyPackageName);DependencyPackageVersion=$(DependencyPackageVersion)"
       Targets="Restore" />
   </Target>
 
   <Target Name="PrepareBundledDependencyProps">
     <PropertyGroup>
-      <DependencyNuPkgPath>$(NuGetPackageRoot)/$(DependencyPackageName.ToLower())/$(DependencyPackageVersion.ToLower())</DependencyNuPkgPath>
+      <DependencyNuPkgPath>$(NuGetPackageRoot)$(DependencyPackageName.ToLower())\$(DependencyPackageVersion.ToLower())\</DependencyNuPkgPath>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/Layout/redist/targets/RestoreDependency.proj
+++ b/src/Layout/redist/targets/RestoreDependency.proj
@@ -10,8 +10,7 @@
  -->
 
   <Target Name="CopySdkToOutput"
-          DependsOnTargets="PrepareBundledDependencyProps;
-                            EnsureDependencyRestored;
+          DependsOnTargets="EnsureDependencyRestored;
                             GetSdkItemsToCopy"
           Condition="'$(SdkLayoutDirectory)' != ''"
 >
@@ -33,7 +32,6 @@
   </Target>
 
   <Target Name="EnsureDependencyRestored"
-          DependsOnTargets="PrepareBundledDependencyProps"
           Condition="!Exists('$(DependencyNuPkgPath)$(DependencyPackageName.ToLower()).nuspec')">
 
     <Message Text="Dependency has not been restored yet: '$(DependencyNuPkgPath)$(DependencyPackageName.ToLower()).nuspec'"/>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -13,6 +13,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- This file is imported by both cross-targeting and inner builds. Set properties that need to be available to both here. -->
 
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.SourceLink.targets" />
+
   <PropertyGroup>
     <MicrosoftNETBuildTasksDirectoryRoot>$(MSBuildThisFileDirectory)..\tools\</MicrosoftNETBuildTasksDirectoryRoot>
     <MicrosoftNETBuildTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">net8.0</MicrosoftNETBuildTasksTFM>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -13,8 +13,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- This file is imported by both cross-targeting and inner builds. Set properties that need to be available to both here. -->
 
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.SourceLink.targets" />
-
   <PropertyGroup>
     <MicrosoftNETBuildTasksDirectoryRoot>$(MSBuildThisFileDirectory)..\tools\</MicrosoftNETBuildTasksDirectoryRoot>
     <MicrosoftNETBuildTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">net8.0</MicrosoftNETBuildTasksTFM>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CrossTargeting.targets
@@ -12,6 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="Microsoft.NET.Sdk.Common.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.SourceLink.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
 
   <!--
   ============================================================

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
@@ -1,0 +1,30 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.FSharp.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <_SourceLinkSdkSubDir>build</_SourceLinkSdkSubDir>
+    <_SourceLinkSdkSubDir Condition="'$(IsCrossTargetingBuild)' == 'true'">buildMultiTargeting</_SourceLinkSdkSubDir>
+
+    <!-- Suppress implicit SourceLink inclusion if any Microsoft.SourceLink package is referenced. -->
+    <SuppressImplicitGitSourceLink Condition="'$(PkgMicrosoft_SourceLink_Common)' != ''">true</SuppressImplicitGitSourceLink>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\$(_SourceLinkSdkSubDir)\Microsoft.Build.Tasks.Git.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Common\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Common.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitHub.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitLab.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.AzureRepos.Git.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Bitbucket.Git.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Microsoft.NET.Sdk.FSharp.props
+Microsoft.NET.Sdk.SourceLink.props
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
@@ -20,11 +20,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <SuppressImplicitGitSourceLink Condition="'$(PkgMicrosoft_SourceLink_Common)' != ''">true</SuppressImplicitGitSourceLink>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\$(_SourceLinkSdkSubDir)\Microsoft.Build.Tasks.Git.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Common\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Common.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitHub.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitLab.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.AzureRepos.Git.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Bitbucket.Git.props" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <ImportGroup Condition="'$(SuppressImplicitGitSourceLink)' != 'true'">
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\$(_SourceLinkSdkSubDir)\Microsoft.Build.Tasks.Git.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Common\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Common.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitHub.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitLab.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.AzureRepos.Git.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Bitbucket.Git.props"/>
+  </ImportGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
@@ -12,6 +12,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- C++ projects currently do not import Microsoft.NET.Sdk.props. -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.SourceLink.props" Condition="'$(_SourceLinkSdkSubDir)' == ''"/>
+  
   <PropertyGroup>
     <EmbedUntrackedSources Condition="'$(EmbedUntrackedSources)' == ''">true</EmbedUntrackedSources>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Microsoft.NET.Sdk.FSharp.targets
+Microsoft.NET.Sdk.SourceLink.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
@@ -12,15 +12,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup Condition="'$(SuppressImplicitGitSourceLink)' != 'true'">
+  <PropertyGroup>
     <EmbedUntrackedSources Condition="'$(EmbedUntrackedSources)' == ''">true</EmbedUntrackedSources>
   </PropertyGroup>
-  
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\$(_SourceLinkSdkSubDir)\Microsoft.Build.Tasks.Git.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Common\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Common.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitHub.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitLab.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.AzureRepos.Git.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Bitbucket.Git.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\$(_SourceLinkSdkSubDir)\Microsoft.Build.Tasks.Git.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Common\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Common.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitHub.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitLab.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.AzureRepos.Git.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Bitbucket.Git.targets"/>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
@@ -1,0 +1,26 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.FSharp.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition="'$(SuppressImplicitGitSourceLink)' != 'true'">
+    <EmbedUntrackedSources Condition="'$(EmbedUntrackedSources)' == ''">true</EmbedUntrackedSources>
+  </PropertyGroup>
+  
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\$(_SourceLinkSdkSubDir)\Microsoft.Build.Tasks.Git.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Common\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Common.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitHub.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitLab.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.AzureRepos.Git.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Bitbucket.Git.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'"/>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -157,6 +157,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- List of supported .NET windows target platform versions -->
   <Import Project="Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props" />
 
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.SourceLink.props" />
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.CSharp.props" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.VisualBasic.props" Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.FSharp.props" Condition="'$(MSBuildProjectExtension)' == '.fsproj'" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1207,6 +1207,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Remove="ReferenceManagerAssemblies" />
   </ItemGroup>
 
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.SourceLink.targets" Condition="'$(SuppressImplicitGitSourceLink)' != 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DesignerSupport.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.GenerateAssemblyInfo.targets" Condition="'$(UsingNETSdkDefaults)' == 'true'"/>

--- a/src/Tests/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -1,0 +1,238 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class SourceLinkTests : SdkTest
+    {
+        private static readonly Guid s_embeddedSourceKindGuid = new("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
+
+        public SourceLinkTests(ITestOutputHelper log)
+            : base(log)
+        {
+        }
+
+        private void CreateGitFiles(string repoDir, string originUrl, string commitSha = "1200000000000000000000000000000000000000")
+        {
+            var gitDir = Path.Combine(repoDir, ".git");
+            var headsDir = Path.Combine(gitDir, "refs", "heads");
+
+            Directory.CreateDirectory(gitDir);
+            File.WriteAllText(Path.Combine(gitDir, "HEAD"), "ref: refs/heads/master");
+            Directory.CreateDirectory(headsDir);
+
+            if (commitSha != null)
+            {
+                File.WriteAllText(Path.Combine(headsDir, "master"), commitSha);
+            }
+
+            if (originUrl != null)
+            {
+                File.WriteAllText(Path.Combine(gitDir, "config"), $"""
+                [remote "origin"]
+                    url = {originUrl}
+                """);
+            }
+
+            File.WriteAllText(Path.Combine(repoDir, ".gitignore"), """
+                [Bb]in/
+                [Oo]bj/
+                """);
+        }
+
+        private unsafe void ValidatePdb(string pdbPath, bool expectedEmbeddedSources)
+        {
+            // Validates that *.AssemblyAttributes.cs file is embedded in the PDB.
+
+            var pdb = File.ReadAllBytes(pdbPath);
+            fixed (byte* pdbPtr = pdb)
+            {
+                var mdReader = new MetadataReader(pdbPtr, pdb.Length);
+                var attrDocHandle = mdReader.Documents.Single(h => mdReader.GetString(mdReader.GetDocument(h).Name).EndsWith(".AssemblyAttributes.cs"));
+                var cdis = mdReader.GetCustomDebugInformation(attrDocHandle);
+
+                Assert.Equal(expectedEmbeddedSources, cdis.Any(h => mdReader.GetGuid(mdReader.GetCustomDebugInformation(h).Kind) == s_embeddedSourceKindGuid));
+            }
+        }
+
+        [Fact]
+        public void WithNoGitMetadata()
+        {
+            // We need to copy the test project to a directory outside of the SDK repo,
+            // otherwise we would find .git directory in the SDK repo root.
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("SourceLinkTestApp", testDestinationDirectory: Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()))
+                .WithSource();
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute().Should().Pass();
+
+            var intermediateDir = buildCommand.GetIntermediateDirectory();
+            intermediateDir.Should().NotHaveFile("SourceLinkTestApp.sourcelink.json");
+        }
+
+        /// <summary>
+        /// When creating a new repository locally we want the build to work and not report warnings even before the remote is set.
+        /// </summary>
+        [Fact]
+        public void WithNoRemoteNoCommit()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("SourceLinkTestApp")
+                .WithSource();
+
+            CreateGitFiles(testAsset.Path, originUrl: null, commitSha: null);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute().Should().HaveStdOutContaining($"warning : Repository '{testAsset.Path}' has no remote.");
+
+            var intermediateDir = buildCommand.GetIntermediateDirectory();
+            intermediateDir.Should().NotHaveFile("SourceLinkTestApp.sourcelink.json");
+        }
+
+        /// <summary>
+        /// When creating a new repository locally we want the build to work and not report warnings even before the remote is set.
+        /// </summary>
+        [Fact]
+        public void WithNoRemote()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("SourceLinkTestApp")
+                .WithSource();
+
+            CreateGitFiles(testAsset.Path, originUrl: null);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute().Should().HaveStdOutContaining($"warning : Repository '{testAsset.Path}' has no remote.");
+
+            var intermediateDir = buildCommand.GetIntermediateDirectory();
+            intermediateDir.Should().NotHaveFile("SourceLinkTestApp.sourcelink.json");
+        }
+
+        [Fact]
+        public void WithRemoteOrigin_UnknownDomain()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("SourceLinkTestApp")
+                .WithSource();
+
+            CreateGitFiles(testAsset.Path, originUrl: "https://contoso.com");
+
+            var buildCommand = new BuildCommand(testAsset)
+            {
+                WorkingDirectory = testAsset.Path
+            };
+
+            var result = buildCommand.Execute().Should().Pass();
+
+            var intermediateDir = buildCommand.GetIntermediateDirectory();
+            intermediateDir.Should().NotHaveFile("SourceLinkTestApp.sourcelink.json");
+        }
+
+        [Theory]
+        [InlineData("https://github.com/org/repo", "https://raw.githubusercontent.com/org/repo/1200000000000000000000000000000000000000/*")]
+        [InlineData("https://gitlab.com/org/repo", "https://gitlab.com/org/repo/-/raw/1200000000000000000000000000000000000000/*")]
+        [InlineData("https://bitbucket.org/org/repo", "https://api.bitbucket.org/2.0/repositories/org/repo/src/1200000000000000000000000000000000000000/*")]
+        [InlineData("https://test.visualstudio.com/org/_git/repo", "https://test.visualstudio.com/org/_apis/git/repositories/repo/items?api-version=1.0&versionType=commit&version=1200000000000000000000000000000000000000&path=/*")]
+        public void WithRemoteOrigin_KnownDomain(string origin, string expectedLink)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("SourceLinkTestApp", identifier: origin)
+                .WithSource();
+
+            CreateGitFiles(testAsset.Path, origin);
+
+            var buildCommand = new BuildCommand(testAsset)
+            {
+                WorkingDirectory = testAsset.Path
+            };
+
+            var result = buildCommand.Execute().Should().Pass();
+
+            var intermediateDir = buildCommand.GetIntermediateDirectory();
+            var sourceLinkFilePath = Path.Combine(intermediateDir.FullName, "SourceLinkTestApp.sourcelink.json");
+            var actualContent = File.ReadAllText(sourceLinkFilePath, Encoding.UTF8);
+            var expectedPattern = Path.Combine(testAsset.Path, "*").Replace("\\", "\\\\");
+
+            Assert.Equal($$$"""{"documents":{"{{{expectedPattern}}}":"{{{expectedLink}}}"}}""", actualContent);
+
+            ValidatePdb(Path.Combine(intermediateDir.FullName, "SourceLinkTestApp.pdb"), expectedEmbeddedSources: true);
+        }
+
+        [Fact]
+        public void SuppressImplicitGitSourceLink_SetExplicitly()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("SourceLinkTestApp")
+                .WithSource().WithProjectChanges(p =>
+                {
+                    var ns = p.Root.Name.Namespace;
+
+                    var propertyGroup = new XElement(ns + "PropertyGroup");
+                    p.Root.Add(propertyGroup);
+
+                    propertyGroup.Add(new XElement(ns + "SuppressImplicitGitSourceLink", "true"));
+                });
+
+            CreateGitFiles(testAsset.Path, "https://github.com/org/repo");
+
+            var buildCommand = new BuildCommand(testAsset)
+            {
+                WorkingDirectory = testAsset.Path
+            };
+
+            var result = buildCommand.Execute().Should().Pass();
+
+            var intermediateDir = buildCommand.GetIntermediateDirectory();
+            intermediateDir.Should().NotHaveFile("SourceLinkTestApp.sourcelink.json");
+        }
+
+        [Fact]
+        public void SuppressImplicitGitSourceLink_ExplicitPackage()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("SourceLinkTestApp")
+                .WithSource()
+                .WithProjectChanges(p =>
+                {
+                    var ns = p.Root.Name.Namespace;
+
+                    var itemGroup = new XElement(ns + "ItemGroup");
+                    p.Root.Add(itemGroup);
+
+                    itemGroup.Add(new XElement(ns + "PackageReference",
+                                    new XAttribute("Include", "Microsoft.SourceLink.GitHub"),
+                                    new XAttribute("Version", "1.0.0")));
+                });
+
+            CreateGitFiles(testAsset.Path, "https://github.com/org/repo");
+
+            var buildCommand = new BuildCommand(testAsset)
+            {
+                WorkingDirectory = testAsset.Path
+            };
+
+            var result = buildCommand.Execute().Should().Pass();
+
+            var intermediateDir = buildCommand.GetIntermediateDirectory();
+            intermediateDir.Should().HaveFile("SourceLinkTestApp.sourcelink.json");
+
+            // EmbedUntrackedSources is not set by default by SourceLink v1.0.0 package:
+            ValidatePdb(Path.Combine(intermediateDir.FullName, "SourceLinkTestApp.pdb"), expectedEmbeddedSources: false);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.NET.Build.Tests
             CreateGitFiles(testAsset.Path, originUrl: null, commitSha: null);
 
             var buildCommand = new BuildCommand(testAsset);
-            buildCommand.Execute().Should().HaveStdOutContaining($"warning : Repository '{testAsset.Path}' has no remote.");
+            buildCommand.Execute().Should().NotHaveStdOutContaining("warning");
 
             var intermediateDir = buildCommand.GetIntermediateDirectory();
             intermediateDir.Should().NotHaveFile("SourceLinkTestApp.sourcelink.json");
@@ -117,7 +117,7 @@ namespace Microsoft.NET.Build.Tests
             CreateGitFiles(testAsset.Path, originUrl: null);
 
             var buildCommand = new BuildCommand(testAsset);
-            buildCommand.Execute().Should().HaveStdOutContaining($"warning : Repository '{testAsset.Path}' has no remote.");
+            buildCommand.Execute().Should().NotHaveStdOutContaining("warning");
 
             var intermediateDir = buildCommand.GetIntermediateDirectory();
             intermediateDir.Should().NotHaveFile("SourceLinkTestApp.sourcelink.json");

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.NET.Build.Tests
                 WorkingDirectory = testAsset.Path
             };
 
-            var result = buildCommand.Execute().Should().Pass();
+            buildCommand.Execute().Should().Pass();
 
             var intermediateDir = buildCommand.GetIntermediateDirectory();
             intermediateDir.Should().NotHaveFile("SourceLinkTestApp.sourcelink.json");
@@ -196,8 +196,6 @@ namespace Microsoft.NET.Build.Tests
                 testAsset = Multitarget(testAsset, targetFrameworks);
             }
 
-            Assert.NotNull(targetFrameworks);
-
             CreateGitFiles(testAsset.Path, origin);
 
             var buildCommand = new BuildCommand(testAsset)
@@ -205,7 +203,7 @@ namespace Microsoft.NET.Build.Tests
                 WorkingDirectory = testAsset.Path
             };
 
-            var result = buildCommand.Execute().Should().Pass();
+            buildCommand.Execute().Should().Pass();
 
             foreach (var targetFramework in targetFrameworks.Split(';'))
             {
@@ -228,7 +226,7 @@ namespace Microsoft.NET.Build.Tests
             string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? ";netstandard2.0" : "");
 
             var testAsset = _testAssetsManager
-                .CopyTestAsset("SourceLinkTestApp")
+                .CopyTestAsset("SourceLinkTestApp", identifier: multitarget.ToString())
                 .WithSource();
 
             testAsset = WithProperties(testAsset, ("SuppressImplicitGitSourceLink", "true"));
@@ -238,8 +236,6 @@ namespace Microsoft.NET.Build.Tests
                 testAsset = Multitarget(testAsset, targetFrameworks);
             }
 
-            Assert.NotNull(targetFrameworks);
-
             CreateGitFiles(testAsset.Path, "https://github.com/org/repo");
 
             var buildCommand = new BuildCommand(testAsset)
@@ -247,7 +243,7 @@ namespace Microsoft.NET.Build.Tests
                 WorkingDirectory = testAsset.Path
             };
 
-            var result = buildCommand.Execute().Should().Pass();
+            buildCommand.Execute().Should().Pass();
 
             foreach (var targetFramework in targetFrameworks.Split(';'))
             {
@@ -264,7 +260,7 @@ namespace Microsoft.NET.Build.Tests
             string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? ";netstandard2.0" : "");
 
             var testAsset = _testAssetsManager
-                .CopyTestAsset("SourceLinkTestApp")
+                .CopyTestAsset("SourceLinkTestApp", identifier: multitarget.ToString())
                 .WithSource();
 
             if (multitarget)
@@ -274,8 +270,6 @@ namespace Microsoft.NET.Build.Tests
 
             testAsset = WithItems(testAsset, ("PackageReference", new[] { new XAttribute("Include", "Microsoft.SourceLink.GitHub"), new XAttribute("Version", "1.0.0") }));
 
-            Assert.NotNull(targetFrameworks);
-
             CreateGitFiles(testAsset.Path, "https://github.com/org/repo");
 
             var buildCommand = new BuildCommand(testAsset)
@@ -283,7 +277,7 @@ namespace Microsoft.NET.Build.Tests
                 WorkingDirectory = testAsset.Path
             };
 
-            var result = buildCommand.Execute().Should().Pass();
+            buildCommand.Execute().Should().Pass();
 
             foreach (var targetFramework in targetFrameworks.Split(';'))
             {
@@ -302,7 +296,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("NetCoreCsharpAppReferenceCppCliLib")
                 .WithSource();
 
-            testAsset = WithProperties(testAsset, ("EnableManagedpackageReferenceSupport", "true"));
+            testAsset = WithProperties(testAsset, ("EnableManagedPackageReferenceSupport", "true"));
 
             CreateGitFiles(testAsset.Path, "https://github.com/org/repo");
 

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -304,7 +304,7 @@ namespace Microsoft.NET.Build.Tests
 
             testAsset = WithProperties(testAsset, ("EnableManagedpackageReferenceSupport", "true"));
 
-            CreateGitFiles(testAsset.Path, "https://github.com/a/b");
+            CreateGitFiles(testAsset.Path, "https://github.com/org/repo");
 
             var buildCommand = new BuildCommand(testAsset, "NETCoreCppCliTest")
             {

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -316,7 +316,8 @@ namespace Microsoft.NET.Build.Tests
             var outputDir = Path.Combine(testAsset.Path, "NETCoreCppCliTest", "x64", "Debug");
             var sourceLinkFilePath = Path.Combine(outputDir, "NETCoreCppCliTest.sourcelink.json");
             var actualContent = File.ReadAllText(sourceLinkFilePath, Encoding.UTF8);
-            var expectedSourceLink = """{"documents":{"https://github.com/org/repo":"https://raw.githubusercontent.com/org/repo/1200000000000000000000000000000000000000/*"}}""";
+            var expectedPattern = Path.Combine(testAsset.Path, "*").Replace("\\", "\\\\");
+            var expectedSourceLink = $$$"""{"documents":{"{{{expectedPattern}}}":"https://raw.githubusercontent.com/org/repo/1200000000000000000000000000000000000000/*"}}""";
             Assert.Equal(expectedSourceLink, actualContent);
 
             var pdbText = File.ReadAllText(Path.Combine(outputDir, "NETCoreCppCliTest.pdb"), Encoding.UTF8);

--- a/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
@@ -43,13 +43,13 @@ namespace Microsoft.NET.TestFramework
             [CallerFilePath] string callerFilePath = null,
             string identifier = "",
             string testAssetSubdirectory = "",
+            string testDestinationDirectory = null,
             bool allowCopyIfPresent = false)
         {
             var testProjectDirectory = GetAndValidateTestProjectDirectory(testProjectName, testAssetSubdirectory);
 
             var fileName = Path.GetFileNameWithoutExtension(callerFilePath);
-            var testDestinationDirectory =
-                GetTestDestinationDirectoryPath(testProjectName, callingMethod + "_" + fileName, identifier, allowCopyIfPresent);
+            testDestinationDirectory ??= GetTestDestinationDirectoryPath(testProjectName, callingMethod + "_" + fileName, identifier, allowCopyIfPresent);
             TestDestinationDirectories.Add(testDestinationDirectory);
 
             var testAsset = new TestAsset(testProjectDirectory, testDestinationDirectory, TestContext.Current.SdkVersion, Log);


### PR DESCRIPTION
Source Link targets are included automatically unless the project has already a `PackageReference` to any Source Link package.

Property `SuppressImplicitGitSourceLink` can be used to disable automatic inclusion of Source Link.