### PR TITLE
dotnet-watch: Enable nullable annotations on project level

### DIFF
--- a/src/BuiltInTools/DotNetWatchTasks/DotNetWatchTasks.csproj
+++ b/src/BuiltInTools/DotNetWatchTasks/DotNetWatchTasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BuiltInTools/DotNetWatchTasks/FileSetSerializer.cs
+++ b/src/BuiltInTools/DotNetWatchTasks/FileSetSerializer.cs
@@ -14,25 +14,25 @@ namespace DotNetWatchTasks
 {
     public class FileSetSerializer : Task
     {
-        public ITaskItem[] WatchFiles { get; set; }
+        public ITaskItem[] WatchFiles { get; set; } = null!;
 
         public bool IsNetCoreApp { get; set; }
 
-        public string TargetFrameworkVersion { get; set; }
+        public string TargetFrameworkVersion { get; set; } = null!;
 
-        public string RuntimeIdentifier { get; set; }
+        public string RuntimeIdentifier { get; set; } = null!;
 
-        public string DefaultAppHostRuntimeIdentifier { get; set; }
+        public string DefaultAppHostRuntimeIdentifier { get; set; } = null!;
 
-        public string RunCommand { get; set; }
+        public string RunCommand { get; set; } = null!;
 
-        public string RunArguments { get; set; }
+        public string RunArguments { get; set; } = null!;
 
-        public string RunWorkingDirectory { get; set; }
+        public string RunWorkingDirectory { get; set; } = null!;
 
-        public ITaskItem OutputPath { get; set; }
+        public ITaskItem OutputPath { get; set; } = null!;
 
-        public string[] PackageIds { get; set; }
+        public string[] PackageIds { get; set; } = null!;
 
         public override bool Execute()
         {

--- a/src/BuiltInTools/DotNetWatchTasks/Utilities/CompilerFeatureRequiredAttribute.cs
+++ b/src/BuiltInTools/DotNetWatchTasks/Utilities/CompilerFeatureRequiredAttribute.cs
@@ -5,7 +5,15 @@
 // Copied from:
 // https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CompilerFeatureRequiredAttribute.cs
 
-#if !NET7_0_OR_GREATER
+#if NET7_0_OR_GREATER
+
+using System.Runtime.CompilerServices;
+
+#pragma warning disable RS0016 // Add public types and members to the declared API (this is a supporting forwarder for an internal polyfill API)
+[assembly: TypeForwardedTo(typeof(CompilerFeatureRequiredAttribute))]
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
+#else
 
 namespace System.Runtime.CompilerServices
 {

--- a/src/BuiltInTools/DotNetWatchTasks/Utilities/CompilerFeatureRequiredAttribute.cs
+++ b/src/BuiltInTools/DotNetWatchTasks/Utilities/CompilerFeatureRequiredAttribute.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Copied from:
+// https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CompilerFeatureRequiredAttribute.cs
+
+#if !NET7_0_OR_GREATER
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that compiler support for a particular feature is required for the location where this attribute is applied.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public CompilerFeatureRequiredAttribute(string featureName)
+        {
+            FeatureName = featureName;
+        }
+
+        /// <summary>
+        /// The name of the compiler feature.
+        /// </summary>
+        public string FeatureName { get; }
+
+        /// <summary>
+        /// If true, the compiler can choose to allow access to the location where this attribute is applied if it does not understand <see cref="FeatureName"/>.
+        /// </summary>
+        public bool IsOptional { get; init; }
+
+        /// <summary>
+        /// The <see cref="FeatureName"/> used for the ref structs C# feature.
+        /// </summary>
+        public const string RefStructs = nameof(RefStructs);
+
+        /// <summary>
+        /// The <see cref="FeatureName"/> used for the required members C# feature.
+        /// </summary>
+        public const string RequiredMembers = nameof(RequiredMembers);
+    }
+}
+
+#endif

--- a/src/BuiltInTools/DotNetWatchTasks/Utilities/RequiredMemberAttribute.cs
+++ b/src/BuiltInTools/DotNetWatchTasks/Utilities/RequiredMemberAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Copied from:
+// https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RequiredMemberAttribute.cs
+
+#if !NET7_0_OR_GREATER
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Specifies that a type has required members or that a member is required.</summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    internal sealed class RequiredMemberAttribute : Attribute
+    {
+    }
+}
+
+#endif

--- a/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Generic;

--- a/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System.Collections.Generic;
 
@@ -16,9 +15,9 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public IReporter Reporter { get; init; } = NullReporter.Singleton;
 
-        public ProcessSpec ProcessSpec { get; init; } = default!;
+        public ProcessSpec? ProcessSpec { get; init; } = default!;
 
-        public FileSet FileSet { get; set; } = default!;
+        public FileSet? FileSet { get; set; }
 
         public int Iteration { get; set; } = -1;
 

--- a/src/BuiltInTools/dotnet-watch/DotNetWatchOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatchOptions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 

--- a/src/BuiltInTools/dotnet-watch/FileItem.cs
+++ b/src/BuiltInTools/dotnet-watch/FileItem.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 namespace Microsoft.DotNet.Watcher
 {
     internal readonly struct FileItem

--- a/src/BuiltInTools/dotnet-watch/FileSet.cs
+++ b/src/BuiltInTools/dotnet-watch/FileSet.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -9,9 +10,10 @@ namespace Microsoft.DotNet.Watcher
 {
     internal sealed class FileSet : IEnumerable<FileItem>
     {
+        public ProjectInfo? Project { get; }
         private readonly Dictionary<string, FileItem> _files;
 
-        public FileSet(ProjectInfo projectInfo, IEnumerable<FileItem> files)
+        public FileSet(ProjectInfo? projectInfo, IEnumerable<FileItem> files)
         {
             Project = projectInfo;
             _files = new Dictionary<string, FileItem>(StringComparer.Ordinal);
@@ -24,10 +26,6 @@ namespace Microsoft.DotNet.Watcher
         public bool TryGetValue(string filePath, out FileItem fileItem) => _files.TryGetValue(filePath, out fileItem);
 
         public int Count => _files.Count;
-
-        public ProjectInfo Project { get; }
-
-        public static readonly FileSet Empty = new FileSet(null, Array.Empty<FileItem>());
 
         public IEnumerator<FileItem> GetEnumerator() => _files.Values.GetEnumerator();
 

--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
+            Debug.Assert(context.ProcessSpec != null);
+
             if (_options.SuppressBrowserRefresh)
             {
                 return;

--- a/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/DotNetBuildFilter.cs
@@ -1,10 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices.Marshalling;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Watcher.Internal;
@@ -29,6 +30,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
+            Debug.Assert(context.ProcessSpec != null);
+
             while (!cancellationToken.IsCancellationRequested)
             {
                 var arguments = new List<string>()

--- a/src/BuiltInTools/dotnet-watch/Filters/IWatchFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/IWatchFilter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/BuiltInTools/dotnet-watch/Filters/MSBuildEvaluationFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/MSBuildEvaluationFilter.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -23,7 +25,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         private readonly IFileSetFactory _factory;
 
-        private List<(string fileName, DateTime lastWriteTimeUtc)> _msbuildFileTimestamps;
+        private List<(string fileName, DateTime lastWriteTimeUtc)>? _msbuildFileTimestamps;
 
         public MSBuildEvaluationFilter(IFileSetFactory factory)
         {
@@ -55,6 +57,9 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         private bool RequiresMSBuildRevaluation(DotNetWatchContext context)
         {
+            Debug.Assert(context.Iteration > 0);
+            Debug.Assert(_msbuildFileTimestamps != null);
+
             var changedFile = context.ChangedFile;
             if (changedFile != null && IsMsBuildFileExtension(changedFile.Value.FilePath))
             {
@@ -82,6 +87,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         private List<(string fileName, DateTime lastModifiedUtc)> GetMSBuildFileTimeStamps(DotNetWatchContext context)
         {
+            Debug.Assert(context.FileSet != null);
+
             var msbuildFiles = new List<(string fileName, DateTime lastModifiedUtc)>();
             foreach (var file in context.FileSet)
             {

--- a/src/BuiltInTools/dotnet-watch/Filters/NoRestoreFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/NoRestoreFilter.cs
@@ -14,10 +14,11 @@ namespace Microsoft.DotNet.Watcher.Tools
     internal sealed class NoRestoreFilter : IWatchFilter
     {
         private bool _canUseNoRestore;
-        private string[] _noRestoreArguments;
+        private string[]? _noRestoreArguments;
 
         public ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
+            Debug.Assert(context.ProcessSpec != null);
             Debug.Assert(!context.HotReloadEnabled);
 
             if (context.SuppressMSBuildIncrementalism)
@@ -27,7 +28,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             if (context.Iteration == 0)
             {
-                var arguments = context.ProcessSpec.Arguments;
+                var arguments = context.ProcessSpec.Arguments ?? Array.Empty<string>();
                 _canUseNoRestore = CanUseNoRestore(arguments, context.Reporter);
                 if (_canUseNoRestore)
                 {

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -1,12 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Text;
@@ -30,6 +30,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public override void Initialize(DotNetWatchContext context, CancellationToken cancellationToken)
         {
+            Debug.Assert(context.ProcessSpec != null);
+
             base.Initialize(context, cancellationToken);
 
             // Configure the app for EnC
@@ -143,7 +145,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         private readonly struct UpdatePayload
         {
             public string Type => "BlazorHotReloadDeltav1";
-            public string SharedSecret { get; init; }
+            public string? SharedSecret { get; init; }
             public IEnumerable<UpdateDelta> Deltas { get; init; }
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Immutable;

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -46,6 +45,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         public async Task InitializeAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
             Debug.Assert(context.ProjectGraph is not null);
+            Debug.Assert(context.FileSet?.Project is not null);
 
             if (_deltaApplier is null)
             {

--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Buffers;
@@ -35,6 +34,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public override void Initialize(DotNetWatchContext context, CancellationToken cancellationToken)
         {
+            Debug.Assert(context.ProcessSpec != null);
+
             base.Initialize(context, cancellationToken);
 
             if (!SuppressNamedPipeForTests)

--- a/src/BuiltInTools/dotnet-watch/HotReload/DeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DeltaApplier.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Immutable;

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 using System;
 using System.Diagnostics.Tracing;
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfile.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 namespace Microsoft.DotNet.Watcher.Tools
 {
     internal enum HotReloadProfile

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfileReader.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfileReader.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System.Collections.Generic;
 using Microsoft.Build.Execution;

--- a/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
@@ -1,10 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/BuiltInTools/dotnet-watch/HotReload/RudeEditDialog.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/RudeEditDialog.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.IO;

--- a/src/BuiltInTools/dotnet-watch/HotReload/SingleProcessDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/SingleProcessDeltaApplier.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Generic;

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -58,6 +57,8 @@ namespace Microsoft.DotNet.Watcher
 
         public async Task WatchAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
+            Debug.Assert(context.ProcessSpec != null);
+
             var processSpec = context.ProcessSpec;
 
             var forceReload = new CancellationTokenSource();
@@ -100,6 +101,8 @@ namespace Microsoft.DotNet.Watcher
                     return;
                 }
 
+                Debug.Assert(fileSet.Project != null);
+
                 if (!fileSet.Project.IsNetCoreApp60OrNewer())
                 {
                     _reporter.Error($"Hot reload based watching is only supported in .NET 6.0 or newer apps. Update the project's launchSettings.json to disable this feature.");
@@ -131,7 +134,7 @@ namespace Microsoft.DotNet.Watcher
                     // when the solution captures state of the file after the changes has already been made.
                     await hotReload.InitializeAsync(context, cancellationToken);
 
-                    _reporter.Verbose($"Running {processSpec.ShortDisplayName()} with the following arguments: '{string.Join(" ", processSpec.Arguments)}'");
+                    _reporter.Verbose($"Running {processSpec.ShortDisplayName()} with the following arguments: '{string.Join(" ", processSpec.Arguments ?? Array.Empty<string>())}'");
                     var processTask = _processRunner.RunAsync(processSpec, combinedCancellationSource.Token);
 
                     _reporter.Output("Started", emoji: "🚀");
@@ -297,7 +300,9 @@ namespace Microsoft.DotNet.Watcher
 
         private void ConfigureExecutable(DotNetWatchContext context, ProcessSpec processSpec)
         {
-            var project = context.FileSet.Project;
+            var project = context.FileSet?.Project;
+            Debug.Assert(project != null);
+
             processSpec.Executable = project.RunCommand;
             if (!string.IsNullOrEmpty(project.RunArguments))
             {
@@ -321,7 +326,7 @@ namespace Microsoft.DotNet.Watcher
 
             if (rootVariableName != null && string.IsNullOrEmpty(Environment.GetEnvironmentVariable(rootVariableName)))
             {
-                processSpec.EnvironmentVariables[rootVariableName] = Path.GetDirectoryName(_muxerPath);
+                processSpec.EnvironmentVariables[rootVariableName] = Path.GetDirectoryName(_muxerPath)!;
             }
 
             if (context.LaunchSettingsProfile.EnvironmentVariables is { } envVariables)

--- a/src/BuiltInTools/dotnet-watch/IFileSetFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/IFileSetFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,6 +9,6 @@ namespace Microsoft.DotNet.Watcher
 {
     internal interface IFileSetFactory
     {
-        Task<FileSet> CreateAsync(CancellationToken cancellationToken);
+        Task<FileSet?> CreateAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/BuiltInTools/dotnet-watch/Internal/ConsoleReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ConsoleReporter.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/BuiltInTools/dotnet-watch/Internal/ConsoleRequester.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ConsoleRequester.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/BuiltInTools/dotnet-watch/Internal/Ensure.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/Ensure.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 
 namespace Microsoft.Extensions.Tools.Internal

--- a/src/BuiltInTools/dotnet-watch/Internal/FileSetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileSetWatcher.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.IO;
 using System.Threading;

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/DotnetFileWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/DotnetFileWatcher.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.ComponentModel;
 using System.IO;

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/FileWatcherFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/FileWatcherFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 
 namespace Microsoft.DotNet.Watcher.Internal

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/IFileSystemWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/IFileSystemWatcher.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 
 namespace Microsoft.DotNet.Watcher.Internal

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/PollingFileWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/PollingFileWatcher.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/BuiltInTools/dotnet-watch/Internal/HotReloadFileSetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/HotReloadFileSetWatcher.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Concurrent;

--- a/src/BuiltInTools/dotnet-watch/Internal/IConsole.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IConsole.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.IO;
 

--- a/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 namespace Microsoft.Extensions.Tools.Internal
 {
     /// <summary>

--- a/src/BuiltInTools/dotnet-watch/Internal/IRequester.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IRequester.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/BuiltInTools/dotnet-watch/Internal/MSBuildFileSetResult.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MSBuildFileSetResult.cs
@@ -11,28 +11,28 @@ namespace Microsoft.DotNet.Watcher.Internal
     internal sealed class MSBuildFileSetResult
     {
         [DataMember]
-        public string RunCommand { get; init; }
+        public required string RunCommand { get; init; }
 
         [DataMember]
-        public string RunArguments { get; init; }
+        public required string RunArguments { get; init; }
 
         [DataMember]
-        public string RunWorkingDirectory { get; init; }
+        public required string RunWorkingDirectory { get; init; }
 
         [DataMember]
-        public bool IsNetCoreApp { get; init; }
+        public required bool IsNetCoreApp { get; init; }
 
         [DataMember]
-        public string TargetFrameworkVersion { get; init; }
+        public required string TargetFrameworkVersion { get; init; }
 
         [DataMember]
-        public string RuntimeIdentifier { get; init; }
+        public required string RuntimeIdentifier { get; init; }
 
         [DataMember]
-        public string DefaultAppHostRuntimeIdentifier { get; init; }
+        public required string DefaultAppHostRuntimeIdentifier { get; init; }
 
         [DataMember]
-        public Dictionary<string, ProjectItems> Projects { get; init; }
+        public required Dictionary<string, ProjectItems> Projects { get; init; }
     }
 
     [DataContract]
@@ -49,9 +49,9 @@ namespace Microsoft.DotNet.Watcher.Internal
     internal sealed class StaticFileItem
     {
         [DataMember]
-        public string FilePath { get; init; }
+        public required string FilePath { get; init; }
 
         [DataMember]
-        public string StaticWebAssetPath { get; init; }
+        public required string StaticWebAssetPath { get; init; }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -170,7 +169,7 @@ namespace Microsoft.DotNet.Watcher.Internal
                     {
                         _reporter.Warn("Fix the error to continue or press Ctrl+C to exit.");
 
-                        var fileSet = new FileSet(null, new[] { new FileItem { FilePath = _projectFile } });
+                        var fileSet = new FileSet(projectInfo: null, new[] { new FileItem { FilePath = _projectFile } });
 
                         using (var watcher = new FileSetWatcher(fileSet, _reporter))
                         {

--- a/src/BuiltInTools/dotnet-watch/Internal/MsBuildProjectFinder.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MsBuildProjectFinder.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Globalization;
 using System.IO;

--- a/src/BuiltInTools/dotnet-watch/Internal/NullReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/NullReporter.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 namespace Microsoft.Extensions.Tools.Internal
 {
     /// <summary>

--- a/src/BuiltInTools/dotnet-watch/Internal/OutputCapture.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/OutputCapture.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Watcher.Internal

--- a/src/BuiltInTools/dotnet-watch/Internal/OutputSink.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/OutputSink.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 namespace Microsoft.DotNet.Watcher.Internal
 {
     internal sealed class OutputSink

--- a/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -71,7 +70,7 @@ namespace Microsoft.DotNet.Watcher.Internal
                 stopwatch.Start();
                 process.Start();
 
-                var args = processSpec.EscapedArguments ?? string.Join(" ", processSpec.Arguments);
+                var args = processSpec.EscapedArguments ?? string.Join(" ", processSpec.Arguments ?? Array.Empty<string>());
                 _reporter.Verbose($"Started '{processSpec.Executable}' '{args}' with process id {process.Id}", emoji: "🚀");
 
                 if (readOutput)
@@ -112,7 +111,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             {
                 process.StartInfo.Arguments = processSpec.EscapedArguments;
             }
-            else
+            else if (processSpec.Arguments is not null)
             {
                 for (var i = 0; i < processSpec.Arguments.Count; i++)
                 {

--- a/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Generic;

--- a/src/BuiltInTools/dotnet-watch/ProcessSpec.cs
+++ b/src/BuiltInTools/dotnet-watch/ProcessSpec.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using Microsoft.DotNet.Watcher.Internal;
@@ -11,27 +13,26 @@ namespace Microsoft.DotNet.Watcher
 {
     internal sealed class ProcessSpec
     {
-        public string Executable { get; set; }
-        public string WorkingDirectory { get; set; }
-        public ProcessSpecEnvironmentVariables EnvironmentVariables { get; } = new();
-
-        public IReadOnlyList<string> Arguments { get; set; }
-        public string EscapedArguments { get; set; }
-        public OutputCapture OutputCapture { get; set; }
-
-        public string ShortDisplayName()
-            => Path.GetFileNameWithoutExtension(Executable);
-
-        public bool IsOutputCaptured => OutputCapture != null;
-
-        public DataReceivedEventHandler OnOutput { get; set; }
-
-        public CancellationToken CancelOutputCapture { get; set; }
-
         internal sealed class ProcessSpecEnvironmentVariables : Dictionary<string, string>
         {
             public List<string> DotNetStartupHooks { get; } = new();
             public List<string> AspNetCoreHostingStartupAssemblies { get; } = new();
+
         }
+
+        public string? Executable { get; set; }
+        public string? WorkingDirectory { get; set; }
+        public ProcessSpecEnvironmentVariables EnvironmentVariables { get; } = new();
+        public IReadOnlyList<string>? Arguments { get; set; }
+        public string? EscapedArguments { get; set; }
+        public OutputCapture? OutputCapture { get; set; }
+        public DataReceivedEventHandler? OnOutput { get; set; }
+        public CancellationToken CancelOutputCapture { get; set; }
+
+        [MemberNotNullWhen(true, nameof(OutputCapture))]
+        public bool IsOutputCaptured => OutputCapture != null;
+
+        public string? ShortDisplayName()
+            => Path.GetFileNameWithoutExtension(Executable);
     }
 }

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 
 using System;
 using System.Collections.Generic;

--- a/src/BuiltInTools/dotnet-watch/ProjectInfo.cs
+++ b/src/BuiltInTools/dotnet-watch/ProjectInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.DotNet.Watcher

--- a/src/BuiltInTools/dotnet-watch/Properties/AssemblyInfo.cs
+++ b/src/BuiltInTools/dotnet-watch/Properties/AssemblyInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("dotnet-watch.Tests, PublicKey = 0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/BuiltInTools/dotnet-watch/Properties/AssemblyInfo.cs
+++ b/src/BuiltInTools/dotnet-watch/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("dotnet-watch.Tests, PublicKey = 0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -33,11 +33,31 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\BrowserRefresh\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" TargetPath="middleware\Microsoft.AspNetCore.Watch.BrowserRefresh.dll" CopyToOutputDirectory="PreserveNewest" />
+    <ProjectReference Include="..\BrowserRefresh\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj"
+                      PrivateAssets="All"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      UndefineProperties="TargetFramework;TargetFrameworks"
+                      OutputItemType="Content"
+                      TargetPath="middleware\Microsoft.AspNetCore.Watch.BrowserRefresh.dll"
+                      CopyToOutputDirectory="PreserveNewest"/>
 
-    <ProjectReference Include="..\DotNetDeltaApplier\Microsoft.Extensions.DotNetDeltaApplier.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" TargetPath="hotreload\Microsoft.Extensions.DotNetDeltaApplier.dll" CopyToOutputDirectory="PreserveNewest" />
+    <ProjectReference Include="..\DotNetDeltaApplier\Microsoft.Extensions.DotNetDeltaApplier.csproj"
+                      PrivateAssets="All"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      UndefineProperties="TargetFramework;TargetFrameworks"
+                      OutputItemType="Content"
+                      TargetPath="hotreload\Microsoft.Extensions.DotNetDeltaApplier.dll"
+                      CopyToOutputDirectory="PreserveNewest"/>
 
-    <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" CopyToOutputDirectory="PreserveNewest" />
+    <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj"
+                      PrivateAssets="All"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      UndefineProperties="TargetFramework;TargetFrameworks"
+                      OutputItemType="Content"
+                      CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 
   <!--
@@ -45,5 +65,7 @@
     These files are used for layout generation in redist project.
     Tests are also running dotnet.exe from redist artifacts.
   -->
-  <Target Name="PublishToRedist" DependsOnTargets="PublishDotnetWatchToRedist" BeforeTargets="AfterBuild" />
+  <Target Name="PublishToRedist"
+          DependsOnTargets="PublishDotnetWatchToRedist"
+          BeforeTargets="AfterBuild" />
 </Project>

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(RepoRoot)\src\Layout\redist\targets\PublishDotnetWatch.targets"/>
+  <Import Project="$(RepoRoot)\src\Layout\redist\targets\PublishDotnetWatch.targets" />
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
@@ -9,6 +9,7 @@
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <UseAppHost>false</UseAppHost>
     <RuntimeIdentifier />
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,31 +33,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\BrowserRefresh\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj"
-                      PrivateAssets="All"
-                      ReferenceOutputAssembly="false"
-                      SkipGetTargetFrameworkProperties="true"
-                      UndefineProperties="TargetFramework;TargetFrameworks"
-                      OutputItemType="Content"
-                      TargetPath="middleware\Microsoft.AspNetCore.Watch.BrowserRefresh.dll"
-                      CopyToOutputDirectory="PreserveNewest"/>
+    <ProjectReference Include="..\BrowserRefresh\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" TargetPath="middleware\Microsoft.AspNetCore.Watch.BrowserRefresh.dll" CopyToOutputDirectory="PreserveNewest" />
 
-    <ProjectReference Include="..\DotNetDeltaApplier\Microsoft.Extensions.DotNetDeltaApplier.csproj"
-                      PrivateAssets="All"
-                      ReferenceOutputAssembly="false"
-                      SkipGetTargetFrameworkProperties="true"
-                      UndefineProperties="TargetFramework;TargetFrameworks"
-                      OutputItemType="Content"
-                      TargetPath="hotreload\Microsoft.Extensions.DotNetDeltaApplier.dll"
-                      CopyToOutputDirectory="PreserveNewest"/>
+    <ProjectReference Include="..\DotNetDeltaApplier\Microsoft.Extensions.DotNetDeltaApplier.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" TargetPath="hotreload\Microsoft.Extensions.DotNetDeltaApplier.dll" CopyToOutputDirectory="PreserveNewest" />
 
-    <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj"
-                      PrivateAssets="All"
-                      ReferenceOutputAssembly="false"
-                      SkipGetTargetFrameworkProperties="true"
-                      UndefineProperties="TargetFramework;TargetFrameworks"
-                      OutputItemType="Content"
-                      CopyToOutputDirectory="PreserveNewest"/>
+    <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!--
@@ -64,7 +45,5 @@
     These files are used for layout generation in redist project.
     Tests are also running dotnet.exe from redist artifacts.
   -->
-  <Target Name="PublishToRedist"
-          DependsOnTargets="PublishDotnetWatchToRedist"
-          BeforeTargets="AfterBuild" />
+  <Target Name="PublishToRedist" DependsOnTargets="PublishDotnetWatchToRedist" BeforeTargets="AfterBuild" />
 </Project>

--- a/src/Common/EnvironmentVariableNames.cs
+++ b/src/Common/EnvironmentVariableNames.cs
@@ -3,6 +3,8 @@
 
 #pragma warning disable IDE0240 // Nullable directive is redundant (when file is included to a project that already enables nullable
 
+#nullable enable
+
 using System.Runtime.InteropServices;
 using System;
 

--- a/src/Common/EnvironmentVariableNames.cs
+++ b/src/Common/EnvironmentVariableNames.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable IDE0240 // Nullable directive is redundant (when file is included to a project that already enables nullable
-#nullable enable
 
 using System.Runtime.InteropServices;
 using System;

--- a/src/Common/PathUtilities.cs
+++ b/src/Common/PathUtilities.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/Common/PathUtilities.cs
+++ b/src/Common/PathUtilities.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
+#pragma warning disable IDE0240 // Nullable directive is redundant (when file is included to a project that already enables nullable
+
+#nullable enable
 
 using System;
 using System.IO;

--- a/src/Tests/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
+++ b/src/Tests/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
@@ -12,8 +12,10 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     public class MSBuildEvaluationFilterTest
     {
+        private static readonly FileSet s_emptyFileSet = new(projectInfo: null!, Array.Empty<FileItem>());
+
         private readonly IFileSetFactory _fileSetFactory = Mock.Of<IFileSetFactory>(
-            f => f.CreateAsync(It.IsAny<CancellationToken>()) == Task.FromResult<FileSet>(FileSet.Empty));
+            f => f.CreateAsync(It.IsAny<CancellationToken>()) == Task.FromResult(s_emptyFileSet));
 
         [Fact]
         public async Task ProcessAsync_EvaluatesFileSetIfProjFileChanges()


### PR DESCRIPTION
Enable nullable annotations on project level