### PR TITLE
[release/7.0.4xx] Fix fingerprinting of relinked dotnet.js during build

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -153,11 +153,16 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'@(_BlazorJSFile->Count())' == '0'" />
 
       <_BlazorConfigFileCandidates Include="@(StaticWebAsset)" Condition="'%(SourceType)' == 'Discovered'" />
+      
+      <_DotNetJsItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(FileName)' == 'dotnet' and '%(Extension)' == '.js'" />
 
       <!-- Remove dotnet.js/wasm from runtime pack, in favor of the relinked ones in @(WasmNativeAsset) -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
                                Condition="@(WasmNativeAsset->Count()) > 0 and '%(FileName)' == 'dotnet' and ('%(Extension)' == '.wasm' or '%(Extension)' == '.js')" />
     </ItemGroup>
+    <PropertyGroup>
+      <_DotNetJsBuildVersion>%(_DotNetJsItem.NuGetPackageVersion)</_DotNetJsBuildVersion>
+    </PropertyGroup>
 
     <ComputeBlazorBuildAssets
       Candidates="@(ReferenceCopyLocalPaths);@(WasmNativeAsset)"
@@ -167,6 +172,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ProjectSatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
       TimeZoneSupport="$(_BlazorEnableTimeZoneSupport)"
       InvariantGlobalization="$(_BlazorInvariantGlobalization)"
+      DotNetJsVersion="$(_DotNetJsBuildVersion)"
       CopySymbols="$(_BlazorCopyOutputSymbolsToOutputDirectory)"
       OutputPath="$(OutputPath)"
     >

--- a/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
+++ b/src/BlazorWasmSdk/Tasks/ComputeBlazorBuildAssets.cs
@@ -34,6 +34,9 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
         public string OutputPath { get; set; }
 
         [Required]
+        public string DotNetJsVersion { get; set; }
+
+        [Required]
         public bool TimeZoneSupport { get; set; }
 
         [Required]
@@ -99,7 +102,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly
                     if (candidate.GetMetadata("FileName") == "dotnet" && candidate.GetMetadata("Extension") == ".js")
                     {
                         var itemHash = FileHasher.GetFileHash(candidate.ItemSpec);
-                        var cacheBustedDotNetJSFileName = $"dotnet.{candidate.GetMetadata("NuGetPackageVersion")}.{itemHash}.js";
+                        var cacheBustedDotNetJSFileName = $"dotnet.{DotNetJsVersion}.{itemHash}.js";
 
                         var originalFileFullPath = Path.GetFullPath(candidate.ItemSpec);
                         var originalFileDirectory = Path.GetDirectoryName(originalFileFullPath);

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests/WasmAoTPublishIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests/WasmAoTPublishIntegrationTest.cs
@@ -211,7 +211,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests
                 dotnetJs.Should().NotBeNull();
                 dotnetJs.Should().NotContain("..");
 
-                buildDirectory.Should().HaveFile(Path.Combine("wwwroot", "_framework", dotnetJs));
+                buildDirectory.Should().HaveFile(Path.Combine(buildDirectory.ToString(), "wwwroot", "_framework", dotnetJs));
             }
         }
 

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests/WasmAoTPublishIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests/WasmAoTPublishIntegrationTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization.Json;
 using System.Xml.Linq;
 using Microsoft.NET.Sdk.BlazorWebAssembly.Tests;
 using static Microsoft.NET.Sdk.BlazorWebAssembly.Tests.ServiceWorkerAssert;
@@ -186,6 +187,41 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests
                             }
                         }
                     });
+        }
+
+        [RequiresMSBuildVersionFact("17.0.0")]
+        public void AoT_BuildWithRelink_DotnetJsContainsVersion()
+        {
+            // Arrange
+            var testAppName = "BlazorWasmWithLibrary";
+            var testInstance = CreateAspNetSdkTestAssetWithAot(testAppName, new[] { "blazorwasm" });
+
+            var command = new BuildCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
+            command.Execute("/p:WasmBuildNative=true").Should().Pass();
+
+            var buildDirectory = command.GetOutputDirectory(DefaultTfm, "Debug");
+            var bootConfigPath = Path.Combine(buildDirectory.ToString(), "wwwroot", "_framework", "blazor.boot.json");
+
+            buildDirectory.Should().HaveFile(bootConfigPath);
+
+            using (var bootConfigContent = File.OpenRead(bootConfigPath))
+            {
+                var bootConfig = ParseBootData(bootConfigContent);
+                var dotnetJs = bootConfig.resources.runtime.Keys.FirstOrDefault(k => k.StartsWith("dotnet.") && k.EndsWith(".js"));
+                dotnetJs.Should().NotBeNull();
+                dotnetJs.Should().NotContain("..");
+
+                buildDirectory.Should().HaveFile(Path.Combine("wwwroot", "_framework", dotnetJs));
+            }
+        }
+
+        private static BootJsonData ParseBootData(Stream stream)
+        {
+            stream.Position = 0;
+            var serializer = new DataContractJsonSerializer(
+                typeof(BootJsonData),
+                new DataContractJsonSerializerSettings { UseSimpleDictionaryFormat = true });
+            return (BootJsonData)serializer.ReadObject(stream);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests/WasmAoTPublishIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests/WasmAoTPublishIntegrationTest.cs
@@ -200,18 +200,18 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests
             command.Execute("/p:WasmBuildNative=true").Should().Pass();
 
             var buildDirectory = command.GetOutputDirectory(DefaultTfm, "Debug");
-            var bootConfigPath = Path.Combine(buildDirectory.ToString(), "wwwroot", "_framework", "blazor.boot.json");
+            var bootConfigRelativePath = "wwwroot/_framework/blazor.boot.json";
 
-            buildDirectory.Should().HaveFile(bootConfigPath);
+            buildDirectory.Should().HaveFile(bootConfigRelativePath);
 
-            using (var bootConfigContent = File.OpenRead(bootConfigPath))
+            using (var bootConfigContent = File.OpenRead(Path.Combine(buildDirectory.ToString(), bootConfigRelativePath)))
             {
                 var bootConfig = ParseBootData(bootConfigContent);
                 var dotnetJs = bootConfig.resources.runtime.Keys.FirstOrDefault(k => k.StartsWith("dotnet.") && k.EndsWith(".js"));
                 dotnetJs.Should().NotBeNull();
                 dotnetJs.Should().NotContain("..");
 
-                buildDirectory.Should().HaveFile(Path.Combine(buildDirectory.ToString(), "wwwroot", "_framework", dotnetJs));
+                buildDirectory.Should().HaveFile($"wwwroot/_framework/{dotnetJs}");
             }
         }
 


### PR DESCRIPTION
- dotnet.js from runtime pack is replaced by relinked version
- reading `NuGetPackageVersion` metadata doesn't provide a value
- instead we read the version from runtime pack file and than pass it to the task

Closes https://github.com/dotnet/sdk/issues/30802