### PR TITLE
Add AssemblyName metadata to references based on FrameworkList.xml

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
@@ -34,7 +34,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             task.Execute().Should().BeTrue();
 
-            task.ReferencesToAdd[0].ItemSpec.Should().Be(Path.Combine(mockPackageDirectory, "lib/Microsoft.Windows.SDK.NET.dll"));
+            var reference = task.ReferencesToAdd[0];
+            reference.ItemSpec.Should().Be(Path.Combine(mockPackageDirectory, "lib/Microsoft.Windows.SDK.NET.dll"));
+            reference.GetMetadata("AssemblyName").Should().Be("Microsoft.Windows.SDK.NET");
+            reference.GetMetadata("AssemblyVersion").Should().Be("10.0.18362.3");
+            reference.GetMetadata("FileVersion").Should().Be("10.0.18362.3");
+            reference.GetMetadata("PublicKeyToken").Should().Be("null");
+            reference.GetMetadata("FrameworkReferenceName").Should().Be("Microsoft.Windows.SDK.NET.Ref");
+            reference.GetMetadata("FrameworkReferenceVersion").Should().Be("5.0.0-preview1");
+
             task.PlatformManifests[0].ItemSpec.Should().Be(Path.Combine(mockPackageDirectory, $"data{Path.DirectorySeparatorChar}PlatformManifest.txt"));
             task.AnalyzersToAdd.Length.Should().Be(2);
             task.AnalyzersToAdd[0].ItemSpec.Should().Be(Path.Combine(mockPackageDirectory, "analyzers/dotnet/anyAnalyzer.dll"));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -361,12 +361,15 @@ namespace Microsoft.NET.Build.Tasks
                 string itemType = fileElement.Attribute("Type")?.Value;
                 bool isAnalyzer = itemType?.Equals("Analyzer", StringComparison.OrdinalIgnoreCase) ?? false;
 
+                string assemblyName = fileElement.Attribute("AssemblyName").Value;
+
                 string dllPath = usePathElementsInFrameworkListAsFallBack || isAnalyzer ?
                     Path.Combine(definition.TargetingPackRoot, fileElement.Attribute("Path").Value) :
-                    GetDllPathViaAssemblyName(definition.TargetingPackDllFolder, fileElement);
+                    GetDllPathViaAssemblyName(definition.TargetingPackDllFolder, assemblyName);
 
                 var item = CreateItem(dllPath, definition.FrameworkReferenceName, definition.NuGetPackageId, definition.NuGetPackageVersion);
 
+                item.SetMetadata("AssemblyName", assemblyName);
                 item.SetMetadata("AssemblyVersion", fileElement.Attribute("AssemblyVersion").Value);
                 item.SetMetadata("FileVersion", fileElement.Attribute("FileVersion").Value);
                 item.SetMetadata("PublicKeyToken", fileElement.Attribute("PublicKeyToken").Value);
@@ -436,6 +439,11 @@ namespace Microsoft.NET.Build.Tasks
         private static string GetDllPathViaAssemblyName(string targetingPackDllFolder, XElement fileElement)
         {
             string assemblyName = fileElement.Attribute("AssemblyName").Value;
+            return GetDllPathViaAssemblyName(targetingPackDllFolder, assemblyName);
+        }
+
+        private static string GetDllPathViaAssemblyName(string targetingPackDllFolder, string assemblyName)
+        {
             var dllPath = Path.Combine(targetingPackDllFolder, assemblyName + ".dll");
             return dllPath;
         }


### PR DESCRIPTION
We are adding an optimization to RAR to use metadata passed from the `ResolveTargetingPackAssets` task to eliminate the costly sniffing of framework assemblies: https://github.com/dotnet/msbuild/pull/8688

In this PR I am adding the `AssemblyName` metadatum to the output references for MSBuild to consume. I am also adding test coverage for this and few other metadata RAR is newly depending on.