### PR TITLE
[Own build] Don't use AssemblyInformationCachePaths

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,9 +43,5 @@
     <!-- <TestRunnerAdditionalArguments>-parallel none</TestRunnerAdditionalArguments> -->
   </PropertyGroup>
 
-  <PropertyGroup>
-    <AssemblyInformationCachePaths Condition="Exists('$(NetCoreRoot)sdk\$(NetCoreSdkVersion)\SdkPrecomputedAssemblyReferences.cache')">$(AssemblyInformationCachePaths);$(NetCoreRoot)sdk\$(NetCoreSdkVersion)\SDKPrecomputedAssemblyReferences.cache</AssemblyInformationCachePaths>
-  </PropertyGroup>
-
   <Import Project="build/GenerateResxSource.targets" />
 </Project>


### PR DESCRIPTION
Now that https://github.com/dotnet/msbuild/pull/8688 is in, we no longer get value from the SDK pre-cache. The cost of reading the cache is >50 ms per project, which typically makes it the most expensive part of RAR.

Trace from MSBuild command line build:

![image](https://github.com/dotnet/msbuild/assets/12206368/10f6494d-95ed-4bf4-ba75-145fa0699531)
