### PR TITLE
Fix incorrect MicrosoftSourceLinkBitbucketGitVersion property name

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -181,7 +181,7 @@
     <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkAzureReposGitVersion>
     <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftSourceLinkGitLabVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkGitLabVersion>
-    <MicrosoftSourceLinkBitbucketGitVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkBitbucketGitVersion>
+    <MicrosoftSourceLinkBitBucketGitVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkBitBucketGitVersion>
   </PropertyGroup>
   <!-- Get .NET Framework reference assemblies from NuGet packages -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -181,7 +181,7 @@
     <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkAzureReposGitVersion>
     <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftSourceLinkGitLabVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkGitLabVersion>
-    <MicrosoftSourceLinkBitBucketVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkBitBucketVersion>
+    <MicrosoftSourceLinkBitbucketGitVersion>8.0.0-beta.23210.3</MicrosoftSourceLinkBitbucketGitVersion>
   </PropertyGroup>
   <!-- Get .NET Framework reference assemblies from NuGet packages -->
   <PropertyGroup>

--- a/src/Layout/redist/targets/BundledSdks.targets
+++ b/src/Layout/redist/targets/BundledSdks.targets
@@ -10,6 +10,6 @@
     <BundledSdk Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(MicrosoftSourceLinkAzureReposGitVersion)" />
     <BundledSdk Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" />
     <BundledSdk Include="Microsoft.SourceLink.GitLab" Version="$(MicrosoftSourceLinkGitLabVersion)" />
-    <BundledSdk Include="Microsoft.SourceLink.Bitbucket.Git" Version="$(MicrosoftSourceLinkBitBucketVersion)" />
+    <BundledSdk Include="Microsoft.SourceLink.Bitbucket.Git" Version="$(MicrosoftSourceLinkBitBucketGitVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/31632 introduced the wrong property name - it is missing the `Git` part.  This is causing a prebuilt in source-build.  Source-build is trying to override this property with the live version but because the property is named incorrectly, it is not overridden.

