### PR TITLE
Some additional prebuilt baseline cleanup

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -6,10 +6,6 @@
     <UsagePattern IdentityGlob="Nuget.*/*" />
     <UsagePattern IdentityGlob="Microsoft.Build.NuGetSdkResolver/*" />
     
-    <!-- TODO: Ignore needed until vstest gets a source build leg that publishes outputs
-         https://github.com/microsoft/vstest/pull/4332. -->
-    <UsagePattern IdentityGlob="Microsoft.TestPlatform.*/*" />
-    
     <!-- TODO: Figure out what to do about the netcoreapp ref packages (these are probably being pulled
          in via implicit versions and net6 targeting projects (e.g. tests)
          https://github.com/dotnet/source-build/issues/3356 -->
@@ -19,12 +15,6 @@
          https://github.com/dotnet/source-build/issues/3357 -->
     <UsagePattern IdentityGlob="Microsoft.Build.Locator/*1.5.3*" />
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.AnalyzerUtilities/*3.3.0*" />
-    <UsagePattern IdentityGlob="Microsoft.Css.Parser/*1.0.0-20200708.1*" />
-    <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/*7.0.0*" />
-    <UsagePattern IdentityGlob="System.IO.Pipelines/*6.0.3*" />
-    <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*7.0.1*" />
-    <UsagePattern IdentityGlob="System.Security.Permissions/*7.0.0*" />
-    <UsagePattern IdentityGlob="System.Threading.Channels/*6.0.0*" />
     
     <!-- This may be coming in transitively from aspnetcore. Needs evaluation.
          https://github.com/dotnet/source-build/issues/3358. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -266,9 +266,9 @@
       <Sha>de4dda48d0cf31e13182bc24107b2246c61ed483</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23214.3">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23217.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>94178e62553730ae42f6e02bb2f0ca45d9c3e28d</Sha>
+      <Sha>8a91992a869b6e4dccd49b1c3246486e963595af</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview.6.23206.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -114,6 +114,7 @@
     <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.7.0-preview.23214.2">
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>1541fc31ead99a358c649e7e9fa203e0dd4d20a5</Sha>
+      <SourceBuild RepoName="vstest" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.4.23218.1">
       <Uri>https://github.com/dotnet/runtime</Uri>


### PR DESCRIPTION
- Remove some items that made it into SBRP
- VStest is now producing proper intermediate packages
- css parser now aligns its source-built versioning with the official packaging.