### PR TITLE
add artifacts path to buildprops template

### DIFF
--- a/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#MSBuild-Directory-Build-props-file#-n#item#--inherit#--use-artifacts.verified/MSBuild-Directory-Build-props-file/Directory.Build.props
+++ b/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#MSBuild-Directory-Build-props-file#-n#item#--inherit#--use-artifacts.verified/MSBuild-Directory-Build-props-file/Directory.Build.props
@@ -1,0 +1,10 @@
+﻿<Project>
+  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+          Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''" />
+  <PropertyGroup>
+
+  <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+
+  </PropertyGroup>
+</Project>

--- a/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#MSBuild-Directory-Build-props-file#-n#item#--inherit#--use-artifacts.verified/std-streams/stdout.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#MSBuild-Directory-Build-props-file#-n#item#--inherit#--use-artifacts.verified/std-streams/stdout.txt
@@ -1,0 +1,1 @@
+﻿The template "%TEMPLATE_NAME%" was created successfully.

--- a/src/Tests/dotnet-new.Tests/CommonTemplatesTests.cs
+++ b/src/Tests/dotnet-new.Tests/CommonTemplatesTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         [InlineData("EditorConfig file", "editorconfig", new[] { "--empty" })]
         [InlineData("EditorConfig file", ".editorconfig", null)]
         [InlineData("EditorConfig file", ".editorconfig", new[] { "--empty" })]
-        [InlineData("MSBuild Directory.Build.props file", "buildprops", new[] { "--inherit" })]
+        [InlineData("MSBuild Directory.Build.props file", "buildprops", new[] { "--inherit", "--use-artifacts" })]
         [InlineData("MSBuild Directory.Build.targets file", "buildtargets", new[] { "--inherit" })]
         public async void AllCommonItemsCreate(string expectedTemplateName, string templateShortName, string[]? args)
         {

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/dotnetcli.host.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "useArtifacts": {
+      "longName": "use-artifacts",
+      "shortName": ""
+    },
+    "inherit": {
+      "shortName": ""
+    }
+  }
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.cs.json
@@ -3,5 +3,7 @@
   "name": "Soubor MSBuild Directory.Build.props",
   "description": "Prázdný soubor Directory.Build.props, který lze použít k určení vlastností MSBuild pro celou složku",
   "symbols/inherit/displayName": "Zdědit",
-  "symbols/inherit/description": "Při hodnotě true přidá import pro nejbližší soubor Directory.Build.props v hierarchii adresářů systému souborů. Directory.Build.props ve výchozím nastavení nedědí, takže můžete vytvořit sadu přizpůsobení pro každou složku zvlášť."
+  "symbols/inherit/description": "Při hodnotě true přidá import pro nejbližší soubor Directory.Build.props v hierarchii adresářů systému souborů. Directory.Build.props ve výchozím nastavení nedědí, takže můžete vytvořit sadu přizpůsobení pro každou složku zvlášť.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.de.json
@@ -3,5 +3,7 @@
   "name": "Datei \"MSBuild Directory.Build.props\"",
   "description": "Eine leere \"Directory.Build.props\"-Datei, die zum Angeben von MSBuild-Eigenschaften für einen gesamten Ordner verwendet werden kann.",
   "symbols/inherit/displayName": "Erben",
-  "symbols/inherit/description": "Bei \"true\" wird ein Import für die nächstgelegene Datei \"Directory.Build.props\" in der Verzeichnishierarchie des Dateisystems hinzugefügt. \"Directory.Build.props\" erbt nicht standardmäßig. Auf diese Weise können Sie einen Satz von Anpassungen für einzelne Ordner erstellen."
+  "symbols/inherit/description": "Bei \"true\" wird ein Import für die nächstgelegene Datei \"Directory.Build.props\" in der Verzeichnishierarchie des Dateisystems hinzugefügt. \"Directory.Build.props\" erbt nicht standardmäßig. Auf diese Weise können Sie einen Satz von Anpassungen für einzelne Ordner erstellen.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.en.json
@@ -3,5 +3,7 @@
   "name": "MSBuild Directory.Build.props file",
   "description": "An empty Directory.Build.props file which can be used to specify MSBuild properties for an entire folder",
   "symbols/inherit/displayName": "Inherit",
