### PR TITLE
Use 'artifacts' instead of `.artifacts` for default artifacts path

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -900,4 +900,9 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</value>
     <comment>{StrBegin="NETSDK1199: "}</comment>
   </data>
+  <data name="UseArtifactsOutputRequiresDirectoryBuildProps" xml:space="preserve">
+    <value>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</value>
+    <comment>{StrBegin="NETSDK1200: "}</comment>
+  </data>
+  
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -896,4 +896,8 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</value>
     <comment>{StrBegin="NETSDK1198: "}</comment>
   </data>
+  <data name="ArtifactsPathCannotBeSetInProject" xml:space="preserve">
+    <value>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</value>
+    <comment>{StrBegin="NETSDK1199: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: Nepovedlo se podepsat hostitele aplikace s kódem chyby {1}: {0}.</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: Když se cílí na .NET Core 3.0 nebo vyšší, balíček Microsoft.AspNetCore.All se nepodporuje. Místo něj by se měl použít odkaz FrameworkReference na Microsoft.AspNetCore.App, který se implicitně zahrne pomocí Microsoft.NET.Sdk.Web.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: Identifikátor cílové platformy {0} se nerozpoznal.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: K sestavování desktopových aplikací pro Windows se vyžaduje Microsoft.NET.Sdk.WindowsDesktop. Aktuální verze sady SDK nepodporuje hodnoty UseWpf a UseWindowsForms.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: Der Zielplattformbezeichner "{0}" wurde nicht erkannt.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Für das Erstellen von Windows-Desktopanwendungen ist Microsoft.NET.Sdk.WindowsDesktop erforderlich. "UseWpf" und "UseWindowsForms" werden vom aktuellen SDK nicht unterstützt.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: Fehler beim Signieren von apphost mit Fehlercode {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: Das Paket "Microsoft.AspNetCore.All" wird für .NET Core 3.0 oder höher nicht unterstützt. Verwenden Sie stattdessen eine FrameworkReference auf Microsoft.AspNetCore.App, die daraufhin implizit von Microsoft.NET.Sdk.Web eingeschlossen wird.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: No se pudo firmar apphost con el código de error {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: El paquete Microsoft.AspNetCore.All no se admite cuando el destino es .NET Core 3.0 o posterior. En su lugar, se debe usar un valor de FrameworkReference para Microsoft.AspNetCore.App, y se incluirá implícitamente en Microsoft.NET.Sdk.Web.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: No se reconoció el identificador de la plataforma de destino {0}.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Se requiere Microsoft.NET.Sdk.WindowsDesktop para compilar las aplicaciones de escritorio de Windows. El SDK actual no admite "UseWpf" ni "UseWindowsForms".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: L'identificateur de la plateforme cible {0} n'a pas été reconnu.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: vous devez disposer de Microsoft.NET.Sdk.WindowsDesktop pour générer des applications de bureau Windows. 'UseWpf' et 'UseWindowsForms' ne sont pas pris en charge par le kit SDK actuel.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: échec de la signature de apphost avec le code d’erreur {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: le package Microsoft.AspNetCore.All n'est pas pris en charge pour le ciblage de .NET Core 3.0 ou une version ultérieure. Vous devez utiliser à la place un FrameworkReference pour Microsoft.AspNetCore.App. Il est inclus implicitement par Microsoft.NET.Sdk.Web.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: l'identificatore di piattaforma di destinazione {0} non è stato riconosciuto.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: per compilare applicazioni desktop di Windows, è necessario Microsoft.NET.Sdk.WindowsDesktop. 'UseWpf' e 'UseWindowsForms' non sono supportati dall'SDK corrente.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: impossibile firmare apphost con codice di errore {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: il pacchetto Microsoft.AspNetCore.All non è supportato quando la destinazione è .NET Core 3.0 o versione successiva. È necessario un elemento FrameworkReference per Microsoft.AspNetCore.App, che verrà incluso in modo implicito da Microsoft.NET.Sdk.Web.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: エラー コード {1} が発生して AppHost に署名できませんでした: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: .NET Core 3.0 以上がターゲットの場合、Microsoft.AspNetCore.All パッケージはサポートされていません。代わりに Microsoft.AspNetCore.App への FrameworkReference を使用する必要があり、これは Microsoft.NET.Sdk.Web によって暗黙的に含まれます。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: ターゲット プラットフォーム識別子 {0} は認識されませんでした。</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Windows デスクトップ アプリケーションを作成するには、Microsoft.NET.Sdk.WindowsDesktop が必要です。現在の SDK では、'UseWpf' と 'UseWindowsForms' はサポートされていません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: apphost에 서명하지 못했습니다(오류 코드 {1}: {0})</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: .NET Core 3.0 이상을 대상으로 할 경우 Microsoft.AspNetCore.All 패키지가 지원되지 않습니다. Microsoft.AspNetCore.App에 대한 FrameworkReference가 대신 사용되어야 하며, Microsoft.NET.Sdk.Web에 의해 암시적으로 포함됩니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: 대상 플랫폼 식별자 {0}을(를) 인식할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop을 사용하려면 Windows 데스크톱 애플리케이션을 빌드해야 합니다. 'UseWpf' 및 'UseWindowsForms'는 현재 SDK에서 지원하지 않습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: nie rozpoznano identyfikatora platformy docelowej {0}.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Do kompilowania aplikacji klasycznych systemu Windows konieczny jest zestaw Microsoft.NET.Sdk.WindowsDesktop. Właściwości „UseWpf” i „UseWindowsForms” nie są obsługiwane przez bieżący zestaw SDK.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: Nie można podpisać hosta aplikacji z kodem błędu {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: Pakiet Microsoft.AspNetCore.All nie jest obsługiwany w przypadku ukierunkowania na program .NET Core w wersji 3.0 lub wyższej. Zamiast tego powinien zostać użyty element FrameworkReference dla pakietu Microsoft.AspNetCore.App, który zostanie niejawnie uwzględniony przez pakiet Microsoft.NET.Sdk.Web.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: o identificador de plataforma de destino {0} não foi reconhecido.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop é necessário para compilar aplicativos da área de trabalho do Windows. Não há suporte para 'UseWpf' e 'UseWindowsForms' no SDK atual.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: falha ao assinar appHost com o código de erro {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: o pacote Microsoft.AspNetCore.All não tem suporte quando direcionado ao .NET Core 3.0 ou superior. Um FrameworkReference para Microsoft.AspNetCore.App deve ser usado e será incluído implicitamente pelo Microsoft.NET.Sdk.Web.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: не удалось распознать идентификатор целевой платформы {0}.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: для сборки классических приложений для Windows требуется Microsoft.NET.Sdk.WindowsDesktop. "UseWpf" и "UseWindowsForms" не поддерживаются текущим пакетом SDK.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: не удалось подписать APPHOST с кодом ошибки {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: пакет Microsoft.AspNetCore.All не поддерживается при ориентации на .NET Core 3.0 или более поздней версии. Вместо этого нужно использовать ссылку FrameworkReference на Microsoft.AspNetCore.App, которая будет неявно включена пакетом Microsoft.NET.Sdk.Web.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: apphost şu hata koduyla imzalanamadı: {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: Microsoft.AspNetCore.All paketi .NET Core 3.0 veya üzeri hedeflenirken desteklenmez. Bunun yerine Microsoft.AspNetCore.App için bir FrameworkReference kullanılmalıdır. Bu, Microsoft.NET.Sdk.Web tarafından örtük olarak eklenecektir.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: {0} hedef platform tanımlayıcısı tanınmadı.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Windows Masaüstü uygulamalarını derlemek için Microsoft.NET.Sdk.WindowsDesktop gereklidir. 'UseWpf' ve 'UseWindowsForms' geçerli SDK tarafından desteklenmiyor.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: 无法对 Apphost 进行签名，错误代码为 {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: 当面向 .NET Core 3.0 或更高版本时，不支持 Microsoft.AspNetCore.All 包。应改为使用 Microsoft.AspNetCore.App 的 FrameworkReference，并且 Microsoft.NET.Sdk.Web 将隐式包含它。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: 无法识别目标平台标识符 {0}。</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: 要构建 Windows 桌面应用程序，需使用 Microsoft.NET.Sdk.WindowsDesktop。当前 SDK 不支持 "UseWpf" 和 "UseWindowsForms"。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="translated">NETSDK1177: 無法簽署 AppHost，錯誤碼 {1}: {0}</target>
         <note>{StrBegin="NETSDK1177: "}</note>
       </trans-unit>
+      <trans-unit id="ArtifactsPathCannotBeSetInProject">
+        <source>NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</source>
+        <target state="new">NETSDK1199: The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See https://aka.ms/netsdk1199 for more information.</target>
+        <note>{StrBegin="NETSDK1199: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreAllNotSupported">
         <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
         <target state="translated">NETSDK1079: 目標為 .NET Core 3.0 或更新的版本時，不支援 Microsoft.AspNetCore.All 套件。應改用 Microsoft.AspNetCore.App 的 FrameworkReference，且會由 Microsoft.NET.Sdk.Web 隱含包含。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -937,6 +937,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: 無法辨識目標平台識別碼 {0}。</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UseArtifactsOutputRequiresDirectoryBuildProps">
+        <source>NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</source>
+        <target state="new">NETSDK1200: If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.</target>
+        <note>{StrBegin="NETSDK1200: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: 需有 Microsoft.NET.Sdk.WindowsDesktop 才能建置 Windows 傳統型應用程式。目前的 SDK 不支援 'UseWpf' 和 'UseWindowsForms'。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -74,6 +74,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(ArtifactsPath)\obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
+  <!-- Record whether ArtifactsPath / UseArtifactsOutput was set at this point in evaluation.  We will generate an error if these properties are set
+       after this point (ie in the project file). -->
+  <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true'">
+    <_ArtifactsPathSetEarly>true</_ArtifactsPathSetEarly>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(MSBuildProjectFullPath)' == '$(ProjectToOverrideProjectExtensionsPath)'">
     <MSBuildProjectExtensionsPath>$(ProjectExtensionsPathForSpecifiedProject)</MSBuildProjectExtensionsPath>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultArtifactsPath.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultArtifactsPath.props
@@ -30,14 +30,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true' And '$(ArtifactsPath)' == '' And '$(_DirectoryBuildPropsBasePath)' != ''">
     <!-- Default ArtifactsPath to be in the directory where Directory.Build.props is found
          Note that we do not append a backslash to the ArtifactsPath as we do with most paths, because it may be a global property passed in on the command-line which we can't easily change -->
-    <ArtifactsPath>$(_DirectoryBuildPropsBasePath)\.artifacts</ArtifactsPath>
+    <ArtifactsPath>$(_DirectoryBuildPropsBasePath)\artifacts</ArtifactsPath>
     <IncludeProjectNameInArtifactsPaths Condition="'$(IncludeProjectNameInArtifactsPaths)' == ''">true</IncludeProjectNameInArtifactsPaths>
     <_ArtifactsPathLocationType>DirectoryBuildPropsFolder</_ArtifactsPathLocationType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true' And '$(ArtifactsPath)' == ''">
     <!-- If there was no Directory.Build.props file, then put the artifacts path in the project folder -->
-    <ArtifactsPath>$(MSBuildProjectDirectory)\.artifacts</ArtifactsPath>
+    <ArtifactsPath>$(MSBuildProjectDirectory)\artifacts</ArtifactsPath>
     <_ArtifactsPathLocationType>ProjectFolder</_ArtifactsPathLocationType>
   </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -154,6 +154,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NetSdkError Condition="'$(UseArtifactsOutput)' == 'true' and '$(_ArtifactsPathSetEarly)' != 'true'"
                  ResourceName="ArtifactsPathCannotBeSetInProject" />
+    
+    <NetSdkError Condition="'$(_ArtifactsPathLocationType)' == 'ProjectFolder'"
+                 ResourceName="UseArtifactsOutputRequiresDirectoryBuildProps" />
+
   </Target>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -140,4 +140,20 @@ Copyright (c) .NET Foundation. All rights reserved.
                             '$(AppendTargetFrameworkToOutputPath)' == 'true' and '$(TargetFramework)' != '' and '$(_UnsupportedTargetFrameworkError)' != 'true'">
     <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>
   </PropertyGroup>
+
+
+  <Target Name="_CheckForUnsupportedArtifactsPath"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
+
+    <!-- Generate an error if ArtifactsPath or UseArtifactsOutput are set in the project file.
+
+         We generate an error because if they are set in the project file, it is too late to change the intermediate output path,
+         and because it would be confusing to set the property in the project file and have the artifacts path depend on whether
+         there happened to be a Directory.Build.props file defined.
+    -->
+
+    <NetSdkError Condition="'$(UseArtifactsOutput)' == 'true' and '$(_ArtifactsPathSetEarly)' != 'true'"
+                 ResourceName="ArtifactsPathCannotBeSetInProject" />
+  </Target>
+
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
@@ -76,21 +76,18 @@ namespace Microsoft.NET.Build.Tests
             return (testProjects, testAsset);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ItUsesArtifactsOutputPathForBuild(bool useDirectoryBuildProps)
+        [Fact]
+        public void ItUsesArtifactsOutputPathForBuild()
         {
-            var (testProjects, testAsset) = GetTestProjects(useDirectoryBuildProps);
+            var (testProjects, testAsset) = GetTestProjects(useDirectoryBuildProps: true);
 
             new DotnetCommand(Log, "build")
                 .WithWorkingDirectory(testAsset.Path)
-                .SetEnvironmentVariables(useDirectoryBuildProps)
                 .Execute()
                 .Should()
                 .Pass();
 
-            ValidateIntermediatePaths(testAsset, testProjects, useDirectoryBuildProps);
+            ValidateIntermediatePaths(testAsset, testProjects, useDirectoryBuildProps: true);
 
             foreach (var testProject in testProjects)
             {
@@ -101,21 +98,18 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ItUsesArtifactsOutputPathForPublish(bool useDirectoryBuildProps)
+        [Fact]
+        public void ItUsesArtifactsOutputPathForPublish()
         {
-            var (testProjects, testAsset) = GetTestProjects(useDirectoryBuildProps);
+            var (testProjects, testAsset) = GetTestProjects(useDirectoryBuildProps: true);
 
             new DotnetCommand(Log, "publish")
                 .WithWorkingDirectory(testAsset.Path)
-                .SetEnvironmentVariables(useDirectoryBuildProps)
                 .Execute()
                 .Should()
                 .Pass();
 
-            ValidateIntermediatePaths(testAsset, testProjects, useDirectoryBuildProps, "release");
+            ValidateIntermediatePaths(testAsset, testProjects, useDirectoryBuildProps: true, "release");
 
             foreach (var testProject in testProjects)
             {
@@ -129,21 +123,18 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ItUseArtifactstOutputPathForPack(bool useDirectoryBuildProps)
+        [Fact]
+        public void ItUseArtifactsOutputPathForPack()
         {
-            var (testProjects, testAsset) = GetTestProjects(useDirectoryBuildProps);
+            var (testProjects, testAsset) = GetTestProjects(useDirectoryBuildProps: true);
 
             new DotnetCommand(Log, "pack")
                 .WithWorkingDirectory(testAsset.Path)
-                .SetEnvironmentVariables(useDirectoryBuildProps)
                 .Execute()
                 .Should()
                 .Pass();
 
-            ValidateIntermediatePaths(testAsset, testProjects, useDirectoryBuildProps, "release");
+            ValidateIntermediatePaths(testAsset, testProjects, useDirectoryBuildProps: true, "release");
 
             foreach (var testProject in testProjects)
             {
@@ -181,7 +172,7 @@ namespace Microsoft.NET.Build.Tests
                         .Should()
                         .NotHaveSubDirectories();
 
-                    new DirectoryInfo(Path.Combine(testAsset.TestRoot, ".artifacts", "obj", testProject.Name, configuration))
+                    new DirectoryInfo(Path.Combine(testAsset.TestRoot, "artifacts", "obj", testProject.Name, configuration))
                         .Should()
                         .Exist();
                 };
@@ -205,16 +196,6 @@ namespace Microsoft.NET.Build.Tests
                 .Pass();
 
             new DirectoryInfo(OutputPathCalculator.FromProject(testAsset.Path, testProject).GetOutputDirectory())
-                .Should()
-                .Exist();
-
-            //  Now build as if UseArtifactsOutput was set in project file
-            new BuildCommand(testAsset)
-                .Execute("/p:UseArtifactsOutput=true", "/p:ImportDirectoryBuildProps=false")
-                .Should()
-                .Pass();
-
-            new DirectoryInfo(Path.Combine(testAsset.Path, testProject.Name, ".artifacts", "bin", "debug"))
                 .Should()
                 .Exist();
 
@@ -279,19 +260,19 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
 
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "bin", testProject.Name, "NET8_Debug")).Should().Exist();
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "bin", testProject.Name, "NET7_Debug")).Should().Exist();
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "bin", testProject.Name, "debug_netstandard2.0")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "bin", testProject.Name, "NET8_Debug")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "bin", testProject.Name, "NET7_Debug")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "bin", testProject.Name, "debug_netstandard2.0")).Should().Exist();
 
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "bin", testProject.Name, "debug_net8.0")).Should().NotExist();
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "bin", testProject.Name, "debug_net7.0")).Should().NotExist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "bin", testProject.Name, "debug_net8.0")).Should().NotExist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "bin", testProject.Name, "debug_net7.0")).Should().NotExist();
 
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "obj", testProject.Name, "NET8_Debug")).Should().Exist();
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "obj", testProject.Name, "NET7_Debug")).Should().Exist();
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "obj", testProject.Name, "debug_netstandard2.0")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "obj", testProject.Name, "NET8_Debug")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "obj", testProject.Name, "NET7_Debug")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "obj", testProject.Name, "debug_netstandard2.0")).Should().Exist();
 
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "obj", testProject.Name, "debug_net8.0")).Should().NotExist();
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "obj", testProject.Name, "debug_net7.0")).Should().NotExist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "obj", testProject.Name, "debug_net8.0")).Should().NotExist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "obj", testProject.Name, "debug_net7.0")).Should().NotExist();
 
             foreach (var targetFramework in testProject.TargetFrameworks.Split(';'))
             {
@@ -303,9 +284,9 @@ namespace Microsoft.NET.Build.Tests
             }
 
             //  Note that publish defaults to release configuration for .NET 8 but not prior TargetFrameworks
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "publish", testProject.Name, "NET8_Release")).Should().Exist();
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "publish", testProject.Name, "NET7_Debug")).Should().Exist();
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "publish", testProject.Name, "debug_netstandard2.0")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "publish", testProject.Name, "NET8_Release")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "publish", testProject.Name, "NET7_Debug")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "publish", testProject.Name, "debug_netstandard2.0")).Should().Exist();
 
             new DotnetPackCommand(Log)
                 .WithWorkingDirectory(Path.Combine(testAsset.Path, testProject.Name))
