### PR TITLE
Update 303 branding

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <VersionPrefix>7.0.302</VersionPrefix>
+    <VersionPrefix>7.0.303</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>


### PR DESCRIPTION
7.0.302 will end up shipping with 17.6.0 after a few internal rebuilds. Updating this branding to 303 to match.