### PR TITLE
Copied some out of sync loc files into main

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">Spustí testy v režimu blame a umožní shromažďování výpisů stavu systému, když se hostitel testů neočekávaně ukončí. 
+        <target state="needs-review-translation">Spustí testy v režimu blame a umožní shromažďování výpisů stavu systému, když se hostitel testů neočekávaně ukončí. 
 V současné době se tato možnost podporuje jen ve Windows a vyžaduje, aby v proměnné PATH byly k dispozici nástroje procdump.exe a procdump64.exe.
 Případně může být nastavená proměnná prostředí PROCDUMP_PATH, která vede na adresář s nástroji procdump.exe a procdump64.exe.
 Tyto nástroje se dají stáhnout tady: https://docs.microsoft.com/sysinternals/downloads/procdump.
@@ -31,8 +37,8 @@ Tato možnost představuje přepínač --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">Typ výpisu stavu systému, který se má shromáždit. Tato možnost představuje přepínač --blame-crash.</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">Typ výpisu stavu systému, který se má shromáždit. Tato možnost představuje přepínač --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Tato možnost představuje přepínač --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">Typ výpisu stavu systému, který se má shromáždit. Když se použije možnost Žádný, hostitel testů se po vypršení časového limitu ukončí, ale neshromáždí se žádný výpis. Tato možnost představuje přepínač --blame-hang.</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">Typ výpisu stavu systému, který se má shromáždit. Když se použije možnost Žádný, hostitel testů se po vypršení časového limitu ukončí, ale neshromáždí se žádný výpis. Tato možnost představuje přepínač --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">Časový limit pro jednotlivé testy, po kterém se aktivuje výpis stavu systému při zablokování a ukončí se proces hostitele testů. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">Časový limit pro jednotlivé testy, po kterém se aktivuje výpis stavu systému při zablokování a ukončí se proces hostitele testů. 
 Hodnota časového limitu se zadává v následujícím formátu: 1.5h / 90m / 5400s / 5400000ms. Když se nepoužije žádná jednotka (např. 5400000), předpokládá se, že hodnota představuje milisekundy.
 Když se časový limit použije spolu s testy řízenými daty, jeho chování závisí na použitém adaptéru testu. Pro xUnit a NUnit se časový limit obnovuje po každém testovacím případu.
 Pro MSTest se časový limit používá pro všechny testovací případy.
@@ -245,9 +250,12 @@ Argumenty RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">Spustí testy v režimu blame. Tato možnost je užitečná při izolaci problémových testů, které způsobují chybové ukončení nebo zablokování hostitele testů. 
+        <target state="needs-review-translation">Spustí testy v režimu blame. Tato možnost je užitečná při izolaci problémových testů, které způsobují chybové ukončení nebo zablokování hostitele testů. 
 Když se zjistí chybové ukončení, vytvoří se v TestResults/guid/guid_Sequence.xml soubor sekvence, která zachycuje pořadí testů spuštěných před chybovým ukončením.
 Na základě dalších nastavení je možné shromažďovat výpisy stavu paměti i při zablokování nebo chybovém ukončení.
 Příklad: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">Spustí testy v režimu blame a umožní shromažďování výpisů stavu systému, když se hostitel testů neočekávaně ukončí. 
+V současné době se tato možnost podporuje jen ve Windows a vyžaduje, aby v proměnné PATH byly k dispozici nástroje procdump.exe a procdump64.exe.
+Případně může být nastavená proměnná prostředí PROCDUMP_PATH, která vede na adresář s nástroji procdump.exe a procdump64.exe.
+Tyto nástroje se dají stáhnout tady: https://docs.microsoft.com/sysinternals/downloads/procdump.
+Tato možnost představuje přepínač --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">Typ výpisu stavu systému, který se má shromáždit. Tato možnost představuje přepínač --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">Typ výpisu stavu systému, který se má shromáždit. Když se použije možnost Žádný, hostitel testů se po vypršení časového limitu ukončí, ale neshromáždí se žádný výpis. Tato možnost představuje přepínač --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">Časový limit pro jednotlivé testy, po kterém se aktivuje výpis stavu systému při zablokování a ukončí se proces hostitele testů. 
+Hodnota časového limitu se zadává v následujícím formátu: 1.5h / 90m / 5400s / 5400000ms. Když se nepoužije žádná jednotka (např. 5400000), předpokládá se, že hodnota představuje milisekundy.
+Když se časový limit použije spolu s testy řízenými daty, jeho chování závisí na použitém adaptéru testu. Pro xUnit a NUnit se časový limit obnovuje po každém testovacím případu.
+Pro MSTest se časový limit používá pro všechny testovací případy.
+V současné době se tato možnost podporuje jen ve Windows spolu s netcoreapp2.1 a novějšími a Linuxu s netcoreapp3.1 a novějšími. OSX a UPW se nepodporují.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ Argumenty RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">Spustí testy v režimu blame. Tato možnost je užitečná při izolaci problémových testů, které způsobují chybové ukončení nebo zablokování hostitele testů. 
+Když se zjistí chybové ukončení, vytvoří se v TestResults/guid/guid_Sequence.xml soubor sekvence, která zachycuje pořadí testů spuštěných před chybovým ukončením.
+Na základě dalších nastavení je možné shromažďovat výpisy stavu paměti i při zablokování nebo chybovém ukončení.
+Příklad: 
+  Vypršení časového limitu, když testovací běh trvá déle než výchozí limit, který je 1 hodina, a shromáždění výpisu stavu systému, když se hostitel testů neočekávaně ukončí 
+  (Výpisy stavu paměti vyžadují další nastavování. Informace najdete níže.)
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+Příklad: 
+  Vypršení časového limitu pro testovací běh, když test trvá déle než 20 minut, a shromáždění výpisu stavu systému při zablokování 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">Führt den Test im Modus "Verantwortung zuweisen" aus und aktiviert die Erfassung von Absturzabbildern bei einer unerwarteten Beendigung des Testhosts. 
+Diese Option wird derzeit nur unter Windows unterstützt und erfordert, dass "procdump.exe" und "procdump64.exe" in PATH verfügbar sind.
+Alternativ dazu kann die Umgebungsvariable PROCDUMP_PATH festgelegt werden und auf ein Verzeichnis verweisen, das "procdump.exe" und "procdump64.exe" enthält. 
+Die Tools können hier heruntergeladen werden: https://docs.microsoft.com/sysinternals/downloads/procdump 
+Impliziert "--blame".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">Der Typ des zu erfassenden Absturzspeicherabbilds. Impliziert "--blame-crash".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">Der Typ des zu erfassenden Absturzabbilds. Bei Festlegung auf "None" wird der Testhost bei einem Timeout beendet, aber es wird kein Speicherabbild erfasst. Impliziert "--blame-hang".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">Timeout pro Test, nach dem ein Blockadeabbild ausgelöst und der Testhostprozess beendet wird. 
+Der Timeoutwert wird im folgenden Format angegeben: 1.5h / 90m / 5400s / 5400000ms. Ist keine Einheit angegeben (z. B. 5400000), wird von einem Wert in Millisekunden ausgegangen.
+Bei Verwendung in Verbindung mit datengesteuerten Tests hängt das Timeoutverhalten vom verwendeten Testadapter ab. Für xUnit und NUnit wird das Timeout nach jedem Testfall erneuert,
+für MSTest wird das Timeout für alle Testfälle verwendet.
+Diese Option wird aktuell nur unter Windows zusammen mit netcoreapp 2.1 und höher unterstützt. Unter Linux wird die Option mit netcoreapp 3.1 und höher unterstützt. OSX und UWP werden nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ RunSettings-Argumente:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">Führt den Test im Modus "Verantwortung zuweisen" aus. Diese Option ist hilfreich zum Isolieren des problematischen Tests, der dazu geführt hat, dass der Testhost abgestürzt ist oder nicht mehr reagiert.
+Wird ein Absturz erkannt, wird in "TestResults/guid/guid_Sequence.xml" eine Sequenzdatei erstellt, in der die Reihenfolge der Testausführung vor dem Absturz erfasst wird.
+Basierend auf den zusätzlichen Einstellungen kann auch ein Blockade- oder Absturzabbild erfasst werden.
+Beispiel: 
+  Es wird ein Timeout für die Testausführung ausgelöst, wenn der Test länger als 1 Stunde (Standardwert) dauert, und es wird ein Absturzabbild erfasst, wenn der Testhost unerwartet beendet wird. 
+  (Für Absturzabbilder ist eine zusätzliche Einrichtung erforderlich, siehe unten.)
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+Beispiel: 
+  Es wird ein Timeout für die Testausführung ausgelöst, wenn der Test mehr als 20 Minuten dauert, und es wird ein Blockadeabbild erfasst. 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">Führt den Test im Modus "Verantwortung zuweisen" aus und aktiviert die Erfassung von Absturzabbildern bei einer unerwarteten Beendigung des Testhosts. 
+        <target state="needs-review-translation">Führt den Test im Modus "Verantwortung zuweisen" aus und aktiviert die Erfassung von Absturzabbildern bei einer unerwarteten Beendigung des Testhosts. 
 Diese Option wird derzeit nur unter Windows unterstützt und erfordert, dass "procdump.exe" und "procdump64.exe" in PATH verfügbar sind.
 Alternativ dazu kann die Umgebungsvariable PROCDUMP_PATH festgelegt werden und auf ein Verzeichnis verweisen, das "procdump.exe" und "procdump64.exe" enthält. 
 Die Tools können hier heruntergeladen werden: https://docs.microsoft.com/sysinternals/downloads/procdump 
@@ -31,8 +37,8 @@ Impliziert "--blame".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">Der Typ des zu erfassenden Absturzspeicherabbilds. Impliziert "--blame-crash".</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">Der Typ des zu erfassenden Absturzspeicherabbilds. Impliziert "--blame-crash".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Impliziert "--blame".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">Der Typ des zu erfassenden Absturzabbilds. Bei Festlegung auf "None" wird der Testhost bei einem Timeout beendet, aber es wird kein Speicherabbild erfasst. Impliziert "--blame-hang".</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">Der Typ des zu erfassenden Absturzabbilds. Bei Festlegung auf "None" wird der Testhost bei einem Timeout beendet, aber es wird kein Speicherabbild erfasst. Impliziert "--blame-hang".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">Timeout pro Test, nach dem ein Blockadeabbild ausgelöst und der Testhostprozess beendet wird. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">Timeout pro Test, nach dem ein Blockadeabbild ausgelöst und der Testhostprozess beendet wird. 
 Der Timeoutwert wird im folgenden Format angegeben: 1.5h / 90m / 5400s / 5400000ms. Ist keine Einheit angegeben (z. B. 5400000), wird von einem Wert in Millisekunden ausgegangen.
 Bei Verwendung in Verbindung mit datengesteuerten Tests hängt das Timeoutverhalten vom verwendeten Testadapter ab. Für xUnit und NUnit wird das Timeout nach jedem Testfall erneuert,
 für MSTest wird das Timeout für alle Testfälle verwendet.
@@ -245,9 +250,12 @@ RunSettings-Argumente:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">Führt den Test im Modus "Verantwortung zuweisen" aus. Diese Option ist hilfreich zum Isolieren des problematischen Tests, der dazu geführt hat, dass der Testhost abgestürzt ist oder nicht mehr reagiert.
+        <target state="needs-review-translation">Führt den Test im Modus "Verantwortung zuweisen" aus. Diese Option ist hilfreich zum Isolieren des problematischen Tests, der dazu geführt hat, dass der Testhost abgestürzt ist oder nicht mehr reagiert.
 Wird ein Absturz erkannt, wird in "TestResults/guid/guid_Sequence.xml" eine Sequenzdatei erstellt, in der die Reihenfolge der Testausführung vor dem Absturz erfasst wird.
 Basierend auf den zusätzlichen Einstellungen kann auch ein Blockade- oder Absturzabbild erfasst werden.
 Beispiel: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">Ejecuta las pruebas en modo de culpa y habilita la recopilación del volcado de memoria cuando el host de prueba se cierra de forma inesperada. 
+        <target state="needs-review-translation">Ejecuta las pruebas en modo de culpa y habilita la recopilación del volcado de memoria cuando el host de prueba se cierra de forma inesperada. 
 Actualmente, esta opción solo se admite en Windows y requiere que procdump.exe y procdump64.exe estén disponibles en PATH.
 O bien que se establezca la variable de entorno PROCDUMP_PATH y apunte a un directorio que contenga procdump.exe y procdump64.exe. 
 Las herramientas se pueden descargar aquí: https://docs.microsoft.com/sysinternals/downloads/procdump 
@@ -31,8 +37,8 @@ Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">Tipo de volcado de memoria que se va a recopilar. Implica --blame-crash.</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">Tipo de volcado de memoria que se va a recopilar. Implica --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">Tipo de volcado de memoria que se va a recopilar. Cuando se usa None, el host de prueba finaliza en el tiempo de espera, pero no se recopila ningún volcado. Implica --blame-hang.</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">Tipo de volcado de memoria que se va a recopilar. Cuando se usa None, el host de prueba finaliza en el tiempo de espera, pero no se recopila ningún volcado. Implica --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">Tiempo de espera por prueba, después del cual se desencadena el volcado de memoria y se termina el proceso del host de prueba. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">Tiempo de espera por prueba, después del cual se desencadena el volcado de memoria y se termina el proceso del host de prueba. 
 El valor de tiempo de espera se especifica con el siguiente formato: 1,5 h/90m/5400s/5400000ms. Cuando no se usa ninguna unidad (por ejemplo, 5400000), se supone que el valor está en milisegundos.
 Cuando se usa junto con las pruebas controladas por datos, el comportamiento de tiempo de espera depende del adaptador de prueba utilizado. Para xUnit y NUnit, el tiempo de espera se renueva después de cada caso de prueba.
 Para MSTest, el tiempo de espera se usa para todos los casos de prueba.
@@ -245,9 +250,12 @@ Argumentos RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">Ejecuta las pruebas en el modo de culpa. Esta opción es útil para aislar las pruebas problemáticas que provocan el bloqueo del host de prueba. 
+        <target state="needs-review-translation">Ejecuta las pruebas en el modo de culpa. Esta opción es útil para aislar las pruebas problemáticas que provocan el bloqueo del host de prueba. 
 Cuando se detecta un bloqueo, crea un archivo de secuencia en TestResults/guid/guid_Sequence.xml que captura el orden de las pruebas que se ejecutaron antes de que se produjera el bloqueo.
 En función de la configuración adicional, también se puede recopilar el volcado de memoria o el volcado del bloqueo.
 Ejemplo 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">Ejecuta las pruebas en modo de culpa y habilita la recopilación del volcado de memoria cuando el host de prueba se cierra de forma inesperada. 
+Actualmente, esta opción solo se admite en Windows y requiere que procdump.exe y procdump64.exe estén disponibles en PATH.
+O bien que se establezca la variable de entorno PROCDUMP_PATH y apunte a un directorio que contenga procdump.exe y procdump64.exe. 
+Las herramientas se pueden descargar aquí: https://docs.microsoft.com/sysinternals/downloads/procdump 
+Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">Tipo de volcado de memoria que se va a recopilar. Implica --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">Tipo de volcado de memoria que se va a recopilar. Cuando se usa None, el host de prueba finaliza en el tiempo de espera, pero no se recopila ningún volcado. Implica --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">Tiempo de espera por prueba, después del cual se desencadena el volcado de memoria y se termina el proceso del host de prueba. 
+El valor de tiempo de espera se especifica con el siguiente formato: 1,5 h/90m/5400s/5400000ms. Cuando no se usa ninguna unidad (por ejemplo, 5400000), se supone que el valor está en milisegundos.
+Cuando se usa junto con las pruebas controladas por datos, el comportamiento de tiempo de espera depende del adaptador de prueba utilizado. Para xUnit y NUnit, el tiempo de espera se renueva después de cada caso de prueba.
+Para MSTest, el tiempo de espera se usa para todos los casos de prueba.
+Actualmente, esta opción solo se admite en Windows junto con netcoreapp 2.1 y versiones posteriores. Y en Linux con netcoreapp 3.1 y versiones posteriores. OSX y UWP no son compatibles.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ Argumentos RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">Ejecuta las pruebas en el modo de culpa. Esta opción es útil para aislar las pruebas problemáticas que provocan el bloqueo del host de prueba. 
+Cuando se detecta un bloqueo, crea un archivo de secuencia en TestResults/guid/guid_Sequence.xml que captura el orden de las pruebas que se ejecutaron antes de que se produjera el bloqueo.
+En función de la configuración adicional, también se puede recopilar el volcado de memoria o el volcado del bloqueo.
+Ejemplo 
+  Se agota el tiempo de espera de la serie de pruebas cuando la prueba tarda más del tiempo de espera predeterminado de 1 hora y recopila el volcado de memoria cuando el host de prueba se cierra inesperadamente. 
+  (Los volcados de memoria requieren una configuración adicional; consulte más adelante).
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+Ejemplo 
+  Se agota el tiempo de espera de la ejecución de pruebas cuando una prueba tarda más de 20 minutos y recopila el volcado de bloqueo. 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <target state="translated">Exécute les tests en mode blame (responsabilité) et active la collecte des données de vidage sur plantage en cas de sortie inattendue de testhost. 
+Cette option est uniquement prise en charge sur Windows. Elle nécessite la présence de procdump.exe et procdump64.exe dans PATH.
+Sinon, la variable d'environnement PROCDUMP_PATH doit être définie et pointer vers un répertoire qui contient procdump.exe et procdump64.exe. 
+Vous pouvez télécharger les outils ici : https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">Type de données de vidage sur plantage à collecter. Implique --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">Type de données de vidage sur plantage à collecter. En l'absence de spécification du type de vidage, l'exécution de l'hôte de test prend fin à l'issue du délai d'expiration mais aucune donnée de vidage n'est collectée. Implique --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">Définissez un délai d'expiration spécifique à chaque test. À l'issue de ce délai, un vidage sur blocage se déclenche et l'exécution du processus testhost prend fin. 
+La valeur du délai d'expiration est spécifiée au format suivant : 1.5h / 90m / 5400s / 5400000ms. Quand aucune unité n'est utilisée (par exemple 5400000), la valeur est supposée être en millisecondes.
+En cas d'utilisation avec des tests pilotés par les données, le comportement du délai d'expiration dépend de l'adaptateur de test utilisé. Pour xUnit et NUnit, le délai d'expiration est renouvelé après chaque cas de test.
+Avec MSTest, le délai d'expiration est utilisé pour tous les cas de test.
+Cette option est prise en charge uniquement sur Windows avec netcoreapp2.1 et les versions ultérieures. Elle est également prise en charge sur Linux avec netcoreapp3.1 et les versions ultérieures. OSX et UWP ne sont pas pris en charge.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -85,7 +75,7 @@ Crée la variable si elle n'existe pas, et la remplace si elle existe.
 Cela entraîne l'exécution forcée des tests dans un processus isolé. 
 Vous pouvez spécifier cet argument plusieurs fois pour fournir plusieurs variables.
 
-Exemples :
+Exemples :
 -e VARIABLE=abc
 -e VARIABLE="valeur avec des espaces"
 -e VARIABLE="valeur;séparée;par;des;points;virgules"
@@ -132,10 +122,10 @@ Exemples :
                                         See https://aka.ms/vstest-filtering for more information on filtering support.
                                         </source>
         <target state="translated">Permet d'exécuter les tests qui correspondent à l'expression indiquée.
-                                        Exemples :
-                                        Exécuter les tests de priorité 1 : --filter "Priority = 1"
-                                        Exécuter un test avec le nom complet spécifié : --filter "FullyQualifiedName=Namespace.ClassName.MethodName"
-                                        Exécuter les tests qui contiennent le nom spécifié : --filter "FullyQualifiedName~Namespace.Class"
+                                        Exemples :
+                                        Exécuter les tests de priorité 1 : --filter "Priority = 1"
+                                        Exécuter un test avec le nom complet spécifié : --filter "FullyQualifiedName=Namespace.ClassName.MethodName"
+                                        Exécuter les tests qui contiennent le nom spécifié : --filter "FullyQualifiedName~Namespace.Class"
                                         Pour plus d'informations sur la prise en charge du filtrage, consultez https://aka.ms/vstest-filtering.
                                         </target>
         <note />
@@ -157,9 +147,9 @@ Exemples :
                                         Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         See https://aka.ms/vstest-report for more information on logger arguments.</source>
         <target state="translated">Journaliseur à utiliser pour les résultats des tests.
-                                        Exemples :
-                                        Journal au format trx avec un nom de fichier unique : --logger trx
-                                        Journal au format trx avec le nom de fichier spécifié : --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
+                                        Exemples :
+                                        Journal au format trx avec un nom de fichier unique : --logger trx
+                                        Journal au format trx avec le nom de fichier spécifié : --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         Pour plus d'informations sur les arguments du journaliseur, consultez https://aka.ms/vstest-report.</target>
         <note />
       </trans-unit>
@@ -222,7 +212,7 @@ Le répertoire spécifié est créé, s'il n'existe pas déjà.</target>
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">
         <source>The following arguments have been ignored : "{0}"</source>
-        <target state="translated">Les arguments suivants ont été ignorés : "{0}"</target>
+        <target state="translated">Les arguments suivants ont été ignorés : "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
@@ -235,11 +225,11 @@ RunSettings arguments:
   Example: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</source>
         <target state="translated">
 