@@ -313,8 +294,8 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
 
-            new DirectoryInfo(Path.Combine(testAsset.Path, ".artifacts", "package", "release")).Should().Exist();
-            new FileInfo(Path.Combine(testAsset.Path, ".artifacts", "package", "release", testProject.Name + ".1.0.0.nupkg")).Should().Exist();
+            new DirectoryInfo(Path.Combine(testAsset.Path, "artifacts", "package", "release")).Should().Exist();
+            new FileInfo(Path.Combine(testAsset.Path, "artifacts", "package", "release", testProject.Name + ".1.0.0.nupkg")).Should().Exist();
         }
 
         TestAsset CreateCustomizedTestProject(bool useDirectoryBuildProps, string propertyName, string propertyValue, [CallerMemberName] string callingMethod = "")
@@ -350,17 +331,14 @@ namespace Microsoft.NET.Build.Tests
             return testAsset;
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ArtifactsPathCanBeSet(bool useDirectoryBuildProps)
+        [Fact]
+        public void ArtifactsPathCanBeSet()
         {
             var artifactsFolder = _testAssetsManager.CreateTestDirectory(identifier: "ArtifactsPath").Path;
 
-            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps, "ArtifactsPath", artifactsFolder);
+            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps: true, "ArtifactsPath", artifactsFolder);
 
             new DotnetBuildCommand(testAsset)
