### PR TITLE
Fix dotnet/sdk-container-builds#414 by using three-digit version

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageTag.cs
@@ -77,7 +77,7 @@ public sealed class ComputeDotnetBaseImageTag : Microsoft.Build.Utilities.Task
     }
 
      private string? DetermineLabelBasedOnChannel(int major, int minor, string[] releaseLabels) {
-      // this would be a switch, but we have to support net47s where Range and Index aren't available
+      // this would be a switch, but we have to support net47x where Range and Index aren't available
         if (releaseLabels.Length == 0)
         {
             return $"{major}.{minor}";
@@ -89,7 +89,9 @@ public sealed class ComputeDotnetBaseImageTag : Microsoft.Build.Utilities.Task
             {
                 if (releaseLabels.Length > 1)
                 {
-                    return $"{major}.{minor}-{channel}.{releaseLabels[1]}";
+                    // Per the dotnet-docker team, the major.minor preview tag format is a fluke and the major.minor.0 form
+                    // should be used for all previews going forward.
+                    return $"{major}.{minor}.0-{channel}.{releaseLabels[1]}";
                 }
                 else
                 {
@@ -97,11 +99,7 @@ public sealed class ComputeDotnetBaseImageTag : Microsoft.Build.Utilities.Task
                     return null;
                 }
             }
-            else if (channel == "alpha")
-            {
-                return $"{major}.{minor}-preview.1";
-            }
-            else if (channel == "dev" || channel == "ci")
+            else if (channel == "alpha" || channel == "dev" || channel == "ci")
             {
                 return $"{major}.{minor}-preview";
             }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -131,8 +131,8 @@ public class TargetsTests
     [InlineData("7.0.100-rc.1", "v7.0", "7.0")]
     [InlineData("8.0.100", "v8.0", "8.0")]
     [InlineData("8.0.100", "v7.0", "7.0")]
-    [InlineData("8.0.100-preview.7", "v8.0", "8.0-preview.7")]
-    [InlineData("8.0.100-rc.1", "v8.0", "8.0-rc.1")]
+    [InlineData("8.0.100-preview.7", "v8.0", "8.0.0-preview.7")]
+    [InlineData("8.0.100-rc.1", "v8.0", "8.0.0-rc.1")]
     [InlineData("8.0.100-rc.1", "v7.0", "7.0")]
     [InlineData("8.0.200", "v8.0", "8.0")]
     [InlineData("8.0.200", "v7.0", "7.0")]
@@ -142,8 +142,8 @@ public class TargetsTests
     [InlineData("6.0.100-preview.1", "v6.0", "6.0")]
     [InlineData("8.0.100-dev", "v8.0", "8.0-preview")]
     [InlineData("8.0.100-ci", "v8.0", "8.0-preview")]
-    [InlineData("8.0.100-alpha.12345", "v8.0", "8.0-preview.1")]
-    [InlineData("9.0.100-alpha.12345", "v9.0", "9.0-preview.1")]
+    [InlineData("8.0.100-alpha.12345", "v8.0", "8.0-preview")]
+    [InlineData("9.0.100-alpha.12345", "v9.0", "9.0-preview")]
     [Theory]
     public void CanComputeTagsForSupportedSDKVersions(string sdkVersion, string tfm, string expectedTag)
     {


### PR DESCRIPTION
Fixes dotnet/sdk-container-builds#414

Per https://github.com/dotnet/dotnet-docker/issues/4524#issuecomment-1505716092, the original MAJOR.MINOR-CHANNEL.N version scheme was under-documented and should have been MAJOR.MINOR.PATCH-CHANNEL.N instead.  This updates our inference task to use this scheme, and updates test expectations to match.