### PR TITLE
[release/7.0.4xx] Add warning for optional workload EOL

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -891,4 +891,8 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1198: A publish profile with the name '{0}' was not found in the project. Set the PublishProfile property to a valid file name.</value>
     <comment>{StrBegin="NETSDK1198: "}</comment>
   </data>
+  <data name="WorkloadIsEol" xml:space="preserve">
+    <value>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</value>
+    <comment>{StrBegin="NETSDK1202: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: Odkazované sestavení se zkompilovalo pomocí novější verze Microsoft.Windows.SDK.NET.dll. Pokud chcete odkazovat na toto sestavení, aktualizujte prosím novější sadu .NET SDK.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: Eine referenzierte Assembly wurde mit einer neueren Version von "Microsoft.Windows.SDK.NET.dll" kompiliert. Aktualisieren Sie auf ein neueres .NET SDK, um auf diese Assembly zu verweisen.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: Un ensamblado al que se hace referencia se compiló con una versión más reciente de Microsoft.Windows.SDK.NET.dll. Actualice a un SDK de .NET más reciente para hacer referencia a este ensamblado.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: un assembly de référence a été compilé à l'aide d'une version plus récente de Microsoft.Windows.SDK.NET.dll. Effectuez une mise à jour vers un kit SDK .NET plus récent pour référencer cet assembly.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: un assembly di riferimento è stato compilato con una versione più recente di Microsoft.Windows.SDK.NET.dll. Eseguire l'aggiornamento a un SDK .NET più recente per fare riferimento a questo assembly.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: 参照アセンブリは、より新しいバージョンの Microsoft.Windows.SDK.NET.dll を使用してコンパイルされています。このアセンブリを参照するには、より新しい .NET SDK に更新してください。</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: 참조된 어셈블리가 최신 버전의 Microsoft.Windows.SDK.NET.dll을 사용하여 컴파일되었습니다. 이 어셈블리를 참조하려면 최신 .NET SDK로 업데이트하세요.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: Przywoływany zestaw został skompilowany przy użyciu nowszej wersji biblioteki Microsoft.Windows.SDK.NET.dll. Aby odwoływać się do tego zestawu, zaktualizuj do nowszego zestawu .NET SDK.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: um assembly referenciado foi compilado usando uma versão mais recente do Microsoft.Windows.SDK.NET.dll. Atualize para um SDK do .NET mais recente para referenciar este assembly.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: сборка, на которую указывает ссылка, была скомпилирована с помощью более новой версии Microsoft.Windows.SDK.NET.dll. Обновите пакет SDK для .NET до более поздней версии, чтобы можно было ссылаться на эту сборку.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: Başvurulan bütünleştirilmiş kod, Microsoft.Windows.SDK.NET.dll'nin daha yeni bir sürümü kullanılarak derlendi. Bu bütünleştirilmiş koda başvurmak için lütfen daha yeni bir .NET SDK'ya güncelleştirin.</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: 使用更新版本的 Microsoft.Windows.SDK.NET.dll 编译了引用的程序集。请更新为更新的 .NET SDK 以引用此程序集。</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -975,6 +975,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1148: 參考的組件是使用 Microsoft.Windows.SDK.NET.dll 的較新版本編譯的。若要參考此組件，請更新至較新的 .NET SDK。</target>
         <note>{StrBegin="NETSDK1148: "}</note>
       </trans-unit>
+      <trans-unit id="WorkloadIsEol">
+        <source>NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</source>
+        <target state="new">NETSDK1202: The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.</target>
+        <note>{StrBegin="NETSDK1202: "}</note>
+      </trans-unit>
       <trans-unit id="WorkloadNotAvailable">
         <source>NETSDK1178: The project depends on the following workload packs that do not exist in any of the workloads available in this installation: {0}
 You may need to build the project on another operating system or architecture, or update the .NET SDK.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
@@ -13,6 +13,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <!-- Default the check to true, but allow developers to turn the warning off. -->
     <CheckEolTargetFramework Condition="'$(CheckEolTargetFramework)' == ''">true</CheckEolTargetFramework>
+    <CheckEolWorkloads Condition="'$(CheckEolWorkloads)' == ''">true</CheckEolWorkloads>
   </PropertyGroup>
 
   <!--
@@ -27,5 +28,11 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'@(_EolNetCoreTargetFrameworkVersions->AnyHaveMetadataValue('Identity', '$(_TargetFrameworkVersionWithoutV)'))' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(CheckEolTargetFramework)' == 'true'">
     <NETSdkWarning ResourceName="TargetFrameworkIsEol"
                    FormatArguments="$(TargetFramework.ToLowerInvariant());https://aka.ms/dotnet-core-support" />
+  </Target>
+
+  <Target Name="_CheckForEolWorkloads" AfterTargets="_CheckForUnsupportedNETCoreVersion"
+          Condition="'@(EolWorkload)' != '' and '$(CheckEolWorkloads)' == 'true'">
+    <NETSdkWarning ResourceName="WorkloadIsEol"
+                   FormatArguments="%(EolWorkload.Identity);$([MSBuild]::ValueOrDefault('%(EolWorkload.Url)', 'https://aka.ms/dotnet-core-support'))" />
   </Target>
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetEolFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetEolFrameworks.cs
@@ -96,5 +96,65 @@ namespace Microsoft.NET.Build.Tests
                 .And
                 .NotHaveStdOutContaining("NETSDK1138");
         }
