### PR TITLE
[release/7.0.4xx] Default all containers to linux instead of the current SDK's OS

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
@@ -27,6 +27,8 @@ internal static class KnownStrings
         public static readonly string ContainerBaseTag = nameof(ContainerBaseTag);
 
         public static readonly string ContainerGenerateLabels = nameof(ContainerGenerateLabels);
+
+        public static readonly string ContainerRuntimeIdentifier = nameof(ContainerRuntimeIdentifier);
     }
 
     public static class ErrorCodes

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -84,9 +84,9 @@
       <ContainerImageTag Condition="'$(AutoGenerateImageTag)' == 'true' and '$(ContainerImageTags)' == ''">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
 
       <!-- The Container RID should default to the RID used for the entire build (to ensure things run on the platform they are built for), but the user knows best and so should be able to set it explicitly.
-                 For builds that have a RID, we default to that RID. Otherwise, we default to the RID of the currently-executing SDK. -->
+           For builds that have a RID, we default to that RID. Otherwise, we default to the Linux RID matching the architecture of the currently-executing SDK. -->
       <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == '' and '$(IsRidAgnostic)' != 'true'">$(RuntimeIdentifier)</ContainerRuntimeIdentifier>
-      <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == '' ">$(NETCoreSdkPortableRuntimeIdentifier)</ContainerRuntimeIdentifier>
+      <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == ''">linux-$(NETCoreSdkPortableRuntimeIdentifier.Split('-')[1])</ContainerRuntimeIdentifier>
       <_ContainerIsTargetingWindows>false</_ContainerIsTargetingWindows>
       <_ContainerIsTargetingWindows Condition="$(ContainerRuntimeIdentifier.StartsWith('win'))">true</_ContainerIsTargetingWindows>
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
@@ -49,6 +49,8 @@ public sealed class ProjectInitializer
         // test setup parameters so that we can load the props/targets/tasks
         props["ContainerCustomTasksAssembly"] = Path.GetFullPath(Path.Combine(".", "Microsoft.NET.Build.Containers.dll"));
         props["_IsTest"] = "true";
+        // default here, can be overridden by tests if needed
+        props["NETCoreSdkPortableRuntimeIdentifier"] = "linux-x64";
 
         var safeBinlogFileName = projectName.Replace(" ", "_").Replace(":", "_").Replace("/", "_").Replace("\\", "_").Replace("*", "_");
         var loggers = new List<ILogger>

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -180,4 +180,23 @@ public class TargetsTests
         var computedTag = instance.GetProperty("ContainerUser")?.EvaluatedValue;
         computedTag.Should().Be(expectedUser);
     }
+
+    [InlineData("linux-x64", "linux-x64")]
+    [InlineData("linux-arm64", "linux-arm64")]
+    [InlineData("windows-x64", "linux-x64")]
+    [InlineData("windows-arm64", "linux-arm64")]
+    [Theory]
+    public void WindowsUsersGetLinuxContainers(string sdkPortableRid, string expectedRid)
+    {
+        var (project, logger, d) = ProjectInitializer.InitProject(new()
+        {
+            ["TargetFrameworkVersion"] = "v6.0",
+            ["NETCoreSdkPortableRuntimeIdentifier"] = sdkPortableRid
+        }, projectName: $"{nameof(WindowsUsersGetLinuxContainers)}_{sdkPortableRid}_{expectedRid}");
+        using var _ = d;
+        var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
+        instance.Build(new[]{ComputeContainerConfig}, null, null, out var outputs).Should().BeTrue(String.Join(Environment.NewLine, logger.Errors));
+        var computedRid = instance.GetProperty(KnownStrings.Properties.ContainerRuntimeIdentifier)?.EvaluatedValue;
+        computedRid.Should().Be(expectedRid);
+    }
 }


### PR DESCRIPTION
Most containers usage is Linux, even on Windows, and so our out-of-the-box defaults should make that pathway easy to use.

This changes the default container RID logic to prefer the Linux RID matching the architecture of the current SDK. This helps us ensure a minimal amount of emulation. Critically, it makes 'normal' `dotnet publish` commands for containers use a more reasonable default - in .NET 8 `dotnet publish -p PublishProfile=DefaultContainer` means 'a release mode Linux container'.