-  "symbols/inherit/description": "If true, adds an Import for the closest Directory.Build.props in the file system directory hierarchy. Directory.Build.props don't inherit by default, so doing this allows you to build up a set of customizations folder-by-folder."
+  "symbols/inherit/description": "If true, adds an Import for the closest Directory.Build.props in the file system directory hierarchy. Directory.Build.props don't inherit by default, so doing this allows you to build up a set of customizations folder-by-folder.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.es.json
@@ -3,5 +3,7 @@
   "name": "Archivo Directory.Build.props de MSBuild",
   "description": "Un archivo Directory.Build.props vacío que se puede usar para especificar propiedades de MSBuild para toda una carpeta",
   "symbols/inherit/displayName": "Heredar",
-  "symbols/inherit/description": "Si es true, agrega una importación para el archivo Directory.Build.props más cercano en la jerarquía de directorios del sistema de archivos. Directory.Build.props no hereda de forma predeterminada, por lo que esto le permite crear un conjunto de personalizaciones carpeta por carpeta."
+  "symbols/inherit/description": "Si es true, agrega una importación para el archivo Directory.Build.props más cercano en la jerarquía de directorios del sistema de archivos. Directory.Build.props no hereda de forma predeterminada, por lo que esto le permite crear un conjunto de personalizaciones carpeta por carpeta.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.fr.json
@@ -3,5 +3,7 @@
   "name": "Fichier MSBuild Directory.Build.props",
   "description": "Fichier Directory.Build.props vide qui peut être utilisé pour spécifier les propriétés MSBuild d’un dossier entier",
   "symbols/inherit/displayName": "Hériter",
-  "symbols/inherit/description": "Si la valeur est true, ajoute une importation pour Directory.Build.props le plus proche dans la hiérarchie du répertoire du système de fichiers. Directory.Build.props n’hérite pas par défaut. Cela vous permet donc de créer un ensemble de personnalisations dossier par dossier."
+  "symbols/inherit/description": "Si la valeur est true, ajoute une importation pour Directory.Build.props le plus proche dans la hiérarchie du répertoire du système de fichiers. Directory.Build.props n’hérite pas par défaut. Cela vous permet donc de créer un ensemble de personnalisations dossier par dossier.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.it.json
@@ -3,5 +3,7 @@
   "name": "File MSBuild Directory.Build.props",
   "description": "File Directory.Build.props vuoto che può essere usato per specificare le proprietà di MSBuild per un'intera cartella",
   "symbols/inherit/displayName": "Ereditare",
-  "symbols/inherit/description": "Se True, aggiunge un'importazione di Directory.Build.props più vicino nella gerarchia delle directory del file system. Directory.Build.props non eredita per impostazione predefinita. In questo modo è possibile creare un set di personalizzazioni cartella per cartella."
+  "symbols/inherit/description": "Se True, aggiunge un'importazione di Directory.Build.props più vicino nella gerarchia delle directory del file system. Directory.Build.props non eredita per impostazione predefinita. In questo modo è possibile creare un set di personalizzazioni cartella per cartella.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.ja.json
@@ -3,5 +3,7 @@
   "name": "MSBuild Directory.Build.props ファイル",
   "description": "フォルダー全体の MSBuild プロパティを指定するために使用できる空の Directory.Build.props ファイル",
   "symbols/inherit/displayName": "継承する",
