### PR TITLE
Remove usages of CentOS 7

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -96,7 +96,7 @@ stages:
     parameters:
       platform:
         name: 'Managed'
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/build.yml
       parameters:

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToCrossPublish.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToCrossPublish.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "CrossPublish",
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
-                RuntimeIdentifier = "centos.7-x64"
+                RuntimeIdentifier = "centos.8-x64"
             };
 
             testProject.PackageReferences.Add(new TestPackageReference("System.Threading", "4.3.0"));


### PR DESCRIPTION
As we don't support running .NET 8 on CentOS 7 as it is nearing EOL, update references and usages of CentOS 7 to CentOS 8.

Also, update the CI pipeline source-build runs on to CentOS Stream 8 so it is not on CentOS 7 when it goes out of support.