-                .SetEnvironmentVariables(useDirectoryBuildProps)
                 .Execute()
                 .Should()
                 .Pass();
@@ -372,116 +350,67 @@ namespace Microsoft.NET.Build.Tests
                 .Exist();
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void BinOutputNameCanBeSet(bool useDirectoryBuildProps)
+        [Fact]
+        public void BinOutputNameCanBeSet()
         {
-            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps, "ArtifactsBinOutputName", "binaries");
+            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps: true, "ArtifactsBinOutputName", "binaries");
 
             new DotnetBuildCommand(testAsset)
-                .SetEnvironmentVariables(useDirectoryBuildProps)
                 .Execute()
                 .Should()
                 .Pass();
 
-            if (useDirectoryBuildProps)
-            {
-                new FileInfo(Path.Combine(testAsset.Path, ".artifacts", "binaries", "App", "debug", "App.dll"))
-                    .Should()
-                    .Exist();
-            }
-            else
-            {
-                new FileInfo(Path.Combine(testAsset.Path, "App", ".artifacts", "binaries", "debug", "App.dll"))
-                    .Should()
-                    .Exist();
-            }
+            new FileInfo(Path.Combine(testAsset.Path, "artifacts", "binaries", "App", "debug", "App.dll"))
+                .Should()
+                .Exist();
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void PublishOutputNameCanBeSet(bool useDirectoryBuildProps)
+        [Fact]
+        public void PublishOutputNameCanBeSet()
         {
-            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps, "ArtifactsPublishOutputName", "published_app");
+            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps: true, "ArtifactsPublishOutputName", "published_app");
 
             new DotnetPublishCommand(Log)
                 .WithWorkingDirectory(testAsset.Path)
