### PR TITLE
Remove reference to 'BINDING' in 'BlazorHotReload.js'

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -1,8 +1,4 @@
-export function receiveHotReload() {
-  return BINDING.js_to_mono_obj(new Promise((resolve) => receiveHotReloadAsync().then(resolve(0))));
-}
-
-async function receiveHotReloadAsync() {
+export async function receiveHotReloadAsync() {
   const cache = window.sessionStorage.getItem('blazor-webassembly-cache');
   let headers;
   if (cache) {
@@ -17,7 +13,7 @@ async function receiveHotReloadAsync() {
       } catch (error) {
         console.warn(error);
         return;
-      } 
+      }
     }
   }
 }


### PR DESCRIPTION
This is the last step required to enable the removal of `disableDotnet6Compatibility: false` from https://github.com/maraf/aspnetcore/blob/99a1d2c0cb39cbddb0e771d76c15fa96cae46261/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts#L347.

This change will require a corresponding reaction in dotnet/aspnetcore: https://github.com/dotnet/aspnetcore/pull/47964

Fixes https://github.com/dotnet/aspnetcore/issues/47878