### PR TITLE
Update AOT console template

### DIFF
--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.TemplateCommand_GetAllSuggestions.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.TemplateCommand_GetAllSuggestions.verified.txt
@@ -1,5 +1,16 @@
 ﻿[
   {
+    Label: --aot,
+    Kind: Keyword,
+    SortText: --aot,
+    InsertText: --aot,
+    Detail:
+Whether to enable the project for publishing as native AOT.
+Type: bool
+Default: false
+
+  },
+  {
     Label: --dry-run,
     Kind: Keyword,
     SortText: --dry-run,
@@ -82,17 +93,6 @@ Default: false
     Detail: Location to place the generated output.
   },
   {
-    Label: --publish-native-aot,
-    Kind: Keyword,
-    SortText: --publish-native-aot,
-    InsertText: --publish-native-aot,
-    Detail:
-Whether to enable the project for publishing as native AOT.
-Type: bool
-Default: false
-
-  },
-  {
     Label: --type,
     Kind: Keyword,
     SortText: --type,
@@ -116,17 +116,6 @@ Default: false
     SortText: -?,
     InsertText: -?,
     Detail: Show help and usage information
-  },
-  {
-    Label: -aot,
-    Kind: Keyword,
-    SortText: -aot,
-    InsertText: -aot,
-    Detail:
-Whether to enable the project for publishing as native AOT.
-Type: bool
-Default: false
-
   },
   {
     Label: -f,

--- a/src/Tests/dotnet-new.Tests/Approvals/AotVariants.console.cs.verified/MyProject/console.csproj
+++ b/src/Tests/dotnet-new.Tests/Approvals/AotVariants.console.cs.verified/MyProject/console.csproj
@@ -7,9 +7,6 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
-
-    <!-- Uncomment below line to make native publish outputs a lot smaller on Linux and macOS -->
-    <!-- <StripSymbols>true</StripSymbols> -->
   </PropertyGroup>
 
 </Project>

--- a/src/Tests/dotnet-new.Tests/Approvals/AotVariants.console.vb.verified/MyProject/vb-console.csproj
+++ b/src/Tests/dotnet-new.Tests/Approvals/AotVariants.console.vb.verified/MyProject/vb-console.csproj
@@ -8,9 +8,6 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
-
-    <!-- Uncomment below line to make native publish outputs a lot smaller on Linux and macOS -->
-    <!-- <StripSymbols>true</StripSymbols> -->
   </PropertyGroup>
 
 </Project>

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplate_MatchOnNonChoiceParam.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplate_MatchOnNonChoiceParam.verified.txt
@@ -30,7 +30,7 @@ Template options:
   --use-program-main                      Whether to generate an explicit Program class and Main method instead of top-level statements.
                                           Type: bool
                                           Default: false
-  -aot, --publish-native-aot              Whether to enable the project for publishing as native AOT.
+  --aot                                   Whether to enable the project for publishing as native AOT.
                                           Type: bool
                                           Default: false
 

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplate_console.verified.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetNewHelpTests.CanShowHelpForTemplate_console.verified.txt
@@ -30,7 +30,7 @@ Template options:
   --use-program-main                      Whether to generate an explicit Program class and Main method instead of top-level statements.
                                           Type: bool
                                           Default: false
-  -aot, --publish-native-aot              Whether to enable the project for publishing as native AOT.
+  --aot                                   Whether to enable the project for publishing as native AOT.
                                           Type: bool
                                           Default: false
 

--- a/src/Tests/dotnet-new.Tests/CommonTemplatesTests.cs
+++ b/src/Tests/dotnet-new.Tests/CommonTemplatesTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 args.Add("-n");
                 args.Add(projName);
             }
-            args.Add("-aot");
+            args.Add("--aot");
 
             // Do not bother restoring. This would need to restore the AOT compiler.
             // We would need a nuget.config for that and it's a waste of time anyway.

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.8.0/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.8.0/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
@@ -22,8 +22,8 @@
       "shortName": ""
     },
     "NativeAot": {
-      "longName": "publish-native-aot",
-      "shortName": "aot"
+      "longName": "aot",
+      "shortName": ""
     }
   },
   "usageExamples": [

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.8.0/content/ConsoleApplication-CSharp/Company.ConsoleApplication1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.8.0/content/ConsoleApplication-CSharp/Company.ConsoleApplication1.csproj
@@ -11,9 +11,6 @@
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
-
-    <!-- Uncomment below line to make native publish outputs a lot smaller on Linux and macOS -->
-    <!-- <StripSymbols>true</StripSymbols> -->
     <!--#endif -->
   </PropertyGroup>
 

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.8.0/content/ConsoleApplication-VisualBasic/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.8.0/content/ConsoleApplication-VisualBasic/.template.config/dotnetcli.host.json
@@ -18,8 +18,8 @@
       "shortName": ""
     },
     "NativeAot": {
-      "longName": "publish-native-aot",
-      "shortName": "aot"
+      "longName": "aot",
+      "shortName": ""
     }
   },
   "usageExamples": [

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.8.0/content/ConsoleApplication-VisualBasic/Company.ConsoleApplication1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.8.0/content/ConsoleApplication-VisualBasic/Company.ConsoleApplication1.vbproj
@@ -9,9 +9,6 @@
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
-
-    <!-- Uncomment below line to make native publish outputs a lot smaller on Linux and macOS -->
-    <!-- <StripSymbols>true</StripSymbols> -->
     <!--#endif -->
   </PropertyGroup>
 


### PR DESCRIPTION
Based on discussions.

* StripSymbols is going to be SDK default.
* `--aot` instead of `-aot` to match Unix conventions.

Cc @dotnet/ilc-contrib @am11 @DamianEdwards @eerhardt 