-                .SetEnvironmentVariables(useDirectoryBuildProps)
                 .Execute()
                 .Should()
                 .Pass();
 
-            if (useDirectoryBuildProps)
-            {
-                new FileInfo(Path.Combine(testAsset.Path, ".artifacts", "published_app", "App", "release", "App.dll"))
-                    .Should()
-                    .Exist();
-            }
-            else
-            {
-                new FileInfo(Path.Combine(testAsset.Path, "App", ".artifacts", "published_app", "release", "App.dll"))
-                    .Should()
-                    .Exist();
-            }
+            new FileInfo(Path.Combine(testAsset.Path, "artifacts", "published_app", "App", "release", "App.dll"))
+                .Should()
+                .Exist();
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void PackageOutputNameCanBeSet(bool useDirectoryBuildProps)
+        [Fact]
+        public void PackageOutputNameCanBeSet()
         {
-            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps, "ArtifactsPackageOutputName", "package_output");
+            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps: true, "ArtifactsPackageOutputName", "package_output");
 
             new DotnetPackCommand(Log)
                 .WithWorkingDirectory(testAsset.Path)
-                .SetEnvironmentVariables(useDirectoryBuildProps)
                 .Execute()
                 .Should()
                 .Pass();
 
-            if (useDirectoryBuildProps)
-            {
-                new FileInfo(Path.Combine(testAsset.Path, ".artifacts", "package_output", "release", "App.1.0.0.nupkg"))
-                    .Should()
-                    .Exist();
-            }
-            else
-            {
-                new FileInfo(Path.Combine(testAsset.Path, "App", ".artifacts", "package_output", "release", "App.1.0.0.nupkg"))
-                    .Should()
-                    .Exist();
-            }
+            new FileInfo(Path.Combine(testAsset.Path, "artifacts", "package_output", "release", "App.1.0.0.nupkg"))
+                .Should()
+                .Exist();
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ProjectNameCanBeSet(bool useDirectoryBuildProps)
+        [Fact]
+        public void ProjectNameCanBeSet()
         {
-            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps, "ArtifactsProjectName", "Apps\\MyApp");
+            var testAsset = CreateCustomizedTestProject(useDirectoryBuildProps: true, "ArtifactsProjectName", "Apps\\MyApp");
 
             new DotnetBuildCommand(Log)
                 .WithWorkingDirectory(testAsset.Path)