-  "symbols/inherit/description": "true の場合、ファイル システム ディレクトリ階層内の最も近い Directory.Build.props のインポートを追加します。Directory.Build.props は既定では継承されないため、これを行うと、フォルダーごとにカスタマイズのセットをビルドできます。"
+  "symbols/inherit/description": "true の場合、ファイル システム ディレクトリ階層内の最も近い Directory.Build.props のインポートを追加します。Directory.Build.props は既定では継承されないため、これを行うと、フォルダーごとにカスタマイズのセットをビルドできます。",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.ko.json
@@ -3,5 +3,7 @@
   "name": "MSBuild Directory.Build.props 파일",
   "description": "전체 폴더에 대해 MSBuild 속성을 지정하는 데 사용할 수 있는 빈 Directory.Build.props 파일입니다.",
   "symbols/inherit/displayName": "상속",
-  "symbols/inherit/description": "true이면 파일 시스템 디렉터리 계층에서 가장 가까운 Directory.Build.props에 대해 Import를 추가합니다. Directory.Build.props는 기본적으로 상속되지 않으므로 이 작업을 수행하여 폴더별 사용자 지정 집합을 만들 수 있습니다."
+  "symbols/inherit/description": "true이면 파일 시스템 디렉터리 계층에서 가장 가까운 Directory.Build.props에 대해 Import를 추가합니다. Directory.Build.props는 기본적으로 상속되지 않으므로 이 작업을 수행하여 폴더별 사용자 지정 집합을 만들 수 있습니다.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.pl.json
@@ -3,5 +3,7 @@
   "name": "Plik Directory.Build.props platformy MsBuild",
   "description": "Pusty plik Directory.Build.props, którego można użyć do określenia właściwości platformy MSBuild dla całego folderu",
   "symbols/inherit/displayName": "Dziedzicz",
-  "symbols/inherit/description": "Jeśli jest prawdą, dodaje import dla najbliższego pliku Directory.Build.props w hierarchii katalogów systemu plików. Plik Directory.Build.props nie dziedziczy domyślnie, więc pozwala to na utworzenie zestawu dostosowań dla każdego folderu z osobna."
+  "symbols/inherit/description": "Jeśli jest prawdą, dodaje import dla najbliższego pliku Directory.Build.props w hierarchii katalogów systemu plików. Plik Directory.Build.props nie dziedziczy domyślnie, więc pozwala to na utworzenie zestawu dostosowań dla każdego folderu z osobna.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.pt-BR.json
@@ -3,5 +3,7 @@
   "name": "Arquivo MSBuild Directory.Build.props",
   "description": "Um arquivo Directory.Build.props vazio que pode ser usado para especificar as propriedades do MSBuild para uma pasta inteira",
   "symbols/inherit/displayName": "Herdar",
-  "symbols/inherit/description": "Se verdadeiro, adiciona um Import para o Directory.Build.props mais próximo na hierarquia de diretórios do sistema de arquivos. Directory.Build.props não herdam por padrão, portanto, isso permite que você crie um conjunto de personalizações pasta por pasta."
+  "symbols/inherit/description": "Se verdadeiro, adiciona um Import para o Directory.Build.props mais próximo na hierarquia de diretórios do sistema de arquivos. Directory.Build.props não herdam por padrão, portanto, isso permite que você crie um conjunto de personalizações pasta por pasta.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.ru.json
@@ -3,5 +3,7 @@
   "name": "Файл Directory.Build.props MSBuild",
   "description": "Пустой файл Directory.Build.props, который можно использовать для указания свойств MSBuild для всей папки",
   "symbols/inherit/displayName": "Наследовать",
-  "symbols/inherit/description": "Если значение равно \"true\", добавляет импорт для ближайшего Directory.Build.props в иерархии каталогов файловой системы. Directory.Build.props не наследуется по умолчанию, поэтому это позволяет создать набор папок настроек по папкам."
+  "symbols/inherit/description": "Если значение равно \"true\", добавляет импорт для ближайшего Directory.Build.props в иерархии каталогов файловой системы. Directory.Build.props не наследуется по умолчанию, поэтому это позволяет создать набор папок настроек по папкам.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.tr.json
@@ -3,5 +3,7 @@
   "name": "MSBuild Directory.Build.props dosyası",
   "description": "Bir klasörün tamamı için MSBuild özelliklerini belirtmek üzere kullanılabilecek boş bir Directory.Build.props dosyası",
   "symbols/inherit/displayName": "Inherit",
