### PR TITLE
[release/7.0.4xx] added `Microsoft.DotNet.Cli.Utils.dll` to package content

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -124,12 +124,12 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
                 {
                     if (destinationImageReference.Registry is not null)
                     {
-                        await (destinationImageReference.Registry.PushAsync(
+                        await destinationImageReference.Registry.PushAsync(
                             builtImage,
                             sourceImageReference,
                             destinationImageReference,
                             message => SafeLog(message),
-                            cancellationToken)).ConfigureAwait(false);
+                            cancellationToken).ConfigureAwait(false);
                         SafeLog("Pushed container '{0}' to registry '{1}'", destinationImageReference.RepositoryAndTag, OutputRegistry);
                     }
                 }

--- a/src/Containers/packaging/package.csproj
+++ b/src/Containers/packaging/package.csproj
@@ -76,6 +76,7 @@
             <Content Include="$(OutDir)Valleysoft.DockerCredsProvider.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
             <Content Include="$(OutDir)NuGet.*.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
             <Content Include="$(OutDir)Newtonsoft.Json.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
+            <Content Include="$(OutDir)Microsoft.DotNet.Cli.Utils.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
             <!-- runtime deps json -->
             <Content Include="$(ArtifactsDir)bin/Microsoft.NET.Build.Containers/$(Configuration)/$(TargetFramework)/Microsoft.NET.Build.Containers.deps.json" Pack="true" PackagePath="tasks/$(TargetFramework)" />
             <!-- actual DLL  -->


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/32080 added a call to `Microsoft.DotNet.Cli.Utils`, but this assembly was not not added to package content for net7.0.

Added `Microsoft.DotNet.Cli.Utils.dll` to package content for net7.0. 
The assembly is not needed for full framework as it works through containerize which already has it as part of the package.