### PR TITLE
Enable documentation files in GenAPI & APICompat

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
-    <StrongNameKeyId>Open</StrongNameKeyId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <!-- This package doesn't contain any lib or ref assemblies because it's a tooling package.-->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
-    <Nullable>enable</Nullable>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
     <PackageDescription>MSBuild tasks and targets to perform api compatibility checks on assemblies and packages.</PackageDescription>
   </PropertyGroup>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidateAssembliesTask.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidateAssembliesTask.cs
@@ -10,7 +10,7 @@ using Microsoft.DotNet.ApiCompatibility.Logging;
 namespace Microsoft.DotNet.ApiCompat.Task
 {
     /// <summary>
-    /// ApiCompat's ValidateAssemblies msbuild frontend.
+    /// ApiCompat's ValidateAssemblies MSBuild frontend.
     /// </summary>
     public class ValidateAssembliesTask : TaskBase
     {
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.ApiCompat.Task
         public string[]? SuppressionFiles { get; set; }
 
         /// <summary>
-        /// The path to the suppression output file that is written to, when <see cref="GenerateCompatibilitySuppressionFile"/> is true.
+        /// The path to the suppression output file that is written to, when <see cref="GenerateSuppressionFile"/> is true.
         /// </summary>
         public string? SuppressionOutputFile { get; set; }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.ApiCompat.Task
         public string[]? SuppressionFiles { get; set; }
 
         /// <summary>
-        /// The path to the suppression output file that is written to, when <see cref="GenerateCompatibilitySuppressionFile"/> is true.
+        /// The path to the suppression output file that is written to, when <see cref="GenerateSuppressionFile"/> is true.
         /// </summary>
         public string? SuppressionOutputFile { get; set; }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
@@ -1,13 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
-    <StrongNameKeyId>Open</StrongNameKeyId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>apicompat</ToolCommandName>
     <PackageDescription>Tool to perform api compatibility checks on assemblies and packages.</PackageDescription>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// </summary>
         /// <param name="left">The metadata information of the left comparison side.</param>
         /// <param name="right">The metadata information of the right comparison side.</param>
-        /// <param name="id"><see cref="string"/> representing the diagnostic ID.</param>
+        /// <param name="diagnosticId"><see cref="string"/> representing the diagnostic ID.</param>
         /// <param name="message"><see cref="string"/> message describing the difference.</param>
         /// <param name="type"><see cref="DifferenceType"/> to describe the type of the difference.</param>
         /// <param name="member"><see cref="ISymbol"/> for which the difference is associated to.</param>
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// </summary>
         /// <param name="left">The metadata information of the left comparison side.</param>
         /// <param name="right">The metadata information of the right comparison side.</param>
-        /// <param name="id"><see cref="string"/> representing the diagnostic ID.</param>
+        /// <param name="diagnosticId"><see cref="string"/> representing the diagnostic ID.</param>
         /// <param name="message"><see cref="string"/> message describing the difference.</param>
         /// <param name="type"><see cref="DifferenceType"/> to describe the type of the difference.</param>
         /// <param name="memberId"><see cref="string"/> containing the member ID for which the difference is associated to.</param>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.ApiCompatibility.Mapping;
 namespace Microsoft.DotNet.ApiCompatibility
 {
     /// <summary>
-    /// The visitor that traverses the mappers' tree and gets it's differences in a <see cref="DiagnosticBag{CompatDifference}"/>.
+    /// A visitor that traverses the mapping tree and stores found differences as <see cref="CompatDifference" /> items.
     /// </summary>
     public class DifferenceVisitor : IDifferenceVisitor
     {

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IDifferenceVisitor.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/IDifferenceVisitor.cs
@@ -7,51 +7,50 @@ using Microsoft.DotNet.ApiCompatibility.Mapping;
 namespace Microsoft.DotNet.ApiCompatibility
 {
     /// <summary>
-    /// The visitor that traverses the mappers' tree and gets it's differences in a <see cref="HashSet{CompatDifference}"/>.
+    /// A visitor that traverses a given mapping tree and stores differences in the <see cref="CompatDifferences"/> collection.
     /// </summary>
     public interface IDifferenceVisitor
     {
         /// <summary>
-        /// A list of <see cref="HashSet{CompatDifference}"/>.
-        /// One per element compared in the right hand side.
+        /// A list of <see cref="CompatDifference"/> items which are associated with <see cref="MetadataInformation" />.
         /// </summary>
         IEnumerable<CompatDifference> CompatDifferences { get; }
 
         /// <summary>
-        /// Visits the tree for the given <see cref="IElementMapper{T}"/>.
+        /// Visits the mapping tree for a given <see cref="IElementMapper{T}"/>.
         /// </summary>
         /// <typeparam name="T">Underlying type for the objects that the mapper holds.</typeparam>
-        /// <param name="mapper"><see cref="ElementMapper{T}"/> to visit.</param>
+        /// <param name="mapper">The <see cref="IElementMapper{T}"/> to visit.</param>
         void Visit<T>(IElementMapper<T> mapper);
 
         /// <summary>
         /// Visits the <see cref="IAssemblySetMapper"/> and visits each <see cref="IAssemblyMapper"/> in the mapper.
         /// </summary>
-        /// <param name="mapper">The <see cref="AssemblySetMapper"/> to visit.</param>
+        /// <param name="mapper">The <see cref="IAssemblySetMapper"/> to visit.</param>
         void Visit(IAssemblySetMapper mapper);
 
         /// <summary>
-        /// Visits an <see cref="IAssemblyMapper"/> and adds it's differences to the <see cref="HashSet{CompatDifference}"/>.
+        /// Visits an <see cref="IAssemblyMapper"/> and stores differences in the <see cref="CompatDifferences"/> collection.
         /// </summary>
-        /// <param name="assembly">The mapper to visit.</param>
+        /// <param name="assembly">The <see cref="IAssemblyMapper"/> to visit.</param>
         void Visit(IAssemblyMapper assembly);
 
         /// <summary>
-        /// Visits the <see cref="INamespaceMapper"/> and visits each <see cref="ITypeMapper"/> in the mapper.
+        /// Visits an <see cref="INamespaceMapper"/> and stores differences in the <see cref="CompatDifferences"/> collection.
         /// </summary>
-        /// <param name="mapper">The <see cref="NamespaceMapper"/> to visit.</param>
+        /// <param name="namespace">The <see cref="INamespaceMapper"/> to visit.</param>
         void Visit(INamespaceMapper @namespace);
 
         /// <summary>
-        /// Visits an <see cref="ITypeMapper"/> and adds it's differences to the <see cref="HashSet{CompatDifference}"/>.
+        /// Visits an <see cref="ITypeMapper"/> and stores differences in the <see cref="CompatDifferences"/> collection.
         /// </summary>
-        /// <param name="type">The mapper to visit.</param>
+        /// <param name="type">The <see cref="ITypeMapper"/> to visit.</param>
         void Visit(ITypeMapper type);
 
         /// <summary>
-        /// Visits an <see cref="IMemberMapper"/> and adds it's differences to the <see cref="HashSet{CompatDifference}"/>.
+        /// Visits an <see cref="IMemberMapper"/> and stores differences in the <see cref="CompatDifferences"/> collection.
         /// </summary>
-        /// <param name="member">The mapper to visit.</param>
+        /// <param name="member">The <see cref="IMemberMapper"/> to visit.</param>
         void Visit(IMemberMapper member);
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressionEngine.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressionEngine.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         /// <param name="target">The target of where the <paramref name="diagnosticId"/> should be applied.</param>
         /// <param name="left">Optional. The left operand in a APICompat error.</param>
         /// <param name="right">Optional. The right operand in a APICompat error.</param>
+        /// <param name="isBaselineSuppression">Optional. <see langword="true"/> if the suppression belongs to a baseline comparison.</param>
         /// <returns><see langword="true"/> if the error is already suppressed. <see langword="false"/> otherwise.</returns>
         bool IsErrorSuppressed(string diagnosticId, string? target, string? left = null, string? right = null, bool isBaselineSuppression = false);
 
@@ -35,6 +36,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         /// <param name="target">The target of where the <paramref name="diagnosticId"/> should be applied.</param>
         /// <param name="left">Optional. The left operand in a APICompat error.</param>
         /// <param name="right">Optional. The right operand in a APICompat error.</param>
+        /// <param name="isBaselineSuppression">Optional. <see langword="true"/> if the suppression belongs to a baseline comparison.</param>
         void AddSuppression(string diagnosticId, string? target, string? left = null, string? right = null, bool isBaselineSuppression = false);
 
         /// <summary>
@@ -46,8 +48,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         /// <summary>
         /// Writes all suppressions in collection down to a file, if empty it doesn't write anything.
         /// </summary>
-        /// <param name="supressionFile">The path to the file to be written.</param>
-        /// <returns>Whether it wrote the file.</returns>
+        /// <param name="suppressionOutputFile">The path to the file to be written.</param>
+        /// <returns><see langword="true" /> if the suppression file is written.</returns>
         bool WriteSuppressionsToFile(string suppressionOutputFile);
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/AssemblyMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/AssemblyMapper.cs
@@ -24,11 +24,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
         public IEnumerable<CompatDifference> AssemblyLoadErrors => _assemblyLoadErrors;
 
         /// <summary>
-        /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
+        /// Instantiates an assembly mapper.
         /// </summary>
-        /// <param name="settings">The settings used to diff the elements in the mapper.</param>
+        /// <param name="ruleRunner">The <see cref="IRuleRunner"/> that compares the assembly mapper elements.</param>
+        /// <param name="settings">The <see cref="IMapperSettings"/> used to compare the assembly mapper elements.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
-        /// <param name="containingAssemblySet">The containing assembly set. Null, if the assembly isn't part of a set.</param>
+        /// <param name="containingAssemblySet">The containing <see cref="IAssemblySetMapper"/>. Null, if the assembly isn't part of a set.</param>
         public AssemblyMapper(IRuleRunner ruleRunner,
             IMapperSettings settings,
             int rightSetSize,
@@ -99,7 +100,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
                     {
                         if (!_namespaces.TryGetValue(ns, out INamespaceMapper? mapper))
                         {
-                            mapper = new NamespaceMapper(RuleRunner, Settings, Right.Length, this, typeforwardsOnly: typeForwardsOnly);
+                            mapper = new NamespaceMapper(RuleRunner, Settings, Right.Length, this, typeForwardsOnly: typeForwardsOnly);
                             _namespaces.Add(ns, mapper);
                         }
                         else if (checkIfExists && mapper.GetElement(side, setIndex) != null)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/AssemblySetMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/AssemblySetMapper.cs
@@ -18,9 +18,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
         public int AssemblyCount => _assemblies != null ? _assemblies.Count : 0;
 
         /// <summary>
-        /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
+        /// Instantiates an assembly set mapper.
         /// </summary>
-        /// <param name="settings">The settings used to diff the elements in the mapper.</param>
+        /// <param name="ruleRunner">The <see cref="IRuleRunner"/> that compares the assembly set mapper elements.</param>
+        /// <param name="settings">The <see cref="IMapperSettings"/> used to compare the assembly set mapper elements.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
         public AssemblySetMapper(IRuleRunner ruleRunner,
             IMapperSettings settings,

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/ElementMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/ElementMapper.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.ApiCompatibility.Rules;
 namespace Microsoft.DotNet.ApiCompatibility.Mapping
 {
     /// <summary>
-    /// Class that represents a mapping in between two objects of type <see cref="T"/>.
+    /// Class that represents a mapping in between two objects.
     /// </summary>
     public abstract class ElementMapper<T> : IElementMapper<T>
     {
@@ -29,11 +29,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
         protected readonly IRuleRunner RuleRunner;
 
         /// <summary>
-        /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
+        /// Instantiates an element mapper.
         /// </summary>
-        /// <param name="settings">The settings used to diff the elements in the mapper.</param>
+        /// <param name="ruleRunner">The <see cref="IRuleRunner"/> that compares the mapper elements.</param>
+        /// <param name="settings">The <see cref="IMapperSettings"/> used to compare the mapper elements.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
-        public ElementMapper(IRuleRunner ruleRunner,
+        protected ElementMapper(IRuleRunner ruleRunner,
             IMapperSettings settings,
             int rightSetSize)
         {

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/IElementMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/IElementMapper.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Microsoft.DotNet.ApiCompatibility.Mapping
 {
     /// <summary>
-    /// Interface that represents a mapping in between two objects of type <see cref="T"/>.
+    /// Interface that represents a mapping in between two objects.
     /// </summary>
     public interface IElementMapper<T>
     {

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/MemberMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/MemberMapper.cs
@@ -15,10 +15,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
         public ITypeMapper ContainingType { get; }
 
         /// <summary>
-        /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
+        /// Instantiates a member mapper.
         /// </summary>
-        /// <param name="settings">The settings used to diff the elements in the mapper.</param>
+        /// <param name="ruleRunner">The <see cref="IRuleRunner"/> that compares the member mapper elements.</param>
+        /// <param name="settings">The <see cref="IMapperSettings"/> used to compare the member mapper elements.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
+        /// <param name="containingType">The containing <see cref="ITypeMapper"/>.</param>
         public MemberMapper(IRuleRunner ruleRunner,
             IMapperSettings settings,
             int rightSetSize,

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/NamespaceMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/NamespaceMapper.cs
@@ -16,27 +16,29 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
     {
         private readonly Dictionary<ITypeSymbol, ITypeMapper> _types;
         private bool _expandedTree = false;
-        private readonly bool _typeforwardsOnly;
+        private readonly bool _typeForwardsOnly;
 
         /// <inheritdoc />
         public IAssemblyMapper ContainingAssembly { get; }
 
         /// <summary>
-        /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
+        /// Instantiates a namespace mapper.
         /// </summary>
-        /// <param name="settings">The settings used to diff the elements in the mapper.</param>
+        /// <param name="ruleRunner">The <see cref="IRuleRunner"/> that compares the namespace mapper elements.</param>
+        /// <param name="settings">The <see cref="IMapperSettings"/> used to compare the namespace mapper elements.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
-        /// <param name="typeforwardsOnly">Indicates if <see cref="GetTypes"/> should only return type forwards.</param>
+        /// <param name="containingAssembly">The containing <see cref="IAssemblyMapper"/>.</param>
+        /// <param name="typeForwardsOnly">Indicates if <see cref="GetTypes"/> should return forwarded types only.</param>
         public NamespaceMapper(IRuleRunner ruleRunner,
             IMapperSettings settings,
             int rightSetSize,
             IAssemblyMapper containingAssembly,
-            bool typeforwardsOnly = false)
+            bool typeForwardsOnly = false)
             : base(ruleRunner, settings, rightSetSize)
         {
             ContainingAssembly = containingAssembly;
             _types = new Dictionary<ITypeSymbol, ITypeMapper>(Settings.SymbolEqualityComparer);
-            _typeforwardsOnly = typeforwardsOnly;
+            _typeForwardsOnly = typeForwardsOnly;
         }
 
         /// <inheritdoc />
@@ -44,12 +46,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
         {
             if (!_expandedTree)
             {
-                // if the typeforwardsOnly flag is specified it means this namespace is already
+                // if the _typeForwardsOnly flag is specified it means this namespace is already
                 // populated with the resolved type forwards by the assembly mapper and that we 
                 // didn't find this namespace in the initial assembly. So we avoid getting the types
                 // as that would return the types defined in the assembly where the type forwards
                 // were resolved from.
-                if (!_typeforwardsOnly)
+                if (!_typeForwardsOnly)
                 {
                     AddOrCreateMappers(Left, ElementSide.Left);
                     for (int i = 0; i < Right.Length; i++)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/TypeMapper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/TypeMapper.cs
@@ -26,10 +26,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
         public ITypeMapper? ContainingType { get; }
 
         /// <summary>
-        /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
+        /// Instantiates a type mapper.
         /// </summary>
-        /// <param name="settings">The settings used to diff the elements in the mapper.</param>
+        /// <param name="ruleRunner">The <see cref="IRuleRunner"/> that compares the type mapper elements.</param>
+        /// <param name="settings">The <see cref="IMapperSettings"/> used to compare the type mapper elements.</param>
         /// <param name="rightSetSize">The number of elements in the right set to compare.</param>
+        /// <param name="containingNamespace">The containing <see cref="INamespaceMapper"/>.</param>
+        /// <param name="containingType">The containing <see cref="ITypeMapper"/>. Null, if the type doesn't have a containing type.</param>
         public TypeMapper(IRuleRunner ruleRunner,
             IMapperSettings settings,
             int rightSetSize,

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -5,8 +5,9 @@
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- We need to compare ISymbols in a special way (by name) and roslyn symbol comparers take more heuristics into consideration.-->
-    <NoWarn>RS1024;$(NoWarn)</NoWarn>
+    <NoWarn>$(NoWarn);RS1024</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,4 +21,5 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
+
 </Project>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AssemblyIdentityMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AssemblyIdentityMustMatch.cs
@@ -10,6 +10,15 @@ using Microsoft.DotNet.ApiSymbolExtensions.Logging;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
+    /// <summary>
+    /// This rule validates that assembly identities are compatible. The following parameters are considered:
+    /// - Assembly exists
+    /// - Assembly name (equality)
+    /// - Assembly culture (equality)
+    /// - Assembly version (compatible)
+    /// - Assembly public key token (compatible)
+    /// Some checks behave differently in strict mode comparison.
+    /// </summary>
     public class AssemblyIdentityMustMatch : IRule
     {
         private readonly ISuppressableLog _log;

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
@@ -6,6 +6,9 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
+    /// <summary>
+    /// This rule validates that members aren't added to interfaces with strict mode comparison.
+    /// </summary>
     public class CannotAddMemberToInterface : IRule
     {
         public CannotAddMemberToInterface(IRuleSettings settings, IRuleRegistrationContext context)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotChangeVisibility.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
@@ -57,8 +56,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             };
         }
 
-        private void RunOnSymbol(
-            ISymbol? left,
+        private void RunOnSymbol(ISymbol? left,
             ISymbol? right,
             MetadataInformation leftMetadata,
             MetadataInformation rightMetadata,
@@ -94,15 +92,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             }
         }
 
-        private void RunOnTypeSymbol(
-            ITypeSymbol? left,
+        private void RunOnTypeSymbol(ITypeSymbol? left,
             ITypeSymbol? right,
             MetadataInformation leftMetadata,
             MetadataInformation rightMetadata,
             IList<CompatDifference> differences) => RunOnSymbol(left, right, leftMetadata, rightMetadata, differences);
 
-        private void RunOnMemberSymbol(
-            ISymbol? left,
+        private void RunOnMemberSymbol(ISymbol? left,
             ISymbol? right,
             ITypeSymbol leftContainingType,
             ITypeSymbol rightContainingType,

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotRemoveBaseTypeOrInterface.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotRemoveBaseTypeOrInterface.cs
@@ -7,6 +7,10 @@ using Microsoft.DotNet.ApiSymbolExtensions;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
+    /// <summary>
+    /// This rule validates that base types and interfaces aren't removed from the right.
+    /// In strict mode, it also validates that the right doesn't add base types and interfaces.
+    /// </summary>
     public class CannotRemoveBaseTypeOrInterface : IRule
     {
         private readonly IRuleSettings _settings;
@@ -88,7 +92,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
                 // Ignore non visible interfaces based on the run Settings
                 // If TypeKind == Error it means the Roslyn couldn't resolve it,
-                // so we are running with a missing assembly reference to where that typeref is defined.
+                // so we are running with a missing assembly reference to where that type ef is defined.
                 // However we still want to consider it as Roslyn does resolve it's name correctly.
                 if (!leftInterface.IsVisibleOutsideOfAssembly(_settings.IncludeInternalSymbols) && leftInterface.TypeKind != TypeKind.Error)
                     return;

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotSealType.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotSealType.cs
@@ -7,6 +7,10 @@ using Microsoft.DotNet.ApiSymbolExtensions;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
+    /// <summary>
+    /// This rule validates that types aren't marked as sealed on the right when they weren't on the left.
+    /// In strict mode, it also validates that types aren't unsealed when they were sealed before.
+    /// </summary>
     public class CannotSealType : IRule
     {
         private readonly IRuleSettings _settings;

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
@@ -16,6 +16,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     {
         private readonly IRuleSettings _settings;
 
+        /// <summary>
+        /// Instantiates the 'MemberMustExist' rule with <see cref="IRuleSettings"/> and an <see cref="IRuleRegistrationContext"/>.
+        /// </summary>
+        /// <param name="settings">The <see cref="IRuleSettings"/> that is used for comparison.</param>
+        /// <param name="context">The <see cref="IRuleRegistrationContext"/> that provides callback registration for comparing elements.</param>
         public MembersMustExist(IRuleSettings settings, IRuleRegistrationContext context)
         {
             _settings = settings;
@@ -24,10 +29,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         }
 
         /// <summary>
-        /// Evaluates whether a type exists on both sides of the <see cref="TypeMapper"/>.
+        /// Evaluates whether a type exists on both sides of the <see cref="ITypeMapper"/>.
         /// </summary>
-        /// <param name="mapper">The <see cref="TypeMapper"/> to evaluate.</param>
-        /// <param name="differences">The list of <see cref="CompatDifference"/> to add differences to.</param>
         private void RunOnTypeSymbol(ITypeSymbol? left, ITypeSymbol? right, MetadataInformation leftMetadata, MetadataInformation rightMetadata, IList<CompatDifference> differences)
         {
             if (left != null && right == null)
@@ -53,10 +56,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         }
 
         /// <summary>
-        /// Evaluates whether member (Field, Property, Method, Constructor, Event) exists on both sides of the <see cref="MemberMapper"/>.
+        /// Evaluates whether member (Field, Property, Method, Constructor, Event) exists on both sides of the <see cref="IMemberMapper"/>.
         /// </summary>
-        /// <param name="mapper">The <see cref="MemberMapper"/> to evaluate.</param>
-        /// <param name="differences">The list of <see cref="CompatDifference"/> to add differences to.</param>
         private void RunOnMemberSymbol(ISymbol? left, ISymbol? right, ITypeSymbol leftContainingType, ITypeSymbol rightContainingType, MetadataInformation leftMetadata, MetadataInformation rightMetadata, IList<CompatDifference> differences)
         {
             if (left != null && right == null)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleContext.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleContext.cs
@@ -17,31 +17,31 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         private readonly List<Action<ISymbol?, ISymbol?, MetadataInformation, MetadataInformation, IList<CompatDifference>>> _onMemberSymbolActions = new();
         private readonly List<Action<ISymbol?, ISymbol?, ITypeSymbol, ITypeSymbol, MetadataInformation, MetadataInformation, IList<CompatDifference>>> _onMemberSymbolWithContainingTypeActions = new();
 
-        /// <inheritdoc> />
+        /// <inheritdoc />
         public void RegisterOnAssemblySymbolAction(Action<IAssemblySymbol?, IAssemblySymbol?, MetadataInformation, MetadataInformation, bool, IList<CompatDifference>> action)
         {
             _onAssemblySymbolActions.Add(action);
         }
 
-        /// <inheritdoc> />
+        /// <inheritdoc />
         public void RegisterOnTypeSymbolAction(Action<ITypeSymbol?, ITypeSymbol?, MetadataInformation, MetadataInformation, IList<CompatDifference>> action)
         {
             _onTypeSymbolActions.Add(action);
         }
 
-        /// <inheritdoc> />
+        /// <inheritdoc />
         public void RegisterOnMemberSymbolAction(Action<ISymbol?, ISymbol?, MetadataInformation, MetadataInformation, IList<CompatDifference>> action)
         {
             _onMemberSymbolActions.Add(action);
         }
 
-        /// <inheritdoc> />
+        /// <inheritdoc />
         public void RegisterOnMemberSymbolAction(Action<ISymbol?, ISymbol?, ITypeSymbol, ITypeSymbol, MetadataInformation, MetadataInformation, IList<CompatDifference>> action)
         {
             _onMemberSymbolWithContainingTypeActions.Add(action);
         }
 
-        /// <inheritdoc> />
+        /// <inheritdoc />
         public void RunOnAssemblySymbolActions(IAssemblySymbol? left, IAssemblySymbol? right, MetadataInformation leftMetadata, MetadataInformation rightMetadata, bool isSingleAssembly, IList<CompatDifference> differences)
         {
             foreach (Action<IAssemblySymbol?, IAssemblySymbol?, MetadataInformation, MetadataInformation, bool, IList<CompatDifference>> action in _onAssemblySymbolActions)
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             }
         }
 
-        /// <inheritdoc> />
+        /// <inheritdoc />
         public void RunOnTypeSymbolActions(ITypeSymbol? left, ITypeSymbol? right, MetadataInformation leftMetadata, MetadataInformation rightMetadata, IList<CompatDifference> differences)
         {
             foreach (Action<ITypeSymbol?, ITypeSymbol?, MetadataInformation, MetadataInformation, IList<CompatDifference>> action in _onTypeSymbolActions)
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             }
         }
 
-        /// <inheritdoc> />
+        /// <inheritdoc />
         public void RunOnMemberSymbolActions(ISymbol? left, ISymbol? right, ITypeSymbol leftContainingType, ITypeSymbol rightContainingType, MetadataInformation leftMetadata, MetadataInformation rightMetadata, IList<CompatDifference> differences)
         {
             foreach (Action<ISymbol?, ISymbol?, MetadataInformation, MetadataInformation, IList<CompatDifference>> action in _onMemberSymbolActions)

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
@@ -16,7 +16,7 @@ using NuGet.RuntimeModel;
 namespace Microsoft.DotNet.PackageValidation
 {
     /// <summary>
-    /// This class represents a nuget package.
+    /// This class represents a NuGet package.
     /// </summary>
     public class Package
     {

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/BaselinePackageValidator.cs
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/BaselinePackageValidator.cs
@@ -28,9 +28,9 @@ namespace Microsoft.DotNet.PackageValidation.Validators
         }
 
         /// <summary>
-        /// Validates the latest nuget package doesnot drop any target framework/rid and does not introduce any breaking changes.
+        /// Validates the latest NuGet package doesn't drop any target framework/rid and does not introduce any breaking changes.
         /// </summary>
-        /// <param name="package">Nuget Package that needs to be validated.</param>
+        /// <param name="options"><see cref="PackageValidatorOption"/> to configure the baseline package validation.</param>
         public void Validate(PackageValidatorOption options)
         {
             if (options.BaselinePackage is null)

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/CompatibleFrameworkInPackageValidator.cs
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/CompatibleFrameworkInPackageValidator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.PackageValidation.Validators
         /// <summary>
         /// Validates that the compatible frameworks have compatible surface area.
         /// </summary>
-        /// <param name="options">The options to configure the validator.</param>
+        /// <param name="options"><see cref="PackageValidatorOption"/> to configure the compatible framework in package validation.</param>
         public void Validate(PackageValidatorOption options)
         {
             ApiCompatRunnerOptions apiCompatOptions = new(options.EnableStrictMode);

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/CompatibleTFMValidator.cs
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/CompatibleTFMValidator.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.PackageValidation.Validators
 {
     /// <summary>
     /// Validates that there are compile time and runtime assets for all the compatible frameworks.
-    /// Queues the apicompat between the applicable compile and runtime assemblies for these frameworks.
+    /// Queues APICompat work items for the applicable compile and runtime assemblies for these frameworks.
     /// </summary>
     public class CompatibleTfmValidator : IPackageValidator
     {
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.PackageValidation.Validators
         /// Validates that there are compile time and runtime assets for all the compatible frameworks.
         /// Validates that the surface between compile time and runtime assets is compatible.
         /// </summary>
-        /// <param name="package">Nuget Package that needs to be validated.</param>
+        /// <param name="options"><see cref="PackageValidatorOption"/> to configure the compatible TFM package validation.</param>
         public void Validate(PackageValidatorOption options)
         {
             ApiCompatRunnerOptions apiCompatOptions = new(options.EnableStrictMode);

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
-    <IsPackable>true</IsPackable>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <!-- This package doesn't contain any lib or ref assemblies because it's a tooling package.-->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
-    <Nullable>enable</Nullable>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
     <PackageDescription>MSBuild tasks and targets to emit Roslyn based source code from input assemblies.</PackageDescription>
   </PropertyGroup>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Microsoft.DotNet.GenAPI.Tool.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Microsoft.DotNet.GenAPI.Tool.csproj
@@ -5,8 +5,10 @@
     <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
-    <IsPackable>true</IsPackable>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>genapi</ToolCommandName>
     <PackageDescription>Tool to emit Roslyn based source code from input assemblies.</PackageDescription>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
@@ -94,10 +94,6 @@ namespace Microsoft.DotNet.GenAPI.Tool
             return rootCommand.Invoke(args);
         }
 
-        /// Splits delimiter separated list of pathes represented as a string to a List of paths.
-        /// </summary>
-        /// <param name="pathSet">Delimiter separated list of paths.</param>
-        /// <returns></returns>
         private static string[] ParseAssemblyArgument(ArgumentResult argumentResult)
         {
             List<string> args = new();

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/AssemblySymbolOrderer.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/AssemblySymbolOrderer.cs
@@ -9,40 +9,35 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.DotNet.GenAPI
 {
     /// <summary>
-    /// Provides ordering for namespaces, types and members.
+    /// Provides extension methods for ordering namespace, type and member symbols.
     /// </summary>
     public static class AssemblySymbolOrderer
     {
         /// <summary>
-        /// Sorts the elements of a INamespaceSymbol.
+        /// Sorts <see cref="INamespaceSymbol" /> elements.
         /// </summary>
-        /// <param name="namespaces">List of namespaces to be sorted.</param>
+        /// <param name="namespaceSymbols">List of namespaces to be sorted.</param>
         /// <returns>Returns namespaces in sorted order.</returns>
-        public static IEnumerable<INamespaceSymbol> Order(this IEnumerable<INamespaceSymbol> namespaces) =>
-            namespaces.OrderBy(s => s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase);
+        public static IEnumerable<INamespaceSymbol> Order(this IEnumerable<INamespaceSymbol> namespaceSymbols) =>
+            namespaceSymbols.OrderBy(s => s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Sorts the elements of a ITypeSymbol.
+        /// Sorts <see cref="ITypeSymbol" /> elements.
         /// </summary>
-        /// <param name="namespaces">List of TypeMembers to be sorted.</param>
+        /// <param name="typeSymbols">List of TypeMembers to be sorted.</param>
         /// <returns>Returns TypeMembers in sorted order.</returns>
-        public static IEnumerable<T> Order<T>(this IEnumerable<T> symbols) where T : ITypeSymbol =>
-            symbols.OrderBy(s => s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase);
+        public static IEnumerable<T> Order<T>(this IEnumerable<T> typeSymbols) where T : ITypeSymbol =>
+            typeSymbols.OrderBy(s => s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Sorts the elements of a ISymbol.
+        /// Sorts <see cref="ISymbol" /> elements.
         /// </summary>
-        /// <param name="namespaces">List of Members to be sorted.</param>
-        /// <returns>Returns Members in sorted order.</returns>
-        public static IEnumerable<ISymbol> Order(this IEnumerable<ISymbol> members)
-        {
-            if (members is IOrderedEnumerable<ITypeSymbol> orderedTypeDefinitionMembers)
-            {
-                return orderedTypeDefinitionMembers.ThenBy(s => s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase);
-            }
-
-            return members.OrderBy(s => (GetMemberOrder(s), s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase));
-        }
+        /// <param name="symbols">List of symbols to be sorted.</param>
+        /// <returns>Returns symbols in sorted order.</returns>
+        public static IEnumerable<ISymbol> Order(this IEnumerable<ISymbol> symbols) =>
+            symbols is IOrderedEnumerable<ITypeSymbol> orderedTypeDefinitionMembers ?
+            orderedTypeDefinitionMembers.ThenBy(s => s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase) :
+            symbols.OrderBy(s => (GetMemberOrder(s), s.GetDocumentationCommentId(), StringComparer.OrdinalIgnoreCase));
 
         private static int GetMemberOrder(ISymbol symbol) =>
             symbol switch

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -317,7 +317,7 @@ namespace Microsoft.DotNet.GenAPI
 
         private OptionSet DefineFormattingOptions()
         {
-            /// TODO: consider to move configuration into file.
+            // TODO: consider to move configuration into file.
             return _adhocWorkspace.Options
                 .WithChangedOption(CSharpFormattingOptions.NewLinesForBracesInTypes, true)
                 .WithChangedOption(CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine, true)

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
     <Nullable>enable</Nullable>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoaderFactory.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoaderFactory.cs
@@ -11,9 +11,9 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         private readonly bool _includeInternals;
 
         /// <summary>
-        /// Creates a new AssemblyLoaderFactory
+        /// Creates a new AssemblySymbolLoaderFactory
         /// </summary>
-        /// <param name="includeInternals">True to include internal API when reading assemblies from the <see cref="AssemblyLoaderFactory"/> created.</param>
+        /// <param name="includeInternals">True to include internal API when reading assemblies from the <see cref="AssemblySymbolLoader"/> created.</param>
         public AssemblySymbolLoaderFactory(bool includeInternals = false)
         {
             _includeInternals = includeInternals;

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/AttributeDataExtensions.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/AttributeDataExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
         /// <summary>
         /// Add a filter object to a list of filters.
         /// </summary>
-        /// <typeparam name="T"><see cref="ISymbolFilter" /> to evaluate.</typeparam>
+        /// <param name="filter">The <see cref="ISymbolFilter" /> to include to the list of filters.</param>
         /// <returns>Returns the current instance of the class.</returns>
         public CompositeSymbolFilter Add(ISymbolFilter filter)
         {

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/IAssemblySymbolLoader.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/IAssemblySymbolLoader.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiSymbolExtensions
 {
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         void AddReferenceSearchPaths(params string[] paths);
 
         /// <summary>
-        /// Indicates if the <see cref="CSharpCompilation"/> used to resolve binaries has any roslyn diagnostics.
+        /// Indicates if the compilation used to resolve binaries has any roslyn diagnostics.
         /// Might be useful when loading an assembly from source files.
         /// </summary>
         /// <param name="diagnostics">List of diagnostics.</param>

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- We pin the code analysis version when not in source build as we need to support running on older
     SDKs when the OOB package is used. -->
     <_MicrosoftCodeAnalysisVersion>4.0.1</_MicrosoftCodeAnalysisVersion>

--- a/src/Tasks/Common/Logger.cs
+++ b/src/Tasks/Common/Logger.cs
@@ -45,8 +45,8 @@ namespace Microsoft.NET.Build.Tasks
     /// Results in LogCore getting a Message instance with Code="NETSDK1234"
     /// and Text="Something is wrong."
     ///
-    /// Pattern inspired by <se cref="TaskLoggingHelper.LogErrorWithCodeFromResources"/>,
-    /// but retains completion via generated <see cref="Strings"/> instead of
+    /// Pattern inspired by TaskLoggingHelper.LogErrorWithCodeFromResources,
+    /// but retains completion via generated Strings instead of
     /// passing resource keys by name.
     ///
     /// All actual logging is deferred to subclass in <see cref="LogCore"/>,


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/32296
Fixes https://github.com/dotnet/sdk/issues/25565

- Enable documentation file generation in GenAPI & APICompat projects
- Fix the incorrect XML documentation
- Add XML documentation where missing
- Document APICompat rules
