### PR TITLE
Add debian to the SupportsTargetFramework logic.

### DIFF
--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -121,6 +121,21 @@ namespace Microsoft.NET.TestFramework
                     }
                 }
             }
+            else if (ridOS.Equals("debian", StringComparison.OrdinalIgnoreCase))
+            {
+                string restOfRid = currentRid.Substring(ridOS.Length + 1);
+                string debianVersionString = restOfRid.Split('-')[0];
+                if (int.TryParse(debianVersionString, out int debianVersion))
+                {
+                    if (debianVersion >= 9)
+                    {
+                        if (nugetFramework.Version < new Version(2, 1, 0, 0))
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
             else if (ridOS.Equals("ubuntu", StringComparison.OrdinalIgnoreCase))
             {
                 string restOfRid = currentRid.Substring(ridOS.Length + 1);


### PR DESCRIPTION
2.1 was introduced with debian 8 but we don't need to go back that far. Mostly just block anythign not 2.1 and above on debian.