### PR TITLE
Remove template runtimeconfig

### DIFF
--- a/src/Tests/Common/runtimeconfig.template.json
+++ b/src/Tests/Common/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-    "rollForwardOnNoCandidateFx": 2
-}

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -13,8 +13,6 @@
 
     <!-- Put packages for tests in subfolder so we don't try to sign them -->
     <PackageOutputPath>$(PackageOutputPath)tests\</PackageOutputPath>
-
-    <UserRuntimeConfig>$(MSBuildThisFileDirectory)Common\runtimeconfig.template.json</UserRuntimeConfig>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(OutputType)' == 'Exe' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">


### PR DESCRIPTION
Fix #32300 

https://github.com/dotnet/sdk/pull/31957 made it so all tools will set rollforward, which clashes with the setting added https://github.com/dotnet/sdk/commit/c5c5011e035c2358f92a012b7c6882f0d1a5f403

This clash was causing the runtime to fail to start.  I'm not sure why that doesn't happen in CI - perhaps in that case SDK is not building the tests with the latest targets?  If so, we might need to make a slightly different change (by ensuring `RollForward` is set in `Tests/Directory.Build.targets` until we get an SDK with that change.