### PR TITLE
[wasm] Move SelfContained=true from pack to SDK

### DIFF
--- a/src/WasmSdk/Sdk/Sdk.props
+++ b/src/WasmSdk/Sdk/Sdk.props
@@ -18,6 +18,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- WASM projects defaults to browser-wasm -->
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">browser-wasm</RuntimeIdentifier>
     <UseMonoRuntime>true</UseMonoRuntime>
+    
+    <SelfContained>true</SelfContained>
 
     <_WasmSdkImportsMicrosoftNETSdkPublish Condition="'$(UsingMicrosoftNETSdkPublish)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkPublish>
     <_WasmSdkImportsMicrosoftNETSdkStaticWebAssets Condition="'$(UsingMicrosoftNETSdkStaticWebAssets)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkStaticWebAssets>


### PR DESCRIPTION
- Based on suggestion from https://github.com/dotnet/sdk/issues/32038#issuecomment-1530685783
- Runtime PR is https://github.com/dotnet/runtime/pull/85636