### PR TITLE
Signing:  enable NuGet signature verification by default on Linux

### DIFF
--- a/src/Cli/dotnet/NuGetForwardingApp.cs
+++ b/src/Cli/dotnet/NuGetForwardingApp.cs
@@ -19,6 +19,8 @@ namespace Microsoft.DotNet.Tools
             _forwardingApp = new ForwardingApp(
                 GetNuGetExePath(),
                 argsToForward);
+
+            NuGetSignatureVerificationEnabler.ConditionallyEnable(_forwardingApp);
         }
 
         public int Execute()

--- a/src/Cli/dotnet/NuGetSignatureVerificationEnabler.cs
+++ b/src/Cli/dotnet/NuGetSignatureVerificationEnabler.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.MSBuild;
+
+namespace Microsoft.DotNet.Tools
+{
+    public static class NuGetSignatureVerificationEnabler
+    {
+        private static readonly EnvironmentProvider s_environmentProvider = new();
+
+        internal static readonly string DotNetNuGetSignatureVerification = "DOTNET_NUGET_SIGNATURE_VERIFICATION";
+
+        public static void ConditionallyEnable(ForwardingApp forwardingApp, IEnvironmentProvider? environmentProvider = null)
+        {
+            ArgumentNullException.ThrowIfNull(forwardingApp, nameof(forwardingApp));
+
+            if (!IsLinux())
+            {
+                return;
+            }
+
+            string value = GetSignatureVerificationEnablementValue(environmentProvider);
+
+            forwardingApp.WithEnvironmentVariable(DotNetNuGetSignatureVerification, value);
+        }
+
+        public static void ConditionallyEnable(MSBuildForwardingApp forwardingApp, IEnvironmentProvider? environmentProvider = null)
+        {
+            ArgumentNullException.ThrowIfNull(forwardingApp, nameof(forwardingApp));
+
+            if (!IsLinux())
+            {
+                return;
+            }
+
+            string value = GetSignatureVerificationEnablementValue(environmentProvider);
+
+            forwardingApp.EnvironmentVariable(DotNetNuGetSignatureVerification, value);
+        }
+
+        private static string GetSignatureVerificationEnablementValue(IEnvironmentProvider? environmentProvider)
+        {
+            string? value = (environmentProvider ?? s_environmentProvider).GetEnvironmentVariable(DotNetNuGetSignatureVerification);
+
+            return string.Equals(bool.FalseString, value, StringComparison.OrdinalIgnoreCase)
+                ? bool.FalseString : bool.TrueString;
+        }
+
+        private static bool IsLinux()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -30,6 +30,11 @@ namespace Microsoft.DotNet.Tools
             Task.Run(() => WorkloadManifestUpdater.BackgroundUpdateAdvertisingManifestsAsync(userProfileDir));
             SeparateRestoreCommand = GetSeparateRestoreCommand(msbuildArgs, noRestore, msbuildPath);
             AdvertiseWorkloadUpdates = advertiseWorkloadUpdates;
+
+            if (!noRestore)
+            {
+                NuGetSignatureVerificationEnabler.ConditionallyEnable(this);
+            }
         }
 
         private static IEnumerable<string> GetCommandArguments(

--- a/src/Cli/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/Program.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.Tools.Restore
         public RestoreCommand(IEnumerable<string> msbuildArgs, string msbuildPath = null)
             : base(msbuildArgs, msbuildPath)
         {
+            NuGetSignatureVerificationEnabler.ConditionallyEnable(this);
         }
 
         public static RestoreCommand FromArgs(string[] args, string msbuildPath = null, bool noLogo = true)

--- a/src/Tests/dotnet.Tests/NuGetSignatureVerificationEnablerTests.cs
+++ b/src/Tests/dotnet.Tests/NuGetSignatureVerificationEnablerTests.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools;
+using Microsoft.DotNet.Tools.MSBuild;
+using Moq;
+
+namespace Microsoft.DotNet.Tests
+{
+    public class NuGetSignatureVerificationEnablerTests
+    {
+        private static readonly string FakeFilePath = Path.Combine(Path.GetTempPath(), "file.fake");
+
+        public static IEnumerable<object[]> GetNonFalseValues()
+        {
+            yield return new object[] { null! };
+            yield return new object[] { string.Empty };
+            yield return new object[] { "0" };
+            yield return new object[] { "1" };
+            yield return new object[] { "no" };
+            yield return new object[] { "yes" };
+            yield return new object[] { "true" };
+            yield return new object[] { "TRUE" };
+        }
+
+        public static IEnumerable<object[]> GetFalseValues()
+        {
+            yield return new object[] { "false" };
+            yield return new object[] { "FALSE" };
+        }
+
+        [Fact]
+        public void GivenANullForwardingAppThrows()
+        {
+            ForwardingApp forwardingApp = null!;
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => NuGetSignatureVerificationEnabler.ConditionallyEnable(forwardingApp));
+
+            Assert.Equal("forwardingApp", exception.ParamName);
+        }
+
+        [Fact]
+        public void GivenANullMSBuildForwardingAppThrows()
+        {
+            MSBuildForwardingApp forwardingApp = null!;
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => NuGetSignatureVerificationEnabler.ConditionallyEnable(forwardingApp));
+
+            Assert.Equal("forwardingApp", exception.ParamName);
+        }
+
+        [LinuxOnlyTheory]
+        [MemberData(nameof(GetNonFalseValues))]
+        public void GivenAForwardingAppAndAnEnvironmentVariableValueThatIsNotFalseSetsTrueOnLinux(string? value)
+        {
+            Mock<IEnvironmentProvider> environmentProvider = CreateEnvironmentProvider(value);
+            ForwardingApp forwardingApp = new(FakeFilePath, Array.Empty<string>());
+
+            NuGetSignatureVerificationEnabler.ConditionallyEnable(forwardingApp, environmentProvider.Object);
+
+            environmentProvider.VerifyAll();
+
+            VerifyEnvironmentVariable(forwardingApp.GetProcessStartInfo(), bool.TrueString);
+        }
+
+        [LinuxOnlyTheory]
+        [MemberData(nameof(GetFalseValues))]
+        public void GivenAForwardingAppAndAnEnvironmentVariableValueThatIsFalseSetsFalseOnLinux(string value)
+        {
+            Mock<IEnvironmentProvider> environmentProvider = CreateEnvironmentProvider(value);
+            ForwardingApp forwardingApp = new(FakeFilePath, Array.Empty<string>());
+
+            NuGetSignatureVerificationEnabler.ConditionallyEnable(forwardingApp, environmentProvider.Object);
+
+            environmentProvider.VerifyAll();
+
+            VerifyEnvironmentVariable(forwardingApp.GetProcessStartInfo(), bool.FalseString);
+        }
+
+        [LinuxOnlyTheory]
+        [MemberData(nameof(GetNonFalseValues))]
+        public void GivenAnMSBuildForwardingAppAndAnEnvironmentVariableValueThatIsNotFalseSetsTrueOnLinux(string? value)
+        {
+            Mock<IEnvironmentProvider> environmentProvider = CreateEnvironmentProvider(value);
+            MSBuildForwardingApp forwardingApp = new(Array.Empty<string>(), FakeFilePath);
+
+            NuGetSignatureVerificationEnabler.ConditionallyEnable(forwardingApp, environmentProvider.Object);
+
+            environmentProvider.VerifyAll();
+
+            VerifyEnvironmentVariable(forwardingApp.GetProcessStartInfo(), bool.TrueString);
+        }
+
+        [LinuxOnlyTheory]
+        [MemberData(nameof(GetFalseValues))]
+        public void GivenAnMSBuildForwardingAppAndAnEnvironmentVariableValueThatIsFalseSetsFalseOnLinux(string value)
+        {
+            Mock<IEnvironmentProvider> environmentProvider = CreateEnvironmentProvider(value);
+            MSBuildForwardingApp forwardingApp = new(Array.Empty<string>(), FakeFilePath);
+
+            NuGetSignatureVerificationEnabler.ConditionallyEnable(forwardingApp, environmentProvider.Object);
+
+            environmentProvider.VerifyAll();
+
+            VerifyEnvironmentVariable(forwardingApp.GetProcessStartInfo(), bool.FalseString);
+        }
+
+        [MacOSOnlyFact]
+        public void GivenAForwardingAppDoesNothingOnMacOs()
+        {
+            var environmentProvider = new Mock<IEnvironmentProvider>(MockBehavior.Strict);
+            ForwardingApp forwardingApp = new(FakeFilePath, Array.Empty<string>());
+
+            NuGetSignatureVerificationEnabler.ConditionallyEnable(forwardingApp, environmentProvider.Object);
+
+            environmentProvider.VerifyAll();
+
+            VerifyNoEnvironmentVariable(forwardingApp.GetProcessStartInfo());
+        }
+
+        [MacOSOnlyFact]
+        public void GivenAnMSBuildForwardingAppDoesNothingOnMacOs()
+        {
+            var environmentProvider = new Mock<IEnvironmentProvider>(MockBehavior.Strict);
+            MSBuildForwardingApp forwardingApp = new(Array.Empty<string>(), FakeFilePath);
+
+            NuGetSignatureVerificationEnabler.ConditionallyEnable(forwardingApp, environmentProvider.Object);
+
+            environmentProvider.VerifyAll();
+
+            VerifyNoEnvironmentVariable(forwardingApp.GetProcessStartInfo());
+        }
+
+        private static Mock<IEnvironmentProvider> CreateEnvironmentProvider(string? value)
+        {
+            Mock<IEnvironmentProvider> provider = new(MockBehavior.Strict);
+
+            provider
+                .Setup(p => p.GetEnvironmentVariable(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification))
+                .Returns(value!);
+
+            return provider;
+        }
+
+        private static void VerifyEnvironmentVariable(ProcessStartInfo startInfo, string expectedValue)
+        {
+            Assert.True(startInfo.EnvironmentVariables.ContainsKey(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification));
+            Assert.Equal(expectedValue, startInfo.EnvironmentVariables[NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification]);
+        }
+
+        private static void VerifyNoEnvironmentVariable(ProcessStartInfo startInfo)
+        {
+            Assert.False(startInfo.EnvironmentVariables.ContainsKey(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification));
+        }
+    }
+}


### PR DESCRIPTION
_Note:  wait for NuGet's automated test results for .NET 8 SDK before merging this PR._

Resolves https://github.com/NuGet/Home/issues/11262

This change enables NuGet signed package verification by default on Linux in .NET 8 SDK.  Because [NuGet.Client](https://github.com/NuGet/NuGet.Client) dual-inserts into both .NET 7 and 8 SDK's, NuGet needed a way to enable verification by default only in .NET 8 SDK not .NET 7 SDK.  Since .NET SDK's `main` branch is .NET 8, this change does that by setting NuGet's environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `true` in all NuGet code paths except when the variable is already set to `false` (because a user explicitly opted out).

The new NuGet warning [NU3042](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu3042) should make new failures on Linux resulting from this change actionable.

@nkolev92 informally reviewed and blessed this change before his OOF-ness.

CC @dotnet/nuget-team, @aortiz-msft, @skofman1