### PR TITLE
[release/7.0.4xx] containers: removed stack trace from logged error message

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -144,7 +144,8 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
                 {
                     if (BuildEngine != null)
                     {
-                        Log.LogErrorWithCodeFromResources(nameof(Strings.RegistryOutputPushFailed), e);
+                        Log.LogErrorWithCodeFromResources(nameof(Strings.RegistryOutputPushFailed), e.Message);
+                        Log.LogMessage(MessageImportance.Low, "Details: {0}", e);
                     }
                 }
             }


### PR DESCRIPTION
fixes https://github.com/dotnet/sdk-container-builds/issues/410

Removed stack trace from logged error message. It appeared to be the only one occurrence. 