-Arguments de RunSettings :
+Arguments de RunSettings :
   Arguments à passer en tant que configurations RunSettings. Spécifiez les arguments en tant que paires '[name]=[value]' après "-- " (notez l'espace après --). 
   Utilisez un espace pour séparer plusieurs paires '[name]=[value]'.
   Pour plus d'informations sur les arguments de RunSettings, consultez https://aka.ms/vstest-runsettings-arguments.
-  Exemple : dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+  Exemple : dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">
@@ -251,16 +241,13 @@ Arguments de RunSettings :
         <source>The friendly name of the data collector to use for the test run.
                                         More info here: https://aka.ms/vstest-collect</source>
         <target state="translated">Nom convivial du collecteur de données à utiliser pour la série de tests.
-                                        Plus d'informations ici : https://aka.ms/vstest-collect</target>
+                                        Plus d'informations ici : https://aka.ms/vstest-collect</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">Exécute les tests en mode blame (responsabilité). Cette option permet d'isoler les tests problématiques à l'origine d'un plantage ou d'un blocage sur l'hôte de test. 
+Quand un plantage est détecté, un fichier de séquence est créé dans TestResults/guid/guid_Sequence.xml pour capturer l'ordre des tests exécutés avant le plantage.
+En fonction de paramètres supplémentaires, des données de vidage sur blocage ou de vidage sur plantage peuvent également être collectées.
+Exemple : 
+  Définissez le délai d'expiration de la série de tests quand les tests prennent plus de temps que le délai par défaut (1 heure), et collectez les données de vidage sur plantage quand l'hôte de test se ferme de manière inattendue. 
+  (Les vidages sur plantage nécessitent une configuration supplémentaire, comme vous pouvez le voir ci-dessous.)
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+Exemple : 
+  Définissez le délai d'expiration de la série de tests quand un test prend plus de 20 minutes, et collectez les données de vidage sur blocage. 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">Exécute les tests en mode blame (responsabilité) et active la collecte des données de vidage sur plantage en cas de sortie inattendue de testhost. 
+        <target state="needs-review-translation">Exécute les tests en mode blame (responsabilité) et active la collecte des données de vidage sur plantage en cas de sortie inattendue de testhost. 
 Cette option est uniquement prise en charge sur Windows. Elle nécessite la présence de procdump.exe et procdump64.exe dans PATH.
 Sinon, la variable d'environnement PROCDUMP_PATH doit être définie et pointer vers un répertoire qui contient procdump.exe et procdump64.exe. 
 Vous pouvez télécharger les outils ici : https://docs.microsoft.com/sysinternals/downloads/procdump 
@@ -31,8 +37,8 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">Type de données de vidage sur plantage à collecter. Implique --blame-crash.</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">Type de données de vidage sur plantage à collecter. Implique --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">Type de données de vidage sur plantage à collecter. En l'absence de spécification du type de vidage, l'exécution de l'hôte de test prend fin à l'issue du délai d'expiration mais aucune donnée de vidage n'est collectée. Implique --blame-hang.</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">Type de données de vidage sur plantage à collecter. En l'absence de spécification du type de vidage, l'exécution de l'hôte de test prend fin à l'issue du délai d'expiration mais aucune donnée de vidage n'est collectée. Implique --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">Définissez un délai d'expiration spécifique à chaque test. À l'issue de ce délai, un vidage sur blocage se déclenche et l'exécution du processus testhost prend fin. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">Définissez un délai d'expiration spécifique à chaque test. À l'issue de ce délai, un vidage sur blocage se déclenche et l'exécution du processus testhost prend fin. 
 La valeur du délai d'expiration est spécifiée au format suivant : 1.5h / 90m / 5400s / 5400000ms. Quand aucune unité n'est utilisée (par exemple 5400000), la valeur est supposée être en millisecondes.
 En cas d'utilisation avec des tests pilotés par les données, le comportement du délai d'expiration dépend de l'adaptateur de test utilisé. Pour xUnit et NUnit, le délai d'expiration est renouvelé après chaque cas de test.
 Avec MSTest, le délai d'expiration est utilisé pour tous les cas de test.
@@ -245,9 +250,12 @@ Arguments de RunSettings :
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">Exécute les tests en mode blame (responsabilité). Cette option permet d'isoler les tests problématiques à l'origine d'un plantage ou d'un blocage sur l'hôte de test. 
+        <target state="needs-review-translation">Exécute les tests en mode blame (responsabilité). Cette option permet d'isoler les tests problématiques à l'origine d'un plantage ou d'un blocage sur l'hôte de test. 
 Quand un plantage est détecté, un fichier de séquence est créé dans TestResults/guid/guid_Sequence.xml pour capturer l'ordre des tests exécutés avant le plantage.
 En fonction de paramètres supplémentaires, des données de vidage sur blocage ou de vidage sur plantage peuvent également être collectées.
 Exemple : 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">Esegue i test in modalità di segnalazione errore e abilita la raccolta del dump di arresto anomalo del sistema in caso di chiusura imprevista dell'host di test. 
+        <target state="needs-review-translation">Esegue i test in modalità di segnalazione errore e abilita la raccolta del dump di arresto anomalo del sistema in caso di chiusura imprevista dell'host di test. 
 Questa opzione è attualmente supportata in Windows e richiede la presenza di procdump.exe e procdump64.exe in PATH.
 In alternativa, è necessario impostare la variabile di ambiente PROCDUMP_PATH in modo che punti a una directory che contiene procdump.exe e procdump64.exe. 
 È possibile scaricare gli strumenti dall'articolo seguente: https://docs.microsoft.com/sysinternals/downloads/procdump 
@@ -31,8 +37,8 @@ Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">Tipo di dump di arresto anomalo del sistema da raccogliere. Implica --blame-crash.</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">Tipo di dump di arresto anomalo del sistema da raccogliere. Implica --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">Tipo del dump di arresto anomalo da raccogliere. Quando è impostato su None, viene usato quando l'host di test viene terminato al raggiungimento del timeout, ma non viene raccolto alcun dump. Implica --blame-hang.</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">Tipo del dump di arresto anomalo da raccogliere. Quando è impostato su None, viene usato quando l'host di test viene terminato al raggiungimento del timeout, ma non viene raccolto alcun dump. Implica --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">Timeout per singolo test dopo il quale viene attivato il dump di blocco e il processo dell'host di test viene terminato. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">Timeout per singolo test dopo il quale viene attivato il dump di blocco e il processo dell'host di test viene terminato. 
 Il valore di timeout viene specificato nel formato seguente: 1.5h / 90m / 5400s / 5400000ms. Quando non viene usata alcuna unità (ad esempio 5400000), si presuppone che il valore sia espresso in millisecondi.
 Se viene usato insieme a test basati sui dati, il comportamento di timeout dipende dall'adattatore di test usato. Per xUnit e NUnit il timeout viene rinnovato dopo ogni test case.
 Per MSTest il timeout viene usato per tutti i test case.
@@ -245,9 +250,12 @@ Argomenti di RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">Esegue i test in modalità di segnalazione errore. Questa opzione è utile per isolare test problematici che causano l'arresto anomalo o il blocco dell'host di test. 
+        <target state="needs-review-translation">Esegue i test in modalità di segnalazione errore. Questa opzione è utile per isolare test problematici che causano l'arresto anomalo o il blocco dell'host di test. 
 Quando viene rilevato un arresto anomalo, crea in TestResults/guid/guid_Sequence.xml un file di sequenza che acquisisce l'ordine dei test eseguiti prima dell'arresto anomalo.
 Sulla base di impostazioni aggiuntive, possono essere raccolti anche i dump di blocco o di arresto anomalo.
 Esempio: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">Esegue i test in modalità di segnalazione errore e abilita la raccolta del dump di arresto anomalo del sistema in caso di chiusura imprevista dell'host di test. 
+Questa opzione è attualmente supportata in Windows e richiede la presenza di procdump.exe e procdump64.exe in PATH.
+In alternativa, è necessario impostare la variabile di ambiente PROCDUMP_PATH in modo che punti a una directory che contiene procdump.exe e procdump64.exe. 
+È possibile scaricare gli strumenti dall'articolo seguente: https://docs.microsoft.com/sysinternals/downloads/procdump 
+Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">Tipo di dump di arresto anomalo del sistema da raccogliere. Implica --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">Tipo del dump di arresto anomalo da raccogliere. Quando è impostato su None, viene usato quando l'host di test viene terminato al raggiungimento del timeout, ma non viene raccolto alcun dump. Implica --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">Timeout per singolo test dopo il quale viene attivato il dump di blocco e il processo dell'host di test viene terminato. 
+Il valore di timeout viene specificato nel formato seguente: 1.5h / 90m / 5400s / 5400000ms. Quando non viene usata alcuna unità (ad esempio 5400000), si presuppone che il valore sia espresso in millisecondi.
+Se viene usato insieme a test basati sui dati, il comportamento di timeout dipende dall'adattatore di test usato. Per xUnit e NUnit il timeout viene rinnovato dopo ogni test case.
+Per MSTest il timeout viene usato per tutti i test case.
+Questa opzione è attualmente supportata solo in Windows insieme a netcoreapp2.1 e versioni successive, nonché in Linux con netcoreapp3.1 e versioni successive. OSX e la piattaforma UWP non sono supportati.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ Argomenti di RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">Esegue i test in modalità di segnalazione errore. Questa opzione è utile per isolare test problematici che causano l'arresto anomalo o il blocco dell'host di test. 
+Quando viene rilevato un arresto anomalo, crea in TestResults/guid/guid_Sequence.xml un file di sequenza che acquisisce l'ordine dei test eseguiti prima dell'arresto anomalo.
+Sulla base di impostazioni aggiuntive, possono essere raccolti anche i dump di blocco o di arresto anomalo.
+Esempio: 
+  Timeout dell'esecuzione dei test quando il test impiega più del timeout predefinito di un'ora e raccoglie il dump di arresto anomalo in caso di chiusura imprevista dell'host di test. 
+  Per i dump di arresto anomalo è richiesta una configurazione aggiuntiva. Vedere di seguito.
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+Esempio: 
+  Timeout dell'esecuzione dei test quando un test impiega più di 20 minuti e raccoglie il dump di blocco. 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">変更履歴モードでテストを実行し、TestHost が予期せず終了したときにクラッシュ ダンプを収集するのを可能にします。
+        <target state="needs-review-translation">変更履歴モードでテストを実行し、TestHost が予期せず終了したときにクラッシュ ダンプを収集するのを可能にします。
 このオプションは現在 Windows 上でのみサポートされており、PATH で procdump.exe および procdump64.exe が参照可能である必要があります。
 または PROCDUMP_PATH 環境変数を設定し、procdump.exe および procdump64.exe を含むディレクトリを指定する必要があります。
 ツールはこちらからダウンロードできます: https://docs.microsoft.com/sysinternals/downloads/procdump 
@@ -31,8 +37,8 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">収集するクラッシュ ダンプの種類。--blame-crash を暗黙的に指定します。</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">収集するクラッシュ ダンプの種類。--blame-crash を暗黙的に指定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">収集するクラッシュ ダンプの種類。[なし] を使用した場合、ホストのテストはタイムアウト時に終了しますが、ダンプは収集されません。--blame-hang を暗黙的に指定します。</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">収集するクラッシュ ダンプの種類。[なし] を使用した場合、ホストのテストはタイムアウト時に終了しますが、ダンプは収集されません。--blame-hang を暗黙的に指定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">テストごとのタイムアウト。これを経過すると、ハング ダンプがトリガーされ、TestHost プロセスが中止されます。
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">テストごとのタイムアウト。これを経過すると、ハング ダンプがトリガーされ、TestHost プロセスが中止されます。
 タイムアウト値は次の形式で指定されます: 1.5h、90m、5400s、5400000ms。単位が使用されていない場合 (例: 5400000)、この値は ms (ミリ秒) 単位であると想定されます。
 データ ドリブン テストと共に使用すると、タイムアウトの動作は使用するテスト アダプターに依存します。xUnit と NUnit の場合、タイムアウトはテスト ケースの後に毎回更新されます。
 MSTest の場合、タイムアウトはすべてのテスト ケースに使用されます。
@@ -245,9 +250,12 @@ RunSettings 引数:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">変更履歴モードでテストを実行します。このオプションは、テスト ホストがクラッシュまたは失敗する原因となる問題のあるテストを分離するのに役立ちます。
+        <target state="needs-review-translation">変更履歴モードでテストを実行します。このオプションは、テスト ホストがクラッシュまたは失敗する原因となる問題のあるテストを分離するのに役立ちます。
 クラッシュが検出されると、クラッシュの前に実行されたテストの順序をキャプチャしたシーケンス ファイルが TestResults/guid/guid_Sequence.xml に作成されます。
 追加設定に基づいて、ハング ダンプまたはクラッシュ ダンプを収集することもできます。
 例: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">変更履歴モードでテストを実行し、TestHost が予期せず終了したときにクラッシュ ダンプを収集するのを可能にします。
+このオプションは現在 Windows 上でのみサポートされており、PATH で procdump.exe および procdump64.exe が参照可能である必要があります。
+または PROCDUMP_PATH 環境変数を設定し、procdump.exe および procdump64.exe を含むディレクトリを指定する必要があります。
+ツールはこちらからダウンロードできます: https://docs.microsoft.com/sysinternals/downloads/procdump 
+--blame を暗黙的に指定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">収集するクラッシュ ダンプの種類。--blame-crash を暗黙的に指定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">収集するクラッシュ ダンプの種類。[なし] を使用した場合、ホストのテストはタイムアウト時に終了しますが、ダンプは収集されません。--blame-hang を暗黙的に指定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">テストごとのタイムアウト。これを経過すると、ハング ダンプがトリガーされ、TestHost プロセスが中止されます。
+タイムアウト値は次の形式で指定されます: 1.5h、90m、5400s、5400000ms。単位が使用されていない場合 (例: 5400000)、この値は ms (ミリ秒) 単位であると想定されます。
+データ ドリブン テストと共に使用すると、タイムアウトの動作は使用するテスト アダプターに依存します。xUnit と NUnit の場合、タイムアウトはテスト ケースの後に毎回更新されます。
+MSTest の場合、タイムアウトはすべてのテスト ケースに使用されます。
+このオプションは現在、netcoreapp2.1 以降がインストールされた Windows、netcoreapp3.1 以降がインストールされた Linux でのみサポートされています。OSX および UWP はサポートされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ RunSettings 引数:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">変更履歴モードでテストを実行します。このオプションは、テスト ホストがクラッシュまたは失敗する原因となる問題のあるテストを分離するのに役立ちます。
+クラッシュが検出されると、クラッシュの前に実行されたテストの順序をキャプチャしたシーケンス ファイルが TestResults/guid/guid_Sequence.xml に作成されます。
+追加設定に基づいて、ハング ダンプまたはクラッシュ ダンプを収集することもできます。
+例: 
+  テストが既定のタイムアウト時間の 1 時間より長くかかる場合にテストの実行をタイムアウトし、テスト ホストが予期せず終了したときにクラッシュ ダンプを収集します。
+  (クラッシュ ダンプには追加のセットアップが必要です。以下を参照してください。)
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+例: 
+  テストが 20 分より長くかかる場合にテストの実行をタイムアウトし、ハング ダンプを収集します。
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">테스트를 원인 모드로 실행하고 테스트 호스트가 예기치 않게 종료될 때 크래시 덤프 수집을 사용하도록 설정합니다. 
+        <target state="needs-review-translation">테스트를 원인 모드로 실행하고 테스트 호스트가 예기치 않게 종료될 때 크래시 덤프 수집을 사용하도록 설정합니다. 
 이 옵션은 현재 Windows에서만 지원되며, PATH에 procdump.exe 및 procdump64.exe를 사용할 수 있어야 합니다.
 또는 PROCDUMP_PATH 환경 변수를 설정하고 procdump.exe 및 procdump64.exe를 포함하는 디렉터리를 가리킵니다. 
 이 도구는 https://docs.microsoft.com/sysinternals/downloads/procdump에서 다운로드할 수 있습니다. 
@@ -31,8 +37,8 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">수집할 크래시 덤프의 유형입니다. --blame-crash를 의미합니다.</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">수집할 크래시 덤프의 유형입니다. --blame-crash를 의미합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">수집할 크래시 덤프의 유형입니다. 없음이 사용된 경우 테스트 호스트가 시간 초과될 때 종료되지만, 덤프가 수집되지 않습니다. --blame-hang을 의미합니다.</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">수집할 크래시 덤프의 유형입니다. 없음이 사용된 경우 테스트 호스트가 시간 초과될 때 종료되지만, 덤프가 수집되지 않습니다. --blame-hang을 의미합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">중단 덤프가 트리거되고 테스트 호스트 프로세스가 종료되는 테스트별 시간 제한입니다. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">중단 덤프가 트리거되고 테스트 호스트 프로세스가 종료되는 테스트별 시간 제한입니다. 
 이 시간 제한 값은 1.5h/90m/5400s/5400000ms 형식으로 지정됩니다. 단위가 사용되지 않으면(예: 5400000), 값은 밀리초 단위로 간주됩니다.
 데이터 기반 테스트와 함께 사용되는 경우 시간 제한 동작은 사용되는 테스트 어댑터에 따라 다릅니다. xUnit 및 NUnit의 경우 모든 테스트 사례 후에 시간 제한이 갱신됩니다.
 MSTest의 경우 모든 테스트 사례에 시간 제한이 사용됩니다.
@@ -245,9 +250,12 @@ RunSettings 인수:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">테스트를 원인 모드로 실행합니다. 이 옵션은 테스트 호스트 크래시 또는 중단을 유발하는 문제 있는 테스트를 격리하는 데 유용합니다. 
+        <target state="needs-review-translation">테스트를 원인 모드로 실행합니다. 이 옵션은 테스트 호스트 크래시 또는 중단을 유발하는 문제 있는 테스트를 격리하는 데 유용합니다. 
 크래시가 탐지되면 크래시 전에 실행된 테스트의 순서를 캡처하는 시퀀스 파일이 TestResults/guid/guid_Sequence.xml에 생성됩니다.
 추가 설정에 따라 중단 덤프 또는 크래시 덤프가 수집될 수도 있습니다.
 예: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">테스트를 원인 모드로 실행하고 테스트 호스트가 예기치 않게 종료될 때 크래시 덤프 수집을 사용하도록 설정합니다. 
+이 옵션은 현재 Windows에서만 지원되며, PATH에 procdump.exe 및 procdump64.exe를 사용할 수 있어야 합니다.
+또는 PROCDUMP_PATH 환경 변수를 설정하고 procdump.exe 및 procdump64.exe를 포함하는 디렉터리를 가리킵니다. 
+이 도구는 https://docs.microsoft.com/sysinternals/downloads/procdump에서 다운로드할 수 있습니다. 
+--blame을 의미합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">수집할 크래시 덤프의 유형입니다. --blame-crash를 의미합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">수집할 크래시 덤프의 유형입니다. 없음이 사용된 경우 테스트 호스트가 시간 초과될 때 종료되지만, 덤프가 수집되지 않습니다. --blame-hang을 의미합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">중단 덤프가 트리거되고 테스트 호스트 프로세스가 종료되는 테스트별 시간 제한입니다. 
+이 시간 제한 값은 1.5h/90m/5400s/5400000ms 형식으로 지정됩니다. 단위가 사용되지 않으면(예: 5400000), 값은 밀리초 단위로 간주됩니다.
+데이터 기반 테스트와 함께 사용되는 경우 시간 제한 동작은 사용되는 테스트 어댑터에 따라 다릅니다. xUnit 및 NUnit의 경우 모든 테스트 사례 후에 시간 제한이 갱신됩니다.
+MSTest의 경우 모든 테스트 사례에 시간 제한이 사용됩니다.
+이 옵션은 현재 netcoreapp2.1 이상이 사용되는 Windows에서만 지원됩니다. 그리고 netcoreapp3.1 이상이 사용되는 Linux에서 지원됩니다. OSX 및 UWP는 지원되지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ RunSettings 인수:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">테스트를 원인 모드로 실행합니다. 이 옵션은 테스트 호스트 크래시 또는 중단을 유발하는 문제 있는 테스트를 격리하는 데 유용합니다. 
+크래시가 탐지되면 크래시 전에 실행된 테스트의 순서를 캡처하는 시퀀스 파일이 TestResults/guid/guid_Sequence.xml에 생성됩니다.
+추가 설정에 따라 중단 덤프 또는 크래시 덤프가 수집될 수도 있습니다.
+예: 
+  테스트에 걸리는 시간이 기본 시간 제한인 1시간보다 길면 테스트 실행이 시간 초과되고, 테스트 호스트가 예기치 않게 종료되면 크래시 덤프를 수집합니다. 
+  (크래시 덤프에는 추가 설정이 필요합니다. 아래를 참조하세요.)
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+예: 
+  테스트에 걸리는 시간이 20분보다 길면 테스트 실행이 시간 초과되고 중단 덤프를 수집합니다. 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">Uruchamia testy w trybie blame i włącza zbieranie zrzutów awaryjnych po nieoczekiwanym zakończeniu działania hosta testowego. 
+        <target state="needs-review-translation">Uruchamia testy w trybie blame i włącza zbieranie zrzutów awaryjnych po nieoczekiwanym zakończeniu działania hosta testowego. 
 Ta opcja jest obecnie obsługiwana tylko w systemie Windows i wymaga, aby w zmiennej PATH były dostępne programy procdump.exe i procdump64.exe.
 Alternatywnie musi być ustawiona zmienna środowiska PROCDUMP_PATH wskazująca katalog z programami procdump.exe i procdump64.exe. 
 Narzędzia można pobrać stąd: https://docs.microsoft.com/sysinternals/downloads/procdump 
@@ -31,8 +37,8 @@ Implikuje użycie parametru --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">Typ zrzutu awaryjnego do zebrania. Implikuje użycie parametru --blame-crash.</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">Typ zrzutu awaryjnego do zebrania. Implikuje użycie parametru --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implikuje użycie parametru --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">Typ zrzutu awaryjnego do zebrania. Jeśli żaden nie jest używany, działanie hosta testowego jest przerywane po upłynięciu limitu czasu, ale nie jest zbierany żaden zrzut. Implikuje użycie parametru --blame-crash.</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">Typ zrzutu awaryjnego do zebrania. Jeśli żaden nie jest używany, działanie hosta testowego jest przerywane po upłynięciu limitu czasu, ale nie jest zbierany żaden zrzut. Implikuje użycie parametru --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">Przekroczono limit czasu na test, po którym jest wyzwalany zrzut stanu zawieszenia, a działanie procesu na hoście testowym jest kończone. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">Przekroczono limit czasu na test, po którym jest wyzwalany zrzut stanu zawieszenia, a działanie procesu na hoście testowym jest kończone. 
 Wartość limitu czasu jest określana w następującym formacie: 1.5h / 90m / 5400s / 5400000ms. Gdy nie jest używana żadna jednostka (np. 5400000), przyjmuje się, że wartość jest w milisekundach.
 W przypadku użycia razem z testami opartymi na danych zachowanie limitu czasu zależy od użytego adaptera testowego. W przypadku programów xUnit i NUnit limit czasu jest odnawiany po każdym przypadku testowym.
 W przypadku programu MSTest limit czasu jest używany dla wszystkich przypadków testowych.
@@ -245,9 +250,12 @@ Argumenty RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">Uruchamia testy w trybie blame. Ta opcja pomaga w izolowaniu problematycznych testów, które powodują awarię lub zawieszanie się hosta testowego. 
+        <target state="needs-review-translation">Uruchamia testy w trybie blame. Ta opcja pomaga w izolowaniu problematycznych testów, które powodują awarię lub zawieszanie się hosta testowego. 
 Gdy zostanie wykryta awaria, tworzy plik sekwencji w lokalizacji TestResults/guid/guid_Sequence.xml, który przechwytuje kolejność testów uruchomionych przed awarią.
 Na podstawie dodatkowych ustawień może być również zbierany zrzut stanu zawieszenia lub zrzut awaryjny.
 Przykład: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">Uruchamia testy w trybie blame i włącza zbieranie zrzutów awaryjnych po nieoczekiwanym zakończeniu działania hosta testowego. 
+Ta opcja jest obecnie obsługiwana tylko w systemie Windows i wymaga, aby w zmiennej PATH były dostępne programy procdump.exe i procdump64.exe.
+Alternatywnie musi być ustawiona zmienna środowiska PROCDUMP_PATH wskazująca katalog z programami procdump.exe i procdump64.exe. 
+Narzędzia można pobrać stąd: https://docs.microsoft.com/sysinternals/downloads/procdump 
+Implikuje użycie parametru --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">Typ zrzutu awaryjnego do zebrania. Implikuje użycie parametru --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">Typ zrzutu awaryjnego do zebrania. Jeśli żaden nie jest używany, działanie hosta testowego jest przerywane po upłynięciu limitu czasu, ale nie jest zbierany żaden zrzut. Implikuje użycie parametru --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">Przekroczono limit czasu na test, po którym jest wyzwalany zrzut stanu zawieszenia, a działanie procesu na hoście testowym jest kończone. 
+Wartość limitu czasu jest określana w następującym formacie: 1.5h / 90m / 5400s / 5400000ms. Gdy nie jest używana żadna jednostka (np. 5400000), przyjmuje się, że wartość jest w milisekundach.
+W przypadku użycia razem z testami opartymi na danych zachowanie limitu czasu zależy od użytego adaptera testowego. W przypadku programów xUnit i NUnit limit czasu jest odnawiany po każdym przypadku testowym.
+W przypadku programu MSTest limit czasu jest używany dla wszystkich przypadków testowych.
+Ta opcja jest obecnie obsługiwana tylko w systemie Windows razem z aplikacją netcoreapp2.1 i nowszymi oraz w systemie Linux z aplikacją netcoreapp3.1 i nowszymi. System OSX i platforma UWP nie są obsługiwane.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ Argumenty RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">Uruchamia testy w trybie blame. Ta opcja pomaga w izolowaniu problematycznych testów, które powodują awarię lub zawieszanie się hosta testowego. 
+Gdy zostanie wykryta awaria, tworzy plik sekwencji w lokalizacji TestResults/guid/guid_Sequence.xml, który przechwytuje kolejność testów uruchomionych przed awarią.
+Na podstawie dodatkowych ustawień może być również zbierany zrzut stanu zawieszenia lub zrzut awaryjny.
+Przykład: 
+  Spowodowanie przekroczenia limitu czasu przebiegu testu, gdy test trwa dłużej niż domyślny limit czasu (1 godzina), i zebranie zrzutu awaryjnego, gdy host testowy nieoczekiwanie zakończy działanie. 
+  (Zrzuty awaryjne wymagają dodatkowej konfiguracji; zobacz poniżej).
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+Przykład: 
+  Spowodowanie przekroczenia limitu czasu przebiegu testu, gdy test trwa dłużej niż 20 minut, i zebranie zrzutu stanu zawieszenia. 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">Executa os testes no modo blame e habilita a coleta de despejo de memória quando o host de teste é encerrado inesperadamente. 
+        <target state="needs-review-translation">Executa os testes no modo blame e habilita a coleta de despejo de memória quando o host de teste é encerrado inesperadamente. 
 No momento, há suporte para essa opção somente no Windows e ela exige que o procdump.exe e o procdump64.exe estejam disponíveis em PATH.
 Ou exige que a variável de ambiente PROCDUMP_PATH esteja definida e aponte para um diretório que contenha o procdump.exe e o procdump64.exe. 
 As ferramentas podem ser baixadas aqui: https://docs.microsoft.com/sysinternals/downloads/procdump 
@@ -31,8 +37,8 @@ Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">O tipo de despejo de memória a ser coletado. Implica --blame-crash.</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">O tipo de despejo de memória a ser coletado. Implica --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">O tipo de despejo de memória a ser coletado. Quando a opção None é usada, o host de teste é encerrado ao atingir o tempo limite, mas o despejo de memória não é coletado. Implica --blame-hang.</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">O tipo de despejo de memória a ser coletado. Quando a opção None é usada, o host de teste é encerrado ao atingir o tempo limite, mas o despejo de memória não é coletado. Implica --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">Tempo limite por teste, após o qual o despejo do travamento é disparado e o processo do host de teste é encerrado. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">Tempo limite por teste, após o qual o despejo do travamento é disparado e o processo do host de teste é encerrado. 
 O valor do tempo limite é especificado no seguinte formato: 1.5h / 90m / 5400s / 5400000ms. Quando não é usada nenhuma unidade (por exemplo, 5400000), considera-se que o valor esteja em milissegundos.
 Quando usado juntamente com testes controlados por dados, o comportamento do tempo limite depende do adaptador de teste usado. Para xUnit e NUnit, o tempo limite é renovado após cada caso de teste,
 Para o MSTest, o tempo limite é usado para todos os casos teste.
@@ -245,9 +250,12 @@ Argumentos de RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">Executa os testes no modo blame. Essa opção é útil para isolar testes problemáticos que fazem com que o host de teste falhe ou trave. 
+        <target state="needs-review-translation">Executa os testes no modo blame. Essa opção é útil para isolar testes problemáticos que fazem com que o host de teste falhe ou trave. 
 Quando uma falha é detectada, ele cria um arquivo de sequência em TestResults/guid/guid_Sequence.xml que captura a ordem dos testes que foram executados antes da falha.
 Com base nas configurações adicionais, o despejo de travamento ou o despejo de memória também podem ser coletados.
 Exemplo 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">Executa os testes no modo blame e habilita a coleta de despejo de memória quando o host de teste é encerrado inesperadamente. 
+No momento, há suporte para essa opção somente no Windows e ela exige que o procdump.exe e o procdump64.exe estejam disponíveis em PATH.
+Ou exige que a variável de ambiente PROCDUMP_PATH esteja definida e aponte para um diretório que contenha o procdump.exe e o procdump64.exe. 
+As ferramentas podem ser baixadas aqui: https://docs.microsoft.com/sysinternals/downloads/procdump 
+Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">O tipo de despejo de memória a ser coletado. Implica --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">O tipo de despejo de memória a ser coletado. Quando a opção None é usada, o host de teste é encerrado ao atingir o tempo limite, mas o despejo de memória não é coletado. Implica --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">Tempo limite por teste, após o qual o despejo do travamento é disparado e o processo do host de teste é encerrado. 
+O valor do tempo limite é especificado no seguinte formato: 1.5h / 90m / 5400s / 5400000ms. Quando não é usada nenhuma unidade (por exemplo, 5400000), considera-se que o valor esteja em milissegundos.
+Quando usado juntamente com testes controlados por dados, o comportamento do tempo limite depende do adaptador de teste usado. Para xUnit e NUnit, o tempo limite é renovado após cada caso de teste,
+Para o MSTest, o tempo limite é usado para todos os casos teste.
+No momento, há suporte para essa opção somente no Windows juntamente com o netcoreapp2.1 e mais recentes. E no Linux com o netcoreapp3.1 e mais recentes. Não há suporte para OSX e UWP.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ Argumentos de RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">Executa os testes no modo blame. Essa opção é útil para isolar testes problemáticos que fazem com que o host de teste falhe ou trave. 
+Quando uma falha é detectada, ele cria um arquivo de sequência em TestResults/guid/guid_Sequence.xml que captura a ordem dos testes que foram executados antes da falha.
+Com base nas configurações adicionais, o despejo de travamento ou o despejo de memória também podem ser coletados.
+Exemplo 
+  Atingir o tempo limite de execução de teste quando o teste durar mais que o tempo limite padrão de uma hora e coletar o despejo de memória quando o host de teste for encerrado inesperadamente. 
+  (Os despejos de memória exigem uma configuração adicional, veja abaixo.)
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+Exemplo 
+  Atingir o tempo limite de execução do teste quando um teste durar mais de 20 minutos e coletar o despejo de travamento. 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">Запускает тесты в режиме обвинения и включает сбор аварийного дампа при неожиданном завершении работы узла тестирования. 
+        <target state="needs-review-translation">Запускает тесты в режиме обвинения и включает сбор аварийного дампа при неожиданном завершении работы узла тестирования. 
 Этот параметр сейчас поддерживается только в Windows, и для его использования необходимо добавить путь к файлам procdump.exe и procdump64.exe в переменную среды PATH.
 Также можно установить переменную среды PROCDUMP_PATH, указав в ней путь к каталогу, в котором находятся файлы procdump.exe и procdump64.exe. 
 Инструменты можно скачать на следующей странице: https://docs.microsoft.com/sysinternals/downloads/procdump. 
@@ -31,8 +37,8 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">Тип собираемого аварийного дампа. Подразумевается использование параметра --blame-crash.</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">Тип собираемого аварийного дампа. Подразумевается использование параметра --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">Тип собираемого аварийного дампа. Если задано значение "None", то узел тестирования завершает работу после истечения времени ожидания, но сбор дампа не выполняется. Подразумевается использование параметра --blame-hang.</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">Тип собираемого аварийного дампа. Если задано значение "None", то узел тестирования завершает работу после истечения времени ожидания, но сбор дампа не выполняется. Подразумевается использование параметра --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">Время ожидания каждого теста, по истечении которого выполняется сбор дампа зависания и процесс узла тестирования завершается. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">Время ожидания каждого теста, по истечении которого выполняется сбор дампа зависания и процесс узла тестирования завершается. 
 Значение времени ожидания задается в следующем формате: 1.5h / 90m / 5400s / 5400000ms. Если единица измерения не указана (например, 5400000), предполагается, что время задано в миллисекундах.
 При использовании времени ожидания для тестов, управляемых данными, время ожидания зависит от используемого адаптера теста. Для xUnit и NUnit отсчет времени ожидания начинается заново для каждого тестового случая.
 Для MSTest время ожидания подсчитывается суммарно для всех тестовых случаев.
@@ -245,9 +250,12 @@ RunSettings arguments:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">Запускает тесты в режиме обвинения. Этот параметр удобно использовать для изоляции проблемных тестов, которые приводят к сбою или зависанию узла тестирования. 
+        <target state="needs-review-translation">Запускает тесты в режиме обвинения. Этот параметр удобно использовать для изоляции проблемных тестов, которые приводят к сбою или зависанию узла тестирования. 
 При обнаружении сбоя создается файл последовательности TestResults/guid/guid_Sequence.xml с указанием порядка тестов, которые были выполнены до возникновения сбоя.
 На основе дополнительных параметров также можно выполнить сбор дампа зависания или аварийного дампа.
 Пример: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">Запускает тесты в режиме обвинения и включает сбор аварийного дампа при неожиданном завершении работы узла тестирования. 
+Этот параметр сейчас поддерживается только в Windows, и для его использования необходимо добавить путь к файлам procdump.exe и procdump64.exe в переменную среды PATH.
+Также можно установить переменную среды PROCDUMP_PATH, указав в ней путь к каталогу, в котором находятся файлы procdump.exe и procdump64.exe. 
+Инструменты можно скачать на следующей странице: https://docs.microsoft.com/sysinternals/downloads/procdump. 
+Подразумевается использование параметра --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">Тип собираемого аварийного дампа. Подразумевается использование параметра --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">Тип собираемого аварийного дампа. Если задано значение "None", то узел тестирования завершает работу после истечения времени ожидания, но сбор дампа не выполняется. Подразумевается использование параметра --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">Время ожидания каждого теста, по истечении которого выполняется сбор дампа зависания и процесс узла тестирования завершается. 
+Значение времени ожидания задается в следующем формате: 1.5h / 90m / 5400s / 5400000ms. Если единица измерения не указана (например, 5400000), предполагается, что время задано в миллисекундах.
+При использовании времени ожидания для тестов, управляемых данными, время ожидания зависит от используемого адаптера теста. Для xUnit и NUnit отсчет времени ожидания начинается заново для каждого тестового случая.
+Для MSTest время ожидания подсчитывается суммарно для всех тестовых случаев.
+Сейчас этот параметр поддерживается только в Windows с netcoreapp2.1 и более поздних версий и в Linux с netcoreapp3.1 и более поздних версий. OSX и UWP не поддерживаются.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -133,7 +123,7 @@ Examples:
                                         </source>
         <target state="translated">Выполнение тестов, соответствующих данному выражению.
                                         Примеры
-                                        Запуск тестов с приоритетом 1: --filter "Priority = 1"
+                                        Запуск тестов с приоритетом 1: --filter "Priority = 1"
                                         Запуск теста с указанным полным именем: --filter "FullyQualifiedName=Namespace.ClassName.MethodName"
                                         Запуск тестов, содержащих указанное имя: --filter "FullyQualifiedName~Namespace.Class"
                                         Дополнительные сведения о поддержке фильтрации: https://aka.ms/vstest-filtering.
@@ -255,12 +245,9 @@ RunSettings arguments:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">Запускает тесты в режиме обвинения. Этот параметр удобно использовать для изоляции проблемных тестов, которые приводят к сбою или зависанию узла тестирования. 
+При обнаружении сбоя создается файл последовательности TestResults/guid/guid_Sequence.xml с указанием порядка тестов, которые были выполнены до возникновения сбоя.
+На основе дополнительных параметров также можно выполнить сбор дампа зависания или аварийного дампа.
+Пример: 
+  Прервать выполнение теста из-за истечения времени ожидания, когда время выполнения теста превышает время ожидания по умолчанию в 1 час, и собрать аварийный дамп при неожиданном завершении работы узла тестирования. 
+  (Для сбора аварийного дампа необходимо задать дополнительные параметры, см. ниже).
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+Пример: 
+  Прервать выполнение теста из-за истечения времени ожидания, когда время выполнения теста превышает 20 минут, и собрать дамп зависания. 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">Testleri blame modunda çalıştırır ve test ana bilgisayarları beklenmedik şekilde çıkış yaptığında kilitlenme bilgi dökümünün toplanmasını sağlar. 
+        <target state="needs-review-translation">Testleri blame modunda çalıştırır ve test ana bilgisayarları beklenmedik şekilde çıkış yaptığında kilitlenme bilgi dökümünün toplanmasını sağlar. 
 Bu seçenek şu anda yalnızca Windows'da desteklenmektedir ve procdump.exe ile procdump64.exe dosyalarının PATH içinde mevcut olmasını gerektirir. 
 Alternatif olarak, PROCDUMP_PATH ortam değişkeninin ayarlanması ve procdump.exe ile procdump64.exe dosyalarını içeren bir dizine işaret etmesi gerekir. 
 Araçları https://docs.microsoft.com/sysinternals/downloads/procdump adresinden indirebilirsiniz 
@@ -31,8 +37,8 @@ Araçları https://docs.microsoft.com/sysinternals/downloads/procdump adresinden
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">Toplanacak kilitlenme bilgi dökümünün türü. --blame-crash anlamına gelir.</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">Toplanacak kilitlenme bilgi dökümünün türü. --blame-crash anlamına gelir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Araçları https://docs.microsoft.com/sysinternals/downloads/procdump adresinden
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">Toplanacak kilitlenme bilgi dökümünün türü. None kullanıldığında test ana bilgisayarı sonlandırılır ancak bilgi dökümü toplanmaz. --blame-hang anlamına gelir.</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">Toplanacak kilitlenme bilgi dökümünün türü. None kullanıldığında test ana bilgisayarı sonlandırılır ancak bilgi dökümü toplanmaz. --blame-hang anlamına gelir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">Yanıt vermemeye başlama bilgi dökümü tetiklendikten ve test ana bilgisayarı işlemi sonlandırıldıktan sonraki test başına zaman aşımı süresi. 
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">Yanıt vermemeye başlama bilgi dökümü tetiklendikten ve test ana bilgisayarı işlemi sonlandırıldıktan sonraki test başına zaman aşımı süresi. 
 Zaman aşımı değeri şu biçimde belirtilir: 1.5h / 90m / 5400s / 5400000ms. Birim kullanılmadığında (ör. 5400000) değerin milisaniye cinsinden olduğu kabul edilir.
 Zaman aşımı davranışı veri tabanlı testlerle birlikte kullanıldığında, kullanılan test bağdaştırıcısına göre farklılık gösterir. xUnit and NUnit için zaman aşımı süresi her test çalışmasından sonra yenilenir.
 MSTest için zaman aşımı süresi tüm test çalışmalarına yönelik olarak kullanılır.
@@ -245,9 +250,12 @@ RunSettings bağımsız değişkenleri:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">Testleri blame modunda çalıştırır. Bu seçenek, test ana bilgisayarının kilitlenmesine veya yanıt vermemeye başlamasına neden olan sorunlu testleri yalıtmak için yararlıdır. 
+        <target state="needs-review-translation">Testleri blame modunda çalıştırır. Bu seçenek, test ana bilgisayarının kilitlenmesine veya yanıt vermemeye başlamasına neden olan sorunlu testleri yalıtmak için yararlıdır. 
 Kilitlenme algılandığında, TestResults/guid/guid_Sequence.xml içinde kilitlenmeden önce çalıştırılan testlerin sırasını yakalayan bir sıra dosyası oluşturur.
 Ek ayarlara bağlı olarak, yanıt vermemeye başlama veya kilitlenme bilgi dökümü de toplanabilir.
 Örnek: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">Testleri blame modunda çalıştırır ve test ana bilgisayarları beklenmedik şekilde çıkış yaptığında kilitlenme bilgi dökümünün toplanmasını sağlar. 
+Bu seçenek şu anda yalnızca Windows'da desteklenmektedir ve procdump.exe ile procdump64.exe dosyalarının PATH içinde mevcut olmasını gerektirir. 
+Alternatif olarak, PROCDUMP_PATH ortam değişkeninin ayarlanması ve procdump.exe ile procdump64.exe dosyalarını içeren bir dizine işaret etmesi gerekir. 
+Araçları https://docs.microsoft.com/sysinternals/downloads/procdump adresinden indirebilirsiniz 
+--blame anlamına gelir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">Toplanacak kilitlenme bilgi dökümünün türü. --blame-crash anlamına gelir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">Toplanacak kilitlenme bilgi dökümünün türü. None kullanıldığında test ana bilgisayarı sonlandırılır ancak bilgi dökümü toplanmaz. --blame-hang anlamına gelir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">Yanıt vermemeye başlama bilgi dökümü tetiklendikten ve test ana bilgisayarı işlemi sonlandırıldıktan sonraki test başına zaman aşımı süresi. 
+Zaman aşımı değeri şu biçimde belirtilir: 1.5h / 90m / 5400s / 5400000ms. Birim kullanılmadığında (ör. 5400000) değerin milisaniye cinsinden olduğu kabul edilir.
+Zaman aşımı davranışı veri tabanlı testlerle birlikte kullanıldığında, kullanılan test bağdaştırıcısına göre farklılık gösterir. xUnit and NUnit için zaman aşımı süresi her test çalışmasından sonra yenilenir.
+MSTest için zaman aşımı süresi tüm test çalışmalarına yönelik olarak kullanılır.
+Bu seçenek, şu anda yalnızca netcoreapp2.1 ve üzeri bir sürüme sahip Windows ile netcoreapp3.1 ve üzeri bir sürüme sahip Linux'ta desteklenmektedir. OSX ve UWP desteklenmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ RunSettings bağımsız değişkenleri:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
-  dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+        <target state="translated">Testleri blame modunda çalıştırır. Bu seçenek, test ana bilgisayarının kilitlenmesine veya yanıt vermemeye başlamasına neden olan sorunlu testleri yalıtmak için yararlıdır. 
+Kilitlenme algılandığında, TestResults/guid/guid_Sequence.xml içinde kilitlenmeden önce çalıştırılan testlerin sırasını yakalayan bir sıra dosyası oluşturur.
+Ek ayarlara bağlı olarak, yanıt vermemeye başlama veya kilitlenme bilgi dökümü de toplanabilir.
+Örnek: 
+  Test 1 saatlik varsayılan zaman aşımı süresinden uzun sürdüğünde test çalıştırmasını zaman aşımına uğratın ve test ana bilgisayarı beklenmedik bir şekilde çıkış yaptığında kilitlenme dökümünü toplayın.
+ (Kilitlenme bilgi dökümleri için ek kurulum gerekir, aşağıya bakın.)
+ dotnet test --blame-hang --blame-crash
+Örnek: 
+\   Test 20 dakikadan uzun sürdüğünde test çalıştırmasını zaman aşımına uğratın ve yanıt vermemeye başlama bilgi dökümünü toplayın. 
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">在追责模式下运行测试，并允许在 testhost 意外退出时收集故障转储。
+        <target state="needs-review-translation">在追责模式下运行测试，并允许在 testhost 意外退出时收集故障转储。
 此选项当前仅在 Windows 上受支持并且需要 procdump.exe 和 procdump64.exe 在 PATH 中可用。
 或需要设置 PROCDUMP_PATH 环境变量并指向包含 procdump.exe 和 procdump64.exe 的目录。
 可在此处下载工具: https://docs.microsoft.com/sysinternals/downloads/procdump 
@@ -31,8 +37,8 @@ Implies --blame。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">要收集的故障转储的类型。Implies --blame-crash。</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">要收集的故障转储的类型。Implies --blame-crash。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implies --blame。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">要收集的故障转储的类型。如果使用的类型为“无”，那么超时时会终止测试主机，但不收集转储。Implies --blame-hang。</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">要收集的故障转储的类型。如果使用的类型为“无”，那么超时时会终止测试主机，但不收集转储。Implies --blame-hang。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">基于测试的超时，超时后会触发挂起转储且 testhost 进程终止。
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">基于测试的超时，超时后会触发挂起转储且 testhost 进程终止。
 此超时值的指定格式如下: 1.5h / 90m / 5400s / 5400000ms。如果不使用单位(例如 5400000)，此值被视为以毫秒计。
 如果与数据驱动的测试一起使用，超时行为取决于所使用的测试适配器。对于 xUnit 和 NUnit，每个测试用例后，会更新超时值。
 对于 MSTest，超时值用于所有测试用例。
@@ -245,9 +250,12 @@ RunSettings 参数:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">在追责模式下运行测试。此操作适用于隔离导致测试主机故障或挂起的有问题的测试。
+        <target state="needs-review-translation">在追责模式下运行测试。此操作适用于隔离导致测试主机故障或挂起的有问题的测试。
 检测到故障时，它会在 TestResults/guid/guid_Sequence.xml 中创建顺序文件，该文件捕获故障前测试运行的顺序。
 基于其他设置，还可以收集挂起转储或故障转储。
 示例: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">在追责模式下运行测试，并允许在 testhost 意外退出时收集故障转储。
+此选项当前仅在 Windows 上受支持并且需要 procdump.exe 和 procdump64.exe 在 PATH 中可用。
+或需要设置 PROCDUMP_PATH 环境变量并指向包含 procdump.exe 和 procdump64.exe 的目录。
+可在此处下载工具: https://docs.microsoft.com/sysinternals/downloads/procdump 
+Implies --blame。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">要收集的故障转储的类型。Implies --blame-crash。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">要收集的故障转储的类型。如果使用的类型为“无”，那么超时时会终止测试主机，但不收集转储。Implies --blame-hang。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">基于测试的超时，超时后会触发挂起转储且 testhost 进程终止。
+此超时值的指定格式如下: 1.5h / 90m / 5400s / 5400000ms。如果不使用单位(例如 5400000)，此值被视为以毫秒计。
+如果与数据驱动的测试一起使用，超时行为取决于所使用的测试适配器。对于 xUnit 和 NUnit，每个测试用例后，会更新超时值。
+对于 MSTest，超时值用于所有测试用例。
+此选项目前仅在配有 netcoreapp3.1 和更高版本的 Windows 上受支持。OSX 和 UWP 不受支持。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ RunSettings 参数:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">在追责模式下运行测试。此操作适用于隔离导致测试主机故障或挂起的有问题的测试。
+检测到故障时，它会在 TestResults/guid/guid_Sequence.xml 中创建顺序文件，该文件捕获故障前测试运行的顺序。
+基于其他设置，还可以收集挂起转储或故障转储。
+示例: 
+  当测试时长超过默认超时时长(即 1 小时)时，对测试运行执行超时操作，当测试主机意外退出时，收集故障转储。
+  (故障转储需要其他设置，请参阅下文。)
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+示例: 
+  当测试时长超过 20 分钟时，对测试运行执行超时操作并收集挂起转储。
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -18,12 +18,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
-This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
-Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
+        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
+  
+For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
+
+Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
+
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
+  
+To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
+
 Implies --blame.</source>
-        <target state="translated">當測試主機意外結束時，在改動者模式中執行測試，並允許收集損毀傾印。
+        <target state="needs-review-translation">當測試主機意外結束時，在改動者模式中執行測試，並允許收集損毀傾印。
 目前只有 Windows 支援此選項，而且必須在 PATH 中提供 procdump.exe 與 procdump64.exe。
 也可以設定 PROCDUMP_PATH 環境變數，並指向包含 procdump.exe 與 procdump64.exe 的目錄。
 這些工具可從下列網址下載: https://docs.microsoft.com/sysinternals/downloads/procdump 
@@ -31,8 +37,8 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
-        <target state="translated">要收集的損毀傾印類型。Implies --blame-crash。</target>
+        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
+        <target state="needs-review-translation">要收集的損毀傾印類型。Implies --blame-crash。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -41,17 +47,16 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="translated">要收集之損毀傾印的類型。若使用 [無]，測試主機將會在逾時時終止，但不會收集任何傾印。Implies --blame-hang。</target>
+        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="needs-review-translation">要收集之損毀傾印的類型。若使用 [無]，測試主機將會在逾時時終止，但不會收集任何傾印。Implies --blame-hang。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
-For MSTest, the timeout is used for all testcases.
-This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
-        <target state="translated">每個測試的逾時，在此之後將會觸發停止回應傾印，而且測試主機處理序將會終止。
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
+For MSTest before 2.2.4, the timeout is used for all testcases.</source>
+        <target state="needs-review-translation">每個測試的逾時，在此之後將會觸發停止回應傾印，而且測試主機處理序將會終止。
 指定此逾時值時，請使用下列格式: 1.5 h/90m/5400s/5400000ms。若未使用單位 (例如 5400000)，將會假設該值的單位為毫秒。
 當與資料驅動型測試並用時，逾時行為取決於使用的測試配接器。對於 xUnit 與 NUnit，此逾時值會在每次執行測試案例之後更新。
 對於 MSTest，此逾時值會套用到所有測試案例。
@@ -245,9 +250,12 @@ RunSettings 引數:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
+
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+
 Based on the additional settings, hang dump or crash dump can also be collected.
+
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -256,7 +264,7 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="translated">在改動者模式中執行測試。此選項可用於找出導致測試主機損毀或停止回應的問題測試。
+        <target state="needs-review-translation">在改動者模式中執行測試。此選項可用於找出導致測試主機損毀或停止回應的問題測試。
 當偵測到損毀時，其會在 TestResults/guid/guid_Sequence.xml 中建立所擷取在損毀前，測試之執行順序的順序檔案。
 依據其他設定，也可收集損毀或停止回應的傾印。
 範例: 

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -18,33 +18,21 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump 
 Implies --blame.</source>
-        <target state="new">Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. This option depends on the version of .NET used, the type of error, and the operating system.
-  
-For exceptions in managed code, a dump will be automatically collected on .NET 5.0 and later versions. It will generate a dump for testhost or any child process that also ran on .NET 5.0 and crashed. Crashes in native code will not generate a dump. This option works on Windows, macOS, and Linux.
-
-Crash dumps in native code, or when targetting .NET Framework, or .NET Core 3.1 and earlier versions, can only be collected on Windows, by using Procdump. A directory that contains procdump.exe and procdump64.exe must be in the PATH or PROCDUMP_PATH environment variable.
-
-The tools can be downloaded here: https://docs.microsoft.com/sysinternals/downloads/procdump
-  
-To collect a crash dump from a native application running on .NET 5.0 or later, the usage of Procdump can be forced by setting the VSTEST_DUMP_FORCEPROCDUMP environment variable to 1.
-
-Implies --blame.</target>
+        <target state="translated">當測試主機意外結束時，在改動者模式中執行測試，並允許收集損毀傾印。
+目前只有 Windows 支援此選項，而且必須在 PATH 中提供 procdump.exe 與 procdump64.exe。
+也可以設定 PROCDUMP_PATH 環境變數，並指向包含 procdump.exe 與 procdump64.exe 的目錄。
+這些工具可從下列網址下載: https://docs.microsoft.com/sysinternals/downloads/procdump 
+表示 --blame。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</source>
-        <target state="new">The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="translated">要收集的損毀傾印類型。Implies --blame-crash。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
@@ -53,19 +41,21 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
-        <target state="new">The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="translated">要收集之損毀傾印的類型。若使用 [無]，測試主機將會在逾時時終止，但不會收集任何傾印。Implies --blame-hang。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
 The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</source>
-        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.
-The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
-When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit, NUnit and MSTest 2.2.4+ the timeout is renewed after every test case,
-For MSTest before 2.2.4, the timeout is used for all testcases.</target>
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="translated">每個測試的逾時，在此之後將會觸發停止回應傾印，而且測試主機處理序將會終止。
+指定此逾時值時，請使用下列格式: 1.5 h/90m/5400s/5400000ms。若未使用單位 (例如 5400000)，將會假設該值的單位為毫秒。
+當與資料驅動型測試並用時，逾時行為取決於使用的測試配接器。對於 xUnit 與 NUnit，此逾時值會在每次執行測試案例之後更新。
+對於 MSTest，此逾時值會套用到所有測試案例。
+目前只有安裝有 netcoreapp 2.1 及更新版本的 Windows 支援此選項。此外安裝有 netcoreapp 3.1 及更新版本的 Linux 也支援此選項。不支援 OSX 與 UWP。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
@@ -255,12 +245,9 @@ RunSettings 引數:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
 When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
 Based on the additional settings, hang dump or crash dump can also be collected.
-
 Example: 
   Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
   (Crash dumps require additional setup, see below.)
@@ -269,18 +256,15 @@ Example:
   Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
   dotnet test --blame-hang-timeout 20min
 </source>
-        <target state="new">Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang, but it does not create a memory dump by default. 
-
-When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
-
-Based on the additional settings, hang dump or crash dump can also be collected.
-
-Example: 
-  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
-  (Crash dumps require additional setup, see below.)
+        <target state="translated">在改動者模式中執行測試。此選項可用於找出導致測試主機損毀或停止回應的問題測試。
+當偵測到損毀時，其會在 TestResults/guid/guid_Sequence.xml 中建立所擷取在損毀前，測試之執行順序的順序檔案。
+依據其他設定，也可收集損毀或停止回應的傾印。
+範例: 
+  當測試進行時間超過預設的 1 小時時，將測試逾時，並在測試主機未預期地結束時收集損毀傾印
+  (損毀傾印需要其他的設定，請參閱下文)。
   dotnet test --blame-hang --blame-crash
-Example: 
-  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+範例: 
+  當測試進行時間超過 20 分鐘時，將測試逾時，並收集停止回應傾印。
   dotnet test --blame-hang-timeout 20min
 </target>
         <note />

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
-        <target state="new">NETSDK1076: AddResource can only be used with integer resource types.</target>
+        <target state="translated">NETSDK1076: AddResource kann nur mit ganzzahligen Ressourcentypen verwendet werden.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
       <trans-unit id="AotNoValidRuntimePackageError">
@@ -19,138 +19,133 @@
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>
+        <target state="translated">NETSDK1070: Die Anwendungskonfigurationsdatei muss das Stammkonfigurationselement enthalten.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCreationFailedWithRetry">
         <source>NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</source>
-        <target state="new">NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</target>
+        <target state="translated">NETSDK1113: Fehler beim Erstellen von apphost (Versuch {0} von {1}): {2}</target>
         <note>{StrBegin="NETSDK1113: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="new">NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</target>
+        <target state="translated">NETSDK1074: Die ausführbare Anwendungshostdatei wird nicht angepasst, weil für das Hinzufügen von Ressourcen eine Ausführung des Builds unter Windows erforderlich ist (Nano Server ausgeschlossen).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
       </trans-unit>
       <trans-unit id="AppHostHasBeenModified">
         <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <target state="translated">NETSDK1029: "{0}" kann nicht als ausführbare Anwendungshostdatei verwendet werden, da die erwartete Platzhalterbytesequenz "{1}" nicht vorhanden ist, die markiert, wo der Anwendungsname geschrieben wird.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
-        <target state="new">NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <target state="translated">NETSDK1078: "{0}" kann nicht als ausführbare Anwendungshostdatei verwendet werden, weil es sich nicht um eine Windows PE-Datei handelt.</target>
         <note>{StrBegin="NETSDK1078: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
         <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
+        <target state="translated">NETSDK1072: "{0}" kann nicht als ausführbare Anwendungshostdatei verwendet werden, weil es sich nicht um eine ausführbare Windows-Datei für das CUI-Subsystem (Konsole) handelt.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppHostSigningFailed">
         <source>NETSDK1177: Failed to sign apphost with error code {1}: {0}</source>
-        <target state="new">NETSDK1177: Failed to sign apphost with error code {1}: {0}</target>
+        <target state="translated">NETSDK1177: Fehler beim Signieren von apphost mit Fehlercode {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="new">NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</target>
+        <target state="translated">NETSDK1079: Das Paket "Microsoft.AspNetCore.All" wird für .NET Core 3.0 oder höher nicht unterstützt. Verwenden Sie stattdessen eine FrameworkReference auf Microsoft.AspNetCore.App, die daraufhin implizit von Microsoft.NET.Sdk.Web eingeschlossen wird.</target>
         <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreUsesFrameworkReference">
         <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="new">NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</target>
+        <target state="translated">NETSDK1080: Eine PackageReference auf Microsoft.AspNetCore.App ist nicht erforderlich, wenn .NET Core 3.0 oder höher als Ziel verwendet wird. Bei Verwendung von Microsoft.NET.Sdk.Web wird das freigegebene Framework automatisch referenziert. Andernfalls muss die PackageReference durch eine FrameworkReference ersetzt werden.</target>
         <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <target state="translated">NETSDK1017: Der Ressourcenpräprozessor muss konfiguriert werden, bevor Ressourcen verarbeitet werden.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingRuntimeIdentifier">
         <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <target state="translated">NETSDK1047: Die Ressourcendatei "{0}" verfügt über kein Ziel für "{1}". Stellen Sie sicher, dass die Wiederherstellung ausgeführt wurde, und dass Sie "{2}" in die TargetFrameworks für Ihr Projekt aufgenommen haben. Unter Umständen müssen Sie auch "{3}" in die RuntimeIdentifiers Ihres Projekts aufnehmen.</target>
         <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingTarget">
         <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <target state="translated">NETSDK1005: Die Ressourcendatei "{0}" weist kein Ziel für "{1}" auf. Stellen Sie sicher, dass die Wiederherstellung ausgeführt wurde, und dass Sie "{2}" in die TargetFrameworks für Ihr Projekt eingeschlossen haben.</target>
         <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotFound">
         <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <target state="translated">NETSDK1004: Die Ressourcendatei "{0}" wurde nicht gefunden. Führen Sie eine NuGet-Paketwiederherstellung aus, um diese Datei zu generieren.</target>
         <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
         <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <target state="translated">NETSDK1063: Der Pfad zur Datei mit den Projektobjekten wurde nicht festgelegt. Führen Sie eine NuGet-Paketwiederherstellung durch, um diese Datei zu generieren.</target>
         <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFilePathNotRooted">
         <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <target state="translated">NETSDK1006: Die Ressourcendateipfad "{0}" hat keinen Stamm. Nur vollständige Pfade werden unterstützt.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
+        <target state="translated">NETSDK1001: Geben Sie mindestens ein mögliches Zielframework an.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
-        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
-        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
-        <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="CannotEmbedClsidMapIntoComhost">
         <source>NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="new">NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</target>
+        <target state="translated">NETSDK1092: CLSIDMap kann auf dem COM-Host nicht eingebettet werden, weil für das Hinzufügen von Ressourcen eine Ausführung des Builds unter Windows erforderlich ist (Nano Server ausgeschlossen).</target>
         <note>{StrBegin="NETSDK1092: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindApphostForRid">
         <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <target state="translated">NETSDK1065: Der App-Host für "{0}" wurde nicht gefunden. "{0}" könnte ein ungültiger Runtimebezeichner (RID) sein. Weitere Informationen zum RID finden Sie unter https://aka.ms/rid-catalog.</target>
         <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindComhost">
         <source>NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</source>
-        <target state="new">NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</target>
+        <target state="translated">NETSDK1091: Es wurde kein .NET Core-COM-Host gefunden. Der .NET Core-COM-Host ist nur unter .NET Core 3.0 oder höher verfügbar, wenn Windows als Ziel verwendet wird.</target>
         <note>{StrBegin="NETSDK1091: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindIjwhost">
         <source>NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</source>
-        <target state="new">NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</target>
+        <target state="translated">NETSDK1114: Es wurde kein .NET Core-IJW-Host gefunden. Der .NET Core-IJW-Host ist nur unter .NET Core 3.1 oder höher verfügbar, wenn Windows als Ziel verwendet wird.</target>
         <note>{StrBegin="NETSDK1114: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindProjectInfo">
         <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <target state="translated">NETSDK1007: Die Projektinformationen für "{0}" wurden nicht gefunden. Dies ist möglicherweise auf einen fehlenden Projektverweis zurückzuführen.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <target state="translated">NETSDK1032: Die RuntimeIdentifier-Plattform "{0}" und das PlatformTarget "{1}" müssen kompatibel sein.</target>
         <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <target state="translated">NETSDK1031: Das Erstellen oder Veröffentlichen einer eigenständigen Anwendung ohne die Angabe eines RuntimeIdentifier wird nicht unterstützt. Geben Sie entweder einen RuntimeIdentifier an, oder legen Sie SelfContained auf FALSE fest.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="translated">NETSDK1097: Das Veröffentlichen einer Anwendung in einer einzelnen Datei ohne Angabe eines RuntimeIdentifier wird nicht unterstützt. Geben Sie entweder einen RuntimeIdentifier an, oder legen Sie PublishSingleFile auf FALSE fest.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutAppHost">
         <source>NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <target state="translated">NETSDK1098: Anwendungen, die in einer einzelnen Datei veröffentlicht wurden, müssen den Anwendungshost verwenden. Legen Sie PublishSingleFile auf FALSE oder UseAppHost auf TRUE fest.</target>
         <note>{StrBegin="NETSDK1098: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutExecutable">
         <source>NETSDK1099: Publishing to a single-file is only supported for executable applications.</source>
-        <target state="new">NETSDK1099: Publishing to a single-file is only supported for executable applications.</target>
+        <target state="translated">NETSDK1099: Die Veröffentlichung in einer einzelnen Datei wird nur für ausführbare Anwendungen unterstützt.</target>
         <note>{StrBegin="NETSDK1099: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
         <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
@@ -164,57 +159,62 @@
       </trans-unit>
       <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
         <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <target state="translated">NETSDK1135: SupportedOSPlatformVersion {0} darf nicht höher sein als TargetPlatformVersion {1}.</target>
         <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>
-        <target state="new">NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</target>
+        <target state="translated">NETSDK1143: Wenn der gesamte Inhalt in einem einzelnen Dateipaket eingeschlossen wird, sind darin auch native Bibliotheken enthalten. Wenn "IncludeAllContentForSelfExtract" auf TRUE festgelegt wird, darf "IncludeNativeLibrariesForSelfExtract" nicht FALSE lauten.</target>
         <note>{StrBegin="NETSDK1143: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeSymbolsInSingleFile">
         <source>NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</source>
-        <target state="new">NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</target>
+        <target state="translated">NETSDK1142: Das Einschließen von Symbolen in ein einzelnes Dateipaket wird beim Veröffentlichen für .NET5 oder höher nicht unterstützt.</target>
         <note>{StrBegin="NETSDK1142: "}</note>
       </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <target state="translated">NETSDK1013: Der TargetFramework-Wert "{0}" wurde nicht erkannt. Unter Umständen ist die Schreibweise nicht korrekt. Andernfalls müssen die Eigenschaften TargetFrameworkIdentifier und/oder TargetFrameworkVersion explizit angegeben werden.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <target state="translated">NETSDK1067: Eigenständige Anwendungen müssen den Anwendungshost verwenden. Legen Sie "SelfContained" auf FALSE oder "UseAppHost" auf TRUE fest.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="translated">NETSDK1125: Das Veröffentlichen in einer einzelnen Datei wird nur für das netcoreapp-Ziel unterstützt.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <target state="translated">Auswahl von "{0}", weil AssemblyVersion {1} höher ist als {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingCopyLocalArbitrarily_Info">
         <source>Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</source>
-        <target state="new">Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</target>
+        <target state="translated">Zufällige Auswahl von "{0}", weil für beide Elemente "copy-local" festgelegt wurde und sie die gleiche Datei- und Assemblyversion aufweisen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingFileVersion_Info">
         <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <target state="translated">Auswahl von "{0}", weil die Dateiversion {1} höher ist als {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPlatformItem_Info">
         <source>Choosing '{0}' because it is a platform item.</source>
-        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <target state="translated">Auswahl von "{0}", weil es sich um ein Plattformelement handelt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPreferredPackage_Info">
         <source>Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <target state="translated">Auswahl von "{0}", weil es aus einem bevorzugten Paket stammt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClsidMapConflictingGuids">
         <source>NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</source>
-        <target state="new">NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</target>
+        <target state="translated">NETSDK1089: Für die Typen "{0}" und "{1}" ist dieselbe CLSID "{2}" im GuidAttribute festgelegt. Jede COMVisible-Klasse muss eine eindeutige GUID für ihre CLSID aufweisen.</target>
         <note>{StrBegin="NETSDK1089: "}
 {0} - The first type with the conflicting guid.
 {1} - The second type with the conflicting guid.
@@ -222,241 +222,241 @@
       </trans-unit>
       <trans-unit id="ClsidMapExportedTypesRequireExplicitGuid">
         <source>NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</source>
-        <target state="new">NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</target>
+        <target state="translated">NETSDK1088: Die COMVisible-Klasse "{0}" muss ein GuidAttribute mit der CLSID der Klasse aufweisen, damit sie für COM in .NET Core sichtbar gemacht wird.</target>
         <note>{StrBegin="NETSDK1088: "}
 {0} - The ComVisible class that doesn't have a GuidAttribute on it.</note>
       </trans-unit>
       <trans-unit id="ClsidMapInvalidAssembly">
         <source>NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</source>
-        <target state="new">NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</target>
+        <target state="translated">NETSDK1090: Die angegebene Assembly "{0}" ist ungültig. Daraus kann keine CLSIDMap generiert werden.</target>
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequires60">
         <source>NETSDK1167: Compression in a single file bundle is only supported when publishing for .NET6 or higher.</source>
-        <target state="new">NETSDK1167: Compression in a single file bundle is only supported when publishing for .NET6 or higher.</target>
+        <target state="translated">NETSDK1167: Die Komprimierung in einem einzelnen Dateipaket wird nur beim Veröffentlichen für .NET6 oder höher verwendet.</target>
         <note>{StrBegin="NETSDK1167: "}</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequiresSelfContained">
         <source>NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.</source>
-        <target state="new">NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.</target>
+        <target state="translated">NETSDK1176: Die Komprimierung zu einem einzelnen Dateibündel wird nur beim Veröffentlichen einer eigenständigen Anwendung unterstützt.</target>
         <note>{StrBegin="NETSDK1176: "}</note>
       </trans-unit>
       <trans-unit id="ConflictingRuntimePackInformation">
         <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
 {1}</source>
-        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+        <target state="translated">NETSDK1133: Es lagen widersprüchliche Informationen zu den für "{0}" verfügbaren Runtimepaketen vor:
 {1}</target>
         <note>{StrBegin="NETSDK1133: "}</note>
       </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <target state="translated">NETSDK1014: Das Inhaltselement für "{0}" legt "{1}" fest, gibt aber "{2}" oder "{3}" nicht an.</target>
         <note>{StrBegin="NETSDK1014: "}</note>
       </trans-unit>
       <trans-unit id="ContentPreproccessorParameterRequired">
         <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <target state="translated">NETSDK1010: Der Aufgabe "{0}" muss für die Nutzung vorverarbeiteter Inhalte mit einem Wert für den Parameter "{1}" versehen werden.</target>
         <note>{StrBegin="NETSDK1010: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesNotExist_Info">
         <source>Could not determine winner because '{0}' does not exist.</source>
-        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <target state="translated">Der Gewinner konnte nicht bestimmt werden, weil "{0}" nicht vorhanden ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_EqualVersions_Info">
         <source>Could not determine winner due to equal file and assembly versions.</source>
-        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <target state="translated">Der Gewinner konnte aufgrund übereinstimmender Datei- und Assemblyversionen nicht bestimmt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NoFileVersion_Info">
         <source>Could not determine a winner because '{0}' has no file version.</source>
-        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <target state="translated">Der Gewinner konnte nicht bestimmt werden, weil "{0}" keine Dateiversion aufweist.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NotAnAssembly_Info">
         <source>Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <target state="translated">Der Gewinner konnte nicht bestimmt werden, weil es sich bei "{0}" nicht um eine Assembly handelt.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
         <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
-        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <target state="translated">NETSDK1181: Fehler beim Abrufen der Paketversion: Das Paket „{0}“ war in Workloadmanifesten nicht vorhanden.</target>
         <note>{StrBegin="NETSDK1181: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <target state="translated">NETSDK1042: PlatformManifest konnte nicht von "{0}" geladen werden, weil es nicht vorhanden ist.</target>
         <note>{StrBegin="NETSDK1042: "}</note>
       </trans-unit>
       <trans-unit id="CppRequiresTFMVersion31">
         <source>NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</source>
-        <target state="new">NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</target>
+        <target state="translated">NETSDK1120: C++/CLI-Projekte für .NET Core erfordern als Zielframework mindestens "netcoreapp 3.1".</target>
         <note>{StrBegin="NETSDK1120: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2MissingRequiredMetadata">
         <source>NETSDK1158: Required '{0}' metadata missing on Crossgen2Tool item.</source>
-        <target state="new">NETSDK1158: Required '{0}' metadata missing on Crossgen2Tool item.</target>
+        <target state="translated">NETSDK1158: Erforderliche Metadaten von "{0}" fehlen im Crossgen2Tool-Element.</target>
         <note>{StrBegin="NETSDK1158: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2RequiresSelfContained">
         <source>NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</source>
-        <target state="new">NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</target>
+        <target state="translated">NETSDK1126: Das Veröffentlichen von ReadyToRun mit Crossgen2 wird nur für eigenständige Anwendungen unterstützt.</target>
         <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolExecutableNotFound">
         <source>NETSDK1155: Crossgen2Tool executable '{0}' not found.</source>
-        <target state="new">NETSDK1155: Crossgen2Tool executable '{0}' not found.</target>
+        <target state="translated">NETSDK1155: Die ausführbare Crossgen2Tool-Datei "{0}" wurde nicht gefunden.</target>
         <note>{StrBegin="NETSDK1155: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolMissingWhenUseCrossgen2IsSet">
         <source>NETSDK1154: Crossgen2Tool must be specified when UseCrossgen2 is set to true.</source>
-        <target state="new">NETSDK1154: Crossgen2Tool must be specified when UseCrossgen2 is set to true.</target>
+        <target state="translated">NETSDK1154: "Crossgen2Tool" muss angegeben werden, wenn "UseCrossgen2" auf TRUE festgelegt ist.</target>
         <note>{StrBegin="NETSDK1154: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
-        <target state="new">NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</target>
+        <target state="translated">NETSDK1166: Bei der Veröffentlichung für .NET 5 mit Crossgen2 im zusammengesetzten Modus können keine Symbole ausgegeben werden.</target>
         <note>{StrBegin="NETSDK1166: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolExecutableNotFound">
         <source>NETSDK1160: CrossgenTool executable '{0}' not found.</source>
-        <target state="new">NETSDK1160: CrossgenTool executable '{0}' not found.</target>
+        <target state="translated">NETSDK1160: Die ausführbare CrossgenTool-Datei "{0}" wurde nicht gefunden.</target>
         <note>{StrBegin="NETSDK1160: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingInPDBCompilationMode">
         <source>NETSDK1153: CrossgenTool not specified in PDB compilation mode.</source>
-        <target state="new">NETSDK1153: CrossgenTool not specified in PDB compilation mode.</target>
+        <target state="translated">NETSDK1153: "CrossgenTool" wurde im PDB-Kompilierungsmodus nicht angegeben.</target>
         <note>{StrBegin="NETSDK1153: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingWhenUseCrossgen2IsNotSet">
         <source>NETSDK1159: CrossgenTool must be specified when UseCrossgen2 is set to false.</source>
-        <target state="new">NETSDK1159: CrossgenTool must be specified when UseCrossgen2 is set to false.</target>
+        <target state="translated">NETSDK1159: "CrossgenTool" muss angegeben werden, wenn "UseCrossgen2" auf FALSE festgelegt ist.</target>
         <note>{StrBegin="NETSDK1159: "}</note>
       </trans-unit>
       <trans-unit id="DiaSymReaderLibraryNotFound">
         <source>NETSDK1161: DiaSymReader library '{0}' not found.</source>
-        <target state="new">NETSDK1161: DiaSymReader library '{0}' not found.</target>
+        <target state="translated">NETSDK1161: Die DiaSymReader-Bibliothek "{0}" wurde nicht gefunden.</target>
         <note>{StrBegin="NETSDK1161: "}</note>
       </trans-unit>
       <trans-unit id="DotNetHostExecutableNotFound">
         <source>NETSDK1156: .NET host executable '{0}' not found.</source>
-        <target state="new">NETSDK1156: .NET host executable '{0}' not found.</target>
+        <target state="translated">NETSDK1156: Die ausführbare .NET-Hostdatei "{0}" wurde nicht gefunden.</target>
         <note>{StrBegin="NETSDK1156: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
         <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <target state="translated">NETSDK1055: DotnetTool unterstützt kein Zielframework vor netcoreapp2.1.</target>
         <note>{StrBegin="NETSDK1055: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolOnlySupportNetcoreapp">
         <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <target state="translated">NETSDK1054: Unterstützt nur .NET Core.</target>
         <note>{StrBegin="NETSDK1054: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateItemsError">
         <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <target state="translated">NETSDK1022: Es wurden doppelte {0}-Elemente eingeschlossen. Das .NET SDK enthält standardmäßig {0}-Elemente aus ihrem Projektverzeichnis. Sie können entweder diese Elemente aus der Projektdatei entfernen oder die Eigenschaft "{1}" auf "{2}" festlegen, wenn Sie sie explizit in Ihre Projektdatei einbeziehen möchten. Weitere Informationen erhalten Sie unter "{4}". Die doppelten Elemente waren: {3}.</target>
         <note>{StrBegin="NETSDK1022: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePreprocessorToken">
         <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <target state="translated">NETSDK1015: Das Präprozessortoken "{0}" wurde mit mehreren Werten versehen. "{1}" wird als Wert ausgewählt.</target>
         <note>{StrBegin="NETSDK1015: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePublishOutputFiles">
         <source>NETSDK1152: Found multiple publish output files with the same relative path: {0}.</source>
-        <target state="new">NETSDK1152: Found multiple publish output files with the same relative path: {0}.</target>
+        <target state="translated">NETSDK1152: Es wurden mehrere Ausgabedateien für die Veröffentlichung mit demselben relativen Pfad gefunden: {0}.</target>
         <note>{StrBegin="NETSDK1152: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateRuntimePackAsset">
         <source>NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="new">NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="translated">NETSDK1110: Mehr als eine Ressource im Runtimepaket weist den gleichen Zielunterpfad "{0}" auf. Melden Sie diesen Fehler hier dem .NET-Team: https://aka.ms/dotnet-sdk-issue.</target>
         <note>{StrBegin="NETSDK1110: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateTypeLibraryIds">
         <source>NETSDK1169: The same resource ID {0} was specified for two type libraries '{1}' and '{2}'. Duplicate type library IDs are not allowed.</source>
-        <target state="new">NETSDK1169: The same resource ID {0} was specified for two type libraries '{1}' and '{2}'. Duplicate type library IDs are not allowed.</target>
+        <target state="translated">NETSDK1169: Für zwei Typbibliotheken ("{1}" und "{2}") wurde dieselbe Ressourcen-ID {0} angegeben. Doppelte IDs für Typbibliotheken sind nicht zulässig.</target>
         <note>{StrBegin="NETSDK1169: "}</note>
       </trans-unit>
       <trans-unit id="EncounteredConflict_Info">
         <source>Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <target state="translated">Zwischen "{0}" und "{1}" wurde ein Konflikt festgestellt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">
         <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <target state="translated">NETSDK1051: Fehler beim Analysieren von FrameworkList aus "{0}". {1} "{2}" war ungültig.</target>
         <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <target state="translated">NETSDK1043: Fehler beim Analysieren von PlatformManifest von "{0}" Zeile {1}. Zeilen müssen das Format "{2}" aufweisen.</target>
         <note>{StrBegin="NETSDK1043: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <target state="translated">NETSDK1044: Fehler beim Analysieren von PlatformManifest von "{0}" Zeile {1}. {2} "{3}" war ungültig.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">
         <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <target state="translated">NETSDK1060: Fehler beim Lesen der Ressourcendatei: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
       <trans-unit id="FailedToDeleteApphost">
         <source>NETSDK1111: Failed to delete output apphost: {0}</source>
-        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <target state="translated">NETSDK1111: Fehler beim Löschen von Ausgabe-apphost: {0}</target>
         <note>{StrBegin="NETSDK1111: "}</note>
       </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="new">NETSDK1077: Failed to lock resource.</target>
+        <target state="translated">NETSDK1077: Fehler beim Sperren der Ressource.</target>
         <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
       <trans-unit id="FileNameIsTooLong">
         <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <target state="translated">NETSDK1030: Der angegebene Dateiname "{0}" ist länger als 1024 Byte.</target>
         <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
       <trans-unit id="FolderAlreadyExists">
         <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <target state="translated">NETSDK1024: Der Ordner "{0}" ist bereits vorhanden. Löschen Sie ihn, oder geben Sie ein anderes "ComposeWorkingDir" an.</target>
         <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <target state="translated">NETSDK1068: Für den frameworkabhängigen Anwendungshost ist mindestens das Zielframework "netcoreapp2.1" erforderlich.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <target state="translated">NETSDK1052: Der FrameworkList-Dateipfad "{0}" enthält keinen Stamm. Nur vollständige Pfade werden unterstützt.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceDuplicateError">
         <source>NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</source>
-        <target state="new">NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</target>
+        <target state="translated">NETSDK1087: In das Projekt wurden mehrere FrameworkReference-Elemente für "{0}" einbezogen.</target>
         <note>{StrBegin="NETSDK1087: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceOverrideWarning">
         <source>NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="new">NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <target state="translated">NETSDK1086: Ein FrameworkReference für "{0}" wurde in das Projekt einbezogen. Darauf wird vom .NET SDK implizit verwiesen, und Sie müssen in der Regel nicht von Ihrem Projekt aus darauf verweisen. Weitere Informationen finden Sie unter "{1}".</target>
         <note>{StrBegin="NETSDK1086: "}</note>
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
         <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <target state="translated">NETSDK1049: Die aufgelöste Datei enthält ein fehlerhaftes Image oder keine Metadaten, oder der Zugriff ist aus anderen Gründen nicht möglich. {0} {1}</target>
         <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
       <trans-unit id="GlobalJsonSDKResolutionFailed">
         <source>NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</source>
-        <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
+        <target state="translated">NETSDK1141: Die .NET SDK-Version kann nicht aufgelöst werden, wie in der global.json-Datei unter "{0}" angegeben.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
         <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
+        <target state="translated">NETSDK1144: Fehler bei der Größenoptimierung von Assemblys. Die Optimierung kann durch Festlegen der PublishTrimmed-Eigenschaft auf FALSE deaktiviert werden.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNoValidRuntimePackageError">
@@ -466,90 +466,90 @@
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
-        <target state="new">NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</target>
+        <target state="translated">NETSDK1102: Die Größenoptimierung von Assemblys wird für die ausgewählte Veröffentlichungskonfiguration nicht unterstützt. Stellen Sie sicher, dass Sie eine eigenständige App veröffentlichen.</target>
         <note>{StrBegin="NETSDK1102: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkOptimizedAssemblies">
         <source>Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</source>
-        <target state="new">Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</target>
+        <target state="translated">Das Optimieren der Assembly für die Größe kann das Verhalten der App ändern. Stellen Sie sicher, dass nach der Veröffentlichung Tests durchgeführt werden. Informationen finden Sie unter https://aka.ms/dotnet-illink.</target>
         <note />
       </trans-unit>
       <trans-unit id="ILLinkRunning">
         <source>Optimizing assemblies for size. This process might take a while.</source>
-        <target state="new">Optimizing assemblies for size. This process might take a while.</target>
+        <target state="translated">Assemblys werden für die Größe optimiert. Dieser Vorgang kann eine Weile dauern.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed">
         <source>NETSDK1191: A runtime identifier for the property '{0}' couldn't be inferred. Specify a rid explicitly.</source>
-        <target state="new">NETSDK1191: A runtime identifier for the property '{0}' couldn't be inferred. Specify a rid explicitly.</target>
+        <target state="translated">NETSDK1191: Ein Runtimebezeichner für die Eigenschaft „{0}“ konnte nicht abgeleitet werden. Geben Sie eine RID explizit an.</target>
         <note>{StrBegin="NETSDK1191: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectPackageRoot">
         <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <target state="translated">NETSDK1020: Der Paketstamm "{0}" war für die aufgelöste Bibliothek "{1}" falsch angegeben.</target>
         <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectTargetFormat">
         <source>NETSDK1025: The target manifest {0} provided is of not the correct format</source>
-        <target state="new">NETSDK1025: The target manifest {0} provided is of not the correct format</target>
+        <target state="translated">NETSDK1025: Das angegebene Zielmanifest "{0}" weist nicht das richtige Format auf.</target>
         <note>{StrBegin="NETSDK1025: "}</note>
       </trans-unit>
       <trans-unit id="InputAssemblyNotFound">
         <source>NETSDK1163: Input assembly '{0}' not found.</source>
-        <target state="new">NETSDK1163: Input assembly '{0}' not found.</target>
+        <target state="translated">NETSDK1163: Die Eingabeassembly "{0}" wurde nicht gefunden.</target>
         <note>{StrBegin="NETSDK1163: "}</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <target state="translated">NETSDK1003: Ungültiger Frameworkname: "{0}".</target>
         <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <target state="translated">NETSDK1058: Ungültiger Wert für den ItemSpecToUse-Parameter: "{0}". Diese Eigenschaft muss leer oder auf "Left" bzw. "Right" festgelegt sein.</target>
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionString">
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <target state="translated">NETSDK1018: Ungültige NuGet-Versionszeichenfolge: "{0}".</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidResourceUpdate">
         <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="new">NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</target>
+        <target state="translated">NETSDK1075: Das Updatehandle ist ungültig. Diese Instanz darf für weitere Updates nicht verwendet werden.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="InvalidRollForwardValue">
         <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
-        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <target state="translated">NETSDK1104: Der RollForward-Wert "{0}" ist ungültig. Zulässige Werte: {1}.</target>
         <note>{StrBegin="NETSDK1104: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTargetPlatformVersion">
         <source>NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
 {2}</source>
-        <target state="new">NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
+        <target state="translated">NETSDK1140: {0} ist keine gültige TargetPlatformVersion für "{1}". Gültige Versionen sind:
 {2}</target>
         <note>{StrBegin="NETSDK1140: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibrary">
         <source>NETSDK1173: The provided type library '{0}' is in an invalid format.</source>
-        <target state="new">NETSDK1173: The provided type library '{0}' is in an invalid format.</target>
+        <target state="translated">NETSDK1173: Die angegebene Typbibliothek "{0}" weist ein ungültiges Format auf.</target>
         <note>{StrBegin="NETSDK1173: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibraryId">
         <source>NETSDK1170: The provided type library ID '{0}' for type library '{1}' is invalid. The ID must be a positive integer less than 65536.</source>
-        <target state="new">NETSDK1170: The provided type library ID '{0}' for type library '{1}' is invalid. The ID must be a positive integer less than 65536.</target>
+        <target state="translated">NETSDK1170: Die angegebene Typenbibliotheks-ID „{0}“ für die Typbibliothek „{1}“ ist ungültig. Die ID muss eine positive Ganzzahl kleiner als 65536 sein.</target>
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
-        <target state="new">NETSDK1157: JIT library '{0}' not found.</target>
+        <target state="translated">NETSDK1157: Die JIT-Bibliothek "{0}" wurde nicht gefunden.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <target state="translated">NETSDK1061: Das Projekt wurde mit {0}, Version {1} wiederhergestellt, aber mit den aktuellen Einstellungen würde stattdessen Version {2} verwendet werden. Um dieses Problem zu beheben, müssen Sie sicherstellen, dass für die Wiederherstellung und für nachfolgende Vorgänge wie das Kompilieren oder Veröffentlichen dieselben Einstellungen verwendet werden. Dieses Problem tritt typischerweise auf, wenn die RuntimeIdentifier-Eigenschaft bei der Kompilierung oder Veröffentlichung, aber nicht bei der Wiederherstellung festgelegt wird. Weitere Informationen finden Sie unter https://aka.ms/dotnet-runtime-patch-selection.</target>
         <note>{StrBegin="NETSDK1061: "}
 {0} - Package Identifier for platform package
 {1} - Restored version of platform package
@@ -557,172 +557,172 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="MissingItemMetadata">
         <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <target state="translated">NETSDK1008: Die Metadaten "{0}" für das Element "{2}" vom Typ "{1}" sind nicht vorhanden.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputPDBImagePath">
         <source>NETSDK1164: Missing output PDB path in PDB generation mode (OutputPDBImage metadata).</source>
-        <target state="new">NETSDK1164: Missing output PDB path in PDB generation mode (OutputPDBImage metadata).</target>
+        <target state="translated">NETSDK1164: Fehlender PDB-Ausgabepfad im PDB-Generierungsmodus (OutputPDBImage-Metadaten).</target>
         <note>{StrBegin="NETSDK1164: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputR2RImageFileName">
         <source>NETSDK1165: Missing output R2R image path (OutputR2RImage metadata).</source>
-        <target state="new">NETSDK1165: Missing output R2R image path (OutputR2RImage metadata).</target>
+        <target state="translated">NETSDK1165: Fehlender Ausgabepfad für R2R-Image (OutputR2RImage-Metadaten).</target>
         <note>{StrBegin="NETSDK1165: "}</note>
       </trans-unit>
       <trans-unit id="MissingTypeLibraryId">
         <source>NETSDK1171: An integer ID less than 65536 must be provided for type library '{0}' because more than one type library is specified.</source>
-        <target state="new">NETSDK1171: An integer ID less than 65536 must be provided for type library '{0}' because more than one type library is specified.</target>
+        <target state="translated">NETSDK1171: Für die Typbibliothek "{0}" muss eine ganzzahlige ID kleiner als 65536 angegeben werden, weil mehrere Typbibliotheken angegeben wurden.</target>
         <note>{StrBegin="NETSDK1171: "}</note>
       </trans-unit>
       <trans-unit id="MultipleFilesResolved">
         <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <target state="translated">NETSDK1021: Für "{0}" wurden mehrere Dateien gefunden.</target>
         <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="new">NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <target state="translated">NETSDK1069: Dieses Projekt verwendet eine Bibliothek, die auf .NET Standard 1.5 oder höher ausgerichtet ist, und das Projekt ist auf eine Version von .NET Framework ausgerichtet, die keine integrierte Unterstützung für diese .NET Standard-Version bietet. Besuchen Sie https://aka.ms/net-standard-known-issues for a set of known issues. Ziehen Sie eine neue Ausrichtung auf .NET Framework 4.7.2 in Betracht.</target>
         <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkWithoutUsingNETSdkDefaults">
         <source>NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</source>
-        <target state="new">NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</target>
+        <target state="translated">NETSDK1115: Das aktuelle .NET SDK unterstützt das .NET Framework nur, wenn .NET SDK-Standardwerte verwendet werden. Wahrscheinlich liegt ein Konflikt zwischen der CLRSupport-Eigenschaft des C++-/CLI-Projekts und TargetFramework vor.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
         <source>NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</source>
-        <target state="new">NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</target>
+        <target state="translated">NETSDK1182: .NET 6.0 oder höher wird als Ziel in Visual Studio 2019 nicht unterstützt.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="Net7NotCompatibleWithDev173">
         <source>NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.</source>
-        <target state="new">NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.</target>
+        <target state="translated">NETSDK1192: Die Ausrichtung auf .NET 7.0 oder höher in Visual Studio 2022 17.3 wird nicht unterstützt.</target>
         <note>{StrBegin="NETSDK1192: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <target state="translated">NETSDK1084: Für den angegebenen RuntimeIdentifier "{0}" ist kein Anwendungshost verfügbar.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
       <trans-unit id="NoBuildRequested">
         <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
-        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <target state="translated">NETSDK1085: Die Eigenschaft "NoBuild" wurde auf TRUE festgelegt, aber das Ziel "Build" wurde aufgerufen.</target>
         <note>{StrBegin="NETSDK1085: "}</note>
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
+        <target state="translated">NETSDK1002: Das Projekt "{0}" hat das Ziel "{2}". Ein Verweis über ein Projekt mit dem Ziel "{1}" ist nicht möglich.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackAvailable">
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <target state="translated">NETSDK1082: Für "{0}" stand für den angegebenen RuntimeIdentifier "{1}" kein Runtimepaket zur Verfügung.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackInformation">
         <source>NETSDK1132: No runtime pack information was available for {0}.</source>
-        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <target state="translated">NETSDK1132: Für "{0}" waren keine Runtimepaketinformationen verfügbar.</target>
         <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
-        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <target state="translated">NETSDK1128: Beim COM-Hosting werden keine eigenständigen Bereitstellungen unterstützt.</target>
         <note>{StrBegin="NETSDK1128: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
-        <target state="new">NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</target>
+        <target state="translated">NETSDK1119: C++-/CLI-Projekte für .NET Core können "EnableComHosting=true" nicht verwenden.</target>
         <note>{StrBegin="NETSDK1119: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppNonDynamicLibraryDotnetCore">
         <source>NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</source>
-        <target state="new">NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</target>
+        <target state="translated">NETSDK1116: C++-/CLI-Projekte für .NET Core müssen dynamische Bibliotheken sein.</target>
         <note>{StrBegin="NETSDK1116: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPackDotnetCore">
         <source>NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</source>
-        <target state="new">NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</target>
+        <target state="translated">NETSDK1118: C++-/CLI-Projekte für .NET Core können nicht paketiert werden.</target>
         <note>{StrBegin="NETSDK1118: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPublishDotnetCore">
         <source>NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</source>
-        <target state="new">NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</target>
+        <target state="translated">NETSDK1117: Keine Unterstützung für die Veröffentlichung des C++-/CLI-Projekts für .NET Core.</target>
         <note>{StrBegin="NETSDK1117: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppSelfContained">
         <source>NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</source>
-        <target state="new">NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</target>
+        <target state="translated">NETSDK1121: C++-/CLI-Projekte für .NET Core können "SelfContained=true" nicht verwenden.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
       <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
         <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</source>
-        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</target>
+        <target state="translated">NETSDK1151: Das referenzierte Projekt „{0}“ ist eine eigenständige ausführbare Datei. Auf eine eigenständige ausführbare Datei kann nicht von einer nicht eigenständigen ausführbaren Datei verwiesen werden. Weitere Informationen finden Sie unter https://aka.ms/netsdk1151.</target>
         <note>{StrBegin="NETSDK1151: "}</note>
       </trans-unit>
       <trans-unit id="PDBGeneratorInputExecutableNotFound">
         <source>NETSDK1162: PDB generation: R2R executable '{0}' not found.</source>
-        <target state="new">NETSDK1162: PDB generation: R2R executable '{0}' not found.</target>
+        <target state="translated">NETSDK1162: PDB-Generierung: Die ausführbare R2R-Datei "{0}" wurde nicht gefunden.</target>
         <note>{StrBegin="NETSDK1162: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <target state="translated">NETSDK1053: Die Paketierung als Tool unterstützt keine eigenständige Bereitstellung.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
         <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
-        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
+        <target state="translated">NETSDK1146: Die Festlegung von TargetPlatformIdentifier wird von PackAsTool nicht unterstützt. Beispielsweise kann nicht "net5.0-windows", sondern nur "net5.0" als TargetFramework verwendet werden. Bei Festlegung von .NET 5 oder höher als Ziel werden auch UseWPF oder UseWindowsForms von PackAsTool nicht unterstützt.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageContainsIncorrectlyCasedLocale">
         <source>NETSDK1187: Package {0} {1} has a resource with the locale '{2}'. This locale has been normalized to the standard format '{3}' to prevent casing issues in the build. Consider notifying the package author about this casing issue.</source>
-        <target state="new">NETSDK1187: Package {0} {1} has a resource with the locale '{2}'. This locale has been normalized to the standard format '{3}' to prevent casing issues in the build. Consider notifying the package author about this casing issue.</target>
+        <target state="translated">NETSDK1187: Das Paket {0} {1} verfügt über eine Ressource mit dem gebietsschema-'{2}'. Dieses Gebietsschema wurde auf das Standardformat '{3}' normalisiert, um Groß-/Kleinschreibungsprobleme im Build zu vermeiden. Erwägen Sie, den Paketautor über dieses Groß-/Kleinschreibungsproblem zu benachrichtigen.</target>
         <note>Error code is NETSDK1187. 0 is a package name, 1 is a package version, 2 is the incorrect locale string, and 3 is the correct locale string.</note>
       </trans-unit>
       <trans-unit id="PackageContainsUnknownLocale">
         <source>NETSDK1188: Package {0} {1} has a resource with the locale '{2}'. This locale is not recognized by .NET. Consider notifying the package author that it appears to be using an invalid locale.</source>
-        <target state="new">NETSDK1188: Package {0} {1} has a resource with the locale '{2}'. This locale is not recognized by .NET. Consider notifying the package author that it appears to be using an invalid locale.</target>
+        <target state="translated">NETSDK1188: Das Paket {0} {1} verfügt über eine Ressource mit dem gebietsschema-'{2}'. Dieses Gebietsschema wird von .NET nicht erkannt. Erwägen Sie, den Paketautor darüber zu benachrichtigen, dass offenbar ein ungültiges Gebietsschema verwendet wird.</target>
         <note>Error code is NETSDK1188. 0 is a package name, 1 is a package version, and 2 is the incorrect locale string</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
+        <target state="translated">NETSDK1064: Das Paket "{0}", Version {1}, wurde nicht gefunden. Möglicherweise wurde es nach der NuGet-Wiederherstellung gelöscht. Andernfalls wurde die NuGet-Wiederherstellung aufgrund von Beschränkungen der maximalen Pfadlänge eventuell nur teilweise abgeschlossen.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceOverrideWarning">
         <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <target state="translated">NETSDK1023: Ein PackageReference für "{0}" war in Ihrem Projekt vorhanden. Auf dieses Paket wird vom .NET SDK implizit verwiesen, und Sie müssen in der Regel nicht von Ihrem Projekt aus darauf verweisen. Weitere Informationen finden Sie unter "{1}".</target>
         <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceVersionNotRecommended">
         <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <target state="translated">NETSDK1071: Ein PackageReference-Verweis auf "{0}" hat die Version "{1}" angegeben. Die Angabe der Version dieses Pakets wird nicht empfohlen. Weitere Informationen finden Sie unter https://aka.ms/sdkimplicitrefs.</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
         <source>NETSDK1174: Placeholder</source>
-        <target state="new">NETSDK1174: Placeholder</target>
+        <target state="translated">NETSDK1174: Platzhalter</target>
         <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
       </trans-unit>
       <trans-unit id="Prefer32BitIgnoredForNetCoreApp">
         <source>NETSDK1189: Prefer32Bit is not supported and has no effect for netcoreapp target.</source>
-        <target state="new">NETSDK1189: Prefer32Bit is not supported and has no effect for netcoreapp target.</target>
+        <target state="translated">NETSDK1189: Prefer32Bit wird nicht unterstützt und hat keine Auswirkungen auf das netcoreapp-Ziel.</target>
         <note>{StrBegin="NETSDK1189: "}</note>
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
+        <target state="translated">NETSDK1011: Es werden Ressourcen aus dem Projekt "{0}" genutzt, in "{1}" wurde jedoch kein entsprechender MSBuild-Projektpfad gefunden.</target>
         <note>{StrBegin="NETSDK1011: "}</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
         <source>NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <target state="translated">NETSDK1059: Das Tool "{0}" ist jetzt im .NET SDK enthalten. Informationen zum Auflösen dieser Warnung sind unter https://aka.ms/dotnetclitools-in-box verfügbar.</target>
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
         <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="new">NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</target>
+        <target state="translated">NETSDK1093: Projekttools (DotnetCliTool) unterstützen als Ziel nur .NET Core 2.2 und früher.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
@@ -732,92 +732,92 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1122: Die ReadyToRun-Kompilierung wird übersprungen, weil sie nur für .NET Core 3.0 oder höher unterstützt wird.</target>
         <note>{StrBegin="NETSDK1122: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedMustBeBool">
         <source>NETSDK1193: If PublishSelfContained is set, it must be either true or false. The value given was '{0}'.</source>
-        <target state="new">NETSDK1193: If PublishSelfContained is set, it must be either true or false. The value given was '{0}'.</target>
+        <target state="translated">NETSDK1193: Wenn PublishSelfContained festgelegt ist, muss es entweder "true" oder "false" sein. Der angegebene Wert war "{0}".</target>
         <note>{StrBegin="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1123: Zum Veröffentlichen einer Anwendung in einer einzelnen Datei ist .NET Core 3.0 oder höher erforderlich.</target>
         <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="PublishTrimmedRequiresVersion30">
         <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1124: Zum Kürzen von Assemblys ist .NET Core 3.0 oder höher erforderlich.</target>
         <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="PublishUnsupportedWithoutTargetFramework">
         <source>NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</source>
-        <target state="new">NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</target>
+        <target state="translated">NETSDK1129: Das Ziel für "Publish" wird ohne Angabe eines Zielframeworks nicht unterstützt. Das aktuelle Projekt verwendet mehrere Frameworks als Ziel. Sie müssen das Framework für die veröffentlichte Anwendung angeben.</target>
         <note>{StrBegin="NETSDK1129: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>
-        <target state="new">NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</target>
+        <target state="translated">NETSDK1096: Fehler bei der Leistungsoptimierung von Assemblys. Sie können entweder die fehlerhaften Assemblys von der Optimierung ausschließen oder die PublishReadyToRun-Eigenschaft auf FALSE festlegen.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
         <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
-        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <target state="translated">Einige ReadyToRun-Kompilierungen haben Warnungen ausgegeben, dies kann auf fehlende Abhängigkeiten hinweisen. Fehlende Abhängigkeiten können zu Laufzeitfehlern führen. Legen Sie die PublishReadyToRunShowWarnings-Eigenschaft auf TRUE fest, um die Warnungen anzuzeigen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing and make sure to restore packages with the PublishReadyToRun property set to true.</source>
-        <target state="new">NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing and make sure to restore packages with the PublishReadyToRun property set to true.</target>
+        <target state="needs-review-translation">NETSDK1094: Assemblys können nicht für Leistung optimiert werden: Es wurde kein gültiges Runtimepaket gefunden. Legen Sie entweder die PublishReadyToRun-Eigenschaft auf FALSE fest, oder verwenden Sie beim Veröffentlichen einen unterstützten Runtimebezeichner. Wenn Sie .NET 6 oder höher verwenden, stellen Sie sicher, dass Sie Pakete wiederherstellen, bei denen die PublishReadyToRun-Eigenschaft auf TRUE festgelegt ist.</target>
         <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunTargetNotSupportedError">
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
-        <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
+        <target state="translated">NETSDK1095: Die Leistungsoptimierung von Assemblys wird für die ausgewählte Zielplattform oder -architektur nicht unterstützt. Überprüfen Sie, ob Sie einen unterstützten Runtimebezeichner verwenden, oder legen Sie die PublishReadyToRun-Eigenschaft auf FALSE fest.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
       </trans-unit>
       <trans-unit id="RollForwardRequiresVersion30">
         <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1103: Die RollForward-Einstellung wird nur für .NET Core 3.0 oder höher unterstützt.</target>
         <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <target state="translated">NETSDK1083: Der angegebene RuntimeIdentifier "{0}" wird nicht erkannt.</target>
         <note>{StrBegin="NETSDK1083: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <target state="translated">NETSDK1028: Geben Sie einen RuntimeIdentifier an.</target>
         <note>{StrBegin="NETSDK1028: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeListNotFound">
         <source>NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="new">NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="translated">NETSDK1109: Die Runtimelistendatei "{0}" wurde nicht gefunden. Melden Sie diesen Fehler hier dem .NET-Team: https://aka.ms/dotnet-sdk-issue.</target>
         <note>{StrBegin="NETSDK1109: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotDownloaded">
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</target>
+        <target state="translated">NETSDK1112: Das Laufzeitpaket für "{0}" wurde nicht heruntergeladen. Führen Sie eine NuGet-Wiederherstellung mit RuntimeIdentifier "{1}" aus.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
         <source>NETSDK1185: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1185: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <target state="translated">NETSDK1185: Das Runtimepaket für FrameworkReference „{0}“ war nicht verfügbar. Dies kann daran liegen, dass DisableTransitiveFrameworkReferenceDownloads auf TRUE festgelegt wurde.</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
-        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</target>
+        <target state="translated">NETSDK1150: Das referenzierte Projekt „{0}“ ist keine eigenständige ausführbare Datei. Auf eine nicht eigenständige ausführbare Datei kann nicht von einer eigenständigen ausführbaren Datei verwiesen werden. Weitere Informationen finden Sie unter https://aka.ms/netsdk1150.</target>
         <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionShouldBeUsedWithRuntime">
         <source>NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</source>
-        <target state="new">NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</target>
+        <target state="translated">NETSDK1179: Eine der Optionen „--self-contained“ oder „--no-self-contained“ ist erforderlich, wenn „--runtime“ verwendet wird.</target>
         <note>{StrBegin="NETSDK1179: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <target state="translated">NETSDK1048: Für GenerateRuntimeConfigurationFiles wurden "AdditionalProbingPaths" angegeben, sie werden jedoch übersprungen, weil "RuntimeConfigDevPath" leer ist.</target>
         <note>{StrBegin="NETSDK1048: "}</note>
       </trans-unit>
       <trans-unit id="SolutionProjectConfigurationsConflict">
@@ -829,171 +829,171 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="TargetFrameworkIsEol">
         <source>NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
-        <target state="new">NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <target state="translated">NETSDK1138: Das Zielframework "{0}" wird nicht mehr unterstützt und erhält in Zukunft keine Sicherheitsupdates mehr. Weitere Informationen zur Supportrichtlinie finden Sie unter "{1}".</target>
         <note>{StrBegin="NETSDK1138: "}</note>
       </trans-unit>
       <trans-unit id="TargetFrameworkWithSemicolon">
         <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <target state="translated">NETSDK1046: Der TargetFramework-Wert "{0}" ist nicht gültig. Verwenden Sie für mehrere Ziele die Eigenschaft "TargetFrameworks".</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
       <trans-unit id="TargetingApphostPackMissingCannotRestore">
         <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
-        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <target state="translated">NETSDK1145: Das Paket "{0}" ist nicht installiert, und die NuGet-Paketwiederherstellung wird nicht unterstützt. Führen Sie ein Upgrade von Visual Studio durch, entfernen Sie die Datei "global.json", sofern sie eine bestimmte SDK-Version angibt, und deinstallieren Sie das neuere SDK. Weitere Optionen finden Sie unter https://aka.ms/targeting-apphost-pack-missing. Pakettyp: {0}, Paketverzeichnis: {1}, Zielframework: {2}, PackageId des Pakets: {3}, Paketversion: {4}</target>
         <note>{StrBegin="NETSDK1145: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
-        <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>
+        <target state="translated">NETSDK1127: Das Paket zur Festlegung von Zielversionen "{0}" ist nicht installiert. Führen Sie eine Wiederherstellung durch, und versuchen Sie es noch mal.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
         <source>NETSDK1184: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <target state="translated">NETSDK1184: Das Zielpaket für FrameworkReference „{0}“ war nicht verfügbar. Dies kann daran liegt, dass DisableTransitiveFrameworkReferenceDownloads auf TRUE festgelegt wurde.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>
-        <target state="new">NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</target>
+        <target state="translated">NETSDK1175: Windows Forms wird nicht unterstützt oder empfohlen, wenn das Zuschneiden aktiviert ist. Weitere Details finden Sie unter https://aka.ms/dotnet-illink/windows-forms.</target>
         <note>{StrBegin="NETSDK1175: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWpfIsNotSupported">
         <source>NETSDK1168: WPF is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/wpf for more details.</source>
-        <target state="new">NETSDK1168: WPF is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/wpf for more details.</target>
+        <target state="translated">NETSDK1168: Windows Presentation Foundation (WPF) wird nicht unterstützt oder empfohlen, wenn das Kürzen aktiviert ist. Weitere Informationen finden Sie unter „https://aka.ms/dotnet-illink/wpf“.</target>
         <note>{StrBegin="NETSDK1168: "}</note>
       </trans-unit>
       <trans-unit id="TypeLibraryDoesNotExist">
         <source>NETSDK1172: The provided type library '{0}' does not exist.</source>
-        <target state="new">NETSDK1172: The provided type library '{0}' does not exist.</target>
+        <target state="translated">NETSDK1172: Die angegebene Typbibliothek "{0}" ist nicht vorhanden.</target>
         <note>{StrBegin="NETSDK1172: "}</note>
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
+        <target state="translated">NETSDK1016: Der aufgelöste Pfad für "{0}" wurde nicht gefunden.</target>
         <note>{StrBegin="NETSDK1016: "}</note>
       </trans-unit>
       <trans-unit id="UnableToUsePackageAssetsCache_Info">
         <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <target state="translated">Der Cache für Paketressourcen kann aufgrund eines E/A-Fehlers nicht verwendet werden. Dieses Problem kann auftreten, wenn dasselbe Projekt gleichzeitig mehrfach kompiliert wird. Die Leistung ist möglicherweise herabgesetzt, aber das Buildergebnis wird nicht beeinträchtigt.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedFileType">
         <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <target state="translated">NETSDK1012: Unerwarteter Dateityp für "{0}". Der Typ ist sowohl "{1}" als auch "{2}".</target>
         <note>{StrBegin="NETSDK1012: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference">
         <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="new">NETSDK1073: The FrameworkReference '{0}' was not recognized</target>
+        <target state="translated">NETSDK1073: Die FrameworkReference "{0}" wurde nicht erkannt.</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
         <source>NETSDK1186: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1186: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <target state="translated">NETSDK1186: Dieses Projekt ist über einen Projekt- oder NuGet-Paketverweis von Maui Essentials abhängig, deklariert diese Abhängigkeit jedoch nicht explizit. Um dieses Projekt zu erstellen, müssen Sie die UseMauiEssentials-Eigenschaft auf TRUE festlegen (und bei Bedarf den Maui-Workload installieren).</target>
         <note>{StrBegin="NETSDK1186: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
-        <target state="new">NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</target>
+        <target state="translated">NETSDK1137: Es ist nicht länger erforderlich, das Microsoft.NET.Sdk.WindowsDesktop SDK zu verwenden. Erwägen Sie eine Änderung des Sdk-Attributs für das root-Projektelement in "Microsoft.NET.Sdk".</target>
         <note>{StrBegin="NETSDK1137: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
+        <target state="translated">NETSDK1009: Unbekanntes Präprozessortoken "{0}" in "{1}".</target>
         <note>{StrBegin="NETSDK1009: "}</note>
       </trans-unit>
       <trans-unit id="UnresolvedTargetingPack">
         <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <target state="translated">NETSDK1081: Das Zielpaket für "{0}" wurde nicht gefunden. Sie können dieses Problem möglicherweise beheben, indem Sie eine NuGet-Wiederherstellung für das Projekt ausführen.</target>
         <note>{StrBegin="NETSDK1081: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
+        <target state="translated">NETSDK1019: "{0}" ist ein nicht unterstütztes Framework.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
+        <target state="translated">NETSDK1056: Das Projekt ist auf die Runtime "{0}" ausgelegt, aber hat keine runtimespezifischen Pakete aufgelöst. Diese Runtime wird vom Zielframework möglicherweise nicht unterstützt.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">
         <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <target state="translated">NETSDK1050: Die von diesem Projekt verwendete Microsoft.NET.Sdk-Version reicht zur Unterstützung von Verweisen auf Bibliotheken für .NET Standard 1.5 oder höher nicht aus. Installieren Sie mindestens .NET Core SDK 2.0.</target>
         <note>{StrBegin="NETSDK1050: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetFrameworkVersion">
         <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <target state="translated">NETSDK1045: Das aktuelle .NET SDK unterstützt {0} {1} nicht als Ziel. Geben Sie entweder {0} {2} oder niedriger als Ziel an, oder verwenden Sie eine .NET SDK-Version, die {0} {1} unterstützt.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifier">
         <source>NETSDK1139: The target platform identifier {0} was not recognized.</source>
-        <target state="new">NETSDK1139: The target platform identifier {0} was not recognized.</target>
+        <target state="translated">NETSDK1139: Der Zielplattformbezeichner "{0}" wurde nicht erkannt.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
-        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <target state="translated">NETSDK1107: Für das Erstellen von Windows-Desktopanwendungen ist Microsoft.NET.Sdk.WindowsDesktop erforderlich. "UseWpf" und "UseWindowsForms" werden vom aktuellen SDK nicht unterstützt.</target>
         <note>{StrBegin="NETSDK1107: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdk_Info">
         <source>NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy</source>
-        <target state="new">NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy</target>
+        <target state="translated">NETSDK1057: Sie verwenden eine Vorschauversion von .NET. Weitere Informationen: https://aka.ms/dotnet-support-policy</target>
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
+        <target state="translated">NETSDK1131: Das Erstellen einer verwalteten Windows-Metadatenkomponente mit WinMDExp wird mit dem Ziel "{0}" nicht unterstützt.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
         <source>NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</source>
-        <target state="new">NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</target>
+        <target state="translated">NETSDK1130: Auf "{1}" kann nicht verwiesen werden. Direkte Verweise auf eine Windows-Metadatenkomponente werden bei Verwendung von .NET 5 oder höher als Ziel nicht unterstützt. Weitere Informationen finden Sie unter https://aka.ms/netsdk1130.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WinMDTransitiveReferenceNotSupported">
         <source>NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</source>
-        <target state="new">NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</target>
+        <target state="translated">NETSDK1149: Auf "{0}" kann nicht verwiesen werden, weil die integrierte Unterstützung für WinRT verwendet wird. Diese wird in .NET 5 und höher nicht mehr unterstützt. Es ist eine aktualisierte Version der Komponente mit Unterstützung für .NET 5 erforderlich. Weitere Informationen finden Sie unter https://aka.ms/netsdk1149.</target>
         <note>{StrBegin="NETSDK1149: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
-        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <target state="translated">NETSDK1106: Für Microsoft.NET.Sdk.WindowsDesktop muss "UseWpf" oder "UseWindowsForms" auf TRUE festgelegt werden.</target>
         <note>{StrBegin="NETSDK1106: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
         <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1105: Windows-Desktopanwendungen werden nur unter .NET Core 3.0 oder höher unterstützt.</target>
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
-        <target state="new">NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</target>
+        <target state="translated">NETSDK1100: Um ein Projekt für Windows unter diesem Betriebssystem zu erstellen, legen Sie die EnableWindowsTargeting-Eigenschaft auf TRUE fest.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">
         <source>NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</source>
-        <target state="new">NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</target>
+        <target state="translated">NETSDK1136: Die Zielplattform muss auf Windows festgelegt werden (üblicherweise durch Einbeziehen von "-windows" in die TargetFramework-Eigenschaft), wenn Windows Forms oder WPF verwendet wird oder auf Projekte oder Pakete verwiesen wird, die dies tun.</target>
         <note>{StrBegin="NETSDK1136: "}</note>
       </trans-unit>
       <trans-unit id="WindowsSDKVersionConflicts">
         <source>NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</source>
-        <target state="new">NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</target>
+        <target state="translated">NETSDK1148: Eine referenzierte Assembly wurde mit einer neueren Version von "Microsoft.Windows.SDK.NET.dll" kompiliert. Aktualisieren Sie auf ein neueres .NET SDK, um auf diese Assembly zu verweisen.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>
-        <target state="new">NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
-You may need to build the project on another operating system or architecture, or update the .NET SDK.</target>
+        <target state="translated">NETSDK1178: Das Projekt hängt von den folgenden Workloadpaketen ab, die in keiner der in dieser Installation verfügbaren Workloads vorhanden sind: {0}
+Sie müssen das Projekt möglicherweise unter einem anderen Betriebssystem oder einer anderen Architektur erstellen, oder das .NET-SDK aktualisieren.</target>
         <note>{StrBegin="NETSDK1178: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotInstalled">
         <source>NETSDK1147: To build this project, the following workloads must be installed: {0}
 To install these workloads, run the following command: dotnet workload restore</source>
-        <target state="new">NETSDK1147: To build this project, the following workloads must be installed: {0}
-To install these workloads, run the following command: dotnet workload restore</target>
+        <target state="translated">NETSDK1147: Zum Erstellen dieses Projekts müssen die folgenden Workloads installiert sein: {0}
+Führen Sie den folgenden Befehl aus, um diese Workloads zu installieren: dotnet workload restore</target>
         <note>{StrBegin="NETSDK1147: "} LOCALIZATION: Do not localize "dotnet workload restore"</note>
       </trans-unit>
     </body>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
-        <target state="new">NETSDK1076: AddResource can only be used with integer resource types.</target>
+        <target state="translated">NETSDK1076: AddResource는 정수 리소스 형식에만 사용할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
       <trans-unit id="AotNoValidRuntimePackageError">
@@ -19,138 +19,133 @@
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>
+        <target state="translated">NETSDK1070: 애플리케이션 구성 파일에는 루트 구성 요소가 있어야 합니다.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCreationFailedWithRetry">
         <source>NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</source>
-        <target state="new">NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</target>
+        <target state="translated">NETSDK1113: apphost를 만들지 못했습니다(시도 횟수: {0}/{1}). {2}</target>
         <note>{StrBegin="NETSDK1113: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="new">NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</target>
+        <target state="translated">NETSDK1074: 리소스를 추가하려면 빌드가 Windows(Nano Server 제외)에서 수행되어야 하므로 애플리케이션 호스트 실행 파일이 사용자 지정되지 않습니다.</target>
         <note>{StrBegin="NETSDK1074: "}</note>
       </trans-unit>
       <trans-unit id="AppHostHasBeenModified">
         <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <target state="translated">NETSDK1029: 애플리케이션 이름이 기록되는 위치를 표시하는 '{1}' 예상 자리 표시자 바이트 시퀀스가 포함되지 않아서 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
-        <target state="new">NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <target state="translated">NETSDK1078: Windows PE 파일이 아니므로 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1078: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
         <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
+        <target state="translated">NETSDK1072: CUI(콘솔) 하위 시스템용 Windows 실행 파일이 아니므로 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppHostSigningFailed">
         <source>NETSDK1177: Failed to sign apphost with error code {1}: {0}</source>
-        <target state="new">NETSDK1177: Failed to sign apphost with error code {1}: {0}</target>
+        <target state="translated">NETSDK1177: apphost에 서명하지 못했습니다(오류 코드 {1}: {0})</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="new">NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</target>
+        <target state="translated">NETSDK1079: .NET Core 3.0 이상을 대상으로 할 경우 Microsoft.AspNetCore.All 패키지가 지원되지 않습니다. Microsoft.AspNetCore.App에 대한 FrameworkReference가 대신 사용되어야 하며, Microsoft.NET.Sdk.Web에 의해 암시적으로 포함됩니다.</target>
         <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreUsesFrameworkReference">
         <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="new">NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</target>
+        <target state="translated">NETSDK1080: .NET Core 3.0을 이상을 대상으로 할 경우 Microsoft.AspNetCore.App에 대한 PackageReference는 필요하지 않습니다. Microsoft.NET.Sdk.Web이 사용되는 경우 공유 프레임워크가 자동으로 참조됩니다. 그렇지 않은 경우 PackageReference를 FrameworkReference로 바꿔야 합니다.</target>
         <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <target state="translated">NETSDK1017: 자산을 처리하려면 먼저 자산 전처리기를 구성해야 합니다.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingRuntimeIdentifier">
         <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <target state="translated">NETSDK1047: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요. 프로젝트의 RuntimeIdentifiers에 '{3}'을(를) 포함해야 할 수도 있습니다.</target>
         <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingTarget">
         <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <target state="translated">NETSDK1005: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요.</target>
         <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotFound">
         <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <target state="translated">NETSDK1004: 자산 파일 '{0}'을(를) 찾을 수 없습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
         <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
         <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <target state="translated">NETSDK1063: 프로젝트 자산 파일에 대한 경로가 설정되지 않았습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
         <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFilePathNotRooted">
         <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <target state="translated">NETSDK1006: 자산 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
+        <target state="translated">NETSDK1001: 가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
-        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
-        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
-        <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="CannotEmbedClsidMapIntoComhost">
         <source>NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="new">NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</target>
+        <target state="translated">NETSDK1092: 리소스를 추가하려면 빌드가 Windows(Nano Server 제외)에서 수행되어야 하므로 CLSIDMap을 COM 호스트에 포함할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1092: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindApphostForRid">
         <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <target state="translated">NETSDK1065: {0}에 대한 앱 호스트를 찾을 수 없습니다. {0}이(가) 잘못된 RID(런타임 식별자)일 수 있습니다. RID에 대한 자세한 내용은 https://aka.ms/rid-catalog를 참조하세요.</target>
         <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindComhost">
         <source>NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</source>
-        <target state="new">NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</target>
+        <target state="translated">NETSDK1091: .NET Core COM 호스트를 찾을 수 없습니다. .NET Core COM 호스트는 Windows를 대상으로 할 경우 .NET Core 3.0 이상에서만 사용할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1091: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindIjwhost">
         <source>NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</source>
-        <target state="new">NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</target>
+        <target state="translated">NETSDK1114: .NET Core IJW 호스트를 찾을 수 없습니다. .NET Core IJW 호스트는 Windows를 대상으로 할 경우 .NET Core 3.1 이상에서만 사용할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1114: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindProjectInfo">
         <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <target state="translated">NETSDK1007: '{0}'에 대한 프로젝트 정보를 찾을 수 없습니다. 프로젝트 참조가 없음을 나타낼 수 있습니다.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <target state="translated">NETSDK1032: RuntimeIdentifier 플랫폼 '{0}'과(와) PlatformTarget '{1}'은(는) 호환되어야 합니다.</target>
         <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <target state="translated">NETSDK1031: RuntimeIdentifier를 지정하지 않고 자체 포함 애플리케이션을 빌드하거나 게시할 수 없습니다. RuntimeIdentifier를 지정하거나 SelfContained를 false로 설정해야 합니다.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="translated">NETSDK1097: RuntimeIdentifier를 지정하지 않고 애플리케이션을 단일 파일에 게시할 수 없습니다. RuntimeIdentifier를 지정하거나 PublishSingleFile을 false로 설정해야 합니다.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutAppHost">
         <source>NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <target state="translated">NETSDK1098: 애플리케이션 호스트를 사용하려면 단일 파일에 게시된 애플리케이션이 필요합니다. PublishSingleFile을 false로 설정하거나 UseAppHost를 true로 설정해야 합니다.</target>
         <note>{StrBegin="NETSDK1098: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutExecutable">
         <source>NETSDK1099: Publishing to a single-file is only supported for executable applications.</source>
-        <target state="new">NETSDK1099: Publishing to a single-file is only supported for executable applications.</target>
+        <target state="translated">NETSDK1099: 실행 가능한 애플리케이션의 경우에만 단일 파일에 게시할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1099: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
         <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
@@ -164,57 +159,62 @@
       </trans-unit>
       <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
         <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <target state="translated">NETSDK1135: SupportedOSPlatformVersion {0}은(는) TargetPlatformVersion {1}보다 높을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>
-        <target state="new">NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</target>
+        <target state="translated">NETSDK1143: 단일 파일 번들에 모든 콘텐츠를 포함하면 네이티브 라이브러리도 포함됩니다. IncludeAllContentForSelfExtract가 true면 IncludeNativeLibrariesForSelfExtract는 false가 아니어야 합니다.</target>
         <note>{StrBegin="NETSDK1143: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeSymbolsInSingleFile">
         <source>NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</source>
-        <target state="new">NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</target>
+        <target state="translated">NETSDK1142: .NET5 이상을 게시할 때 단일 파일 번들에서 기호를 포함할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1142: "}</note>
       </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <target state="translated">NETSDK1013: TargetFramework 값 '{0}'을(를) 인식하지 못했습니다. 철자가 틀렸을 수 있습니다. 그렇지 않은 경우 TargetFrameworkIdentifier 및/또는 TargetFrameworkVersion 속성을 명시적으로 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <target state="translated">NETSDK1067: 애플리케이션 호스트를 사용하려면 자체 포함 애플리케이션이 필요합니다. SelfContained를 false로 설정하거나 UseAppHost를 true로 설정하세요.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="translated">NETSDK1125: 단일 파일에 게시는 netcoreapp 대상에만 지원됩니다.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <target state="translated">AssemblyVersion '{1}'이(가) '{2}'보다 크기 때문에 '{0}'을(를) 선택합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingCopyLocalArbitrarily_Info">
         <source>Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</source>
-        <target state="new">Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</target>
+        <target state="translated">두 항목이 모두 로컬 복사이고 파일 및 어셈블리 버전이 같으므로 임의로 '{0}'을(를) 선택합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingFileVersion_Info">
         <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <target state="translated">파일 버전 '{1}'이(가) '{2}'보다 크기 때문에 '{0}'을(를) 선택합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPlatformItem_Info">
         <source>Choosing '{0}' because it is a platform item.</source>
-        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <target state="translated">플랫폼 항목이기 때문에 '{0}'을(를) 선택합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPreferredPackage_Info">
         <source>Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <target state="translated">기본 설정되는 패키지에 있기 때문에 '{0}'을(를) 선택합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClsidMapConflictingGuids">
         <source>NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</source>
-        <target state="new">NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</target>
+        <target state="translated">NETSDK1089: '{0}' 및 '{1}' 형식이 GuidAttribute에 설정된 같은 CLSID '{2}'을(를) 포함합니다. 각 COMVisible 클래스는 해당 CLSID에 대해 고유한 guid를 포함해야 합니다.</target>
         <note>{StrBegin="NETSDK1089: "}
 {0} - The first type with the conflicting guid.
 {1} - The second type with the conflicting guid.
@@ -222,241 +222,241 @@
       </trans-unit>
       <trans-unit id="ClsidMapExportedTypesRequireExplicitGuid">
         <source>NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</source>
-        <target state="new">NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</target>
+        <target state="translated">NETSDK1088: COMVisible 클래스 '{0}'이(가) .NET Core에서 COM에 표시되려면 클래스의 CLSID가 포함된 GuidAttribute를 포함해야 합니다.</target>
         <note>{StrBegin="NETSDK1088: "}
 {0} - The ComVisible class that doesn't have a GuidAttribute on it.</note>
       </trans-unit>
       <trans-unit id="ClsidMapInvalidAssembly">
         <source>NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</source>
-        <target state="new">NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</target>
+        <target state="translated">NETSDK1090: 제공된 어셈블리 '{0}'이(가) 잘못되었습니다. 해당 어셈블리에서 CLSIDMap을 생성할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequires60">
         <source>NETSDK1167: Compression in a single file bundle is only supported when publishing for .NET6 or higher.</source>
-        <target state="new">NETSDK1167: Compression in a single file bundle is only supported when publishing for .NET6 or higher.</target>
+        <target state="translated">NETSDK1167: 단일 파일 번들에서 압축은 .NET6 이상에 게시할 때만 지원됩니다.</target>
         <note>{StrBegin="NETSDK1167: "}</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequiresSelfContained">
         <source>NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.</source>
-        <target state="new">NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.</target>
+        <target state="translated">NETSDK1176: 자체 포함 애플리케이션이 게시된 경우 단일 파일 번들의 압축만 지원됩니다.</target>
         <note>{StrBegin="NETSDK1176: "}</note>
       </trans-unit>
       <trans-unit id="ConflictingRuntimePackInformation">
         <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
 {1}</source>
-        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+        <target state="translated">NETSDK1133: {0}에 사용할 수 있는 런타임 팩에 대해 충돌하는 정보가 있습니다.
 {1}</target>
         <note>{StrBegin="NETSDK1133: "}</note>
       </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <target state="translated">NETSDK1014: '{0}'의 콘텐츠 항목이 '{1}'을(를) 설정하지만, '{2}' 또는 '{3}'을(를) 제공하지 않습니다.</target>
         <note>{StrBegin="NETSDK1014: "}</note>
       </trans-unit>
       <trans-unit id="ContentPreproccessorParameterRequired">
         <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <target state="translated">NETSDK1010: 전처리된 콘텐츠를 사용하려면 '{0}' 작업에서 '{1}' 매개 변수의 값을 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1010: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesNotExist_Info">
         <source>Could not determine winner because '{0}' does not exist.</source>
-        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <target state="translated">'{0}'이(가) 존재하지 않기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_EqualVersions_Info">
         <source>Could not determine winner due to equal file and assembly versions.</source>
-        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <target state="translated">동일한 파일 및 어셈블리 버전으로 인해 적용되는 내용을 확인할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NoFileVersion_Info">
         <source>Could not determine a winner because '{0}' has no file version.</source>
-        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <target state="translated">'{0}'에 파일 버전이 없기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NotAnAssembly_Info">
         <source>Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <target state="translated">'{0}'이(가) 어셈블리가 아니기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
         <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
-        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <target state="translated">NETSDK1181: 팩 버전 가져오기 오류: {0} 팩이 워크로드 매니페스트에 없습니다.</target>
         <note>{StrBegin="NETSDK1181: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <target state="translated">NETSDK1042: PlatformManifest가 존재하지 않기 때문에 '{0}'에서 로드할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1042: "}</note>
       </trans-unit>
       <trans-unit id="CppRequiresTFMVersion31">
         <source>NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</source>
-        <target state="new">NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</target>
+        <target state="translated">NETSDK1120: .NET Core를 대상으로 하는 C++/CLI 프로젝트에 'netcoreapp3.1' 이상의 대상 프레임워크가 필요합니다.</target>
         <note>{StrBegin="NETSDK1120: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2MissingRequiredMetadata">
         <source>NETSDK1158: Required '{0}' metadata missing on Crossgen2Tool item.</source>
-        <target state="new">NETSDK1158: Required '{0}' metadata missing on Crossgen2Tool item.</target>
+        <target state="translated">NETSDK1158: Crossgen2Tool 항목에 필요한 '{0}' 메타데이터가 없습니다.</target>
         <note>{StrBegin="NETSDK1158: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2RequiresSelfContained">
         <source>NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</source>
-        <target state="new">NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</target>
+        <target state="translated">NETSDK1126: Crossgen2를 사용한 ReadyToRun 게시는 자체 포함 애플리케이션에서만 지원됩니다.</target>
         <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolExecutableNotFound">
         <source>NETSDK1155: Crossgen2Tool executable '{0}' not found.</source>
-        <target state="new">NETSDK1155: Crossgen2Tool executable '{0}' not found.</target>
+        <target state="translated">NETSDK1155: Crossgen2Tool 실행 파일 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1155: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolMissingWhenUseCrossgen2IsSet">
         <source>NETSDK1154: Crossgen2Tool must be specified when UseCrossgen2 is set to true.</source>
-        <target state="new">NETSDK1154: Crossgen2Tool must be specified when UseCrossgen2 is set to true.</target>
+        <target state="translated">NETSDK1154: UseCrossgen2가 true로 설정된 경우 Crossgen2Tool을 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1154: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
-        <target state="new">NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</target>
+        <target state="translated">NETSDK1166: 복합 모드를 사용하여 Crossgen2를 사용하여 .NET 5에 게시할 때 기호를 내보낼 수 없습니다.</target>
         <note>{StrBegin="NETSDK1166: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolExecutableNotFound">
         <source>NETSDK1160: CrossgenTool executable '{0}' not found.</source>
-        <target state="new">NETSDK1160: CrossgenTool executable '{0}' not found.</target>
+        <target state="translated">NETSDK1160: CrossgenTool 실행 파일 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1160: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingInPDBCompilationMode">
         <source>NETSDK1153: CrossgenTool not specified in PDB compilation mode.</source>
-        <target state="new">NETSDK1153: CrossgenTool not specified in PDB compilation mode.</target>
+        <target state="translated">NETSDK1153: PDB 컴파일 모드에 CrossgenTool이 지정되지 않았습니다.</target>
         <note>{StrBegin="NETSDK1153: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingWhenUseCrossgen2IsNotSet">
         <source>NETSDK1159: CrossgenTool must be specified when UseCrossgen2 is set to false.</source>
-        <target state="new">NETSDK1159: CrossgenTool must be specified when UseCrossgen2 is set to false.</target>
+        <target state="translated">NETSDK1159: UseCrossgen2가 false로 설정된 경우 CrossgenTool을 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1159: "}</note>
       </trans-unit>
       <trans-unit id="DiaSymReaderLibraryNotFound">
         <source>NETSDK1161: DiaSymReader library '{0}' not found.</source>
-        <target state="new">NETSDK1161: DiaSymReader library '{0}' not found.</target>
+        <target state="translated">NETSDK1161: DiaSymReader 라이브러리 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1161: "}</note>
       </trans-unit>
       <trans-unit id="DotNetHostExecutableNotFound">
         <source>NETSDK1156: .NET host executable '{0}' not found.</source>
-        <target state="new">NETSDK1156: .NET host executable '{0}' not found.</target>
+        <target state="translated">NETSDK1156: .NET 호스트 실행 파일 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1156: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
         <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <target state="translated">NETSDK1055: DotnetTool가 netcoreapp2.1보다 낮은 대상 프레임워크를 지원하지 않습니다.</target>
         <note>{StrBegin="NETSDK1055: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolOnlySupportNetcoreapp">
         <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <target state="translated">NETSDK1054: .NET Core만 지원합니다.</target>
         <note>{StrBegin="NETSDK1054: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateItemsError">
         <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <target state="translated">NETSDK1022: '{0}' 중복 항목이 포함되었습니다. .NET SDK에는 기본적으로 프로젝트 디렉터리의 '{0}' 항목이 포함됩니다. 프로젝트 파일에서 이러한 항목을 제거하거나, 프로젝트 파일에 해당 항목을 명시적으로 포함하려면 '{1}' 속성을 '{2}'(으)로 설정할 수 있습니다. 자세한 내용은 {4}을(를) 참조하세요. 중복 항목은 다음과 같습니다. {3}</target>
         <note>{StrBegin="NETSDK1022: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePreprocessorToken">
         <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <target state="translated">NETSDK1015: 전처리기 토큰 '{0}'의 값이 두 개 이상 지정되었습니다. '{1}'을(를) 값으로 선택합니다.</target>
         <note>{StrBegin="NETSDK1015: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePublishOutputFiles">
         <source>NETSDK1152: Found multiple publish output files with the same relative path: {0}.</source>
-        <target state="new">NETSDK1152: Found multiple publish output files with the same relative path: {0}.</target>
+        <target state="translated">NETSDK1152: 상대 경로가 같은 여러 게시 출력 파일을 찾았습니다. {0}.</target>
         <note>{StrBegin="NETSDK1152: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateRuntimePackAsset">
         <source>NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="new">NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="translated">NETSDK1110: 런타임 팩에 있는 두 개 이상 자산에 동일한 대상 하위 경로인 '{0}'이(가) 있습니다. https://aka.ms/dotnet-sdk-issue에서 .NET 팀에 이 오류를 보고하세요.</target>
         <note>{StrBegin="NETSDK1110: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateTypeLibraryIds">
         <source>NETSDK1169: The same resource ID {0} was specified for two type libraries '{1}' and '{2}'. Duplicate type library IDs are not allowed.</source>
-        <target state="new">NETSDK1169: The same resource ID {0} was specified for two type libraries '{1}' and '{2}'. Duplicate type library IDs are not allowed.</target>
+        <target state="translated">NETSDK1169: 두 형식 라이브러리 '{1}' 및 '{2}'에 대해 동일한 리소스 ID {0}가 지정되었습니다. 중복 형식 라이브러리 ID는 허용되지 않습니다.</target>
         <note>{StrBegin="NETSDK1169: "}</note>
       </trans-unit>
       <trans-unit id="EncounteredConflict_Info">
         <source>Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <target state="translated">'{0}'과(와) '{1}' 사이에 충돌이 발생했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">
         <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <target state="translated">NETSDK1051: '{0}'의 FrameworkList를 구문 분석하는 동안 오류가 발생했습니다. {1} '{2}'이(가) 잘못되었습니다.</target>
         <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <target state="translated">NETSDK1043: '{0}' 줄 {1}에서 PlatformManifest를 구문 분석하는 중 오류가 발생했습니다. 줄이 {2} 형식이어야 합니다.</target>
         <note>{StrBegin="NETSDK1043: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <target state="translated">NETSDK1044: '{0}' 줄 {1}에서 PlatformManifest를 구문 분석하는 중 오류가 발생했습니다. {2} '{3}'이(가) 잘못되었습니다.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">
         <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <target state="translated">NETSDK1060: 자산 파일 {0}을(를) 읽는 동안 오류가 발생했습니다.</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
       <trans-unit id="FailedToDeleteApphost">
         <source>NETSDK1111: Failed to delete output apphost: {0}</source>
-        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <target state="translated">NETSDK1111: 출력 apphost를 삭제하지 못했습니다. {0}</target>
         <note>{StrBegin="NETSDK1111: "}</note>
       </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="new">NETSDK1077: Failed to lock resource.</target>
+        <target state="translated">NETSDK1077: 리소스를 잠그지 못했습니다.</target>
         <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
       <trans-unit id="FileNameIsTooLong">
         <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <target state="translated">NETSDK1030: 제공한 파일 이름 '{0}'이(가) 1024바이트보다 깁니다.</target>
         <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
       <trans-unit id="FolderAlreadyExists">
         <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <target state="translated">NETSDK1024: '{0}' 폴더가 이미 있습니다. 폴더를 삭제하거나 다른 ComposeWorkingDir을 제공하세요.</target>
         <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <target state="translated">NETSDK1068: 프레임워크 종속 애플리케이션 호스트는 'netcoreapp2.1' 이상의 대상 프레임워크가 필요합니다.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <target state="translated">NETSDK1052: 프레임워크 목록 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceDuplicateError">
         <source>NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</source>
-        <target state="new">NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</target>
+        <target state="translated">NETSDK1087: 프로젝트에 '{0}'에 대한 여러 FrameworkReference 항목이 포함되었습니다.</target>
         <note>{StrBegin="NETSDK1087: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceOverrideWarning">
         <source>NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="new">NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <target state="translated">NETSDK1086: '{0}'에 대한 FrameworkReference가 프로젝트에 포함되었습니다. 이는 .NET SDK에서 암시적으로 참조되며, 일반적으로 사용자가 프로젝트에서 참조할 필요가 없습니다. 자세한 내용은 {1}을(를) 참조하세요.</target>
         <note>{StrBegin="NETSDK1086: "}</note>
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
         <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <target state="translated">NETSDK1049: 확인된 파일의 이미지가 잘못되었거나, 메타데이터가 없거나, 파일 자체에 액세스할 수 없습니다. {0} {1}</target>
         <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
       <trans-unit id="GlobalJsonSDKResolutionFailed">
         <source>NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</source>
-        <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
+        <target state="translated">NETSDK1141: {0}에서 global.json에 지정된 .NET SDK 버전을 확인할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
         <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
+        <target state="translated">NETSDK1144: 어셈블리의 크기를 최적화하지 못했습니다. PublishTrimmed 속성을 false로 설정하여 최적화를 사용하지 않도록 설정할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNoValidRuntimePackageError">
@@ -466,90 +466,90 @@
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
-        <target state="new">NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</target>
+        <target state="translated">NETSDK1102: 선택한 게시 구성에서는 크기에 대한 어셈블리 최적화가 지원되지 않습니다. 자체 포함 앱을 게시하고 있는지 확인하세요.</target>
         <note>{StrBegin="NETSDK1102: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkOptimizedAssemblies">
         <source>Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</source>
-        <target state="new">Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</target>
+        <target state="translated">크기에 맞게 어셈블리를 최적화하면 앱의 동작이 변경될 수 있습니다. 퍼블리싱 후 꼭 테스트 해보세요. 참조: https://aka.ms/dotnet-illink</target>
         <note />
       </trans-unit>
       <trans-unit id="ILLinkRunning">
         <source>Optimizing assemblies for size. This process might take a while.</source>
-        <target state="new">Optimizing assemblies for size. This process might take a while.</target>
+        <target state="translated">크기에 맞게 어셈블리 최적화. 이 프로세스는 시간이 걸릴 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed">
         <source>NETSDK1191: A runtime identifier for the property '{0}' couldn't be inferred. Specify a rid explicitly.</source>
-        <target state="new">NETSDK1191: A runtime identifier for the property '{0}' couldn't be inferred. Specify a rid explicitly.</target>
+        <target state="translated">NETSDK1191: '{0}' 속성의 런타임 식별자를 유추할 수 없습니다. RID를 명시적으로 지정하세요.</target>
         <note>{StrBegin="NETSDK1191: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectPackageRoot">
         <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <target state="translated">NETSDK1020: 패키지 루트 {0}이(가) 확인된 라이브러리 {1}에 대해 잘못 지정되었습니다.</target>
         <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectTargetFormat">
         <source>NETSDK1025: The target manifest {0} provided is of not the correct format</source>
-        <target state="new">NETSDK1025: The target manifest {0} provided is of not the correct format</target>
+        <target state="translated">NETSDK1025: 제공한 대상 매니페스트 {0}이(가) 올바른 형식이 아닙니다.</target>
         <note>{StrBegin="NETSDK1025: "}</note>
       </trans-unit>
       <trans-unit id="InputAssemblyNotFound">
         <source>NETSDK1163: Input assembly '{0}' not found.</source>
-        <target state="new">NETSDK1163: Input assembly '{0}' not found.</target>
+        <target state="translated">NETSDK1163: 입력 어셈블리 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1163: "}</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <target state="translated">NETSDK1003: 프레임워크 이름 '{0}'이(가) 잘못되었습니다.</target>
         <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <target state="translated">NETSDK1058: ItemSpecToUse 매개 변수 값이 잘못되었습니다. '{0}'. 이 속성은 비워 두거나 'Left' 또는 'Right'로 설정해야 합니다.</target>
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionString">
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <target state="translated">NETSDK1018: NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidResourceUpdate">
         <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="new">NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</target>
+        <target state="translated">NETSDK1075: 업데이트 핸들이 잘못되었습니다. 이 인스턴스는 추가 업데이트에 사용되지 않을 수 있습니다.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="InvalidRollForwardValue">
         <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
-        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <target state="translated">NETSDK1104: RollForward 값 '{0}'이(가) 잘못되었습니다. 허용되는 값은 {1}입니다.</target>
         <note>{StrBegin="NETSDK1104: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTargetPlatformVersion">
         <source>NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
 {2}</source>
-        <target state="new">NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
+        <target state="translated">NETSDK1140: {0}은(는) {1}에 대한 유효한 TargetPlatformVersion이 아닙니다. 유효한 버전은 다음과 같습니다.
 {2}</target>
         <note>{StrBegin="NETSDK1140: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibrary">
         <source>NETSDK1173: The provided type library '{0}' is in an invalid format.</source>
-        <target state="new">NETSDK1173: The provided type library '{0}' is in an invalid format.</target>
+        <target state="translated">NETSDK1173: 제공된 형식 라이브러리 '{0}'의 형식이 잘못되었습니다.</target>
         <note>{StrBegin="NETSDK1173: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibraryId">
         <source>NETSDK1170: The provided type library ID '{0}' for type library '{1}' is invalid. The ID must be a positive integer less than 65536.</source>
-        <target state="new">NETSDK1170: The provided type library ID '{0}' for type library '{1}' is invalid. The ID must be a positive integer less than 65536.</target>
+        <target state="translated">NETSDK1170: '{1}' 형식 라이브러리에 대해 제공된 형식 라이브러리 ID '{0}'이(가) 잘못되었습니다. ID는 65536보다 작은 양의 정수여야 합니다.</target>
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
-        <target state="new">NETSDK1157: JIT library '{0}' not found.</target>
+        <target state="translated">NETSDK1157: JIT 라이브러리 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <target state="translated">NETSDK1061: {0} 버전 {1}을(를) 사용하여 프로젝트가 복원되었지만, 현재 설정에서는 버전 {2}을(를) 대신 사용합니다. 이 문제를 해결하려면 복원 및 후속 작업(예: 빌드 또는 게시)에 동일한 설정을 사용해야 합니다. 일반적으로 이 문제는 RuntimeIdentifier 속성이 빌드 또는 게시 중에 설정되었지만, 복원 중에는 설정되지 않은 경우에 발생할 수 있습니다. 자세한 내용은 https://aka.ms/dotnet-runtime-patch-selection을 참조하세요.</target>
         <note>{StrBegin="NETSDK1061: "}
 {0} - Package Identifier for platform package
 {1} - Restored version of platform package
@@ -557,172 +557,172 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="MissingItemMetadata">
         <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <target state="translated">NETSDK1008: '{1}' 항목 '{2}'에 '{0}' 메타데이터가 없습니다.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputPDBImagePath">
         <source>NETSDK1164: Missing output PDB path in PDB generation mode (OutputPDBImage metadata).</source>
-        <target state="new">NETSDK1164: Missing output PDB path in PDB generation mode (OutputPDBImage metadata).</target>
+        <target state="translated">NETSDK1164: PDB 생성 모드(OutputPDBImage 메타데이터)에 출력 PDB 경로가 없습니다.</target>
         <note>{StrBegin="NETSDK1164: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputR2RImageFileName">
         <source>NETSDK1165: Missing output R2R image path (OutputR2RImage metadata).</source>
-        <target state="new">NETSDK1165: Missing output R2R image path (OutputR2RImage metadata).</target>
+        <target state="translated">NETSDK1165: 출력 R2R 이미지 경로(OutputR2RImage 메타데이터)가 없습니다.</target>
         <note>{StrBegin="NETSDK1165: "}</note>
       </trans-unit>
       <trans-unit id="MissingTypeLibraryId">
         <source>NETSDK1171: An integer ID less than 65536 must be provided for type library '{0}' because more than one type library is specified.</source>
-        <target state="new">NETSDK1171: An integer ID less than 65536 must be provided for type library '{0}' because more than one type library is specified.</target>
+        <target state="translated">NETSDK1171: 두 개 이상의 형식 라이브러리가 지정되었기 때문에 형식 라이브러리 '{0}'에 대해 65536보다 작은 정수 ID를 제공해야 합니다.</target>
         <note>{StrBegin="NETSDK1171: "}</note>
       </trans-unit>
       <trans-unit id="MultipleFilesResolved">
         <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <target state="translated">NETSDK1021: {0}에 대해 두 개 이상의 파일을 찾았습니다.</target>
         <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="new">NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <target state="translated">NETSDK1069: 이 프로젝트는 .NET Standard 1.5 이상을 대상으로 하는 라이브러리를 사용하며, 이 프로젝트는 해당 버전의 .NET Standard를 기본으로 제공하지 않는 .NET Framework 버전을 대상으로 합니다. 알려진 문제에 대해서는 https://aka.ms/net-standard-known-issues를 참조하세요. .NET Framework 4.7.2로 대상을 다시 지정해 보세요.</target>
         <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkWithoutUsingNETSdkDefaults">
         <source>NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</source>
-        <target state="new">NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</target>
+        <target state="translated">NETSDK1115: 현재 .NET SDK는 .NET SDK 기본값을 사용하지 않는 .NET Framework를 지원하지 않습니다. C++/CLI 프로젝트 CLRSupport 속성과 TargetFramework 사이의 불일치 때문일 수 있습니다.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
         <source>NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</source>
-        <target state="new">NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</target>
+        <target state="translated">NETSDK1182: Visual Studio 2019에서 .NET 6.0 이상을 대상으로 하는 것은 지원되지 않습니다.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="Net7NotCompatibleWithDev173">
         <source>NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.</source>
-        <target state="new">NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.</target>
+        <target state="translated">NETSDK1192: Visual Studio 2022 17.3에서 .NET 7.0 이상을 대상으로 하는 것은 지원되지 않습니다.</target>
         <note>{StrBegin="NETSDK1192: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <target state="translated">NETSDK1084: 지정된 RuntimeIdentifier '{0}'에 사용할 수 있는 애플리케이션 호스트가 없습니다.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
       <trans-unit id="NoBuildRequested">
         <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
-        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <target state="translated">NETSDK1085: 'NoBuild' 속성이 true로 설정되었지만, 'Build' 대상이 호출되었습니다.</target>
         <note>{StrBegin="NETSDK1085: "}</note>
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
+        <target state="translated">NETSDK1002: '{0}' 프로젝트가 '{2}'을(를) 대상으로 합니다. '{1}'을(를) 대상으로 하는 프로젝트에서 참조할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackAvailable">
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <target state="translated">NETSDK1082: 지정된 RuntimeIdentifier '{1}'에 사용할 수 있는 {0}용 런타임 팩이 없습니다.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackInformation">
         <source>NETSDK1132: No runtime pack information was available for {0}.</source>
-        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <target state="translated">NETSDK1132: {0}에 사용할 수 있는 런타임 팩 정보가 없습니다.</target>
         <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
-        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <target state="translated">NETSDK1128: COM 호스팅에서는 자체 포함 배포가 지원되지 않습니다.</target>
         <note>{StrBegin="NETSDK1128: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
-        <target state="new">NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</target>
+        <target state="translated">NETSDK1119: .NET Core를 대상으로 하는 C++/CLI 프로젝트는 EnableComHosting=true를 사용할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1119: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppNonDynamicLibraryDotnetCore">
         <source>NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</source>
-        <target state="new">NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</target>
+        <target state="translated">NETSDK1116: .NET Core를 대상으로 하는 C++/CLI 프로젝트는 동적 라이브러리여야 합니다.</target>
         <note>{StrBegin="NETSDK1116: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPackDotnetCore">
         <source>NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</source>
-        <target state="new">NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</target>
+        <target state="translated">NETSDK1118: .NET Core를 대상으로 하는 C++/CLI 프로젝트를 압축할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1118: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPublishDotnetCore">
         <source>NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</source>
-        <target state="new">NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</target>
+        <target state="translated">NETSDK1117: dotnet core를 대상으로 하는 C++/CLI 프로젝트 게시를 지원하지 않습니다.</target>
         <note>{StrBegin="NETSDK1117: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppSelfContained">
         <source>NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</source>
-        <target state="new">NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</target>
+        <target state="translated">NETSDK1121: .NET Core를 대상으로 하는 C++/CLI 프로젝트는 SelfContained=true를 사용할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
       <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
         <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</source>
-        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</target>
+        <target state="translated">NETSDK1151: 참조된 프로젝트 '{0}'은(는) self-contained 실행 파일입니다. self-contained 실행 파일은 self-contained가 아닌 실행 파일에서 참조할 수 없습니다. 자세한 내용은 https://aka.ms/netsdk1151을 참조하세요</target>
         <note>{StrBegin="NETSDK1151: "}</note>
       </trans-unit>
       <trans-unit id="PDBGeneratorInputExecutableNotFound">
         <source>NETSDK1162: PDB generation: R2R executable '{0}' not found.</source>
-        <target state="new">NETSDK1162: PDB generation: R2R executable '{0}' not found.</target>
+        <target state="translated">NETSDK1162: PDB 생성: R2R 실행 파일 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1162: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <target state="translated">NETSDK1053: 도구로서 팩은 자체 포함을 지원하지 않습니다.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
         <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
-        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
+        <target state="translated">NETSDK1146: PackAsTool은 설정 중인 TargetPlatformIdentifier를 지원하지 않습니다. 예를 들어, TargetFramework는 net5.0-windows를 사용할 수 없으며 net5.0만 지원합니다. 또한 PackAsTool은 .NET 5 이상을 대상으로 하는 경우 UseWPF 또는 UseWindowsForms를 지원하지 않습니다.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageContainsIncorrectlyCasedLocale">
         <source>NETSDK1187: Package {0} {1} has a resource with the locale '{2}'. This locale has been normalized to the standard format '{3}' to prevent casing issues in the build. Consider notifying the package author about this casing issue.</source>
-        <target state="new">NETSDK1187: Package {0} {1} has a resource with the locale '{2}'. This locale has been normalized to the standard format '{3}' to prevent casing issues in the build. Consider notifying the package author about this casing issue.</target>
+        <target state="translated">NETSDK1187: 패키지 {0} {1}에 로캘이 '{2}'인 리소스가 있습니다. 이 로캘은 빌드에서 대/소문자 문제를 방지하기 위해 표준 형식 '{3}'(으)로 정규화되었습니다. 패키지 작성자에게 이 대/소문자 문제에 대해 알리는 것이 좋습니다.</target>
         <note>Error code is NETSDK1187. 0 is a package name, 1 is a package version, 2 is the incorrect locale string, and 3 is the correct locale string.</note>
       </trans-unit>
       <trans-unit id="PackageContainsUnknownLocale">
         <source>NETSDK1188: Package {0} {1} has a resource with the locale '{2}'. This locale is not recognized by .NET. Consider notifying the package author that it appears to be using an invalid locale.</source>
-        <target state="new">NETSDK1188: Package {0} {1} has a resource with the locale '{2}'. This locale is not recognized by .NET. Consider notifying the package author that it appears to be using an invalid locale.</target>
+        <target state="translated">NETSDK1188: 패키지 {0} {1}에는 로캘이 '{2}'인 리소스가 있습니다. 이 로캘은 .NET에서 인식할 수 없습니다. 패키지 작성자에게 잘못된 로캘을 사용하는 것 같다고 알리는 것이 좋습니다.</target>
         <note>Error code is NETSDK1188. 0 is a package name, 1 is a package version, and 2 is the incorrect locale string</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
+        <target state="translated">NETSDK1064: 패키지 {0}, 버전 {1}을(를) 찾을 수 없습니다. NuGet 복원 이후 삭제되었을 수 있습니다. 아니면, 최대 경로 길이 제한으로 인해 NuGet 복원이 부분적으로만 완료되었을 수 있습니다.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceOverrideWarning">
         <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <target state="translated">NETSDK1023: '{0}'에 대한 PackageReference가 프로젝트에 포함되어 있습니다. 이 패키지는 .NET SDK에서 암시적으로 참조되며, 일반적으로 사용자가 프로젝트에서 참조할 필요가 없습니다. 자세한 내용은 {1}을(를) 참조하세요.</target>
         <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceVersionNotRecommended">
         <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <target state="translated">NETSDK1071: '{0}'에 대한 PackageReference에서 `{1}`의 버전을 지정했습니다. 이 패키지의 버전을 지정하지 않는 것이 좋습니다. 자세한 내용은 https://aka.ms/sdkimplicitrefs를 참조하세요.</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
         <source>NETSDK1174: Placeholder</source>
-        <target state="new">NETSDK1174: Placeholder</target>
+        <target state="translated">NETSDK1174: 자리 표시자</target>
         <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
       </trans-unit>
       <trans-unit id="Prefer32BitIgnoredForNetCoreApp">
         <source>NETSDK1189: Prefer32Bit is not supported and has no effect for netcoreapp target.</source>
-        <target state="new">NETSDK1189: Prefer32Bit is not supported and has no effect for netcoreapp target.</target>
+        <target state="translated">NETSDK1189: Prefer32Bit는 지원되지 않으며 netcoreapp 대상에는 영향을 주지 않습니다.</target>
         <note>{StrBegin="NETSDK1189: "}</note>
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
+        <target state="translated">NETSDK1011: '{0}' 프로젝트의 자산이 사용되었지만, '{1}'에서 해당 MSBuild 프로젝트 경로를 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1011: "}</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
         <source>NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <target state="translated">NETSDK1059: '{0}' 도구가 현재 .NET SDK에 포함되어 있습니다. 이 경고를 해결하는 방법은 https://aka.ms/dotnetclitools-in-box를 참조하세요.</target>
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
         <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="new">NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</target>
+        <target state="translated">NETSDK1093: 프로젝트 도구(DotnetCliTool)는 .NET Core 2.2 이하를 대상으로 하는 경우만 지원합니다.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
@@ -732,92 +732,92 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1122: ReadyToRun 컴파일은 .NET Core 3.0 이상에서만 지원되므로 건너뜁니다.</target>
         <note>{StrBegin="NETSDK1122: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedMustBeBool">
         <source>NETSDK1193: If PublishSelfContained is set, it must be either true or false. The value given was '{0}'.</source>
-        <target state="new">NETSDK1193: If PublishSelfContained is set, it must be either true or false. The value given was '{0}'.</target>
+        <target state="translated">NETSDK1193: PublishSelfContained가 설정된 경우 true 또는 false여야 합니다. 지정된 값은 '{0}'입니다.</target>
         <note>{StrBegin="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1123: 애플리케이션을 단일 파일에 게시하려면 .NET Core 3.0 이상이 필요합니다.</target>
         <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="PublishTrimmedRequiresVersion30">
         <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1124: 어셈블리를 트리밍하려면 .NET Core 3.0 이상이 필요합니다.</target>
         <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="PublishUnsupportedWithoutTargetFramework">
         <source>NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</source>
-        <target state="new">NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</target>
+        <target state="translated">NETSDK1129: 대상 프레임워크를 지정하지 않고 'Publish' 대상을 사용할 수 없습니다. 현재 프로젝트가 여러 프레임워크를 대상으로 하므로 게시된 애플리케이션의 프레임워크를 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1129: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>
-        <target state="new">NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</target>
+        <target state="translated">NETSDK1096: 성능 향상을 위해 어셈블리를 최적화하지 못했습니다. 오류가 발생하는 어셈블리를 최적화에서 제외하거나 PublishReadyToRun 속성을 false로 설정할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
         <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
-        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <target state="translated">일부 ReadyToRun 컴파일에서 잠재적인 종속성 누락을 나타내는 경고를 발생했습니다. 종속성 누락으로 인해 런타임 오류가 잠재적으로 발생할 수 있습니다. 경고를 표시하려면 PublishReadyToRunShowWarnings 속성을 true로 설정하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing and make sure to restore packages with the PublishReadyToRun property set to true.</source>
-        <target state="new">NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing and make sure to restore packages with the PublishReadyToRun property set to true.</target>
+        <target state="needs-review-translation">NETSDK1094: 성능을 위해 어셈블리를 최적화할 수 없습니다. 유효한 런타임 패키지를 찾을 수 없습니다. PublishReadyToRun 속성을 false로 설정하거나 게시할 때 지원되는 런타임 식별자를 사용하세요. .NET 6 이상을 대상으로 하는 경우 PublishReadyToRun 속성이 true로 설정된 패키지를 복원해야 합니다.</target>
         <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunTargetNotSupportedError">
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
-        <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
+        <target state="translated">NETSDK1095: 선택한 대상 플랫폼 또는 아키텍처의 경우 성능 향상을 위해 어셈블리를 최적화할 수 없습니다. 지원되는 런타임 식별자를 사용하고 있는지 확인하거나 PublishReadyToRun 속성을 false로 설정하세요.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
       </trans-unit>
       <trans-unit id="RollForwardRequiresVersion30">
         <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1103: RollForward 설정은 .NET Core 3.0 이상에서만 지원됩니다.</target>
         <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <target state="translated">NETSDK1083: 지정된 RuntimeIdentifier '{0}'을(를) 인식할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1083: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <target state="translated">NETSDK1028: RuntimeIdentifier 지정</target>
         <note>{StrBegin="NETSDK1028: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeListNotFound">
         <source>NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="new">NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="translated">NETSDK1109: 런타임 목록 파일 '{0}'을(를) 찾을 수 없습니다. https://aka.ms/dotnet-sdk-issue에서 .NET 팀에 이 오류를 보고하세요.</target>
         <note>{StrBegin="NETSDK1109: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotDownloaded">
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</target>
+        <target state="translated">NETSDK1112: {0}용 런타임 팩이 다운로드되지 않았습니다. RuntimeIdentifier '{1}'을(를) 사용하여 NuGet 복원을 실행해 보세요.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
         <source>NETSDK1185: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1185: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <target state="translated">NETSDK1185: FrameworkReference '{0}'용 런타임 팩을 사용할 수 없습니다. DisableTransitiveFrameworkReferenceDownloads가 true로 설정되었기 때문일 수 있습니다.</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
-        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</target>
+        <target state="translated">NETSDK1150: 참조된 프로젝트 '{0}'은(는) self-contained가 아닌 실행 파일입니다. self-contained가 아닌  실행 파일은 self-contained 실행 파일에서 참조할 수 없습니다. 자세한 내용은 https://aka.ms/netsdk1150을 참조하세요</target>
         <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionShouldBeUsedWithRuntime">
         <source>NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</source>
-        <target state="new">NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</target>
+        <target state="translated">NETSDK1179: '--runtime'을 사용하는 경우 '--no-self-contained' 또는 '--no-self-contained' 옵션 중 하나가 필요합니다.</target>
         <note>{StrBegin="NETSDK1179: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <target state="translated">NETSDK1048: GenerateRuntimeConfigurationFiles에 대해 'AdditionalProbingPaths'가 지정되었지만 'RuntimeConfigDevPath'가 비어 있어서 건너뜁니다.</target>
         <note>{StrBegin="NETSDK1048: "}</note>
       </trans-unit>
       <trans-unit id="SolutionProjectConfigurationsConflict">
@@ -829,171 +829,171 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="TargetFrameworkIsEol">
         <source>NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
-        <target state="new">NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <target state="translated">NETSDK1138: 대상 프레임워크 '{0}'은(는) 지원되지 않으며 향후 보안 업데이트를 받을 수 없습니다. 지원 정책에 대한 자세한 내용은 {1}을(를) 참조하세요.</target>
         <note>{StrBegin="NETSDK1138: "}</note>
       </trans-unit>
       <trans-unit id="TargetFrameworkWithSemicolon">
         <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <target state="translated">NETSDK1046: TargetFramework 값 '{0}'이(가) 잘못되었습니다. 여러 대상을 지정하려면 'TargetFrameworks' 속성을 대신 사용하세요.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
       <trans-unit id="TargetingApphostPackMissingCannotRestore">
         <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
-        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <target state="translated">NETSDK1145: {0} 팩이 설치되지 않았으며 NuGet 패키지 복원이 지원되지 않습니다. Visual Studio를 업그레이드하고, 특정 SDK 버전을 지정하는 경우 global.json을 제거하고, 최신 SDK를 설치하세요. 더 많은 옵션을 보려면 https://aka.ms/targeting-apphost-pack-missing을 방문하세요. 팩 형식: {0}, 팩 디렉터리: {1}, 대상 프레임워크: {2}, 팩 패키지 ID: {3}, 팩 패키지 버전: {4}</target>
         <note>{StrBegin="NETSDK1145: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
-        <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>
+        <target state="translated">NETSDK1127: 타기팅 팩 {0}이(가) 설치되어 있지 않습니다. 복원한 후 다시 시도하세요.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
         <source>NETSDK1184: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <target state="translated">NETSDK1184: FrameworkReference '{0}'에 대한 대상 지정 팩을 사용할 수 없습니다. DisableTransitiveFrameworkReferenceDownloads가 true로 설정되었기 때문일 수 있습니다.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>
-        <target state="new">NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</target>
+        <target state="translated">NETSDK1175: 트리밍을 사용하도록 설정하면 Windows Forms이 지원되지 않거나 권장되지 않습니다. 자세한 내용은 https://aka.ms/dotnet-illink/windows-forms를 참조하세요.</target>
         <note>{StrBegin="NETSDK1175: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWpfIsNotSupported">
         <source>NETSDK1168: WPF is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/wpf for more details.</source>
-        <target state="new">NETSDK1168: WPF is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/wpf for more details.</target>
+        <target state="translated">NETSDK1168: 트리밍을 사용하도록 설정하면 WPF가 지원되지 않거나 권장되지 않습니다. 자세한 내용은 https://aka.ms/dotnet-illink/wpf로 이동하세요.</target>
         <note>{StrBegin="NETSDK1168: "}</note>
       </trans-unit>
       <trans-unit id="TypeLibraryDoesNotExist">
         <source>NETSDK1172: The provided type library '{0}' does not exist.</source>
-        <target state="new">NETSDK1172: The provided type library '{0}' does not exist.</target>
+        <target state="translated">NETSDK1172: 제공된 형식 라이브러리 '{0}'이(가) 없습니다.</target>
         <note>{StrBegin="NETSDK1172: "}</note>
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
+        <target state="translated">NETSDK1016: '{0}'에 대해 확인된 경로를 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1016: "}</note>
       </trans-unit>
       <trans-unit id="UnableToUsePackageAssetsCache_Info">
         <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <target state="translated">I/O 오류로 인해 패키지 자산 캐시를 사용할 수 없습니다. 동일한 프로젝트가 두 번 이상 동시에 빌드되면 이 오류가 발생합니다. 성능이 저하될 수 있지만 빌드 결과는 영향을 받지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedFileType">
         <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <target state="translated">NETSDK1012: '{0}'에 대해 예기치 않은 파일 형식입니다. 형식이 '{1}'인 동시에 '{2}'입니다.</target>
         <note>{StrBegin="NETSDK1012: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference">
         <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="new">NETSDK1073: The FrameworkReference '{0}' was not recognized</target>
+        <target state="translated">NETSDK1073: FrameworkReference '{0}'을(를) 인식할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
         <source>NETSDK1186: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1186: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <target state="translated">NETSDK1186: 이 프로젝트는 프로젝트 또는 NuGet 패키지 참조를 통해 Maui Essentials에 종속되지만 해당 종속성을 명시적으로 선언하지 않습니다. 이 프로젝트를 빌드하려면 UseMauiEssentials 속성을 true로 설정해야 합니다(필요한 경우 Maui 워크로드 설치).</target>
         <note>{StrBegin="NETSDK1186: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
-        <target state="new">NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</target>
+        <target state="translated">NETSDK1137: Microsoft.NET.Sdk.WindowsDesktop SDK를 더 이상 사용할 필요가 없습니다. 루트 프로젝트 요소의 SDK 특성을 'Microsoft.NET.Sdk'로 변경하세요.</target>
         <note>{StrBegin="NETSDK1137: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
+        <target state="translated">NETSDK1009: '{1}'에서 전처리기 토큰 '{0}'을(를) 인식할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1009: "}</note>
       </trans-unit>
       <trans-unit id="UnresolvedTargetingPack">
         <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <target state="translated">NETSDK1081: {0}용 타기팅 팩을 찾을 수 없습니다. 프로젝트에서 NuGet 복원을 실행하여 이 문제를 해결할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1081: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
+        <target state="translated">NETSDK1019: {0}은(는) 지원되지 않는 프레임워크입니다.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
+        <target state="translated">NETSDK1056: 프로젝트가 런타임 '{0}'을(를) 대상으로 하지만 런타임 관련 패키지를 확인하지 않았습니다. 이 런타임은 대상 프레임워크에서 지원되지 않을 수 있습니다.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">
         <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <target state="translated">NETSDK1050: 이 프로젝트에서 사용하는 Microsoft.NET.Sdk 버전은 .NET Standard 1.5 이상을 대상으로 하는 라이브러리에 대한 참조를 지원할 수 없습니다. .NET Core SDK 버전 2.0 이상을 설치하세요.</target>
         <note>{StrBegin="NETSDK1050: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetFrameworkVersion">
         <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <target state="translated">NETSDK1045: 현재 .NET SDK에서는 {0} {1}을(를) 대상으로 하는 것을 지원하지 않습니다. {0} {2} 이하를 대상으로 하거나 {0} {1}을(를) 지원하는 .NET SDK 버전을 사용하세요.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifier">
         <source>NETSDK1139: The target platform identifier {0} was not recognized.</source>
-        <target state="new">NETSDK1139: The target platform identifier {0} was not recognized.</target>
+        <target state="translated">NETSDK1139: 대상 플랫폼 식별자 {0}을(를) 인식할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
-        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <target state="translated">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop을 사용하려면 Windows 데스크톱 애플리케이션을 빌드해야 합니다. 'UseWpf' 및 'UseWindowsForms'는 현재 SDK에서 지원하지 않습니다.</target>
         <note>{StrBegin="NETSDK1107: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdk_Info">
         <source>NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy</source>
-        <target state="new">NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy</target>
+        <target state="translated">NETSDK1057: .NET의 미리 보기 버전을 사용하고 있습니다. 참조: https://aka.ms/dotnet-support-policy</target>
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
+        <target state="translated">NETSDK1131: {0}을(를) 대상으로 지정하는 경우 WinMDExp로 관리형 Windows 메타데이터 구성 요소를 생성하는 것은 지원되지 않습니다.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
         <source>NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</source>
-        <target state="new">NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</target>
+        <target state="translated">NETSDK1130: {1}을(를) 참조할 수 없습니다. .NET 5 이상을 대상으로 하는 경우 Windows 메타데이터 구성 요소를 직접 참조하는 것은 지원되지 않습니다. 자세한 내용은 다음 링크를 참조하세요. https://aka.ms/netsdk1130</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WinMDTransitiveReferenceNotSupported">
         <source>NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</source>
-        <target state="new">NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</target>
+        <target state="translated">NETSDK1149: {0}은(는) 더 이상 .NET 5 이상에서 지원되지 않는 WinRT에 대한 기본 제공 지원을 사용하므로 참조할 수 없습니다.  .NET 5를 지원하는 업데이트된 버전의 구성 요소가 필요합니다. 자세한 내용은 다음 링크를 참조하세요. https://aka.ms/netsdk1149</target>
         <note>{StrBegin="NETSDK1149: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
-        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop을 사용하려면 'UseWpf' 또는 'UseWindowsForms'를 'true'로 설정해야 합니다.</target>
         <note>{StrBegin="NETSDK1106: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
         <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1105: Windows 데스크톱 애플리케이션은 .NET Core 3.0 이상에서만 지원됩니다.</target>
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
-        <target state="new">NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</target>
+        <target state="translated">NETSDK1100: 이 운영 체제에서 Windows를 대상으로 하는 프로젝트를 빌드하려면 EnableWindowsTargeting 속성을 true로 설정합니다.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">
         <source>NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</source>
-        <target state="new">NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</target>
+        <target state="translated">NETSDK1136: Windows Forms 또는 WPF를 사용하거나 그러한 작업을 수행하는 프로젝트 또는 패키지를 참조하는 경우 대상 플랫폼을 Windows로 설정해야 합니다(일반적으로 TargetFramework 속성에 '-windows' 포함).</target>
         <note>{StrBegin="NETSDK1136: "}</note>
       </trans-unit>
       <trans-unit id="WindowsSDKVersionConflicts">
         <source>NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</source>
-        <target state="new">NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</target>
+        <target state="translated">NETSDK1148: 참조된 어셈블리가 최신 버전의 Microsoft.Windows.SDK.NET.dll을 사용하여 컴파일되었습니다. 이 어셈블리를 참조하려면 최신 .NET SDK로 업데이트하세요.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>
-        <target state="new">NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
-You may need to build the project on another operating system or architecture, or update the .NET SDK.</target>
+        <target state="translated">NETSDK1178: 이 설치에서 사용 가능한 워크로드에 존재하지 않는 다음 워크로드 팩에 따라 프로젝트가 달라집니다. {0}
+다른 운영 체제나 아키텍처에서 프로젝트를 빌드하거나 .NET SDK를 업데이트해야 할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1178: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotInstalled">
         <source>NETSDK1147: To build this project, the following workloads must be installed: {0}
 To install these workloads, run the following command: dotnet workload restore</source>
-        <target state="new">NETSDK1147: To build this project, the following workloads must be installed: {0}
-To install these workloads, run the following command: dotnet workload restore</target>
+        <target state="translated">NETSDK1147: 이 프로젝트를 빌드하려면 다음 워크로드를 설치해야 합니다. {0}
+ 이러한 워크로드를 설치하려면 dotnet workload restore 명령을 실행합니다.</target>
         <note>{StrBegin="NETSDK1147: "} LOCALIZATION: Do not localize "dotnet workload restore"</note>
       </trans-unit>
     </body>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
-        <target state="new">NETSDK1076: AddResource can only be used with integer resource types.</target>
+        <target state="translated">NETSDK1076: Element AddResource może być używany tylko z typami zasobów o wartości całkowitej.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
       <trans-unit id="AotNoValidRuntimePackageError">
@@ -19,138 +19,133 @@
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>
+        <target state="translated">NETSDK1070: Plik konfiguracji aplikacji musi mieć główny element konfiguracji.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCreationFailedWithRetry">
         <source>NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</source>
-        <target state="new">NETSDK1113: Failed to create apphost (attempt {0} out of {1}): {2}</target>
+        <target state="translated">NETSDK1113: nie można utworzyć hosta aplikacji (próba {0} z {1}): {2}</target>
         <note>{StrBegin="NETSDK1113: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="new">NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</target>
+        <target state="translated">NETSDK1074: Plik wykonywalny hosta aplikacji nie zostanie dostosowany, ponieważ dodawanie zasobów wymaga, aby kompilacja została wykonana w systemie Windows (z wyjątkiem systemu Nano Server).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
       </trans-unit>
       <trans-unit id="AppHostHasBeenModified">
         <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <target state="translated">NETSDK1029: Nie można użyć elementu „{0}” jako pliku wykonywalnego hosta aplikacji, ponieważ nie zawiera on oczekiwanej sekwencji bajtów symbolu zastępczego „{1}”, która wskazuje lokalizację zapisu nazwy aplikacji.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
-        <target state="new">NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <target state="translated">NETSDK1078: Nie można użyć pliku „{0}” jako pliku wykonywalnego hosta aplikacji, ponieważ nie jest to plik systemu Windows PE.</target>
         <note>{StrBegin="NETSDK1078: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
         <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
+        <target state="translated">NETSDK1072: Nie można użyć pliku „{0}” jako pliku wykonywalnego hosta aplikacji, ponieważ nie jest to plik wykonywalny systemu Windows dla podsystemu CUI (konsola).</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppHostSigningFailed">
         <source>NETSDK1177: Failed to sign apphost with error code {1}: {0}</source>
-        <target state="new">NETSDK1177: Failed to sign apphost with error code {1}: {0}</target>
+        <target state="translated">NETSDK1177: Nie można podpisać hosta aplikacji z kodem błędu {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="new">NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</target>
+        <target state="translated">NETSDK1079: Pakiet Microsoft.AspNetCore.All nie jest obsługiwany w przypadku ukierunkowania na program .NET Core w wersji 3.0 lub wyższej. Zamiast tego powinien zostać użyty element FrameworkReference dla pakietu Microsoft.AspNetCore.App, który zostanie niejawnie uwzględniony przez pakiet Microsoft.NET.Sdk.Web.</target>
         <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreUsesFrameworkReference">
         <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="new">NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</target>
+        <target state="translated">NETSDK1080: Element PackageReference dla pakietu Microsoft.AspNetCore.App nie jest konieczny w przypadku ukierunkowania na program .NET Core w wersji 3.0 lub wyższej. Jeśli używany jest pakiet Microsoft.NET.Sdk.Web, odwołanie do udostępnionej struktury zostanie utworzone automatycznie. W przeciwnym razie element PackageReference powinien zostać zastąpiony elementem FrameworkReference.</target>
         <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <target state="translated">NETSDK1017: Preprocesor zasobów musi być skonfigurowany przed przetworzeniem zasobów.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingRuntimeIdentifier">
         <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <target state="translated">NETSDK1047: Plik zasobów „{0}” nie ma obiektu docelowego dla „{1}”. Upewnij się, że uruchomiono przywracanie i że w elemencie TargetFrameworks dla projektu uwzględniono element „{2}”. Może być też konieczne uwzględnienie elementu „{3}” w obszarze RuntimeIdentifiers projektu.</target>
         <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileMissingTarget">
         <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <target state="translated">NETSDK1005: Plik zasobów „{0}” nie ma obiektu docelowego dla „{1}”. Upewnij się, że uruchomiono przywracanie i że w elemencie TargetFrameworks dla projektu uwzględniono element „{2}”.</target>
         <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotFound">
         <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <target state="translated">NETSDK1004: Nie odnaleziono pliku zasobów „{0}”. Uruchom przywracanie pakietu NuGet, aby wygenerować ten plik.</target>
         <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
         <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <target state="translated">NETSDK1063: Nie ustawiono ścieżki do pliku zasobów projektu. Uruchom przywracanie pakietu NuGet, aby wygenerować ten plik.</target>
         <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
       <trans-unit id="AssetsFilePathNotRooted">
         <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <target state="translated">NETSDK1006: Ścieżka pliku zasobów „{0}” nie prowadzi do katalogu głównego. Tylko pełne ścieżki są obsługiwane.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
+        <target state="translated">NETSDK1001: Należy określić co najmniej jedną możliwą platformę docelową.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
-        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
-        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
-        <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="CannotEmbedClsidMapIntoComhost">
         <source>NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
-        <target state="new">NETSDK1092: The CLSIDMap cannot be embedded on the COM host because adding resources requires that the build be performed on Windows (excluding Nano Server).</target>
+        <target state="translated">NETSDK1092: Nie można osadzić elementu CLSIDMap w ramach hosta modelu COM, ponieważ dodawanie zasobów wymaga, aby kompilacja została wykonana w systemie Windows (z wyjątkiem systemu Nano Server).</target>
         <note>{StrBegin="NETSDK1092: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindApphostForRid">
         <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <target state="translated">NETSDK1065: Nie można odnaleźć hosta aplikacji dla elementu {0}. {0} może być nieprawidłowym identyfikatorem środowiska uruchomieniowego. Aby uzyskać więcej informacji na temat identyfikatora środowiska uruchomieniowego, zobacz https://aka.ms/rid-catalog.</target>
         <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindComhost">
         <source>NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</source>
-        <target state="new">NETSDK1091: Unable to find a .NET Core COM host. The .NET Core COM host is only available on .NET Core 3.0 or higher when targeting Windows.</target>
+        <target state="translated">NETSDK1091: Nie można odnaleźć hosta COM programu .NET Core. Host COM programu .NET Core jest dostępny tylko w programie .NET Core w wersji 3.0 lub wyższej w przypadku ukierunkowania na system Windows.</target>
         <note>{StrBegin="NETSDK1091: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindIjwhost">
         <source>NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</source>
-        <target state="new">NETSDK1114: Unable to find a .NET Core IJW host. The .NET Core IJW host is only available on .NET Core 3.1 or higher when targeting Windows.</target>
+        <target state="translated">NETSDK1114: Nie można znaleźć hosta IJW platformy .NET Core. Host IJW platformy .NET Core jest dostępny tylko na platformie .NET Core w wersji 3.1 lub nowszej w przypadku ukierunkowania na system Windows.</target>
         <note>{StrBegin="NETSDK1114: "}</note>
       </trans-unit>
       <trans-unit id="CannotFindProjectInfo">
         <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <target state="translated">NETSDK1007: Nie odnaleziono informacji o projekcie dla elementu „{0}”. Może to wskazywać na brakujące odwołanie do projektu.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <target state="translated">NETSDK1032: Platforma elementu RuntimeIdentifier „{0}” i element PlatformTarget „{1}” muszą być zgodne.</target>
         <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <target state="translated">NETSDK1031: Kompilowanie i publikowanie aplikacji autonomicznej bez określania elementu RuntimeIdentifier nie jest obsługiwane. Należy określić element RuntimeIdentifier lub ustawić wartość false dla elementu SelfContained.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="translated">NETSDK1097: Publikowanie aplikacji w pojedynczym pliku bez określania elementu RuntimeIdentifier nie jest obsługiwane. Należy określić element RuntimeIdentifier lub ustawić wartość false dla elementu PublishSingleFile.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutAppHost">
         <source>NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. You must either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <target state="translated">NETSDK1098: Aplikacje opublikowane w pojedynczym pliku muszą używać hosta aplikacji. Należy ustawić element PublishSingleFile na wartość false lub ustawić element UseAppHost na wartość true.</target>
         <note>{StrBegin="NETSDK1098: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSingleFileWithoutExecutable">
         <source>NETSDK1099: Publishing to a single-file is only supported for executable applications.</source>
-        <target state="new">NETSDK1099: Publishing to a single-file is only supported for executable applications.</target>
+        <target state="translated">NETSDK1099: Publikowanie w pojedynczym pliku jest obsługiwane tylko dla aplikacji wykonywalnych.</target>
         <note>{StrBegin="NETSDK1099: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1097: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSolutionLevelOutputPath">
         <source>NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds.</source>
@@ -164,57 +159,62 @@
       </trans-unit>
       <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
         <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <target state="translated">NETSDK1135: Element SupportedOSPlatformVersion {0} nie może być większy niż element TargetPlatformVersion {1}.</target>
         <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>
-        <target state="new">NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</target>
+        <target state="translated">NETSDK1143: Dołączanie całej zawartości w pojedynczym pakiecie plików obejmuje również biblioteki natywne. Jeśli element IncludeAllContentForSelfExtract ma wartość true, element IncludeNativeLibrariesForSelfExtract nie może mieć wartości false.</target>
         <note>{StrBegin="NETSDK1143: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeSymbolsInSingleFile">
         <source>NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</source>
-        <target state="new">NETSDK1142: Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.</target>
+        <target state="translated">NETSDK1142: Dołączanie symboli w pojedynczym pakiecie plików nie jest obsługiwane w przypadku publikowania dla dla platformy .NET5 lub nowszej.</target>
         <note>{StrBegin="NETSDK1142: "}</note>
       </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <target state="translated">NETSDK1013: Nie rozpoznano wartości „{0}” elementu TargetFramework. Być może wpisano ją niepoprawnie. Jeśli nie, należy jawnie określić właściwości TargetFrameworkIdentifier i/lub TargetFrameworkVersion.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <target state="translated">NETSDK1067: Aplikacje autonomiczne muszą korzystać z hosta aplikacji. Ustaw parametr SelfContained na wartość false lub parametr UseAppHost na wartość true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="translated">NETSDK1125: Publikowanie do pojedynczego pliku jest obsługiwane tylko w przypadku elementu docelowego netcoreapp.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <target state="translated">Zostanie wybrany element „{0}”, ponieważ wartość atrybutu AssemblyVersion „{1}” jest większa niż „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingCopyLocalArbitrarily_Info">
         <source>Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</source>
-        <target state="new">Choosing '{0}' arbitrarily as both items are copy-local and have equal file and assembly versions.</target>
+        <target state="translated">Arbitralnie zostanie wybrany element „{0}”, ponieważ oba elementy mają włączone kopiowanie lokalne i mają takie same wersje plików i zestawów.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingFileVersion_Info">
         <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <target state="translated">Zostanie wybrany element „{0}”, ponieważ wersja pliku „{1}” jest nowsza niż „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPlatformItem_Info">
         <source>Choosing '{0}' because it is a platform item.</source>
-        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <target state="translated">Zostanie wybrany element „{0}”, ponieważ jest to element platformy.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChoosingPreferredPackage_Info">
         <source>Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <target state="translated">Zostanie wybrany element „{0}”, ponieważ pochodzi on z preferowanego pakietu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClsidMapConflictingGuids">
         <source>NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</source>
-        <target state="new">NETSDK1089: The '{0}' and '{1}' types have the same CLSID '{2}' set in their GuidAttribute. Each COMVisible class needs to have a distinct guid for their CLSID.</target>
+        <target state="translated">NETSDK1089: Typy „{0}” i „{1}” mają ustawiony ten sam identyfikator CLSID „{2}” w ich atrybucie GuidAttribute. Każda klasa COMVisible musi mieć unikatowe identyfikatory GUID dla swojego identyfikatora CLSID.</target>
         <note>{StrBegin="NETSDK1089: "}
 {0} - The first type with the conflicting guid.
 {1} - The second type with the conflicting guid.
@@ -222,241 +222,241 @@
       </trans-unit>
       <trans-unit id="ClsidMapExportedTypesRequireExplicitGuid">
         <source>NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</source>
-        <target state="new">NETSDK1088: The COMVisible class '{0}' must have a GuidAttribute with the CLSID of the class to be made visible to COM in .NET Core.</target>
+        <target state="translated">NETSDK1088: Klasa COMVisible „{0}” musi mieć atrybut GuidAttribute z identyfikatorem CLSID klasy, aby była widoczna dla hosta COM w programie .NET Core.</target>
         <note>{StrBegin="NETSDK1088: "}
 {0} - The ComVisible class that doesn't have a GuidAttribute on it.</note>
       </trans-unit>
       <trans-unit id="ClsidMapInvalidAssembly">
         <source>NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</source>
-        <target state="new">NETSDK1090: The supplied assembly '{0}' is not valid. Cannot generate a CLSIDMap from it.</target>
+        <target state="translated">NETSDK1090: Podany zestaw „{0}” jest nieprawidłowy. Nie można wygenerować elementu CLSIDMap na jego podstawie.</target>
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequires60">
         <source>NETSDK1167: Compression in a single file bundle is only supported when publishing for .NET6 or higher.</source>
-        <target state="new">NETSDK1167: Compression in a single file bundle is only supported when publishing for .NET6 or higher.</target>
+        <target state="translated">NETSDK1167: kompresja w pojedynczym pakiecie plików jest obsługiwana tylko w przypadku publikowania na potrzeby platformy .NET6 lub nowszej wersji.</target>
         <note>{StrBegin="NETSDK1167: "}</note>
       </trans-unit>
       <trans-unit id="CompressionInSingleFileRequiresSelfContained">
         <source>NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.</source>
-        <target state="new">NETSDK1176: Compression in a single file bundle is only supported when publishing a self-contained application.</target>
+        <target state="translated">NETSDK1176: Kompresja w pojedynczym pakiecie plików jest obsługiwana tylko w przypadku publikowania samodzielnych aplikacji.</target>
         <note>{StrBegin="NETSDK1176: "}</note>
       </trans-unit>
       <trans-unit id="ConflictingRuntimePackInformation">
         <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
 {1}</source>
-        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+        <target state="translated">NETSDK1133: Informacje o pakietach środowiska uruchomieniowego dostępnych dla elementu {0} były w konflikcie:
 {1}</target>
         <note>{StrBegin="NETSDK1133: "}</note>
       </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <target state="translated">NETSDK1014: Element zawartości dla elementu „{0}” ustawia wartość „{1}”, ale nie zapewnia wartości „{2}” ani „{3}”.</target>
         <note>{StrBegin="NETSDK1014: "}</note>
       </trans-unit>
       <trans-unit id="ContentPreproccessorParameterRequired">
         <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <target state="translated">NETSDK1010: Dla zadania „{0}” musi zostać podana wartość parametru „{1}” w celu użycia wstępnie przetworzonej zawartości.</target>
         <note>{StrBegin="NETSDK1010: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesNotExist_Info">
         <source>Could not determine winner because '{0}' does not exist.</source>
-        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <target state="translated">Nie można określić wyniku, ponieważ element „{0}” nie istnieje.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_EqualVersions_Info">
         <source>Could not determine winner due to equal file and assembly versions.</source>
-        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <target state="translated">Nie można określić wyniku z powodu takich samych wersji pliku i zestawu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NoFileVersion_Info">
         <source>Could not determine a winner because '{0}' has no file version.</source>
-        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <target state="translated">Nie można określić wyniku, ponieważ element „{0}” nie ma wersji pliku.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NotAnAssembly_Info">
         <source>Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <target state="translated">Nie można określić wyniku, ponieważ element „{0}” nie jest zestawem.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotGetPackVersionFromWorkloadManifests">
         <source>NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</source>
-        <target state="new">NETSDK1181: Error getting pack version: Pack '{0}' was not present in workload manifests.</target>
+        <target state="translated">NETSDK1181: Wystąpił błąd podczas uzyskiwania wersji pakietu: pakiet „{0}” nie był obecny w manifestach obciążenia.</target>
         <note>{StrBegin="NETSDK1181: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <target state="translated">NETSDK1042: Nie można załadować elementu PlatformManifest z lokalizacji „{0}”, ponieważ ta lokalizacja nie istnieje.</target>
         <note>{StrBegin="NETSDK1042: "}</note>
       </trans-unit>
       <trans-unit id="CppRequiresTFMVersion31">
         <source>NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</source>
-        <target state="new">NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</target>
+        <target state="translated">NETSDK1120: Projekty języka C++/interfejsu wiersza polecenia dla platformy .NET Core wymagają co najmniej platformy docelowej „netcoreapp 3.1”.</target>
         <note>{StrBegin="NETSDK1120: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2MissingRequiredMetadata">
         <source>NETSDK1158: Required '{0}' metadata missing on Crossgen2Tool item.</source>
-        <target state="new">NETSDK1158: Required '{0}' metadata missing on Crossgen2Tool item.</target>
+        <target state="translated">NETSDK1158: brak wymaganych metadanych "{0}" w elemencie Crossgen2Tool.</target>
         <note>{StrBegin="NETSDK1158: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2RequiresSelfContained">
         <source>NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</source>
-        <target state="new">NETSDK1126: Publishing ReadyToRun using Crossgen2 is only supported for self-contained applications.</target>
+        <target state="translated">NETSDK1126: Publikowanie elementu ReadyToRun przy użyciu elementu Crossgen2 jest obsługiwane tylko w przypadku aplikacji samodzielnych.</target>
         <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolExecutableNotFound">
         <source>NETSDK1155: Crossgen2Tool executable '{0}' not found.</source>
-        <target state="new">NETSDK1155: Crossgen2Tool executable '{0}' not found.</target>
+        <target state="translated">NETSDK1155: nie znaleziono pliku wykonywalnego "{0}" elementu Crossgen2Tool.</target>
         <note>{StrBegin="NETSDK1155: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen2ToolMissingWhenUseCrossgen2IsSet">
         <source>NETSDK1154: Crossgen2Tool must be specified when UseCrossgen2 is set to true.</source>
-        <target state="new">NETSDK1154: Crossgen2Tool must be specified when UseCrossgen2 is set to true.</target>
+        <target state="translated">NETSDK1154: należy określić element Crossgen2Tool, gdy właściwość UseCrossgen2 jest ustawiona na wartość true.</target>
         <note>{StrBegin="NETSDK1154: "}</note>
       </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
-        <target state="new">NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</target>
+        <target state="translated">NETSDK1166: nie można emitować symboli podczas publikowania w przypadku platformy .NET 5 z Crossgen2 przy użyciu trybu złożonego.</target>
         <note>{StrBegin="NETSDK1166: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolExecutableNotFound">
         <source>NETSDK1160: CrossgenTool executable '{0}' not found.</source>
-        <target state="new">NETSDK1160: CrossgenTool executable '{0}' not found.</target>
+        <target state="translated">NETSDK1160: nie znaleziono pliku wykonywalnego "{0}" elementu CrossgenTool.</target>
         <note>{StrBegin="NETSDK1160: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingInPDBCompilationMode">
         <source>NETSDK1153: CrossgenTool not specified in PDB compilation mode.</source>
-        <target state="new">NETSDK1153: CrossgenTool not specified in PDB compilation mode.</target>
+        <target state="translated">NETSDK1153: nie określono elementu CrossgenTool w trybie kompilacji pliku PDB.</target>
         <note>{StrBegin="NETSDK1153: "}</note>
       </trans-unit>
       <trans-unit id="CrossgenToolMissingWhenUseCrossgen2IsNotSet">
         <source>NETSDK1159: CrossgenTool must be specified when UseCrossgen2 is set to false.</source>
-        <target state="new">NETSDK1159: CrossgenTool must be specified when UseCrossgen2 is set to false.</target>
+        <target state="translated">NETSDK1159: należy określić element CrossgenTool, gdy właściwość UseCrossgen2 jest ustawiona na wartość false.</target>
         <note>{StrBegin="NETSDK1159: "}</note>
       </trans-unit>
       <trans-unit id="DiaSymReaderLibraryNotFound">
         <source>NETSDK1161: DiaSymReader library '{0}' not found.</source>
-        <target state="new">NETSDK1161: DiaSymReader library '{0}' not found.</target>
+        <target state="translated">NETSDK1161: nie znaleziono biblioteki DiaSymReader "{0}".</target>
         <note>{StrBegin="NETSDK1161: "}</note>
       </trans-unit>
       <trans-unit id="DotNetHostExecutableNotFound">
         <source>NETSDK1156: .NET host executable '{0}' not found.</source>
-        <target state="new">NETSDK1156: .NET host executable '{0}' not found.</target>
+        <target state="translated">NETSDK1156: nie znaleziono pliku wykonywalnego "{0}" hosta platformy .NET.</target>
         <note>{StrBegin="NETSDK1156: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
         <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <target state="translated">NETSDK1055: Narzędzie DotnetTool nie obsługuje docelowej struktury w wersji niższej niż netcoreapp2.1.</target>
         <note>{StrBegin="NETSDK1055: "}</note>
       </trans-unit>
       <trans-unit id="DotnetToolOnlySupportNetcoreapp">
         <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <target state="translated">NETSDK1054: obsługuje tylko platformę .NET Core.</target>
         <note>{StrBegin="NETSDK1054: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateItemsError">
         <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <target state="translated">NETSDK1022: Zostały uwzględnione zduplikowane elementy „{0}”. Zestaw .NET SDK dołącza domyślnie elementy „{0}” z katalogu projektu. Możesz usunąć te elementy z pliku projektu lub ustawić dla właściwości „{1}” wartość „{2}”, aby jawnie uwzględnić je w pliku projektu.Aby uzyskać więcej informacji, zobacz {4}. Zduplikowane elementy: {3}</target>
         <note>{StrBegin="NETSDK1022: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePreprocessorToken">
         <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <target state="translated">NETSDK1015: Dla tokenu preprocesora „{0}” podano więcej niż jedną wartość. Wybieranie elementu „{1}” jako wartości.</target>
         <note>{StrBegin="NETSDK1015: "}</note>
       </trans-unit>
       <trans-unit id="DuplicatePublishOutputFiles">
         <source>NETSDK1152: Found multiple publish output files with the same relative path: {0}.</source>
-        <target state="new">NETSDK1152: Found multiple publish output files with the same relative path: {0}.</target>
+        <target state="translated">NETSDK1152: znaleziono wiele opublikowanych plików wyjściowych z taką samą ścieżką względną: {0}.</target>
         <note>{StrBegin="NETSDK1152: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateRuntimePackAsset">
         <source>NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="new">NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="translated">NETSDK1110: Więcej niż jeden zasób w pakiecie środowiska uruchomieniowego ma taką samą docelową ścieżkę podrzędną („{0}”). Zgłoś ten błąd zespołowi platformy .NET tutaj: https://aka.ms/dotnet-sdk-issue.</target>
         <note>{StrBegin="NETSDK1110: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateTypeLibraryIds">
         <source>NETSDK1169: The same resource ID {0} was specified for two type libraries '{1}' and '{2}'. Duplicate type library IDs are not allowed.</source>
-        <target state="new">NETSDK1169: The same resource ID {0} was specified for two type libraries '{1}' and '{2}'. Duplicate type library IDs are not allowed.</target>
+        <target state="translated">NETSDK1169: ten sam identyfikator zasobu {0} został określony dla dwóch bibliotek typów "{1}" i "{2}". Duplikowanie identyfikatorów bibliotek typów jest niedozwolone.</target>
         <note>{StrBegin="NETSDK1169: "}</note>
       </trans-unit>
       <trans-unit id="EncounteredConflict_Info">
         <source>Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <target state="translated">Napotkano konflikt między elementem „{0}” i „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">
         <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <target state="translated">NETSDK1051: Błąd analizowania elementu FrameworkList z elementu „{0}”. Element {1} „{2}” był nieprawidłowy.</target>
         <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <target state="translated">NETSDK1043: Wystąpił błąd podczas analizowania elementu PlatformManifest w wierszu „{0}” {1}. Wiersze muszą mieć format {2}.</target>
         <note>{StrBegin="NETSDK1043: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <target state="translated">NETSDK1044: Wystąpił błąd podczas analizowania elementu PlatformManifest w wierszu „{0}” {1}. Element {2} „{3}” jest nieprawidłowy.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">
         <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <target state="translated">NETSDK1060: Błąd podczas odczytywania pliku zasobów: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
       <trans-unit id="FailedToDeleteApphost">
         <source>NETSDK1111: Failed to delete output apphost: {0}</source>
-        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <target state="translated">NETSDK1111: Nie można usunąć wyjściowego elementu apphost: {0}</target>
         <note>{StrBegin="NETSDK1111: "}</note>
       </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="new">NETSDK1077: Failed to lock resource.</target>
+        <target state="translated">NETSDK1077: Nie można zablokować zasobu.</target>
         <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
       <trans-unit id="FileNameIsTooLong">
         <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <target state="translated">NETSDK1030: Podana nazwa pliku „{0}” jest dłuższa niż 1024 bajty</target>
         <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
       <trans-unit id="FolderAlreadyExists">
         <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <target state="translated">NETSDK1024: Folder „{0}” już istnieje. Usuń go lub podaj inny katalog roboczy tworzenia (ComposeWorkingDir)</target>
         <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <target state="translated">NETSDK1068: Host aplikacji zależnych od platformy wymaga co najmniej platformy docelowej „netcoreapp2.1”.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <target state="translated">NETSDK1052: Ścieżka pliku z listą struktur „{0}” nie zaczyna się od katalogu głównego. Obsługiwane są tylko pełne ścieżki.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceDuplicateError">
         <source>NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</source>
-        <target state="new">NETSDK1087: Multiple FrameworkReference items for '{0}' were included in the project.</target>
+        <target state="translated">NETSDK1087: Wiele elementów FrameworkReference dla obiektu „{0}” zostało uwzględnionych w projekcie.</target>
         <note>{StrBegin="NETSDK1087: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkReferenceOverrideWarning">
         <source>NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="new">NETSDK1086: A FrameworkReference for '{0}' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <target state="translated">NETSDK1086: Odwołanie FrameworkReference dla elementu „{0}” zostało uwzględnione w projekcie. Jest on jawnie przywoływany przez zestaw .NET SDK i zwykle nie ma potrzeby tworzenia odwołania do niego z projektu. Aby uzyskać więcej informacji, zobacz {1}</target>
         <note>{StrBegin="NETSDK1086: "}</note>
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
         <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <target state="translated">NETSDK1049: Rozpoznany plik ma nieprawidłowy obraz, nie ma metadanych lub jest w inny sposób niedostępny. {0} {1}</target>
         <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
       <trans-unit id="GlobalJsonSDKResolutionFailed">
         <source>NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</source>
-        <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
+        <target state="translated">NETSDK1141: nie można rozpoznać wersji zestawu .NET SDK określonej w pliku global.json w lokalizacji {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
         <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
+        <target state="translated">NETSDK1144: Optymalizacja zestawów pod kątem rozmiaru nie powiodła się. Optymalizacja może zostać wyłączona przez ustawienie właściwości PublishTrimmed na wartość false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNoValidRuntimePackageError">
@@ -466,90 +466,90 @@
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
-        <target state="new">NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</target>
+        <target state="translated">NETSDK1102: Optymalizacja zestawów pod kątem rozmiaru nie jest obsługiwana w przypadku wybranej konfiguracji publikowania. Upewnij się, że publikujesz niezależną aplikację.</target>
         <note>{StrBegin="NETSDK1102: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkOptimizedAssemblies">
         <source>Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</source>
-        <target state="new">Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink</target>
+        <target state="translated">Zestawy są optymalizowane pod kątem rozmiaru, co może spowodować zmianę zachowania aplikacji. Pamiętaj, aby wykonać testy po opublikowaniu. Zobacz: https://aka.ms/dotnet-illink</target>
         <note />
       </trans-unit>
       <trans-unit id="ILLinkRunning">
         <source>Optimizing assemblies for size. This process might take a while.</source>
-        <target state="new">Optimizing assemblies for size. This process might take a while.</target>
+        <target state="translated">Optymalizowanie zestawów pod kątem rozmiaru. Ten proces może trochę potrwać.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed">
         <source>NETSDK1191: A runtime identifier for the property '{0}' couldn't be inferred. Specify a rid explicitly.</source>
-        <target state="new">NETSDK1191: A runtime identifier for the property '{0}' couldn't be inferred. Specify a rid explicitly.</target>
+        <target state="translated">NETSDK1191: Nie można wywnioskować identyfikatora środowiska uruchomieniowego dla właściwości „{0}”. Jawnie określ identyfikator RID.</target>
         <note>{StrBegin="NETSDK1191: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectPackageRoot">
         <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <target state="translated">NETSDK1020: Podano niepoprawny element główny pakietu {0} dla rozpoznanej biblioteki {1}</target>
         <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
       <trans-unit id="IncorrectTargetFormat">
         <source>NETSDK1025: The target manifest {0} provided is of not the correct format</source>
-        <target state="new">NETSDK1025: The target manifest {0} provided is of not the correct format</target>
+        <target state="translated">NETSDK1025: Podany manifest docelowy {0} ma niepoprawny format</target>
         <note>{StrBegin="NETSDK1025: "}</note>
       </trans-unit>
       <trans-unit id="InputAssemblyNotFound">
         <source>NETSDK1163: Input assembly '{0}' not found.</source>
-        <target state="new">NETSDK1163: Input assembly '{0}' not found.</target>
+        <target state="translated">NETSDK1163: nie znaleziono zestawu danych wejściowych "{0}".</target>
         <note>{StrBegin="NETSDK1163: "}</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <target state="translated">NETSDK1003: Nieprawidłowa nazwa platformy: „{0}”.</target>
         <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <target state="translated">NETSDK1058: Nieprawidłowa wartość parametru ItemSpecToUse: „{0}”. Ta właściwość musi być pusta lub ustawiona na wartość „Left” albo „Right”</target>
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionString">
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <target state="translated">NETSDK1018: Nieprawidłowy ciąg wersji NuGet: „{0}”.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidResourceUpdate">
         <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="new">NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</target>
+        <target state="translated">NETSDK1075: Dojście aktualizacji jest nieprawidłowe. Tego wystąpienia nie można użyć na potrzeby dalszych aktualizacji.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="InvalidRollForwardValue">
         <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
-        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <target state="translated">NETSDK1104: Wartość RollForward „{0}” jest nieprawidłowa. Dozwolone wartości to {1}.</target>
         <note>{StrBegin="NETSDK1104: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTargetPlatformVersion">
         <source>NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
 {2}</source>
-        <target state="new">NETSDK1140: {0} is not a valid TargetPlatformVersion for {1}. Valid versions include:
+        <target state="translated">NETSDK1140: {0} nie jest prawidłowym elementem TargetPlatformVersion dla elementu {1}. Prawidłowe wersje są następujące:
 {2}</target>
         <note>{StrBegin="NETSDK1140: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibrary">
         <source>NETSDK1173: The provided type library '{0}' is in an invalid format.</source>
-        <target state="new">NETSDK1173: The provided type library '{0}' is in an invalid format.</target>
+        <target state="translated">NETSDK1173: podana biblioteka typów "{0}" ma nieprawidłowy format.</target>
         <note>{StrBegin="NETSDK1173: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTypeLibraryId">
         <source>NETSDK1170: The provided type library ID '{0}' for type library '{1}' is invalid. The ID must be a positive integer less than 65536.</source>
-        <target state="new">NETSDK1170: The provided type library ID '{0}' for type library '{1}' is invalid. The ID must be a positive integer less than 65536.</target>
+        <target state="translated">NETSDK1170: podany identyfikator biblioteki typów „{0}” dla biblioteki typów „{1}” jest nieprawidłowy. Identyfikator musi być dodatnią liczbą całkowitą mniejszą niż 65536.</target>
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
-        <target state="new">NETSDK1157: JIT library '{0}' not found.</target>
+        <target state="translated">NETSDK1157: nie znaleziono biblioteki JIT "{0}".</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <target state="translated">NETSDK1061: Projekt został przywrócony przy użyciu pakietu {0} w wersji {1}, ale w przypadku bieżących ustawień zamiast niej zostałaby użyta wersja {2}. Aby rozwiązać ten problem, upewnij się, że te same ustawienia są używane do przywracania i dla kolejnych operacji, takich jak kompilacja lub publikowanie. Ten problem zazwyczaj występuje, gdy właściwość RuntimeIdentifier jest ustawiona podczas kompilacji lub publikowania, ale nie podczas przywracania. Aby uzyskać więcej informacji, zobacz https://aka.ms/dotnet-runtime-patch-selection.</target>
         <note>{StrBegin="NETSDK1061: "}
 {0} - Package Identifier for platform package
 {1} - Restored version of platform package
@@ -557,172 +557,172 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="MissingItemMetadata">
         <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <target state="translated">NETSDK1008: Brak metadanych „{0}” w elemencie „{1}” „{2}”.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputPDBImagePath">
         <source>NETSDK1164: Missing output PDB path in PDB generation mode (OutputPDBImage metadata).</source>
-        <target state="new">NETSDK1164: Missing output PDB path in PDB generation mode (OutputPDBImage metadata).</target>
+        <target state="translated">NETSDK1164: brak ścieżki wyjściowej pliku PDB w trybie generowania pliku PDB (metadane OutputPDBImage).</target>
         <note>{StrBegin="NETSDK1164: "}</note>
       </trans-unit>
       <trans-unit id="MissingOutputR2RImageFileName">
         <source>NETSDK1165: Missing output R2R image path (OutputR2RImage metadata).</source>
-        <target state="new">NETSDK1165: Missing output R2R image path (OutputR2RImage metadata).</target>
+        <target state="translated">NETSDK1165: brak ścieżki obrazu wyjściowego R2R (metadane OutputR2RImage).</target>
         <note>{StrBegin="NETSDK1165: "}</note>
       </trans-unit>
       <trans-unit id="MissingTypeLibraryId">
         <source>NETSDK1171: An integer ID less than 65536 must be provided for type library '{0}' because more than one type library is specified.</source>
-        <target state="new">NETSDK1171: An integer ID less than 65536 must be provided for type library '{0}' because more than one type library is specified.</target>
+        <target state="translated">NETSDK1171: dla biblioteki typów "{0}" należy podać identyfikator liczby całkowitej mniejszej niż 65536, ponieważ określono więcej niż jedną bibliotekę typów.</target>
         <note>{StrBegin="NETSDK1171: "}</note>
       </trans-unit>
       <trans-unit id="MultipleFilesResolved">
         <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <target state="translated">NETSDK1021: Znaleziono więcej niż jeden plik dla elementu {0}</target>
         <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="new">NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <target state="translated">NETSDK1069: Projekt korzysta z biblioteki przeznaczonej dla platformy .NET Standard 1.5 lub nowszej, a projekt jest przeznaczony dla wersji programu .NET Framework, która nie ma wbudowanej obsługi tej wersji platformy .NET Standard. Odwiedź witrynę https://aka.ms/net-standard-known-issues, aby zapoznać się z zestawem znanych problemów. Rozważ zmianę elementu docelowego na program .NET Framework 4.7.2.</target>
         <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkWithoutUsingNETSdkDefaults">
         <source>NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</source>
-        <target state="new">NETSDK1115: The current .NET SDK does not support .NET Framework without using .NET SDK Defaults. It is likely due to a mismatch between C++/CLI project CLRSupport property and TargetFramework.</target>
+        <target state="translated">NETSDK1115: Bieżący zestaw .NET SDK nie obsługuje programu .NET Framework bez użycia wartości domyślnych zestawu .NET SDK. Prawdopodobna przyczyna to niezgodność między właściwością CLRSupport projektu C++/CLI i elementu TargetFramework.</target>
         <note>{StrBegin="NETSDK1115: "}</note>
       </trans-unit>
       <trans-unit id="Net6NotCompatibleWithDev16">
         <source>NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</source>
-        <target state="new">NETSDK1182: Targeting .NET 6.0 or higher in Visual Studio 2019 is not supported.</target>
+        <target state="translated">NETSDK1182: Platforma docelowa .NET 6.0 lub nowsza w usłudze Visual Studio 2019 nie jest obsługiwana.</target>
         <note>{StrBegin="NETSDK1182: "}</note>
       </trans-unit>
       <trans-unit id="Net7NotCompatibleWithDev173">
         <source>NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.</source>
-        <target state="new">NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.</target>
+        <target state="translated">NETSDK1192: Platforma docelowa .NET 7.0 lub nowsza w programie Visual Studio 2022 17.3 nie jest obsługiwana.</target>
         <note>{StrBegin="NETSDK1192: "}</note>
       </trans-unit>
       <trans-unit id="NoAppHostAvailable">
         <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <target state="translated">NETSDK1084: Brak dostępnej aplikacji hosta dla określonego elementu RuntimeIdentifier „{0}”.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
       <trans-unit id="NoBuildRequested">
         <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
-        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <target state="translated">NETSDK1085: Właściwość „NoBuild” została ustawiona na wartość true, ale wywołano element docelowy „Build”.</target>
         <note>{StrBegin="NETSDK1085: "}</note>
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
+        <target state="translated">NETSDK1002: Projekt „{0}” ma platformę docelową „{2}”. Nie może on być przywoływany przez projekt z platformą docelową „{1}”.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackAvailable">
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <target state="translated">NETSDK1082: Brak dostępnego pakietu środowiska uruchomieniowego {0} dla określonego elementu RuntimeIdentifier „{1}”.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
       <trans-unit id="NoRuntimePackInformation">
         <source>NETSDK1132: No runtime pack information was available for {0}.</source>
-        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <target state="translated">NETSDK1132: Nie było dostępnych informacji o pakiecie środowiska uruchomieniowego dla elementu {0}.</target>
         <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
-        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <target state="translated">NETSDK1128: Hosting COM nie obsługuje samodzielnych wdrożeń.</target>
         <note>{StrBegin="NETSDK1128: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
-        <target state="new">NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</target>
+        <target state="translated">NETSDK1119: Projekty C++/CLI przeznaczone dla platformy .NET Core nie mogą używać elementu EnableComHosting=true.</target>
         <note>{StrBegin="NETSDK1119: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppNonDynamicLibraryDotnetCore">
         <source>NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</source>
-        <target state="new">NETSDK1116: C++/CLI projects targeting .NET Core must be dynamic libraries.</target>
+        <target state="translated">NETSDK1116: Projekty C++/CLI przeznaczone dla platformy .NET Core muszą być bibliotekami dynamicznymi.</target>
         <note>{StrBegin="NETSDK1116: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPackDotnetCore">
         <source>NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</source>
-        <target state="new">NETSDK1118: C++/CLI projects targeting .NET Core cannot be packed.</target>
+        <target state="translated">NETSDK1118: Nie można spakować projektów C++/CLI przeznaczonych dla platformy .NET Core.</target>
         <note>{StrBegin="NETSDK1118: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppPublishDotnetCore">
         <source>NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</source>
-        <target state="new">NETSDK1117: Does not support publish of C++/CLI project targeting dotnet core.</target>
+        <target state="translated">NETSDK1117: Brak obsługi publikowania projektu C++/CLI przeznaczonego dla platformy .NET Core.</target>
         <note>{StrBegin="NETSDK1117: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportCppSelfContained">
         <source>NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</source>
-        <target state="new">NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</target>
+        <target state="translated">NETSDK1121: Projekty C++/CLI przeznaczone dla platformy .NET Core nie mogą używać elementu SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
       <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
         <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</source>
-        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.  For more information, see https://aka.ms/netsdk1151</target>
+        <target state="translated">NETSDK1151: Projekt „{0}”, do którego istnieje odwołanie, jest samodzielnym plikiem wykonywalnym.  Samodzielny plik wykonywalny nie może być przywoływany przez niesamodzielny plik wykonywalny. Aby uzyskać więcej informacji, zobacz: https://aka.ms/netsdk1151</target>
         <note>{StrBegin="NETSDK1151: "}</note>
       </trans-unit>
       <trans-unit id="PDBGeneratorInputExecutableNotFound">
         <source>NETSDK1162: PDB generation: R2R executable '{0}' not found.</source>
-        <target state="new">NETSDK1162: PDB generation: R2R executable '{0}' not found.</target>
+        <target state="translated">NETSDK1162: generowanie pliku PDB: nie znaleziono pliku wykonywalnego R2R "{0}".</target>
         <note>{StrBegin="NETSDK1162: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <target state="translated">NETSDK1053: Funkcja pakowania jako narzędzie nie obsługuje elementów autonomicznych.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
         <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
-        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
+        <target state="translated">NETSDK1146: Narzędzie PackAsTool nie obsługuje ustawiania parametru TargetPlatformIdentifier. Na przykład platformą TargetFramework nie może być platforma net5.0-windows, a tylko platforma net5.0. Narzędzie PackAsTool nie obsługuje również parametru UseWPF ani UseWindowsForms, gdy platformą docelową jest platforma .NET 5 lub nowsza.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageContainsIncorrectlyCasedLocale">
         <source>NETSDK1187: Package {0} {1} has a resource with the locale '{2}'. This locale has been normalized to the standard format '{3}' to prevent casing issues in the build. Consider notifying the package author about this casing issue.</source>
-        <target state="new">NETSDK1187: Package {0} {1} has a resource with the locale '{2}'. This locale has been normalized to the standard format '{3}' to prevent casing issues in the build. Consider notifying the package author about this casing issue.</target>
+        <target state="translated">NETSDK1187: Pakiet {0} {1} ma zasób z ustawieniami regionalnymi „{2}”. Te ustawienia regionalne zostały znormalizowane do standardowego formatu „{3}”, aby zapobiec problemom z wielkością liter w kompilacji. Rozważ powiadomienie autora pakietu o tym problemie z wielkością liter.</target>
         <note>Error code is NETSDK1187. 0 is a package name, 1 is a package version, 2 is the incorrect locale string, and 3 is the correct locale string.</note>
       </trans-unit>
       <trans-unit id="PackageContainsUnknownLocale">
         <source>NETSDK1188: Package {0} {1} has a resource with the locale '{2}'. This locale is not recognized by .NET. Consider notifying the package author that it appears to be using an invalid locale.</source>
-        <target state="new">NETSDK1188: Package {0} {1} has a resource with the locale '{2}'. This locale is not recognized by .NET. Consider notifying the package author that it appears to be using an invalid locale.</target>
+        <target state="translated">NETSDK1188: Pakiet {0} {1} ma zasób z ustawieniami regionalnymi „{2}”. To ustawienie regionalne nie jest rozpoznawane przez platformę .NET. Rozważ powiadomienie autora pakietu, że prawdopodobnie używa on nieprawidłowych ustawień regionalnych.</target>
         <note>Error code is NETSDK1188. 0 is a package name, 1 is a package version, and 2 is the incorrect locale string</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
+        <target state="translated">NETSDK1064: Nie odnaleziono pakietu {0} w wersji {1}. Mógł on zostać usunięty po przywróceniu pakietu NuGet. W innym przypadku przywrócenie pakietu NuGet mogło zostać ukończone tylko częściowo, co mogło być spowodowane ograniczeniami wynikającymi z maksymalnej długości ścieżki.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceOverrideWarning">
         <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <target state="translated">NETSDK1023: Odwołanie do pakietu dla „{0}” zostało uwzględnione w projekcie. Ten pakiet jest jawnie przywoływany przez zestaw .NET SDK i zwykle nie ma potrzeby tworzenia odwołania do niego z projektu. Aby uzyskać więcej informacji, zobacz {1}</target>
         <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
       <trans-unit id="PackageReferenceVersionNotRecommended">
         <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <target state="translated">NETSDK1071: Odwołanie PackageReference do pakietu „{0}” określiło wersję „{1}”. Określanie wersji tego pakietu nie jest zalecane. Aby uzyskać więcej informacji, zobacz https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
         <source>NETSDK1174: Placeholder</source>
-        <target state="new">NETSDK1174: Placeholder</target>
+        <target state="translated">NETSDK1174: symbol zastępczy</target>
         <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
       </trans-unit>
       <trans-unit id="Prefer32BitIgnoredForNetCoreApp">
         <source>NETSDK1189: Prefer32Bit is not supported and has no effect for netcoreapp target.</source>
-        <target state="new">NETSDK1189: Prefer32Bit is not supported and has no effect for netcoreapp target.</target>
+        <target state="translated">NETSDK1189: element Prefer32Bit nie jest obsługiwany i nie ma wpływu na element docelowy netcoreapp.</target>
         <note>{StrBegin="NETSDK1189: "}</note>
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
+        <target state="translated">NETSDK1011: Zasoby są używane z projektu „{0}”, ale w elemencie „{1}” nie odnaleziono odpowiadającej ścieżki projektu MSBuild.</target>
         <note>{StrBegin="NETSDK1011: "}</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
         <source>NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <target state="translated">NETSDK1059: Narzędzie „{0}” jest teraz dołączone do zestawu .NET SDK. Informacje dotyczące sposobu rozwiązania problemu wskazanego w ostrzeżeniu można znaleźć na stronie https://aka.ms/dotnetclitools-in-box.</target>
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
         <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="new">NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</target>
+        <target state="translated">NETSDK1093: Narzędzia projektu (DotnetCliTool) obsługują tylko ukierunkowanie na program .NET Core w wersji 2.2 lub niższej.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
       <trans-unit id="PublishProfileNotPresent">
@@ -732,92 +732,92 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1122: Kompilacja ReadyToRun zostanie pominięta, ponieważ jest obsługiwana tylko w przypadku platformy .NET Core 3.0 lub nowszej.</target>
         <note>{StrBegin="NETSDK1122: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedMustBeBool">
         <source>NETSDK1193: If PublishSelfContained is set, it must be either true or false. The value given was '{0}'.</source>
-        <target state="new">NETSDK1193: If PublishSelfContained is set, it must be either true or false. The value given was '{0}'.</target>
+        <target state="translated">NETSDK1193: Jeśli właściwość PublishSelfContained jest ustawiona, musi mieć wartość true lub false. Podana wartość to „{0}”.</target>
         <note>{StrBegin="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1123: Publikowanie aplikacji do pojedynczego pliku wymaga platformy .NET Core 3.0 lub nowszej.</target>
         <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="PublishTrimmedRequiresVersion30">
         <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1124: Przycinanie zestawów wymaga platformy .NET Core 3.0 lub nowszej.</target>
         <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="PublishUnsupportedWithoutTargetFramework">
         <source>NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</source>
-        <target state="new">NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</target>
+        <target state="translated">NETSDK1129: Element docelowy „Publish” nie jest obsługiwany bez określenia platformy docelowej. Bieżący projekt ma wiele platform docelowych. Należy określić platformę publikowanej aplikacji.</target>
         <note>{StrBegin="NETSDK1129: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>
-        <target state="new">NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</target>
+        <target state="translated">NETSDK1096: Optymalizacja zestawów pod kątem wydajności nie powiodła się. Możesz wykluczyć błędne zestawy z procesu optymalizacji lub ustawić właściwość PublishReadyToRun na wartość false.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
         <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
-        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <target state="translated">Niektóre kompilacje ReadyToRun emitowały ostrzeżenia, co wskazuje na potencjalnie brakujące zależności. Brakujące zależności mogą być przyczyną błędów w czasie wykonywania. Aby pokazywać ostrzeżenia, ustaw właściwość PublishReadyToRunShowWarnings na wartość true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing and make sure to restore packages with the PublishReadyToRun property set to true.</source>
-        <target state="new">NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing and make sure to restore packages with the PublishReadyToRun property set to true.</target>
+        <target state="needs-review-translation">NETSDK1094: Nie można zoptymalizować zestawów pod kątem wydajności: nie znaleziono prawidłowego pakietu środowiska uruchomieniowego. Ustaw właściwość PublishReadyToRun na wartość false lub użyj obsługiwanego identyfikatora środowiska uruchomieniowego podczas publikowania. W przypadku określania wartości docelowej platformy .NET 6 lub nowszej należy przywrócić pakiety z właściwością PublishReadyToRun ustawioną na wartość true.</target>
         <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunTargetNotSupportedError">
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
-        <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
+        <target state="translated">NETSDK1095: Optymalizacja zestawów pod kątem wydajności nie jest obsługiwana dla wybranej platformy lub architektury docelowej. Upewnij się, że używasz identyfikatora obsługiwanego środowiska uruchomieniowego, lub ustaw właściwość PublishReadyToRun na wartość false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
       </trans-unit>
       <trans-unit id="RollForwardRequiresVersion30">
         <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1103: Ustawienie RollForward jest obsługiwane tylko w programie .NET Core 3.0 lub nowszym.</target>
         <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <target state="translated">NETSDK1083: Wybrany element RuntimeIdentifier „{0}” nie został rozpoznany.</target>
         <note>{StrBegin="NETSDK1083: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <target state="translated">NETSDK1028: Określ element RuntimeIdentifier</target>
         <note>{StrBegin="NETSDK1028: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeListNotFound">
         <source>NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</source>
-        <target state="new">NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET team here: https://aka.ms/dotnet-sdk-issue.</target>
+        <target state="translated">NETSDK1109: Nie odnaleziono pliku listy środowiska uruchomieniowego „{0}”. Zgłoś ten błąd zespołowi platformy .NET tutaj: https://aka.ms/dotnet-sdk-issue.</target>
         <note>{StrBegin="NETSDK1109: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotDownloaded">
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</target>
+        <target state="translated">NETSDK1112: Nie pobrano pakietu wykonawczego dla: {0}. Spróbuj uruchomić przywracanie NuGet z użyciem wartości RuntimeIdentifier „{1}”.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
       </trans-unit>
       <trans-unit id="RuntimePackNotRestored_TransitiveDisabled">
         <source>NETSDK1185: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1185: The Runtime Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <target state="translated">NETSDK1185: Pakiet środowiska uruchomieniowego dla elementu FrameworkReference „{0}” był niedostępny. Może to być spowodowane tym, że parametr DisableTransitiveFrameworkReferenceDownloads został ustawiony na wartość true.</target>
         <note>{StrBegin="NETSDK1185: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
-        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</target>
+        <target state="translated">NETSDK1150: Projekt „{0}”, do którego istnieje odwołanie, jest niesamodzielnym plikiem wykonywalnym.  Niesamodzielny plik wykonywalny nie może być przywoływany przez samodzielny plik wykonywalny. Aby uzyskać więcej informacji, zobacz: https://aka.ms/netsdk1150</target>
         <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionShouldBeUsedWithRuntime">
         <source>NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</source>
-        <target state="new">NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.</target>
+        <target state="translated">NETSDK1179: Jedna z opcji „--self-contained” lub „--no-self-contained” jest wymagana, gdy jest używany element „--runtime”.</target>
         <note>{StrBegin="NETSDK1179: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <target state="translated">NETSDK1048: Dla elementu GenerateRuntimeConfigurationFiles określono ścieżki AdditionalProbingPaths, ale są one pomijane, ponieważ element „RuntimeConfigDevPath” jest pusty.</target>
         <note>{StrBegin="NETSDK1048: "}</note>
       </trans-unit>
       <trans-unit id="SolutionProjectConfigurationsConflict">
@@ -829,171 +829,171 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="TargetFrameworkIsEol">
         <source>NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
-        <target state="new">NETSDK1138: The target framework '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <target state="translated">NETSDK1138: platforma docelowa „{0}” nie jest już obsługiwana i w przyszłości nie będzie otrzymywać aktualizacji zabezpieczeń. Aby uzyskać więcej informacji na temat zasad pomocy technicznej, zobacz {1}.</target>
         <note>{StrBegin="NETSDK1138: "}</note>
       </trans-unit>
       <trans-unit id="TargetFrameworkWithSemicolon">
         <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <target state="translated">NETSDK1046: Wartość „{0}” elementu TargetFramework jest nieprawidłowa. Aby obsługiwać wiele środowisk docelowych, użyj zamiast tego właściwości TargetFrameworks.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
       <trans-unit id="TargetingApphostPackMissingCannotRestore">
         <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
-        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <target state="translated">NETSDK1145: Nie zainstalowano pakietu {0}, a przywracanie pakietów NuGet nie jest obsługiwane. Uaktualnij program Visual Studio, usuń plik global.json, jeśli określa konkretną wersję zestawu SDK, i odinstaluj nowszy zestaw SDK. Aby uzyskać więcej opcji, odwiedź stronę https://aka.ms/targeting-apphost-pack-missing  Typ pakietu: {0}, katalog pakietu: {1}, platforma docelowa: {2}, identyfikator pakietu: {3}, wersja pakietu: {4}</target>
         <note>{StrBegin="NETSDK1145: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
-        <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>
+        <target state="translated">NETSDK1127: Pakiet docelowy {0} nie jest zainstalowany. Wykonaj przywrócenie i spróbuj ponownie.</target>
         <note>{StrBegin="NETSDK1127: "}</note>
       </trans-unit>
       <trans-unit id="TargetingPackNotRestored_TransitiveDisabled">
         <source>NETSDK1184: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</source>
-        <target state="new">NETSDK1184: The Targeting Pack for FrameworkReference '{0}' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.</target>
+        <target state="translated">NETSDK1184: Pakiet określania wartości docelowej dla elementu FrameworkReference „{0}” był niedostępny. Może to być spowodowane tym, że parametr DisableTransitiveFrameworkReferenceDownloads został ustawiony na wartość true.</target>
         <note>{StrBegin="NETSDK1184: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWindowsFormsIsNotSupported">
         <source>NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</source>
-        <target state="new">NETSDK1175: Windows Forms is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/windows-forms for more details.</target>
+        <target state="translated">NETSDK1175: Aplikacja Windows Forms nie jest obsługiwana lub proponowana z funkcją włączonego przycinania. Aby uzyskać więcej szczegółów, przejdź do: https://aka.ms/dotnet-illink/windows-forms.</target>
         <note>{StrBegin="NETSDK1175: "}</note>
       </trans-unit>
       <trans-unit id="TrimmingWpfIsNotSupported">
         <source>NETSDK1168: WPF is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/wpf for more details.</source>
-        <target state="new">NETSDK1168: WPF is not supported or recommended with trimming enabled. Please go to https://aka.ms/dotnet-illink/wpf for more details.</target>
+        <target state="translated">NETSDK1168: funkcja WPF nie jest obsługiwana lub zalecana z włączonym przycinaniem. Aby uzyskać więcej szczegółów, przejdź do strony https://aka.ms/dotnet-illink/wpf.</target>
         <note>{StrBegin="NETSDK1168: "}</note>
       </trans-unit>
       <trans-unit id="TypeLibraryDoesNotExist">
         <source>NETSDK1172: The provided type library '{0}' does not exist.</source>
-        <target state="new">NETSDK1172: The provided type library '{0}' does not exist.</target>
+        <target state="translated">NETSDK1172: podana biblioteka typów "{0}" nie istnieje.</target>
         <note>{StrBegin="NETSDK1172: "}</note>
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
+        <target state="translated">NETSDK1016: Nie można odnaleźć rozpoznanej ścieżki dla elementu „{0}”.</target>
         <note>{StrBegin="NETSDK1016: "}</note>
       </trans-unit>
       <trans-unit id="UnableToUsePackageAssetsCache_Info">
         <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <target state="translated">Nie można użyć pamięci podręcznej zasobów pakietu ze względu na błąd we/wy. Do tej sytuacji może dochodzić, gdy ten sam projekt jest kompilowany więcej niż raz równolegle. Może wystąpić spadek wydajności, ale nie będzie mieć to wpływu na wyniki kompilacji.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedFileType">
         <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <target state="translated">NETSDK1012: Nieoczekiwany typ pliku dla „{0}”. Typ to „{1}” oraz „{2}”.</target>
         <note>{StrBegin="NETSDK1012: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference">
         <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="new">NETSDK1073: The FrameworkReference '{0}' was not recognized</target>
+        <target state="translated">NETSDK1073: Nie rozpoznano elementu FrameworkReference „{0}”</target>
         <note>{StrBegin="NETSDK1073: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference_MauiEssentials">
         <source>NETSDK1186: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</source>
-        <target state="new">NETSDK1186: This project depends on Maui Essentials through a project or NuGet package reference, but doesn't declare that dependency explicitly. To build this project, you must set the UseMauiEssentials property to true (and install the Maui workload if necessary).</target>
+        <target state="translated">NETSDK1186: Ten projekt zależy od programu Maui Essentials za pomocą projektu lub odwołania do pakietu NuGet, ale nie deklaruje jawnie tej zależności. Aby skompilować ten projekt, należy ustawić właściwość UseMauiEssentials na wartość true (i zainstalować obciążenie Maui w razie potrzeby).</target>
         <note>{StrBegin="NETSDK1186: "}</note>
       </trans-unit>
       <trans-unit id="UnnecessaryWindowsDesktopSDK">
         <source>NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</source>
-        <target state="new">NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.</target>
+        <target state="translated">NETSDK1137: Nie trzeba już używać zestawu SDK Microsoft.NET.Sdk.WindowsDesktop. Rozważ zmianę atrybutu Sdk głównego elementu Project na „Microsoft.NET.Sdk”.</target>
         <note>{StrBegin="NETSDK1137: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
+        <target state="translated">NETSDK1009: Nierozpoznany token preprocesora „{0}” w elemencie „{1}”.</target>
         <note>{StrBegin="NETSDK1009: "}</note>
       </trans-unit>
       <trans-unit id="UnresolvedTargetingPack">
         <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <target state="translated">NETSDK1081: Nie odnaleziono pakietu Targeting Pack dla elementu {0}. Uruchomienie przywracania w rozwiązaniu NuGet w projekcie może rozwiązać ten problem.</target>
         <note>{StrBegin="NETSDK1081: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
+        <target state="translated">NETSDK1019: {0} to nieobsługiwana platforma.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
+        <target state="translated">NETSDK1056: Projekt jest przeznaczony dla środowiska uruchomieniowego „{0}”, ale nie rozpoznaje żadnych pakietów specyficznych dla tego środowiska. To środowisko uruchomieniowe nie może być obsługiwane przez platformę docelową.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">
         <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <target state="translated">NETSDK1050: Używana przez ten projekt wersja zestawu Microsoft.NET.Sdk jest niewystarczająca do zapewnienia obsługi odwołań do bibliotek przeznaczonych dla platformy .NET Standard 1.5 lub nowszych. Zainstaluj zestaw .NET Core SDK w wersji co najmniej 2.0.</target>
         <note>{StrBegin="NETSDK1050: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetFrameworkVersion">
         <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <target state="translated">NETSDK1045: Bieżący zestaw .NET SDK nie obsługuje używania środowiska docelowego {0} {1}. Użyj jako środowiska docelowego wersji {0} {2} lub starszej albo użyj wersji zestawu .NET SDK obsługującej środowisko {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifier">
         <source>NETSDK1139: The target platform identifier {0} was not recognized.</source>
-        <target state="new">NETSDK1139: The target platform identifier {0} was not recognized.</target>
+        <target state="translated">NETSDK1139: nie rozpoznano identyfikatora platformy docelowej {0}.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
-        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <target state="translated">NETSDK1107: Do kompilowania aplikacji klasycznych systemu Windows konieczny jest zestaw Microsoft.NET.Sdk.WindowsDesktop. Właściwości „UseWpf” i „UseWindowsForms” nie są obsługiwane przez bieżący zestaw SDK.</target>
         <note>{StrBegin="NETSDK1107: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdk_Info">
         <source>NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy</source>
-        <target state="new">NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy</target>
+        <target state="translated">NETSDK1057: Korzystasz z wersji zapoznawczej platformy .NET. Zobacz: ttps://aka.ms/dotnet-support-policy</target>
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
+        <target state="translated">NETSDK1131: Generowanie zarządzanego składnika metadanych systemu Windows za pomocą narzędzia WinMDExp nie jest obsługiwane, gdy używany jest element docelowy {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
         <source>NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</source>
-        <target state="new">NETSDK1130: {1} cannot be referenced. Referencing a Windows Metadata component directly when targeting .NET 5 or higher is not supported. For more information, see https://aka.ms/netsdk1130</target>
+        <target state="translated">NETSDK1130: nie można odwoływać się do {1}. Odwołuje się bezpośrednio do składnika metadanych systemu Windows, jeśli element docelowy .NET 5 lub nowszy nie jest obsługiwany. Aby uzyskać więcej informacji, zobacz https://aka.ms/netsdk1130</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WinMDTransitiveReferenceNotSupported">
         <source>NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</source>
-        <target state="new">NETSDK1149: {0} cannot be referenced because it uses built-in support for WinRT, which is no longer supported in .NET 5 and higher.  An updated version of the component supporting .NET 5 is needed. For more information, see https://aka.ms/netsdk1149</target>
+        <target state="translated">NETSDK1149: nie można odwoływać się do {0}, ponieważ używa on wbudowanej obsługi dla środowiska WinRT, która nie jest już obsługiwana w środowisku .NET 5 lub nowszym.  Wymagana jest zaktualizowana wersja składnika obsługującego platformę .NET 5. Aby uzyskać więcej informacji, zobacz https://aka.ms/netsdk1149</target>
         <note>{StrBegin="NETSDK1149: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
-        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <target state="translated">NETSDK1106: Zestaw Microsoft.NET.Sdk.WindowsDesktop wymaga ustawienia właściwości „UseWpf” lub „UseWindowsForms” na wartość „true”</target>
         <note>{StrBegin="NETSDK1106: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
         <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
-        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <target state="translated">NETSDK1105: Aplikacje klasyczne systemu Windows są obsługiwane tylko w programie .NET Core 3.0 lub nowszym.</target>
         <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</source>
-        <target state="new">NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.</target>
+        <target state="translated">NETSDK1100: Aby skompilować projekt przeznaczony dla systemu Windows w tym systemie operacyjnym, ustaw właściwość EnableWindowsTargeting na wartość True.</target>
         <note>{StrBegin="NETSDK1100: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopTargetPlatformMustBeWindows">
         <source>NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</source>
-        <target state="new">NETSDK1136: The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.</target>
+        <target state="translated">NETSDK1136: w przypadku korzystania z modelu Windows Forms lub platformy WPF bądź odwoływania się do projektów lub pakietów, które to robią, platforma docelowa musi być ustawiona na system Windows (zazwyczaj przez dodane parametru „-windows” we właściwości TargetFramework).</target>
         <note>{StrBegin="NETSDK1136: "}</note>
       </trans-unit>
       <trans-unit id="WindowsSDKVersionConflicts">
         <source>NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</source>
-        <target state="new">NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</target>
+        <target state="translated">NETSDK1148: Przywoływany zestaw został skompilowany przy użyciu nowszej wersji biblioteki Microsoft.Windows.SDK.NET.dll. Aby odwoływać się do tego zestawu, zaktualizuj do nowszego zestawu .NET SDK.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>
-        <target state="new">NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
-You may need to build the project on another operating system or architecture, or update the .NET SDK.</target>
+        <target state="translated">NETSDK1178: Projekt zależy od następujących pakietów obciążenia, które nie istnieją w żadnym z obciążeń dostępnych w tej instalacji: {0}
+Może być konieczne skompilowanie projektu w innym systemie operacyjnym lub architekturze albo zaktualizowanie zestawu .NET SDK.</target>
         <note>{StrBegin="NETSDK1178: "}</note>
       </trans-unit>
       <trans-unit id="WorkloadNotInstalled">
         <source>NETSDK1147: To build this project, the following workloads must be installed: {0}
 To install these workloads, run the following command: dotnet workload restore</source>
-        <target state="new">NETSDK1147: To build this project, the following workloads must be installed: {0}
-To install these workloads, run the following command: dotnet workload restore</target>
+        <target state="translated">NETSDK1147: aby utworzyć ten projekt, muszą być zainstalowane następujące pakiety robocze: {0}
+Aby zainstalować te pakiety robocze, uruchom następujące polecenie: dotnet workload restore</target>
         <note>{StrBegin="NETSDK1147: "} LOCALIZATION: Do not localize "dotnet workload restore"</note>
       </trans-unit>
     </body>


### PR DESCRIPTION
Somehow main got out of sync with 4xx. This was confusing the vendors as large sets of error messages were no longer localized. While reviewing the code, I found another set in vstest. There may be more but they'll be fixed in august before we ship once we start localizing the code out of main but I thought I'd fix the large set that I found now.

To fix this, I just copied the raw content from 7.0.4xx and rebuilt which regenerated any new strings in these files.