### PR TITLE
[release/7.0.4xx] removed restriction on Publish SDK to allow publishing non-web project

### DIFF
--- a/src/WebSdk/Publish/Targets/DotNetCLIToolTargets/Microsoft.NET.Sdk.DotNetCLITool.targets
+++ b/src/WebSdk/Publish/Targets/DotNetCLIToolTargets/Microsoft.NET.Sdk.DotNetCLITool.targets
@@ -59,7 +59,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <_DotNetCLIPostPublishDependsOn>
       _InitProjectCapabilityProperties;
-      _AspNetCoreProjectSystemPostPublish;
+      _InitPublishIntermediateOutputPath;
+      $(_DotNetPublishTransformFiles);
+      _PublishFiles;
       AfterPublish;
     </_DotNetCLIPostPublishDependsOn>
   </PropertyGroup>
@@ -68,20 +70,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           DependsOnTargets="$(_DotNetCLIPostPublishDependsOn)"
           AfterTargets="Publish"
           Condition="'$(DeployOnBuild)' != 'true'">
-  </Target>
-
-
-  <PropertyGroup>
-    <_AspNetCoreProjectSystemPostPublishDependsOn>
-      _InitPublishIntermediateOutputPath;
-      $(_DotNetPublishTransformFiles);
-      _PublishFiles;
-    </_AspNetCoreProjectSystemPostPublishDependsOn>
-  </PropertyGroup>
-
-  <Target Name="_AspNetCoreProjectSystemPostPublish"
-          Condition="'$(_IsAspNetCoreProject)' == 'true'"
-          DependsOnTargets="$(_AspNetCoreProjectSystemPostPublishDependsOn)">
   </Target>
 
   <Target Name="_InitPublishIntermediateOutputPath">


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk-container-builds/issues/402

# Background
At the moment the different commands are required to publish containers for different flavours of project
- for existing web project (the package is part of `Microsoft.NET.Sdk.Publish` used for web projects):

```shell
dotnet publish --os linux --arch x64 -c Release /p:PublishProfile=DefaultContainer
```

- for existing non-web project (`Microsoft.NET.Sdk.Publish` is not used):

```shell
dotnet add package Microsoft.NET.Build.Containers
dotnet publish --os linux --arch x64 -c Release /t:PublishContainer
```

This represents an UX issue and confusion for final users. 

# Suggestion

We find `Microsoft.NET.Sdk.Publish` very useful for the case as it allows to define multiple profiles that can be used when publishing containers to different environments. Therefore we started to explore if the use of `Microsoft.NET.Sdk.Publish` is possible outside the web projects.

If the user wants to use containers feature for non-web projects, he will need to change list of sdks used for the project as:
```
<Project Sdk="Microsoft.NET.Sdk;Microsoft.NET.Publish.Sdk">
```
and use the same way of publishing as for web projects using profiles which is more convenient.
On the engineering side, it also simplifies testing and maintainability of .NET containers as it eliminates the other use case.

The problem with this approach is that `Microsoft.NET.Sdk.Publish` is limited to web projects only using target that this PR removes. The initial tests shows no impact if this limiting target is removed.
I'm opening this PR more to involve wider audience to discuss the approach and lifting the restriction.

The added test demonstrates the intended usage of  `Microsoft.NET.Sdk.Publish` with console project.