### PR TITLE
Remove ASP.NET Json feature switch

### DIFF
--- a/src/Tests/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
@@ -47,8 +47,6 @@ namespace Microsoft.NET.Sdk.Web.Tests
             JsonNode runtimeConfig = JsonNode.Parse(runtimeConfigContents);
             JsonNode configProperties = runtimeConfig["runtimeOptions"]["configProperties"];
 
-            configProperties["Microsoft.AspNetCore.EnsureJsonTrimmability"].GetValue<bool>()
-                    .Should().BeTrue();
             configProperties["System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault"].GetValue<bool>()
                     .Should().BeFalse();
         }
@@ -82,7 +80,6 @@ namespace Microsoft.NET.Sdk.Web.Tests
             string responseFile = Path.Combine(outputDirectory, "native", $"{projectName}.ilc.rsp");
             var responseFileContents = File.ReadLines(responseFile);
 
-            responseFileContents.Should().Contain("--feature:Microsoft.AspNetCore.EnsureJsonTrimmability=true");
             responseFileContents.Should().Contain("--feature:System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault=false");
             File.Exists(Path.Combine(outputDirectory, "web.config")).Should().BeFalse();
         }

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -48,7 +48,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup Condition="'$(PublishTrimmed)' == 'true' Or '$(PublishAot)' == 'true'">
     <!-- Runtime feature defaults to trim unnecessary code -->
-    <EnsureAspNetCoreJsonTrimmability Condition="'$(EnsureAspNetCoreJsonTrimmability)' == ''">true</EnsureAspNetCoreJsonTrimmability>
     <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == ''">false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 

--- a/src/WebSdk/Web/Sdk/Sdk.targets
+++ b/src/WebSdk/Web/Sdk/Sdk.targets
@@ -30,20 +30,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
 
-  <!--
-  ============================================================
-    DefaultRuntimeHostConfigurationOptions
-  Defaults @(RuntimeHostConfigurationOption) items based on MSBuild properties.
-  ============================================================
-  -->
-
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="Microsoft.AspNetCore.EnsureJsonTrimmability"
-                                    Condition="'$(EnsureAspNetCoreJsonTrimmability)' != ''"
-                                    Value="$(EnsureAspNetCoreJsonTrimmability)"
-                                    Trim="true" />
-  </ItemGroup>
-
   <!-- include library-packs folder as additional source for the restore -->
   <PropertyGroup Condition=" '$(DisableImplicitMicrosoftNETBuildContainersReference)' != 'true' ">
     <_WebLibraryPacksFolder Condition="'$(WebLibraryPacksFolder)' == ''">$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))../library-packs</_WebLibraryPacksFolder>


### PR DESCRIPTION
This feature switch is now replaced by JsonSerializerIsReflectionEnabledByDefault. All ASP.NET code is switched over to the new setting, so the old switch can now be removed.

The old switch was originally added in https://github.com/dotnet/sdk/commit/a5e74adc7653d302e130071d8eeaa20b5ae95c0d.