### PR TITLE
#30336 Default Dotnet Tool to Run on Latest Runtime - Build time change

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -42,10 +42,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DotnetCliToolTargetFramework>netcoreapp2.2</DotnetCliToolTargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <IncludeBuildOutput Condition=" '$(PackAsTool)' == 'true' ">false</IncludeBuildOutput>
-    <PackageType Condition=" '$(PackAsTool)' == 'true' ">DotnetTool</PackageType>
-    <RuntimeIdentifiers Condition=" '$(PackAsTool)' == 'true' ">$(RuntimeIdentifiers);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
+  <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <PackageType>DotnetTool</PackageType>
+    <RuntimeIdentifiers>$(RuntimeIdentifiers);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
+    <RollForward Condition="'$(RollForward)' == ''">Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(EnablePreviewFeatures)' == 'true' And '$(IsNetCoreAppTargetingLatestTFM)' == 'true'">

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -13,8 +13,10 @@ using Xunit.Abstractions;
 using NuGet.Packaging;
 using System.Xml.Linq;
 using System.Runtime.CompilerServices;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 using System;
 using System.Runtime.InteropServices;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NET.ToolPack.Tests
 {
@@ -299,6 +301,38 @@ namespace Microsoft.NET.ToolPack.Tests
             var result = packCommand.Execute();
             result.Should().Fail().And.HaveStdOutContaining("NETSDK1146");
 
+        }
+
+        [Fact]
+        public void WhenPackAToolItRollForwardDefaultToMajor()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "RollForwardDefault",
+                TargetFrameworks = "netcoreapp3.0",
+                IsWinExe = true,
+            };
+            testProject.AdditionalProperties.Add("PackAsTool", "true");
+
+            TestAsset asset = _testAssetsManager.CreateTestProject(testProject);
+            var packCommand = new PackCommand(Log, Path.Combine(asset.Path, testProject.Name));
+
+            packCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = packCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.Name + ".runtimeconfig.json");
+            JObject runtimeConfig = ReadRuntimeConfig(runtimeConfigFile);
+            runtimeConfig["runtimeOptions"]["rollForward"].Value<string>()
+                .Should().Be("Major");
+        }
+        private JObject ReadRuntimeConfig(string runtimeConfigPath)
+        {
+            string runtimeConfigContents = File.ReadAllText(runtimeConfigPath);
+            return JObject.Parse(runtimeConfigContents);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -304,7 +304,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [Fact]
-        public void WhenPackAToolItRollForwardDefaultToMajor()
+        public void WhenPackingAToolItDefaultsRollsForwardToMajor()
         {
             var testProject = new TestProject()
             {

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -329,6 +329,7 @@ namespace Microsoft.NET.ToolPack.Tests
             runtimeConfig["runtimeOptions"]["rollForward"].Value<string>()
                 .Should().Be("Major");
         }
+
         private JObject ReadRuntimeConfig(string runtimeConfigPath)
         {
             string runtimeConfigContents = File.ReadAllText(runtimeConfigPath);


### PR DESCRIPTION
#30336 NET Tools should default to running on the latest available Runtime 

Build time change: 
Change the `RollForward` of all tools from `LatestPatch` to `Major`, so that tools can be able to run on any .NET runtime equal or greater than the runtime the application originally targeted