### PR TITLE
Enable TestBaseTypeWithAmbiguousNonDefaultConstructorsRegression31655

### DIFF
--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1463,7 +1463,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     """);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/67867")]
+        [Fact()]
         public void TestBaseTypeWithAmbiguousNonDefaultConstructorsRegression31655()
         {
             RunTest(original: """
@@ -1480,9 +1480,9 @@ namespace Microsoft.DotNet.GenAPI.Tests
                             public B() : base(new Id(), new D[0]) {}
                         }
 
-                        public class Id { }
-
                         public class D { }
+
+                        public class Id { }
                     
                         public class V { }
                     }
@@ -1498,12 +1498,12 @@ namespace Microsoft.DotNet.GenAPI.Tests
 
                         public partial class B : A
                         {
-                            public B() : base(default(Id), default(System.Collections.Generic.IEnumerable<D>)) {}
+                            public B() : base(default!, default(System.Collections.Generic.IEnumerable<D>)!) {}
                         }
 
-                        public partial class Id { }
-                    
                         public partial class D { }
+
+                        public partial class Id { }
 
                         public partial class V { }
                     }


### PR DESCRIPTION
Fix #31655 

I had to adjust the test data because it was never passing before, but the new simplified output sufficiently fixes the problem.