### PR TITLE
Clarifying .NET version in test

### DIFF
--- a/src/Assets/TestProjects/WatchApp60/WatchApp60.csproj
+++ b/src/Assets/TestProjects/WatchApp60/WatchApp60.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
**The current version indicates we are targeting .NET 60 - when I believe the intention is .NET 6.0.** Interestingly, `net60` builds a .NET 6 binary, but I don't believe this was the intention of this test. 

Recommendations:
1. Accept this PR, clarifying the version from `net60` to `net6.0`
2. Add a comment to the SDK indicating it's specifically targeting `net60`, either to test an obscure 6.0 version, or to specifically test a .NET version that won't exist for some time (v60). 

Reference: https://github.com/dotnet/designs/blob/main/accepted/2020/net5/net5.md#what-about-net-10