### PR TITLE
[release/7.0.3xx] added `Microsoft.DotNet.Cli.Utils.dll` to package content

### DIFF
--- a/src/Containers/packaging/package.csproj
+++ b/src/Containers/packaging/package.csproj
@@ -76,6 +76,7 @@
             <Content Include="$(OutDir)Valleysoft.DockerCredsProvider.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
             <Content Include="$(OutDir)NuGet.*.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
             <Content Include="$(OutDir)Newtonsoft.Json.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
+            <Content Include="$(OutDir)Microsoft.DotNet.Cli.Utils.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
             <!-- runtime deps json -->
             <Content Include="$(ArtifactsDir)bin/Microsoft.NET.Build.Containers/$(Configuration)/$(TargetFramework)/Microsoft.NET.Build.Containers.deps.json" Pack="true" PackagePath="tasks/$(TargetFramework)" />
             <!-- actual DLL  -->


### PR DESCRIPTION
backporting https://github.com/dotnet/sdk/pull/32301

**Description**
In 7.0.3xx, we added the reference to `Microsoft.DotNet.Cli.Utils` in `Microsoft.NET.Build.Containers`, however didn't include it to NuGet package. In this case  `Microsoft.DotNet.Cli.Utils` from .NET SDK is being used, which might be not backwards compatible.  

**Customer Impact**: 
`Microsoft.NET.Build.Containers` package might not work on older versions of SDK, where `Microsoft.DotNet.Cli.Utils` bits used in `Microsoft.NET.Build.Containers` are not backwards compatible.
Using package with .NET SDK 7.0.100, 7.0.300, and latest preview of .NET SDK 8.0.100 however already works, but some specific builds may not work.

**Regression?**: no

**Risk**: very low