### PR TITLE
Prevent restore loop in VS

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -426,12 +426,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="_FullFrameworkReferenceAssemblyPaths"/>
     </GetReferenceAssemblyPaths>
 
-
     <ItemGroup>
       <_ExistingReferenceAssembliesPackageReference Include="@(PackageReference)" Condition="'%(PackageReference.Identity)' == 'Microsoft.NETFramework.ReferenceAssemblies'"/>
 
       <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion)" IsImplicitlyDefined="true" PrivateAssets="All"
-                        Condition="'$(_FullFrameworkReferenceAssemblyPaths)' == '' and '@(_ExistingReferenceAssembliesPackageReference)' == ''"/>
+                        Condition="('$(_FullFrameworkReferenceAssemblyPaths)' == '' or $(_FullFrameworkReferenceAssemblyPaths.Contains('microsoft.netframework.referenceassemblies'))) and '@(_ExistingReferenceAssembliesPackageReference)' == ''"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes #19506

The `GetReferenceAssemblyPaths` target adds a `PackageReference` to `Microsoft.NETFramework.ReferenceAssemblies` when needed.

In VS, this new package causes VS to nominate a NuGet restore then perform another design-time build.

That second design-time build was previously determining that the `PackageReference` was no longer needed, then removing it. The task's `FullFrameworkReferenceAssemblyPaths` output parameter contains the full path of the reference assembly folder in such a case, which fails the empty-string test.

This change tests whether the output parameter is a reference to the package, and if so allows the `PackageReference` to remain.

---

I'm not sure whether this is the best approach to fixing this, but I identified this as a possible fix and verified it works correctly (when combined with https://github.com/dotnet/msbuild/pull/8660) so wanted to capture it here in a PR for others to build on.