### PR TITLE
Default JsonSerializerIsReflectionEnabledByDefault to true on Blazor WASM.

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -17,6 +17,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Trimmer defaults that depend on user-definable settings.
         This must be configured before it's initialized in the .NET SDK targets (which are imported by the Razor SDK). -->
     <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings>
+
+    <!-- Similarly these feature switches must be configured before it's initialized in imported SDKs -->
+    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == ''">true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -18,7 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         This must be configured before it's initialized in the .NET SDK targets (which are imported by the Razor SDK). -->
     <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings>
 
-    <!-- Similarly these feature switches must be configured before it's initialized in imported SDKs -->
+    <!-- Similarly these feature switches must be configured before they are initialized in imported SDKs -->
     <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == ''">true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 


### PR DESCRIPTION
Since #31626, the Web SDK is defaulting `JsonSerializerIsReflectionEnabledByDefault=false` whenever PublishTrimmed or PublishAot is set to `true`. However, this also affects Blazor WASM since it is importing the Web SDK. For Blazor WASM, we need to keep the normal default of `JsonSerializerIsReflectionEnabledByDefault=true`, so it doesn't break existing Blazor WASM apps that are relying on JsonSerializer using Reflection.

See discussion in https://github.com/dotnet/runtime/issues/84378.

NOTE: I don't know how to test this at this layer. If anyone has a good recommendation for how to test it, I am open to suggestions.