### PR TITLE
Containers/CreateNewImage: don't change the user to root when ContainerUser is empty.

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -80,7 +80,7 @@ public static class ContainerBuilder
             // ports are validated by System.CommandLine API
             imageBuilder.ExposePort(number, type);
         }
-        if (containerUser is { } user)
+        if (containerUser is { Length: > 0 } user)
         {
             imageBuilder.SetUser(user);
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -13,6 +13,8 @@ internal sealed class ImageBuilder
     private readonly ManifestV2 _manifest;
     private readonly ImageConfig _baseImageConfig;
 
+    public ImageConfig BaseImageConfig => _baseImageConfig;
+
     internal ImageBuilder(ManifestV2 manifest, ImageConfig baseImageConfig)
     {
         _manifest = manifest;

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -32,6 +32,8 @@ internal sealed class ImageConfig
     /// </summary>
     public bool IsWindows => "windows".Equals(_os, StringComparison.OrdinalIgnoreCase);
 
+    public string? User => _user;
+
     internal ImageConfig(string imageConfigJson) : this(JsonNode.Parse(imageConfigJson)!)
     {
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -80,7 +80,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         SetPorts(imageBuilder, ExposedPorts);
 
-        if (ContainerUser is { } user)
+        if (ContainerUser is { Length: > 0 } user)
         {
             imageBuilder.SetUser(user);
         }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -186,4 +186,81 @@ public class CreateNewImageTests
             .Should().Pass()
             .And.HaveStdOut("Foo");
     }
+
+    [DockerDaemonAvailableFact]
+    public async System.Threading.Tasks.Task CreateNewImage_RootlessBaseImage()
+    {
+        const string RootlessBase ="dotnet/rootlessbase";
+        const string AppImage = "dotnet/testimagerootless";
+        const string RootlessUser = "101";
+
+        // Build a rootless base runtime image.
+        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
+
+        ImageBuilder imageBuilder = await registry.GetImageManifestAsync(
+            DockerRegistryManager.RuntimeBaseImage,
+            DockerRegistryManager.Net8PreviewImageTag,
+            "linux-x64",
+            ToolsetUtils.GetRuntimeGraphFilePath(),
+            cancellationToken: default).ConfigureAwait(false);
+
+        Assert.NotNull(imageBuilder);
+
+        imageBuilder.SetUser(RootlessUser);
+
+        BuiltImage builtImage = imageBuilder.Build();
+
+        var sourceReference = new ImageReference(registry, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net8PreviewImageTag);
+        var destinationReference = new ImageReference(registry, RootlessBase, "latest");
+
+        await registry.PushAsync(builtImage, sourceReference, destinationReference, Console.WriteLine, cancellationToken: default).ConfigureAwait(false);
+
+        // Build an application image on top of the rootless base runtime image.
+        DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(CreateNewImage_RootlessBaseImage)));
+
+        if (newProjectDir.Exists)
+        {
+            newProjectDir.Delete(recursive: true);
+        }
+
+        newProjectDir.Create();
+
+        new DotnetNewCommand(_testOutput, "console", "-f", ToolsetInfo.CurrentTargetFramework)
+            .WithVirtualHive()
+            .WithWorkingDirectory(newProjectDir.FullName)
+            .Execute()
+            .Should().Pass();
+
+        new DotnetCommand(_testOutput, "publish", "-c", "Release", "-r", "linux-x64", "--no-self-contained")
+            .WithWorkingDirectory(newProjectDir.FullName)
+            .Execute()
+            .Should().Pass();
+
+        CreateNewImage task = new CreateNewImage();
+        task.BaseRegistry = "localhost:5010";
+        task.BaseImageName = RootlessBase;
+        task.BaseImageTag = "latest";
+
+        task.OutputRegistry = "localhost:5010";
+        task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-x64", "publish");
+        task.ImageName = AppImage;
+        task.ImageTags = new[] { "latest" };
+        task.WorkingDirectory = "app/";
+        task.ContainerRuntimeIdentifier = "linux-x64";
+        task.Entrypoint = new TaskItem[] { new("dotnet"), new("build") };
+        task.RuntimeIdentifierGraphPath = ToolsetUtils.GetRuntimeGraphFilePath();
+
+        Assert.True(task.Execute());
+        newProjectDir.Delete(true);
+
+        // Verify the application image uses the non-root user from the base image.
+        imageBuilder = await registry.GetImageManifestAsync(
+            AppImage,
+            "latest",
+            "linux-x64",
+            ToolsetUtils.GetRuntimeGraphFilePath(),
+            cancellationToken: default).ConfigureAwait(false);
+
+        Assert.Equal(RootlessUser, imageBuilder.BaseImageConfig.User);
+    }
 }


### PR DESCRIPTION
When a rootless base image is used without specifying a ContainerUser, the image user was changed to User="". This causes the application image to run as the 'root' user.

@baronfel ptal.