-                .SetEnvironmentVariables(useDirectoryBuildProps)
                 .Execute()
                 .Should()
                 .Pass();
 
-            if (useDirectoryBuildProps)
-            {
-                new FileInfo(Path.Combine(testAsset.Path, ".artifacts", "bin", "Apps", "MyApp", "debug", "App.dll"))
-                    .Should()
-                    .Exist();
-            }
-            else
-            {
-                //  Note that customized ArtifactsProjectName doesn't have an impact here when the artifacts folder is already inside the project folder
-                new FileInfo(Path.Combine(testAsset.Path, "App", ".artifacts", "bin", "debug", "App.dll"))
-                    .Should()
-                    .Exist();
-            }
+            new FileInfo(Path.Combine(testAsset.Path, "artifacts", "bin", "Apps", "MyApp", "debug", "App.dll"))
+                .Should()
+                .Exist();
         }
 
         [Fact]
@@ -513,6 +442,46 @@ namespace Microsoft.NET.Build.Tests
                 .Execute()
                 .Should()
                 .Pass();
+        }
+
+        [Fact]
+        public void ItErrorsIfArtifactsPathIsSetInProject()
+        {
+            var testProject = new TestProject();
+            testProject.AdditionalProperties["ArtifactsPath"] = "$(MSBuildThisFileDirectory)\\..\\artifacts";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            new BuildCommand(testAsset)
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1199");
+
+            new DirectoryInfo(Path.Combine(testAsset.TestRoot, "artifacts"))
+                .Should()
+                .NotExist();
+        }
+
+        [Fact]
+        public void ItErrorsIfUseArtifactsOutputIsSetInProject()
+        {
+            var testProject = new TestProject();
+            testProject.AdditionalProperties["UseArtifactsOutput"] = "true";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            new BuildCommand(testAsset)
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1199");
+
+            new DirectoryInfo(Path.Combine(testAsset.TestRoot, testProject.Name, "artifacts"))
+                .Should()
+                .NotExist();
         }
     }
 