-  "symbols/inherit/description": "True ise, dosya sistemi dizin hiyerarşisindeki en yakın Directory.Build.props için bir Import değeri ekler. Directory.Build.props varsayılan olarak devralmadığından bunu yapmak, klasörden klasöre bir özelleştirme kümesi oluşturmanızı sağlar."
+  "symbols/inherit/description": "True ise, dosya sistemi dizin hiyerarşisindeki en yakın Directory.Build.props için bir Import değeri ekler. Directory.Build.props varsayılan olarak devralmadığından bunu yapmak, klasörden klasöre bir özelleştirme kümesi oluşturmanızı sağlar.",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.zh-Hans.json
@@ -3,5 +3,7 @@
   "name": "MSBuild Directory.Build.props 文件",
   "description": "一个空的 Directory.Build.props 文件，可用于为整个文件夹指定 MSBuild 属性",
   "symbols/inherit/displayName": "继承",
-  "symbols/inherit/description": "如果为 true，则为文件系统目录层次结构中最近的 Directory.Build.props 添加 Import。默认情况下，Directory.Build.props 不会继承，因此这样做可以按文件夹生成一组自定义项。"
+  "symbols/inherit/description": "如果为 true，则为文件系统目录层次结构中最近的 Directory.Build.props 添加 Import。默认情况下，Directory.Build.props 不会继承，因此这样做可以按文件夹生成一组自定义项。",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/localize/templatestrings.zh-Hant.json
@@ -3,5 +3,7 @@
   "name": "MSBuild Directory.Build.props 檔案",
   "description": "空的 Directory.Build.props 檔案，可用來指定整個資料夾的 MSBuild 屬性",
   "symbols/inherit/displayName": "繼承",
-  "symbols/inherit/description": "如果為 True，則會為檔案系統目錄階層中最接近的 Directory.Build.props 新增 Import。Directory.Build.props 預設不會繼承，因此這麼做可讓您建置一組按資料夾的自訂項目。"
+  "symbols/inherit/description": "如果為 True，則會為檔案系統目錄階層中最接近的 Directory.Build.props 新增 Import。Directory.Build.props 預設不會繼承，因此這麼做可讓您建置一組按資料夾的自訂項目。",
+  "symbols/useArtifacts/displayName": "Use Artifacts Output Layout",
+  "symbols/useArtifacts/description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/.template.config/template.json
@@ -21,6 +21,12 @@
       "datatype": "bool",
       "displayName": "Inherit",
       "description": "If true, adds an Import for the closest Directory.Build.props in the file system directory hierarchy. Directory.Build.props don't inherit by default, so doing this allows you to build up a set of customizations folder-by-folder."
+    },
+    "useArtifacts": {
+      "type": "parameter",
+      "datatype": "bool",
+      "displayName": "Use Artifacts Output Layout",
+      "description": "If true, adds a property to enable the artifacts output layout. This is a common pattern for projects that produce build artifacts, such as NuGet packages, that are placed in a common folder."
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/Directory.Build.props
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/BuildProps/Directory.Build.props
@@ -6,5 +6,9 @@
 <!--#endif-->
   <PropertyGroup>
 
+<!--#if useArtifacts -->
+  <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+<!--#endif-->
+
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This adds a flag that users can use to opt into a form of the new SDK artifacts output layout that was introduced in preview 3. Since the 'default' way of enabling this functionality can 'float' the root directory's location as new buildprops are introduced, we think it's safest to pin the artifacts directory location to the directory containing the D.B.p file. Since this gesture is relatively complex to a non-MSBuild user, scaffolding the expression also makes it easier to on-board users to the new functionality.