### PR TITLE
[release/7.0.2xx][test-only] fixed bug in `CreateTemporaryFolder` counter logic

### DIFF
--- a/src/Tests/dotnet-new.Tests/Utilities.cs
+++ b/src/Tests/dotnet-new.Tests/Utilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
@@ -27,11 +27,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             lock (string.Intern(baseDir.ToLowerInvariant()))
             {
                 string workingDir = Path.Combine(baseDir, DateTime.UtcNow.ToString("yyyyMMddHHmmssfff"));
-                if (!Directory.Exists(workingDir))
-                {
-                    Directory.CreateDirectory(workingDir);
-                }
-                else
+                if (Directory.Exists(workingDir))
                 {
                     //simple logic for counts if DateTime.UtcNow is not unique
                     int counter = 1;
@@ -43,8 +39,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                     {
                         throw new Exception("Failed to create temp directory after 100 attempts");
                     }
-                    Directory.CreateDirectory(workingDir + "_" + counter);
+                    workingDir = workingDir + "_" + counter;
                 }
+                Directory.CreateDirectory(workingDir);
                 return workingDir;
             }
         }


### PR DESCRIPTION
Bug in `CreateTemporaryFolder` leads to flaky tests in template engine jobs.
Please merge during servicing window to avoid pipeline re-runs

Backport of fix from https://github.com/dotnet/sdk/pull/30320