### PR TITLE
[release/7.0.4xx] fixed `_ContainerIsTargetingNet8TFM` evaluation

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -12,7 +12,7 @@
                                 )
                           )">true</_IsSDKContainerAllowedVersion>
     <_ContainerIsTargetingNet8TFM>false</_ContainerIsTargetingNet8TFM>
-    <_ContainerIsTargetingNet8TFM Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0'))">true</_ContainerIsTargetingNet8TFM>
+    <_ContainerIsTargetingNet8TFM Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0'))">true</_ContainerIsTargetingNet8TFM>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -11,7 +11,8 @@
                                  OR $(NETCoreSdkVersion.Contains('-')) == false
                                 )
                           )">true</_IsSDKContainerAllowedVersion>
-    <_ContainerIsTargetingNet8TFM>$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0'))</_ContainerIsTargetingNet8TFM>
+    <_ContainerIsTargetingNet8TFM>false</_ContainerIsTargetingNet8TFM>
+    <_ContainerIsTargetingNet8TFM Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0'))">true</_ContainerIsTargetingNet8TFM>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
@@ -43,6 +43,8 @@ public sealed class ProjectInitializer
         props["TargetFileName"] = "foo.dll";
         props["AssemblyName"] = "foo";
         props["TargetFrameworkVersion"] = "v7.0";
+        props["TargetFrameworkIdentifier"] = ".NETCoreApp";
+        props["TargetFramework"] = "net7.0";
         props["_NativeExecutableExtension"] = ".exe"; //TODO: windows/unix split here
         props["Version"] = "1.0.0"; // TODO: need to test non-compliant version strings here
         props["NetCoreSdkVersion"] = "7.0.100"; // TODO: float this to current SDK?

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -174,6 +174,7 @@ public class TargetsTests
         {
             ["TargetFrameworkIdentifier"] = ".NETCoreApp",
             ["TargetFrameworkVersion"] = tfm,
+            ["TargetFramework"] = "net" + tfm.TrimStart('v'),
             ["ContainerRuntimeIdentifier"] = rid
         }, projectName: $"{nameof(CanComputeTagsForSupportedSDKVersions)}_{tfm}_{rid}_{expectedUser}");
         using var _ = d;

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -149,6 +149,7 @@ public class TargetsTests
     {
         var (project, logger, d) = ProjectInitializer.InitProject(new()
         {
+            ["TargetFrameworkIdentifier"] = ".NETCoreApp",
             ["NETCoreSdkVersion"] = sdkVersion,
             ["TargetFrameworkVersion"] = tfm,
             ["PublishProfile"] = "DefaultContainer"
@@ -171,6 +172,7 @@ public class TargetsTests
     {
         var (project, logger, d) = ProjectInitializer.InitProject(new()
         {
+            ["TargetFrameworkIdentifier"] = ".NETCoreApp",
             ["TargetFrameworkVersion"] = tfm,
             ["ContainerRuntimeIdentifier"] = rid
         }, projectName: $"{nameof(CanComputeTagsForSupportedSDKVersions)}_{tfm}_{rid}_{expectedUser}");

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.props
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.props
@@ -18,8 +18,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Container publishing is only supported for a single TFM at a time at this point, so only import those targets in
        'inner' builds  -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props"
-          Condition="'$(EnableSdkContainerSupport)' == 'true'
-                     AND Exists('$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props')
-                     AND '$(TargetFramework)' != '' " />
+          Condition="'$(EnableSdkContainerSupport)' == 'true' AND Exists('$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props')" />
 
 </Project>

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.props
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.props
@@ -15,8 +15,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableSdkContainerSupport Condition="'$(EnableSdkContainerSupport)' == ''">true</EnableSdkContainerSupport>
   </PropertyGroup>
 
-  <!-- Container publishing is only supported for a single TFM at a time at this point, so only import those targets in
-       'inner' builds  -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props"
           Condition="'$(EnableSdkContainerSupport)' == 'true' AND Exists('$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props')" />
 

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.props
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.props
@@ -15,7 +15,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableSdkContainerSupport Condition="'$(EnableSdkContainerSupport)' == ''">true</EnableSdkContainerSupport>
   </PropertyGroup>
 
+  <!-- Container publishing is only supported for a single TFM at a time at this point, so only import those targets in
+       'inner' builds  -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props"
-          Condition="'$(EnableSdkContainerSupport)' == 'true' AND Exists('$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props')" />
+          Condition="'$(EnableSdkContainerSupport)' == 'true'
+                     AND Exists('$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props')
+                     AND '$(TargetFramework)' != '' " />
 
 </Project>

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -30,7 +30,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DotNetCLIToolTargetsDir Condition=" '$(_DotNetCLIToolTargetsDir)'=='' ">$(MSBuildThisFileDirectory)DotNetCLIToolTargets\</_DotNetCLIToolTargetsDir>
     <_PublishProfilesDir Condition=" '$(_PublishProfilesDir)'=='' ">$(MSBuildThisFileDirectory)PublishProfiles\</_PublishProfilesDir>
     <_ContainersTargetsDir Condition=" '$(_ContainersTargetsDir)'=='' ">$(MSBuildThisFileDirectory)..\..\..\Containers\build\</_ContainersTargetsDir>
-    
+
     <PublishIISAssets Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
              And '$(_TargetFrameworkVersionWithoutV)' != ''
              AND $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))
@@ -152,8 +152,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   Import the Containers target
   ***********************************************************************************************
  -->
-
-  <Import Project="$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets" Condition="'$(EnableSdkContainerSupport)' == 'true' AND Exists('$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets')" />
+  <!-- Container publishing is only supported for a single TFM at a time at this point, so only import those targets in
+       'inner' builds  -->
+  <Import Project="$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets"
+    Condition="'$(EnableSdkContainerSupport)' == 'true'
+               AND Exists('$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets')
+               AND '$(TargetFramework)' != ''" />
 
   <!--
   ***********************************************************************************************


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/439

Current implementation of `_ContainerIsTargetingNet8TFM` doesn't work well with multi-framework case. 