### PR TITLE
Container Build: multiple registry push, single archive for multiple tags, tar.gz file writing. 

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -156,16 +156,6 @@ public static class ContainerHelpers
     }
 
     /// <summary>
-    /// Given an already-validated registry domain, this is our hueristic to determine what HTTP protocol should be used to interact with it.
-    /// This is primarily for testing - in the real world almost all usage should be through HTTPS!
-    /// </summary>
-    internal static Uri TryExpandRegistryToUri(string alreadyValidatedDomain)
-    {
-        var prefix = alreadyValidatedDomain.StartsWith("localhost", StringComparison.Ordinal) ? "http" : "https";
-        return new Uri($"{prefix}://{alreadyValidatedDomain}");
-    }
-
-    /// <summary>
     /// Ensures a given environment variable is valid.
     /// </summary>
     /// <param name="envVar"></param>

--- a/src/Containers/Microsoft.NET.Build.Containers/DestinationImageReference.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/DestinationImageReference.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Build.Containers;
+
+/// <summary>
+/// Represents a push destination reference to a Docker image.
+/// A push destination reference is made of a registry, a repository (aka the image name) and multiple tags.
+/// (unlike the <see cref="ImageReference"/> which has a single tag)
+/// </summary>
+internal readonly record struct DestinationImageReference(Registry? Registry, string Repository, string[] Tags)
+{
+    public override string ToString()
+    {
+        string tagList = string.Join(", ", Tags);
+        if (Registry is {} reg)
+        {
+            return $"{reg.RegistryName}/{Repository}:{tagList}";
+        }
+        else
+        {
+            return $"{Repository}:{tagList}";
+        }
+    }
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
@@ -7,12 +7,12 @@ namespace Microsoft.NET.Build.Containers;
 /// Abstracts over the concept of a local container runtime of some kind. Currently this is only modeled by Docker,
 /// but users have expressed desires for Podman, nerdctl, etc as well so this kind of abstraction makes sense to have.
 /// </summary>
-internal interface ILocalDaemon {
-
+internal interface ILocalDaemon
+{
     /// <summary>
     /// Loads an image (presumably from a tarball) into the local container runtime.
     /// </summary>
-    public Task LoadAsync(BuiltImage image, ImageReference sourceReference, ImageReference destinationReference, CancellationToken cancellationToken);
+    public Task LoadAsync(BuiltImage image, ImageReference sourceReference, DestinationImageReference destinationReference, CancellationToken cancellationToken);
 
     /// <summary>
     /// Checks to see if the local container runtime is available. This is used to give nice errors to the user.

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -55,8 +55,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Labels.get -> Microsoft.Buil
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Labels.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalContainerDaemon.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalContainerDaemon.set -> void
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.get -> string!
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistries.get -> string![]!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistries.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.RuntimeIdentifierGraphPath.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -2,7 +2,7 @@
 Microsoft.NET.Build.Containers.BaseImageNotFoundException
 Microsoft.NET.Build.Containers.Constants
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ComputeDotnetBaseImageTag() -> void
-static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! publishDirectory, string! workingDir, string! baseRegistry, string! baseImageName, string! baseImageTag, string![]! entrypoint, string![]? entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, System.Collections.Generic.Dictionary<string!, string!>! labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, System.Collections.Generic.Dictionary<string!, string!>! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, string? containerUser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>!
+static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! publishDirectory, string! workingDir, string! baseRegistry, string! baseImageName, string! baseImageTag, string![]! entrypoint, string![]? entrypointArgs, string! imageName, string![]! imageTags, string?[]! outputRegistries, System.Collections.Generic.Dictionary<string!, string!>! labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, System.Collections.Generic.Dictionary<string!, string!>! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, string? containerUser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>!
 static readonly Microsoft.NET.Build.Containers.Constants.Version -> string!
 Microsoft.NET.Build.Containers.ContainerBuilder
 Microsoft.NET.Build.Containers.ContainerHelpers
@@ -145,8 +145,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Labels.get -> Microsoft.Buil
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Labels.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalContainerDaemon.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalContainerDaemon.set -> void
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.get -> string!
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistries.get -> string![]!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistries.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.RuntimeIdentifierGraphPath.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -666,9 +666,10 @@ internal sealed class Registry
     /// <param name="outputRegistries">The output registries to push to</param>
     /// <returns>A the destination registries to push the image to.</returns>
     /// <exception cref="ArgumentOutOfRangeException">An invalid output mode was provided.</exception>
-    internal static IEnumerable<Registry?> BuildDestinationRegistries(IEnumerable<string?> outputRegistries)
+    internal static IEnumerable<Registry?> BuildDestinationRegistries(IList<string?> outputRegistries)
     {
-        return outputRegistries
-            .Select(r => string.IsNullOrEmpty(r) ? null : new Registry(r));
+        return outputRegistries.Count > 0
+            ? outputRegistries.Select(r => string.IsNullOrEmpty(r) ? null : new Registry(r))
+            : new Registry?[] { null };
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -385,6 +385,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2020: Parent Directory of &apos;{1}&apos; does not exist..
+        /// </summary>
+        internal static string OutputFileDirectoryDoesntExist {
+            get {
+                return ResourceManager.GetString("OutputFileDirectoryDoesntExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CONTAINER2011: {0} &apos;{1}&apos; does not exist.
         /// </summary>
         internal static string PublishDirectoryDoesntExist {

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -196,6 +196,10 @@
     <value>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</value>
     <comment>{StrBegin="CONTAINER2005: "}</comment>
   </data>
+  <data name="OutputFileDirectoryDoesntExist" xml:space="preserve">
+    <value>CONTAINER2020: Parent Directory of '{1}' does not exist.</value>
+    <comment>{StrBegin="CONTAINER2020: "}</comment>
+  </data>
   <data name="InvalidSdkVersion" xml:space="preserve">
     <value>CONTAINER2019: Invalid SDK semantic version '{0}'.</value>
     <comment>{StrBegin="CONTAINER2019: "}</comment>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: Neplatná verze předběžné verze sady SDK '{0}' – podporují se jen 'rc' a 'preview'.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: Neplatná sémantická verze '{0}' sady SDK.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: Ungültige SDK-Vorabversion „{0}“. Es werden nur „rc“ und „preview“ unterstützt.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: Ungültige SDK-semantische Version „{0}“.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: Versión preliminar del SDK "{0}" no válida : solo se admiten "rc" y "preview".</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: Versión "{0}" de semántica del SDK no válida.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: version préliminaire du SDK non valide '{0}' - seuls 'rc' et 'preview' sont pris en charge.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: version sémantique du kit SDK non valide '{0}'.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: valore '{0}' non valido per la versione non definitiva dell'SDK - Sono supportate solo le versioni 'rc' e 'preview'.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: versione semantica dell'SDK non valida '{0}'.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: SDK プレリリース バージョン '{0}' が無効です。'rc' と 'preview' のみがサポートされています。</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: SDK セマンティック バージョン '{0}' が無効です。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: 잘못된 SDK 시험판 버전 '{0}' - 'rc' 및 'preview'만 지원됩니다.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: 잘못된 SDK 의미 체계 버전 '{0}'입니다.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: nieprawidłowa wersja wstępna zestawu SDK „{0}” — obsługiwane są tylko wersje „rc” i „preview”.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: nieprawidłowa wersja semantyczna zestawu SDK „{0}”.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: Versão de pré-lançamento inválida do SDK '{0}' - apenas 'rc' e 'preview' são suportados.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: versão semântica do SDK inválida '{0}'.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: недопустимая предварительная версия SDK "{0}" — поддерживаются только "rc" и "preview".</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: недопустимая семантическая версия SDK "{0}".</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: Geçersiz SDK ön sürümü ('{0}') : yalnızca 'rc' ve 'preview' destekleniyor.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: Geçersiz SDK anlamsal sürümü '{0}'.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: SDK 预发行版本“{0}”无效 - 仅支持“rc”和“preview”。</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: SDK 语义版本“{0}”无效。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -122,6 +122,11 @@
         <target state="translated">CONTAINER2018: 無效的 SDK 發行前版本 '{0}' - 只支援 'rc' 和 'preview'。</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
+      <trans-unit id="OutputFileDirectoryDoesntExist">
+        <source>CONTAINER2020: Parent Directory of '{1}' does not exist.</source>
+        <target state="new">CONTAINER2020: Parent Directory of '{1}' does not exist.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
         <target state="translated">CONTAINER2019: 無效的 SDK 語義版本 '{0}'。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -41,9 +41,9 @@ partial class CreateNewImage
     public string BaseImageTag { get; set; }
 
     /// <summary>
-    /// The registry to push to.
+    /// A list of registries to push to.
     /// </summary>
-    public string OutputRegistry { get; set; }
+    public string[] OutputRegistries { get; set; }
 
     /// <summary>
     /// The kind of local daemon to use, if any.
@@ -139,7 +139,7 @@ partial class CreateNewImage
         BaseRegistry = "";
         BaseImageName = "";
         BaseImageTag = "";
-        OutputRegistry = "";
+        OutputRegistries = Array.Empty<string>();
         ImageName = "";
         ImageTags = Array.Empty<string>();
         PublishDirectory = "";

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -120,10 +120,10 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
         {
             builder.AppendSwitchIfNotNull("--baseimagetag ", BaseImageTag);
         }
-        if (!string.IsNullOrWhiteSpace(OutputRegistry))
-        {
-            builder.AppendSwitchIfNotNull("--outputregistry ", OutputRegistry);
-        }
+
+        string[] sanitizedRegistries = OutputRegistries.Select(r => r ?? "").ToArray();
+        builder.AppendSwitchIfNotNull("--outputregistry ", sanitizedRegistries, delimiter: " ");
+
         if (!string.IsNullOrWhiteSpace(LocalContainerDaemon))
         {
             builder.AppendSwitchIfNotNull("--localcontainerdaemon ", LocalContainerDaemon);

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -122,7 +122,10 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
         }
 
         string[] sanitizedRegistries = OutputRegistries.Select(r => r ?? "").ToArray();
-        builder.AppendSwitchIfNotNull("--outputregistry ", sanitizedRegistries, delimiter: " ");
+        if (sanitizedRegistries.Length > 1 || !string.IsNullOrEmpty(sanitizedRegistries[0]))
+        {
+            builder.AppendSwitchIfNotNull("--outputregistries ", sanitizedRegistries, delimiter: " ");
+        }
 
         if (!string.IsNullOrWhiteSpace(LocalContainerDaemon))
         {

--- a/src/Containers/containerize/ContainerizeCommand.cs
+++ b/src/Containers/containerize/ContainerizeCommand.cs
@@ -37,7 +37,7 @@ internal class ContainerizeCommand : RootCommand
             defaultValueFactory: () => "latest");
 
     internal Option<string[]> OutputRegistryOption { get; } = new Option<string[]>(
-            name: "--outputregistry",
+            name: "--outputregistries",
             description: "The registries to push to.")
             {
                 AllowMultipleArgumentsPerToken = true

--- a/src/Containers/containerize/ContainerizeCommand.cs
+++ b/src/Containers/containerize/ContainerizeCommand.cs
@@ -36,11 +36,11 @@ internal class ContainerizeCommand : RootCommand
             description: "The base image tag. Ex: 6.0",
             defaultValueFactory: () => "latest");
 
-    internal Option<string> OutputRegistryOption { get; } = new Option<string>(
+    internal Option<string[]> OutputRegistryOption { get; } = new Option<string[]>(
             name: "--outputregistry",
-            description: "The registry to push to.")
+            description: "The registries to push to.")
             {
-                IsRequired = false
+                AllowMultipleArgumentsPerToken = true
             };
 
     internal Option<string> ImageNameOption { get; } = new Option<string>(
@@ -168,7 +168,7 @@ internal class ContainerizeCommand : RootCommand
 
 
     internal ContainerizeCommand() : base("Containerize an application without Docker.")
-    { 
+    {
         this.AddArgument(PublishDirectoryArgument);
         this.AddOption(BaseRegistryOption);
         this.AddOption(BaseImageNameOption);
@@ -193,7 +193,7 @@ internal class ContainerizeCommand : RootCommand
             string _baseReg = context.ParseResult.GetValue(BaseRegistryOption)!;
             string _baseName = context.ParseResult.GetValue(BaseImageNameOption)!;
             string _baseTag = context.ParseResult.GetValue(BaseImageTagOption)!;
-            string? _outputReg = context.ParseResult.GetValue(OutputRegistryOption);
+            string[] _outputReg = context.ParseResult.GetValue(OutputRegistryOption) ?? new []{ string.Empty };
             string _name = context.ParseResult.GetValue(ImageNameOption)!;
             string[] _tags = context.ParseResult.GetValue(ImageTagsOption)!;
             string _workingDir = context.ParseResult.GetValue(WorkingDirectoryOption)!;

--- a/src/Containers/containerize/Properties/launchSettings.json
+++ b/src/Containers/containerize/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "containerize": {
       "commandName": "Project",
-      "commandLineArgs": "\"S:\\play\\container-package-test\\obj\\Release\\net7.0\\PubTmp\\Out\" --baseregistry mcr.microsoft.com --baseimagename dotnet/aspnet --baseimagetag 7.0 --outputregistry ghcr.io --imagename baronfel/container-package-test --workingdirectory /app --entrypoint /app/container-package-test.exe --labels org.opencontainers.image.created=2022-10-27T14:17:19.9046559Z --imagetags latest --ports 80/tcp --environmentvariables ASPNETCORE_URLS=http://+:80 \r\n"
+      "commandLineArgs": "\"S:\\play\\container-package-test\\obj\\Release\\net7.0\\PubTmp\\Out\" --baseregistry mcr.microsoft.com --baseimagename dotnet/aspnet --baseimagetag 7.0 --outputregistries ghcr.io --imagename baronfel/container-package-test --workingdirectory /app --entrypoint /app/container-package-test.exe --labels org.opencontainers.image.created=2022-10-27T14:17:19.9046559Z --imagetags latest --ports 80/tcp --environmentvariables ASPNETCORE_URLS=http://+:80 \r\n"
     }
   }
 }

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -73,9 +73,12 @@
       <!-- An empty ContainerRegistry implies pushing to the local daemon, putting this here for documentation purposes -->
       <!-- <ContainerRegistries></ContainerRegistry> -->
 
-      <!-- Backwards compat with single RegistryUrl -->
+      <!-- Backwards compat with single RegistryUrl from VS Defaults -->
       <ContainerRegistries Condition="'$(RegistryUrl)' != '' AND '$(ContainerRegistries)' == '' ">$(RegistryUrl)</ContainerRegistries>
       <ContainerRegistries Condition="'$(RegistryUrl)' != '' AND '$(ContainerRegistries)' != '' ">$(RegistryUrl);$(ContainerRegistries)</ContainerRegistries>
+      <!-- Backwards compat with single ContainerRegistry -->
+      <ContainerRegistries Condition="'$(ContainerRegistry)' != '' AND '$(ContainerRegistries)' == '' ">$(ContainerRegistry)</ContainerRegistries>
+      <ContainerRegistries Condition="'$(ContainerRegistry)' != '' AND '$(ContainerRegistries)' != '' ">$(ContainerRegistry);$(ContainerRegistries)</ContainerRegistries>
 
       <!-- Set which local container daemon to use. We only explicitly support Docker (or things that mimic Docker APIs and binary names) at the moment. -->
       <LocalContainerDaemon Condition="'$(LocalContainerDaemon)' == ''">Docker</LocalContainerDaemon>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -61,7 +61,7 @@
   <Target Name="ComputeContainerConfig" DependsOnTargets="ComputeContainerBaseImage">
     <PropertyGroup Label="VS defaults">
       <!-- RegistryUrl is used by existing VS targets for Docker builds - this lets us fill that void -->
-      <ContainerRegistry Condition="'$(RegistryUrl)' != ''">$(RegistryUrl)</ContainerRegistry>
+      <ContainerRegistries Condition="'$(RegistryUrls)' != ''">$(RegistryUrls)</ContainerRegistries>
       <!-- PublishImageTag is used by existing VS targets for Docker builds - this lets us fill that void -->
       <ContainerImageTag Condition="'$(PublishImageTag)' != ''">$(PublishImageTag)</ContainerImageTag>
       <!-- This line is a compatibility shim for VS support - the VS container targets define a container tag using this property and format. This lets us be a drop-in replacement for them. -->
@@ -71,7 +71,11 @@
     <!-- Container Defaults -->
     <PropertyGroup>
       <!-- An empty ContainerRegistry implies pushing to the local daemon, putting this here for documentation purposes -->
-      <!-- <ContainerRegistry></ContainerRegistry> -->
+      <!-- <ContainerRegistries></ContainerRegistry> -->
+
+      <!-- Backwards compat with single RegistryUrl -->
+      <ContainerRegistries Condition="'$(RegistryUrl)' != '' AND '$(ContainerRegistries)' == '' ">$(RegistryUrl)</ContainerRegistries>
+      <ContainerRegistries Condition="'$(RegistryUrl)' != '' AND '$(ContainerRegistries)' != '' ">$(RegistryUrl);$(ContainerRegistries)</ContainerRegistries>
 
       <!-- Set which local container daemon to use. We only explicitly support Docker (or things that mimic Docker APIs and binary names) at the moment. -->
       <LocalContainerDaemon Condition="'$(LocalContainerDaemon)' == ''">Docker</LocalContainerDaemon>
@@ -122,7 +126,6 @@
       <Output TaskParameter="ParsedContainerTag" PropertyName="ContainerBaseTag" />
       <Output TaskParameter="NewContainerRegistry" PropertyName="ContainerRegistry" />
       <Output TaskParameter="NewContainerImageName" PropertyName="ContainerImageName" />
-      <Output TaskParameter="NewContainerTags" ItemName="ContainerImageTags" />
       <Output TaskParameter="NewContainerEnvironmentVariables" ItemName="ContainerEnvironmentVariables" />
     </ParseContainerProperties>
 
@@ -199,7 +202,7 @@
                     BaseImageName="$(ContainerBaseName)"
                     BaseImageTag="$(ContainerBaseTag)"
                     LocalContainerDaemon="$(LocalContainerDaemon)"
-                    OutputRegistry="$(ContainerRegistry)"
+                    OutputRegistries="@(ContainerRegistries)"
                     ImageName="$(ContainerImageName)"
                     ImageTags="@(ContainerImageTags)"
                     PublishDirectory="$(PublishDir)"

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -50,7 +50,7 @@ public class CreateNewImageTests
         task.BaseImageName = "dotnet/runtime";
         task.BaseImageTag = "7.0";
 
-        task.OutputRegistry = "localhost:5010";
+        task.OutputRegistries = new[] { "localhost:5010" };
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-arm64", "publish");
         task.ImageName = "dotnet/testimage";
         task.ImageTags = new[] { "latest" };
@@ -104,7 +104,7 @@ public class CreateNewImageTests
         cni.BaseImageName = pcp.ParsedContainerImage;
         cni.BaseImageTag = pcp.ParsedContainerTag;
         cni.ImageName = pcp.NewContainerImageName;
-        cni.OutputRegistry = "localhost:5010";
+        cni.OutputRegistries = new[] { "localhost:5010" };
         cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.CurrentTargetFramework);
         cni.WorkingDirectory = "app/";
         cni.Entrypoint = new TaskItem[] { new("ParseContainerProperties_EndToEnd") };
@@ -169,7 +169,7 @@ public class CreateNewImageTests
         cni.BaseImageName = pcp.ParsedContainerImage;
         cni.BaseImageTag = pcp.ParsedContainerTag;
         cni.ImageName = pcp.NewContainerImageName;
-        cni.OutputRegistry = pcp.NewContainerRegistry;
+        cni.OutputRegistries = new[] { pcp.NewContainerRegistry };
         cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.CurrentTargetFramework, "linux-x64");
         cni.WorkingDirectory = "/app";
         cni.Entrypoint = new TaskItem[] { new("/app/Tasks_EndToEnd_With_EnvironmentVariable_Validation") };

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -42,7 +42,7 @@ public class EndToEndTests
 
         // Build the image
 
-        Registry registry = new Registry(ContainerHelpers.DockerRegistryManager.LocalRegistry);
+        Registry registry = new Registry(DockerRegistryManager.LocalRegistry);
 
         ImageBuilder imageBuilder = await registry.GetImageManifestAsync(
             DockerRegistryManager.BaseImage,
@@ -63,7 +63,7 @@ public class EndToEndTests
 
         // Push the image back to the local registry
         var sourceReference = new ImageReference(registry, DockerRegistryManager.BaseImage, DockerRegistryManager.Net6ImageTag);
-        var destinationReference = new ImageReference(registry, NewImageName(), "latest");
+        var destinationReference = new DestinationImageReference(registry, NewImageName(), new[] { "latest" });
 
         await registry.PushAsync(builtImage, sourceReference, destinationReference, Console.WriteLine, cancellationToken: default).ConfigureAwait(false);
 
@@ -105,7 +105,7 @@ public class EndToEndTests
 
         // Load the image into the local Docker daemon
         var sourceReference = new ImageReference(registry, DockerRegistryManager.BaseImage, DockerRegistryManager.Net6ImageTag);
-        var destinationReference = new ImageReference(registry, NewImageName(), "latest");
+        var destinationReference = new DestinationImageReference(registry, NewImageName(), new[] { "latest" });
 
         await new LocalDocker(Console.WriteLine).LoadAsync(builtImage, sourceReference, destinationReference, default).ConfigureAwait(false);
 
@@ -410,7 +410,7 @@ public class EndToEndTests
 
         // Load the image into the local Docker daemon
         var sourceReference = new ImageReference(registry, DockerRegistryManager.BaseImage, DockerRegistryManager.Net7ImageTag);
-        var destinationReference = new ImageReference(registry, NewImageName(), rid);
+        var destinationReference = new DestinationImageReference(registry, NewImageName(), new[] { rid });
         await new LocalDocker(Console.WriteLine).LoadAsync(builtImage, sourceReference, destinationReference, default).ConfigureAwait(false);
 
         // Run the image

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -42,7 +42,7 @@ public class EndToEndTests
 
         // Build the image
 
-        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
+        Registry registry = new Registry(ContainerHelpers.DockerRegistryManager.LocalRegistry);
 
         ImageBuilder imageBuilder = await registry.GetImageManifestAsync(
             DockerRegistryManager.BaseImage,
@@ -85,7 +85,7 @@ public class EndToEndTests
 
         // Build the image
 
-        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
+        Registry registry = new Registry(DockerRegistryManager.LocalRegistry);
 
         ImageBuilder imageBuilder = await registry.GetImageManifestAsync(
             DockerRegistryManager.BaseImage,
@@ -388,7 +388,7 @@ public class EndToEndTests
         string publishDirectory = BuildLocalApp(tfm: ToolsetInfo.CurrentTargetFramework, rid: rid);
 
         // Build the image
-        Registry registry = new(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.BaseImageSource));
+        Registry registry = new(DockerRegistryManager.BaseImageSource);
 
         ImageBuilder? imageBuilder = await registry.GetImageManifestAsync(
             DockerRegistryManager.BaseImage,

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
@@ -112,6 +112,7 @@ public class CreateNewImageToolTaskTests
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("Valid", true)]
+    // TODO: adjust to new output registries handling
     public void GenerateCommandLineCommands_OutputRegistry(string value, bool optionExpected = false)
     {
         CreateNewImage task = new();

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
@@ -58,7 +58,7 @@ public class CreateNewImageToolTaskTests
         e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
         Assert.Equal("CONTAINER4002: Required 'Entrypoint' items were not set.", e.Message);
 
-        task.Entrypoint = new[] { new TaskItem("") }; 
+        task.Entrypoint = new[] { new TaskItem("") };
 
         e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
         Assert.Equal("CONTAINER4003: Required 'Entrypoint' items contain empty items.", e.Message);
@@ -103,7 +103,7 @@ public class CreateNewImageToolTaskTests
         else
         {
             Assert.DoesNotContain("--baseimagetag", args);
-        }      
+        }
     }
 
 
@@ -123,17 +123,17 @@ public class CreateNewImageToolTaskTests
         task.WorkingDirectory = "MyWorkingDirectory";
         task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
 
-        task.OutputRegistry = value;
+        task.OutputRegistries = new[] { value };
 
         string args = task.GenerateCommandLineCommandsInt();
 
         if (optionExpected)
         {
-            Assert.Contains($"--outputregistry {value}", args);
+            Assert.Contains($"--outputregistries {value}", args);
         }
         else
         {
-            Assert.DoesNotContain("--outputregistry", args);
+            Assert.DoesNotContain("--outputregistries", args);
         }
     }
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
@@ -12,7 +12,7 @@ public class RegistryTests
     [DockerDaemonAvailableFact]
     public async Task GetFromRegistry()
     {
-        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
+        Registry registry = new Registry(DockerRegistryManager.LocalRegistry);
         var ridgraphfile = ToolsetUtils.GetRuntimeGraphFilePath();
 
         // Don't need rid graph for local registry image pulls - since we're only pushing single image manifests (not manifest lists)

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Build.Containers.UnitTests
         [Theory]
         public void CheckIfAmazonECR(string registryName, bool isECR)
         {
-            Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(registryName));
+            Registry registry = new Registry(registryName);
             Assert.Equal(isECR, registry.IsAmazonECRRegistry);
         }
 
@@ -27,7 +27,7 @@ namespace Microsoft.NET.Build.Containers.UnitTests
         [Theory]
         public void CheckIfGoogleArtifactRegistry(string registryName, bool isECR)
         {
-            Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(registryName));
+            Registry registry = new Registry(registryName);
             Assert.Equal(isECR, registry.IsGoogleArtifactRegistry);
         }
     }


### PR DESCRIPTION
This PR relates to following issues: 

- https://github.com/dotnet/sdk-container-builds/issues/376
- https://github.com/dotnet/sdk-container-builds/issues/379
- https://github.com/dotnet/sdk-container-builds/issues/283

The issues somehow closely relate to the workflow around registries so I decided to rather tackle them all together. The PR has the following adaptions: 

- The single `OutputRegistry` is converted to an array `OutputRegistries` to support pushing to multiple registries with following syntax: 
	- Not providing any registries to push means a load to local container daemon (e.g. docker)
	- Providing an empty item in the OutputRegistries (or null) also means push to local container daemon. (see open design decision 1) 
	- Providing absolute file paths, relative file paths or file URLs means writing a tar.gz archive
	- Providing any other string means a remote registry to push to. 
- Instead of generating one image per tag we now
	- Write one tar.gz with all tags in the `RepoTags` key (for local tar.gz and daemon load)
	- Pushing the same manifest to multiple tags on the API (for remote registries)

**Open Design Decisions:**

1. Shall we better use an explicit string for the local daemon load? Empty strings are often filtered or ignored. Having something more explicit might be better. 
Proposal: Use a string like `local-container-daemon` as registry to trigger `docker load` flow. 

2. On all registries the image will be named the same. Maybe the image should be named differently on different registries due to naming policies (public vs internal). 
Proposal: Use the URL fragment syntax to define a different name:

```xml
<Project>
  <PropertyGroup>
	<ContainerImageName>my-app</ContainerImageName>
	<!-- Local Docker will have my-app -->
	<ContainerRegistries>local-container-daemon</ContainerRegistries>
	<!-- Internal JFrog Artifactory instance will have team-my-app in the my-docker-repo 'artifactory repository' -->
	<ContainerRegistries>artifactory.my-company.com#my-docker-repo/team-my-app</ContainerRegistries> 
	<!-- Public Docker Hub will  JFrog Artifactory instance will have my-app in the respective user -->
	<ContainerRegistries>artifactory.my-company.com#my-username/my-app</ContainerRegistries> 	
  </PropertyGroup>
</Project>
 
```

**Taken Design Decisions:** 

1. We do not allow different tags on different registries within one single dotnet publish command for now. A user would call dotnet publish multiple times with different tags and repositories to do that individualization. 
	**Pros:**
		- We keep the configuration syntax simple for now. The feature can still be added with a special syntax or an additional configuration file. 
	**Cons:** 
		- Multiple publish commands will result in different layer hashes for the app due to non-deterministic gzip compression and timestamp differences.	


Ping @baronfel for further discussion here. 