--- a/src/Tests/Microsoft.NET.TestFramework/OutputPathCalculator.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/OutputPathCalculator.cs
@@ -88,11 +88,11 @@ namespace Microsoft.NET.TestFramework
                     {
                         throw new InvalidOperationException("Couldn't find Directory.Build.props for test project " + projectPath);
                     }
-                    calculator.ArtifactsPath = Path.Combine(Path.GetDirectoryName(directoryBuildPropsFile), ".artifacts");
+                    calculator.ArtifactsPath = Path.Combine(Path.GetDirectoryName(directoryBuildPropsFile), "artifacts");
                 }
                 else
                 {
-                    calculator.ArtifactsPath = Path.Combine(Path.GetDirectoryName(projectPath), ".artifacts");
+                    calculator.ArtifactsPath = Path.Combine(Path.GetDirectoryName(projectPath), "artifacts");
                 }
             }
             else
@@ -107,7 +107,7 @@ namespace Microsoft.NET.TestFramework
                     if (calculator.UseArtifactsOutput)
                     {
                         calculator.IncludeProjectNameInArtifactsPaths = false;
-                        calculator.ArtifactsPath = Path.Combine(Path.GetDirectoryName(projectPath), ".artifacts");
+                        calculator.ArtifactsPath = Path.Combine(Path.GetDirectoryName(projectPath), "artifacts");
                     }
                 }
 