+
+        [Fact]
+        public void It_warns_for_workloads_out_of_support()
+        {
+            var testProject = new TestProject()
+            {
+                Name = $"EolWorkloads",
+                TargetFrameworks = "net6.0"
+            };
+
+            testProject.AddItem("EolWorkload", new()
+            {
+                { "Include", "android" },
+                { "Url", "https://aka.ms/maui-support-policy" }
+            });
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            var result = buildCommand
+                .Execute();
+
+            result
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("NETSDK1202");
+        }
+
+        [Fact]
+        public void It_does_not_warn_when_deactivating_workloads_check()
+        {
+            var testProject = new TestProject()
+            {
+                Name = $"EolWorkloadsNoWarning",
+                TargetFrameworks = "net6.0"
+            };
+
+            testProject.AdditionalProperties["CheckEolWorkloads"] = "false";
+
+            testProject.AddItem("EolWorkload", new()
+            {
+                { "Include", "android" },
+                { "Url", "https://aka.ms/maui-support-policy" }
+            });
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            var result = buildCommand
+                .Execute();
+
+            result
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("NETSDK1202");
+        }
     }
 }


### PR DESCRIPTION
## Description

The [support policy for .NET MAUI](https://aka.ms/maui-support-policy) is shorter than the rest of .NET.

We would like to introduce a new `NETSDK1202` warning so customers are aware they are using an out-of-support optional workload. This is very similar to the existing warning for `net5.0` projects:

https://github.com/dotnet/sdk/blob/9ea4835ca98ac79470f18403d46e37279cff38f5/src/Tasks/Common/Resources/Strings.resx#L664

## Customer Impact

Customers using `net6.0` .NET MAUI projects may be completely unaware of .NET MAUI's support policy. They might assume .NET 6 means LTS, hence the need for a new build warning.

## Regression?
* [ ] Yes
* [x] No

## Risk
* [ ] High
* [ ] Medium
* [x] Low

The change itself is adding a build warning. To help any possible build breakage from the new warning, customers have multiple ways to opt out of it:

```xml
    <PropertyGroup>
      <CheckEolWorkloads>false</CheckEolWorkloads>
    </PropertyGroup>
    <ItemGroup>
      <EolWorkload Remove="maui" />
    </ItemGroup>
```
Plus the standard MSBuild feature(s) to opt out, such as `$(WarningsAsMessages)`.

## Verification

* [x] manual
* [x] automated tests

## Full PR Details

Backport of https://github.com/dotnet/sdk/pull/32426

Context: https://aka.ms/maui-support-policy
Context: https://github.com/xamarin/xamarin-android/pull/8030

For out-of-support .NET 6 MAUI projects, we'd like to emit the warning:

    Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(35,5):
    warning NETSDK1202: The workload 'android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.

Where each optional workload can opt into this warning via `AutoImport.props`:

    <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
      <EolWorkload Include="android" Url="https://aka.ms/maui-support-policy" />
    </ItemGroup>

We would add to this MSBuild item group in the `android`, `ios`, `macos`, `maccatalyst`, `tvos` and `maui` workloads. In the future, `wasm-tools` could opt into the warning and leave `%(Url)` blank if desired.

Customers can opt out of the warning in their `.csproj` by either:

    <PropertyGroup>
      <CheckEolWorkloads>false</CheckEolWorkloads>
    </PropertyGroup>
    <ItemGroup>
      <EolWorkload Remove="android" />
    </ItemGroup>

See xamarin/xamarin-android#8030 for the exact changes we'd make in optional workloads.