### PR TITLE
[wasm] Fix regression in blazor+aot

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -57,7 +57,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <DisableAutoWasmBuildApp>true</DisableAutoWasmBuildApp>
     <DisableAutoWasmPublishApp>true</DisableAutoWasmPublishApp>
-    <WasmNestedPublishAppDependsOn>_GatherBlazorFilesToPublish;$(WasmNestedPublishAppDependsOn)</WasmNestedPublishAppDependsOn>
   </PropertyGroup>
 
   <!-- Wire-up static web assets -->


### PR DESCRIPTION
- For blazor AOT, the blazor targets explicitly skip `Microsoft.JSInterop.WebAssembly.dll` in `_GatherBlazorFilesToPublish` target.
  - it is done by marking the assembly item in `@(WasmAssembliesToBundle)` with `%(AOT_InternalForceToInterpret)="true"`.

- this target needs to run after `_GatherWasmFilesToPublish` which builds the list of assemblies to AOT in `@(WasmAssembliesToBundle)`

- the order of these two targets was corrected in https://github.com/dotnet/sdk/pull/31640
- but the changes in https://github.com/dotnet/sdk/pull/31559 added the target twice, resulting in the order:

  `_GatherBlazorFilesToPublish;_GatherWasmFilesToPublish;_GatherBlazorFilesToPublish`

  1. in which the first `_GatherBlazorFilesToPublish` tries to remove the assembly from an empty list
  2. then `_GatherWasmFilesToPublish` populates the list
  3. and the last instance of `_GatherBlazorFilesToPublish` target doesn't run because it has already run before in (2).
- thus the assembly never gets removed from the list.

Fixes: https://github.com/dotnet/runtime/issues/85010