### PR TITLE
Fix outer build artifacts output path

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -54,7 +54,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ArtifactsPivots>$(Configuration.ToLowerInvariant())</ArtifactsPivots>
 
     <!-- Include the TargetFramework in the pivots if the project is multi-targeted (ie TargetFrameworks) is defined -->
-    <ArtifactsPivots Condition="'$(TargetFrameworks)' != ''"
+    <ArtifactsPivots Condition="'$(TargetFrameworks)' != '' And '$(TargetFramework)' != ''"
                      >$(ArtifactsPivots)_$(TargetFramework.ToLowerInvariant())</ArtifactsPivots>
 
     <!-- This targets file is evaluated before RuntimeIdentifierInference.targets, so this will only include the

--- a/src/Tests/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
@@ -483,6 +483,37 @@ namespace Microsoft.NET.Build.Tests
                     .Exist();
             }
         }
+
+        [Fact]
+        public void PackageValidationSucceeds()
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = $"{ToolsetInfo.CurrentTargetFramework};net7.0"
+            };
+
+            testProject.AdditionalProperties["EnablePackageValidation"] = "True";
+
+            testProject.UseArtifactsOutput = true;
+            testProject.UseDirectoryBuildPropsForArtifactsOutput = true;
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            File.WriteAllText(Path.Combine(testAsset.Path, "Directory.Build.props"),
+                    $"""
+                    <Project>
+                        <PropertyGroup>
+                            <UseArtifactsOutput>true</UseArtifactsOutput>
+                        </PropertyGroup>
+                    </Project>
+                    """);
+
+            new DotnetPackCommand(Log)
+                .WithWorkingDirectory(Path.Combine(testAsset.TestRoot, testProject.Name))
+                .Execute()
+                .Should()
+                .Pass();
+        }
     }
 
     namespace ArtifactsTestExtensions


### PR DESCRIPTION
Don't try to add `TargetFramework` property to artifacts pivots if it's not defined.

Fixes #31882

