### PR TITLE
Don't generate publish deps.json for excluded packages

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -867,8 +867,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          generate a different one. -->
     <PropertyGroup>
       <_TrimRuntimeAssets Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true'">true</_TrimRuntimeAssets>
-      <_UseBuildDependencyFile Condition="'@(_ExcludeFromPublishPackageReference)' == '' and
-                                          '@(RuntimeStorePackages)' == '' and
+      <_UseBuildDependencyFile Condition="'@(RuntimeStorePackages)' == '' and
                                           '$(PreserveStoreLayout)' != 'true' and
                                           '$(PublishTrimmed)' != 'true' and
                                           '$(_TrimRuntimeAssets)' != 'true'">true</_UseBuildDependencyFile>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/28661 by not regenerating deps.json on publish when there are assets excluded from publish. It looks like the excluded assets are still contained in the deps.json file, so there's no need to regenerate it. But perhaps the inclusion is a bug in the first place @dsplaisted.