### PR TITLE
add more knobs to control upload chunk size, and if parallel upload s…

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Env.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Env.cs
@@ -37,6 +37,11 @@ namespace Microsoft.DotNet.Cli.Utils
             return _environment.GetEnvironmentVariableAsBool(name, defaultValue);
         }
 
+        public static int? GetEnvironmentVariableAsNullableInt(string name)
+        {
+            return _environment.GetEnvironmentVariableAsNullableInt(name);
+        }
+
         public static string GetEnvironmentVariable(string name)
         {
             return _environment.GetEnvironmentVariable(name);

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
@@ -151,5 +151,15 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             Environment.SetEnvironmentVariable(variable, value, target);
         }
+
+        public int? GetEnvironmentVariableAsNullableInt(string variable)
+        {
+            if (Environment.GetEnvironmentVariable(variable) is string strValue && int.TryParse(strValue, out int intValue))
+            {
+                return intValue;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/IEnvironmentProvider.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/IEnvironmentProvider.cs
@@ -18,6 +18,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
         bool GetEnvironmentVariableAsBool(string name, bool defaultValue);
 
+        int? GetEnvironmentVariableAsNullableInt(string name);
+
         string GetEnvironmentVariable(string name);
 
         string GetEnvironmentVariable(string variable, EnvironmentVariableTarget target);

--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -18,6 +18,9 @@ public static class ContainerHelpers
     internal const string HostObjectPass = "SDK_CONTAINER_REGISTRY_PWORD";
 
     internal const string ChunkedUploadEnabled = "SDK_CONTAINER_REGISTRY_CHUNKED_UPLOAD";
+    internal const string ChunkedUploadSizeBytes = "SDK_CONTAINER_REGISTRY_CHUNKED_UPLOAD_SIZE_BYTES";
+
+    internal const string ParallelUploadEnabled = "SDK_CONTAINER_REGISTRY_PARALLEL_UPLOAD";
 
     /// <summary>
     /// Matches an environment variable name - must start with a letter or underscore, and can only contain letters, numbers, and underscores.

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageReference.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageReference.cs
@@ -10,7 +10,7 @@ internal readonly record struct ImageReference(Registry? Registry, string Reposi
     public override string ToString()
     {
         if (Registry is {} reg) {
-            return $"{reg.BaseUri.GetComponents(UriComponents.HostAndPort, UriFormat.Unescaped)}/{Repository}:{Tag}";
+            return $"{reg.RegistryName}/{Repository}:{Tag}";
         } else {
             return RepositoryAndTag;
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -30,6 +30,16 @@ internal sealed class Registry
         StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// When chunking is enabled, allows explicit control over the size of the chunks uploaded
+    /// </summary>
+    /// <remarks>
+    /// Our default of 64KB is very conservative, so raising this to 1MB or more can speed up layer uploads reasonably well.
+    /// </remarks>
+    private static readonly int? s_chunkedUploadSizeBytes =
+        Environment.GetEnvironmentVariable(ContainerHelpers.ChunkedUploadSizeBytes) is string chunkedUploadSizeBytesString
+        && int.TryParse(chunkedUploadSizeBytesString, out int chunkedUploadSizeBytes) ? chunkedUploadSizeBytes : null;
+
+    /// <summary>
     /// Whether we should upload blobs in parallel (enabled by default, but disabled for certain registries in conjunction with the explicit support check below).
     /// </summary>
     /// <remarks>
@@ -39,9 +49,6 @@ internal sealed class Registry
         Environment.GetEnvironmentVariable(ContainerHelpers.ParallelUploadEnabled) ?? "true", // we want to default this to 'on'
         StringComparison.OrdinalIgnoreCase);
 
-    private static readonly int? s_chunkedUploadSizeBytes =
-        Environment.GetEnvironmentVariable(ContainerHelpers.ChunkedUploadSizeBytes) is string chunkedUploadSizeBytesString
-        && int.TryParse(chunkedUploadSizeBytesString, out int chunkedUploadSizeBytes) ? chunkedUploadSizeBytes : null;
 
     private static readonly int s_defaultChunkSizeBytes = 1024 * 64;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.Build.Containers.Resources;
 using NuGet.RuntimeModel;
 using System.Diagnostics;
@@ -25,9 +26,7 @@ internal sealed class Registry
     /// <remarks>
     /// Relates to https://github.com/dotnet/sdk-container-builds/pull/383#issuecomment-1466408853
     /// </remarks>
-    private static readonly bool s_chunkedUploadEnabled = bool.TrueString.Equals(
-        Environment.GetEnvironmentVariable(ContainerHelpers.ChunkedUploadEnabled) ?? "true", // we want to default this to 'on'
-        StringComparison.OrdinalIgnoreCase);
+    private static readonly bool s_chunkedUploadEnabled = Env.GetEnvironmentVariableAsBool(ContainerHelpers.ChunkedUploadEnabled, defaultValue: false);
 
     /// <summary>
     /// When chunking is enabled, allows explicit control over the size of the chunks uploaded
@@ -35,9 +34,7 @@ internal sealed class Registry
     /// <remarks>
     /// Our default of 64KB is very conservative, so raising this to 1MB or more can speed up layer uploads reasonably well.
     /// </remarks>
-    private static readonly int? s_chunkedUploadSizeBytes =
-        Environment.GetEnvironmentVariable(ContainerHelpers.ChunkedUploadSizeBytes) is string chunkedUploadSizeBytesString
-        && int.TryParse(chunkedUploadSizeBytesString, out int chunkedUploadSizeBytes) ? chunkedUploadSizeBytes : null;
+    private static readonly int? s_chunkedUploadSizeBytes = Env.GetEnvironmentVariableAsNullableInt(ContainerHelpers.ChunkedUploadSizeBytes);
 
     /// <summary>
     /// Whether we should upload blobs in parallel (enabled by default, but disabled for certain registries in conjunction with the explicit support check below).
@@ -45,10 +42,7 @@ internal sealed class Registry
     /// <remarks>
     /// Enabling this can swamp some registries, so this is an escape hatch.
     /// </remarks>
-    private static readonly bool s_parallelUploadEnabled = bool.TrueString.Equals(
-        Environment.GetEnvironmentVariable(ContainerHelpers.ParallelUploadEnabled) ?? "true", // we want to default this to 'on'
-        StringComparison.OrdinalIgnoreCase);
-
+    private static readonly bool s_parallelUploadEnabled =  Env.GetEnvironmentVariableAsBool(ContainerHelpers.ParallelUploadEnabled, defaultValue: true);
 
     private static readonly int s_defaultChunkSizeBytes = 1024 * 64;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -50,7 +50,7 @@ internal sealed class Registry
     /// This is used in user-facing error messages, and it should match what the user would manually enter as
     /// part of Docker commands like `docker login`.
     /// </summary>
-    private string RegistryName { get; init; }
+    public string RegistryName { get; init; }
 
     public Registry(Uri baseUri)
     {

--- a/src/Tests/Microsoft.DotNet.ShellShim.Tests/WindowsEnvironmentPathTests.cs
+++ b/src/Tests/Microsoft.DotNet.ShellShim.Tests/WindowsEnvironmentPathTests.cs
@@ -185,6 +185,11 @@ namespace Microsoft.DotNet.ShellShim.Tests
                 throw new NotImplementedException();
             }
 
+            public int? GetEnvironmentVariableAsNullableInt(string variable)
+            {
+                throw new NotImplementedException();
+            }
+
             private static string Expand(string path)
             {
                 return path?.Replace("%USERPROFILE%", @"C:\Users\username");


### PR DESCRIPTION
A common user complaint for the containers tech is that 

* some registries get swamped with uploads, and
* chunked uploads take too long
 
We previously added an environment variable to allow customization of the chunking logic, and I've added two more knobs here:

* a knob to control the size of the chunks when chunking is used (larger chunks -> fewer requests -> faster overall uploads), since our default of 64kb is _very_ conservative
* a knob to control if the layers are uploaded in parallel, since some registries get swamped with multiple uploads

Further work here could make the chunk size dynamic based on the responses from the server - starting from a small chunk size the size could double each successful request, until failure is reached at which point the size could be backed down.