### PR TITLE
Disambiguate GenAPI calls to base constructors

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -226,14 +226,13 @@ namespace Microsoft.DotNet.GenAPI
 
             foreach (IParameterSymbol parameter in baseTypeConstructor.Parameters)
             {
-                IdentifierNameSyntax identifier;
-                // If the parameter's type is known to be a value type or has top-level nullability annotation
-                if (parameter.Type.IsValueType || parameter.NullableAnnotation == NullableAnnotation.Annotated)
-                    identifier = SyntaxFactory.IdentifierName("default");
-                else
-                    identifier = SyntaxFactory.IdentifierName("default!");
+                ExpressionSyntax expression = SyntaxFactory.DefaultExpression(SyntaxFactory.ParseTypeName(parameter.Type.ToDisplayString()));
 
-                constructorInitializer = constructorInitializer.AddArgumentListArguments(SyntaxFactory.Argument(identifier));
+                // If the parameter is not value type and isn't annotated to accept null, suppress the nullable warning with !
+                if (!parameter.Type.IsValueType && parameter.NullableAnnotation != NullableAnnotation.Annotated)
+                    expression = SyntaxFactory.PostfixUnaryExpression(SyntaxKind.SuppressNullableWarningExpression, expression);
+
+                constructorInitializer = constructorInitializer.AddArgumentListArguments(SyntaxFactory.Argument(expression));
             }
 
             return constructorInitializer;

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1321,6 +1321,53 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     """);
         }
 
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/67867")]
+        public void TestBaseTypeWithAmbiguousNonDefaultConstructorsRegression31655()
+        {
+            RunTest(original: """
+                    namespace Foo
+                    {
+                        public class A
+                        {
+                            public A(Id id, System.Collections.Generic.IEnumerable<D> deps) { }
+                            public A(string s, V v) { }
+                        }
+
+                        public class B : A
+                        {
+                            public B() : base(new Id(), new D[0]) {}
+                        }
+
+                        public class Id { }
+
+                        public class D { }
+                    
+                        public class V { }
+                    }
+                    """,
+                expected: """
+                    namespace Foo
+                    {
+                        public partial class A
+                        {
+                            public A(Id id, System.Collections.Generic.IEnumerable<D> deps) { }
+                            public A(string s, V v) { }
+                        }
+
+                        public partial class B : A
+                        {
+                            public B() : base(default(Id), default(System.Collections.Generic.IEnumerable<D>)) {}
+                        }
+
+                        public partial class Id { }
+                    
+                        public partial class D { }
+
+                        public partial class V { }
+                    }
+                    """);
+        }
+
         [Fact]
         public void TestBaseTypeConstructorWithObsoleteAttribute()
         {

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1285,6 +1285,43 @@ namespace Microsoft.DotNet.GenAPI.Tests
         }
 
         [Fact]
+        public void TestBaseTypeWithAmbiguousNonDefaultConstructors()
+        {
+            RunTest(original: """
+                    namespace Foo
+                    {
+                        public class A
+                        {
+                            public A(char c) { }
+                            public A(int i) { }
+                            public A(string s) { }
+                        }
+
+                        public class B : A
+                        {
+                            public B() : base("") {}
+                        }
+                    }
+                    """,
+                expected: """
+                    namespace Foo
+                    {
+                        public partial class A
+                        {
+                            public A(char c) { }
+                            public A(int i) { }
+                            public A(string s) { }
+                        }
+
+                        public partial class B : A
+                        {
+                            public B() : base(default(char)) {}
+                        }
+                    }
+                    """);
+        }
+
+        [Fact]
         public void TestBaseTypeConstructorWithObsoleteAttribute()
         {
             RunTest(original: """


### PR DESCRIPTION
Fix https://github.com/dotnet/sdk/issues/31655