@@ -143,7 +143,7 @@ namespace Microsoft.NET.TestFramework
                         if (calculator.UseArtifactsOutput)
                         {
                             calculator.IncludeProjectNameInArtifactsPaths = true;
-                            calculator.ArtifactsPath = Path.Combine(Path.GetDirectoryName(directoryBuildPropsFile), ".artifacts");
+                            calculator.ArtifactsPath = Path.Combine(Path.GetDirectoryName(directoryBuildPropsFile), "artifacts");
                         }
                     }
                 }

--- a/src/Tests/Microsoft.NET.TestFramework/OutputPathCalculator.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/OutputPathCalculator.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NET.TestFramework
             {
                 calculator.UseArtifactsOutput = testProject.UseArtifactsOutput;
                 calculator.IsSdkProject = testProject.IsSdkProject;
-                calculator.IncludeProjectNameInArtifactsPaths = testProject.UseDirectoryBuildPropsForArtifactsOutput;
+                calculator.IncludeProjectNameInArtifactsPaths = true;
 
                 if (testProject.TargetFrameworks.Contains(';'))
                 {
@@ -258,8 +258,7 @@ namespace Microsoft.NET.TestFramework
 
         public string GetIntermediateDirectory(string targetFramework = null, string configuration = "Debug", string runtimeIdentifier = "")
         {
-            //  IncludeProjectNameInArtifactsPath is likely to be true if UseArtifactsOutput was set in Directory.Build.props, and hence the intermediate folder should be in the artifacts path
-            if (UseArtifactsOutput && IncludeProjectNameInArtifactsPaths)
+            if (UseArtifactsOutput)
             {
                 string pivot = configuration.ToLowerInvariant();
                 if (IsMultiTargeted())
@@ -274,7 +273,16 @@ namespace Microsoft.NET.TestFramework
                 {
                     pivot += "_" + runtimeIdentifier;
                 }
-                return Path.Combine(ArtifactsPath, "obj", Path.GetFileNameWithoutExtension(ProjectPath), pivot);
+
+                if (IncludeProjectNameInArtifactsPaths)
+                {
+                    return Path.Combine(ArtifactsPath, "obj", Path.GetFileNameWithoutExtension(ProjectPath), pivot);
+                }
+                else
+                {
+                    return Path.Combine(ArtifactsPath, "obj", pivot);
+                }
+                
             }
 
             targetFramework = targetFramework ?? TargetFramework ?? string.Empty;

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -54,8 +54,6 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public bool UseArtifactsOutput { get; set; }
 
-        public bool UseDirectoryBuildPropsForArtifactsOutput { get; set; }
-
         public List<TestProject> ReferencedProjects { get; } = new List<TestProject>();
 
         public List<string> References { get; } = new List<string>();
@@ -249,11 +247,6 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
             foreach (var additionalProperty in AdditionalProperties)
             {
                 propertyGroup.Add(new XElement(ns + additionalProperty.Key, additionalProperty.Value));
-            }
-
-            if (UseArtifactsOutput && !UseDirectoryBuildPropsForArtifactsOutput)
-            {
-                propertyGroup.Add(new XElement(ns + "UseArtifactsOutput", "true"));
             }
 
             if (AdditionalItems.Any())


### PR DESCRIPTION
Based on feedback from the .NET 8 Preview 3 support for [artifacts output](https://github.com/dotnet/designs/pull/281), this PR removes the `.` from the default artifacts output path.

It also blocks setting the artifacts path in the project file instead of in Directory.Build.props.  Reasons for this include:

- With the `.` removed, adding a new folder inside the project path would cause problems, since the new folder wouldn't be excluded from the default item includes
- It would be unexpected that simply adding an empty Directory.Build.props file to your repo would move the artifacts path from the project folder up the tree to where the Directory.Build.props file was
- Making it an error now might make it easier to change the heuristic in the future to look for .sln files, which might enable us to turn on the new output path format by default for some future TargetFramework.

Some things I still want to add to this PR:

- [x] Add an error if you set `UseArtifactsOutput` to true on the command line but don't have a Directory.Build.props file.
- [x] Add properties that allow you to opt in to putting the artifacts output in the project folder if you want, and to prevent the project name from being added to the path afterwards.
- [x] Verify that artifacts path is removed from globs