### PR TITLE
add two artifacts-output-related-telemetry properties to emitted events

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -27,6 +27,8 @@ namespace Microsoft.DotNet.Tools.MSBuild
         internal const string SelfContainedTelemetryPropertyKey = "SelfContained";
         internal const string UseApphostTelemetryPropertyKey = "UseApphost";
         internal const string OutputTypeTelemetryPropertyKey = "OutputType";
+        internal const string UseArtifactsOutputPropertyKey = "UseArtifactsOutput";
+        internal const string ArtifactsPathLocationTypePropertyKey = "ArtifactsPathLocationType";
 
         public MSBuildLogger()
         {
@@ -95,7 +97,9 @@ namespace Microsoft.DotNet.Tools.MSBuild
                     RuntimeIdentifierTelemetryPropertyKey,
                     SelfContainedTelemetryPropertyKey,
                     UseApphostTelemetryPropertyKey,
-                    OutputTypeTelemetryPropertyKey
+                    OutputTypeTelemetryPropertyKey,
+                    UseArtifactsOutputPropertyKey,
+                    ArtifactsPathLocationTypePropertyKey
                 })
                 {
                     if (args.Properties.TryGetValue(key, out string value))

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -22,14 +22,6 @@ namespace Microsoft.DotNet.Tools.MSBuild
         internal const string PublishPropertiesTelemetryEventName = "PublishProperties";
         internal const string ReadyToRunTelemetryEventName = "ReadyToRun";
 
-        internal const string TargetFrameworkVersionTelemetryPropertyKey = "TargetFrameworkVersion";
-        internal const string RuntimeIdentifierTelemetryPropertyKey = "RuntimeIdentifier";
-        internal const string SelfContainedTelemetryPropertyKey = "SelfContained";
-        internal const string UseApphostTelemetryPropertyKey = "UseApphost";
-        internal const string OutputTypeTelemetryPropertyKey = "OutputType";
-        internal const string UseArtifactsOutputPropertyKey = "UseArtifactsOutput";
-        internal const string ArtifactsPathLocationTypePropertyKey = "ArtifactsPathLocationType";
-
         public MSBuildLogger()
         {
             try
@@ -90,25 +82,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             if (args.EventName == TargetFrameworkTelemetryEventName)
             {
                 var newEventName = $"msbuild/{TargetFrameworkTelemetryEventName}";
-                Dictionary<string, string> maskedProperties = new Dictionary<string, string>();
-
-                foreach (var key in new[] {
-                    TargetFrameworkVersionTelemetryPropertyKey,
-                    RuntimeIdentifierTelemetryPropertyKey,
-                    SelfContainedTelemetryPropertyKey,
-                    UseApphostTelemetryPropertyKey,
-                    OutputTypeTelemetryPropertyKey,
-                    UseArtifactsOutputPropertyKey,
-                    ArtifactsPathLocationTypePropertyKey
-                })
-                {
-                    if (args.Properties.TryGetValue(key, out string value))
-                    {
-                        maskedProperties.Add(key, Sha256Hasher.HashWithNormalizedCasing(value));
-                    }
-                }
-
-                telemetry.TrackEvent(newEventName, maskedProperties, measurements: null);
+                telemetry.TrackEvent(newEventName, args.Properties, measurements: null);
             }
             else if (args.EventName == BuildTelemetryEventName)
             {
@@ -143,7 +117,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             else
             {
                 var passthroughEvents = new string[] {
-                    SdkTaskBaseCatchExceptionTelemetryEventName, 
+                    SdkTaskBaseCatchExceptionTelemetryEventName,
                     PublishPropertiesTelemetryEventName,
                     ReadyToRunTelemetryEventName };
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Tasks
                     var availableNames = item.MetadataNames.Cast<string>();
                     var hasValue = availableNames.Contains("Value");
                     var value = hasValue ? item.GetMetadata("Value") : null;
-                    if (ShouldHash(item) && value != null)
+                    if (ShouldHash(item, availableNames) && value != null)
                     {
                         value = HashWithNormalizedCasing(value);
                     }
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Tasks
             }
 
             // default to hashing all data unless otherwise told not to
-            bool ShouldHash(ITaskItem item, string[] itemNames) {
+            static bool ShouldHash(ITaskItem item, IEnumerable<string> itemNames) {
                 if (!itemNames.Contains("Hash"))
                 {
                     return true;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
@@ -40,9 +40,7 @@ namespace Microsoft.Build.Tasks
                     var availableNames = item.MetadataNames.Cast<string>();
                     var hasValue = availableNames.Contains("Value");
                     var value = hasValue ? item.GetMetadata("Value") : null;
-                    var hasHash = availableNames.Contains("Hash");
-                    var hash = hasHash ? bool.Parse(item.GetMetadata("Hash")) : false;
-                    if (hash && value != null)
+                    if (ShouldHash(item) && value != null)
                     {
                         value = HashWithNormalizedCasing(value);
                     }
@@ -56,6 +54,24 @@ namespace Microsoft.Build.Tasks
                     }
                 }
                 (BuildEngine as IBuildEngine5)?.LogTelemetry(EventName, properties);
+            }
+
+            // default to hashing all data unless otherwise told not to
+            bool ShouldHash(ITaskItem item, string[] itemNames) {
+                if (!itemNames.Contains("Hash"))
+                {
+                    return true;
+                }
+
+                if (bool.TryParse(item.GetMetadata("Hash"), out var hash))
+                {
+                    return hash;
+                }
+                else
+                {
+                    return true;
+                }
+
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -348,10 +348,10 @@ Copyright (c) .NET Foundation. All rights reserved.
                             _CreateR2RImages;
                             _CreateR2RSymbols">
     <ItemGroup>
-      <R2RTelemetry Include="PublishReadyToRunUseCrossgen2" Value="$(PublishReadyToRunUseCrossgen2)" />
-      <R2RTelemetry Include="Crossgen2PackVersion" Value="%(ResolvedCrossgen2Pack.NuGetPackageVersion)" />
-      <R2RTelemetry Include="CompileListCount" Value="@(_ReadyToRunCompileList->Count())" />
-      <R2RTelemetry Include="FailedCount" Value="@(_ReadyToRunCompilationFailures->Count())" />
+      <R2RTelemetry Include="PublishReadyToRunUseCrossgen2" Value="$(PublishReadyToRunUseCrossgen2)" Hash="false" />
+      <R2RTelemetry Include="Crossgen2PackVersion" Value="%(ResolvedCrossgen2Pack.NuGetPackageVersion)" Hash="false" />
+      <R2RTelemetry Include="CompileListCount" Value="@(_ReadyToRunCompileList->Count())" Hash="false"/>
+      <R2RTelemetry Include="FailedCount" Value="@(_ReadyToRunCompilationFailures->Count())" Hash="false" />
     </ItemGroup>
     <AllowEmptyTelemetry EventName="ReadyToRun" EventData="@(R2RTelemetry)" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -88,11 +88,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Message Importance="High" Text="$(MSBuildProjectName) -> $([System.IO.Path]::GetFullPath('$(PublishDir)'))" />
 
     <ItemGroup>
-      <PublishTelemetry Include="PublishReadyToRun" Value="$(PublishReadyToRun)" />
-      <PublishTelemetry Include="PublishTrimmed" Value="$(PublishTrimmed)" />
-      <PublishTelemetry Include="PublishSingleFile" Value="$(PublishSingleFile)" />
-      <PublishTelemetry Include="PublishAot" Value="$(PublishAot)" />
-      <PublishTelemetry Include="PublishProtocol" Value="$(PublishProtocol)" />
+      <PublishTelemetry Include="PublishReadyToRun" Value="$(PublishReadyToRun)" Hash="false" />
+      <PublishTelemetry Include="PublishTrimmed" Value="$(PublishTrimmed)" Hash="false" />
+      <PublishTelemetry Include="PublishSingleFile" Value="$(PublishSingleFile)" Hash="false" />
+      <PublishTelemetry Include="PublishAot" Value="$(PublishAot)" Hash="false" />
+      <PublishTelemetry Include="PublishProtocol" Value="$(PublishProtocol)" Hash="false" />
     </ItemGroup>
     <AllowEmptyTelemetry EventName="PublishProperties" EventData="@(PublishTelemetry)" />
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -130,7 +130,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TFTelemetry Include="TargetFrameworkVersion" Value="$([MSBuild]::Escape('$(TargetFrameworkMoniker)'))" />
       <TFTelemetry Include="RuntimeIdentifier" Value="$(RuntimeIdentifier)" />
       <TFTelemetry Include="SelfContained" Value="$(SelfContained)" />
-      <TFTelemetry Include="UseApphost" Value="$(UseApphost)" />
+      <TFTelemetry Include="UseAppHost" Value="$(UseAppHost)" />
       <TFTelemetry Include="OutputType" Value="$(OutputType)" />
       <TFTelemetry Include="UseArtifactsOutput" Value="$(UseArtifactsOutput)" />
       <TFTelemetry Include="ArtifactsPathLocationType" Value="$(_ArtifactsPathLocationType)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -127,13 +127,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_CollectTargetFrameworkForTelemetry" AfterTargets="_CheckForUnsupportedTargetFramework">
     <ItemGroup>
-      <TFTelemetry Include="TargetFrameworkVersion" Value="$([MSBuild]::Escape('$(TargetFrameworkMoniker)'))" Hash="true" />
-      <TFTelemetry Include="RuntimeIdentifier" Value="$(RuntimeIdentifier)" Hash="true" />
-      <TFTelemetry Include="SelfContained" Value="$(SelfContained)" />
-      <TFTelemetry Include="UseAppHost" Value="$(UseAppHost)" />
-      <TFTelemetry Include="OutputType" Value="$(OutputType)" />
-      <TFTelemetry Include="UseArtifactsOutput" Value="$(UseArtifactsOutput)"  />
-      <TFTelemetry Include="ArtifactsPathLocationType" Value="$(_ArtifactsPathLocationType)" Hash="true"/>
+      <TFTelemetry Include="TargetFrameworkVersion" Value="$([MSBuild]::Escape('$(TargetFrameworkMoniker)'))" />
+      <TFTelemetry Include="RuntimeIdentifier" Value="$(RuntimeIdentifier)" />
+      <TFTelemetry Include="SelfContained" Value="$(SelfContained)" Hash="false" />
+      <TFTelemetry Include="UseAppHost" Value="$(UseAppHost)" Hash="false" />
+      <TFTelemetry Include="OutputType" Value="$(OutputType)" Hash="false" />
+      <TFTelemetry Include="UseArtifactsOutput" Value="$(UseArtifactsOutput)" Hash="false" />
+      <TFTelemetry Include="ArtifactsPathLocationType" Value="$(_ArtifactsPathLocationType)" />
     </ItemGroup>
     <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="@(TFTelemetry)" />
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -129,10 +129,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <TFTelemetry Include="TargetFrameworkVersion" Value="$([MSBuild]::Escape('$(TargetFrameworkMoniker)'))" />
       <TFTelemetry Include="RuntimeIdentifier" Value="$(RuntimeIdentifier)" />
-      <TFTelemetry Include="SelfContained" Value="$(SelfContained)" Hash="false" />
-      <TFTelemetry Include="UseAppHost" Value="$(UseAppHost)" Hash="false" />
-      <TFTelemetry Include="OutputType" Value="$(OutputType)" Hash="false" />
-      <TFTelemetry Include="UseArtifactsOutput" Value="$(UseArtifactsOutput)" Hash="false" />
+      <TFTelemetry Include="SelfContained" Value="$(SelfContained)" />
+      <TFTelemetry Include="UseAppHost" Value="$(UseAppHost)" />
+      <TFTelemetry Include="OutputType" Value="$(OutputType)" />
+      <TFTelemetry Include="UseArtifactsOutput" Value="$(UseArtifactsOutput)" />
       <TFTelemetry Include="ArtifactsPathLocationType" Value="$(_ArtifactsPathLocationType)" />
     </ItemGroup>
     <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="@(TFTelemetry)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -54,7 +54,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetFrameworkIdentifier>$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)', 2))</TargetFrameworkVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <_TargetFrameworkVersionWithoutV>$(TargetFrameworkVersion.TrimStart('vV'))</_TargetFrameworkVersionWithoutV>
   </PropertyGroup>
@@ -127,13 +127,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_CollectTargetFrameworkForTelemetry" AfterTargets="_CheckForUnsupportedTargetFramework">
     <ItemGroup>
-      <TFTelemetry Include="TargetFrameworkVersion" Value="$([MSBuild]::Escape('$(TargetFrameworkMoniker)'))" />
-      <TFTelemetry Include="RuntimeIdentifier" Value="$(RuntimeIdentifier)" />
+      <TFTelemetry Include="TargetFrameworkVersion" Value="$([MSBuild]::Escape('$(TargetFrameworkMoniker)'))" Hash="true" />
+      <TFTelemetry Include="RuntimeIdentifier" Value="$(RuntimeIdentifier)" Hash="true" />
       <TFTelemetry Include="SelfContained" Value="$(SelfContained)" />
       <TFTelemetry Include="UseAppHost" Value="$(UseAppHost)" />
       <TFTelemetry Include="OutputType" Value="$(OutputType)" />
-      <TFTelemetry Include="UseArtifactsOutput" Value="$(UseArtifactsOutput)" />
-      <TFTelemetry Include="ArtifactsPathLocationType" Value="$(_ArtifactsPathLocationType)" />
+      <TFTelemetry Include="UseArtifactsOutput" Value="$(UseArtifactsOutput)"  />
+      <TFTelemetry Include="ArtifactsPathLocationType" Value="$(_ArtifactsPathLocationType)" Hash="true"/>
     </ItemGroup>
     <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="@(TFTelemetry)" />
   </Target>

--- a/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
@@ -383,7 +383,7 @@ namespace Microsoft.NET.Build.Tests
             };
 
             // enable generating apphost even on macOS
-            testProject.AdditionalProperties.Add("UseApphost", "true");
+            testProject.AdditionalProperties.Add("UseAppHost", "true");
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tests
             buildCommand
                 .Execute(TelemetryTestLogger)
                 .StdOut.Should()
-                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
+                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseAppHost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
         }
 
         [CoreMSBuildOnlyFact]
@@ -60,10 +60,10 @@ namespace Microsoft.NET.Build.Tests
             result
                 .StdOut.Should()
                 .Contain(
-                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}")
+                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseAppHost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}")
                 .And
                 .Contain(
-                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
+                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseAppHost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -28,11 +28,11 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var buildCommand = new BuildCommand(testAsset);
-            var tfmHashValue = Sha256Hasher.HashWithNormalizedCasing($".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}");
+
             buildCommand
                 .Execute(TelemetryTestLogger)
                 .StdOut.Should()
-                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\"{tfmHashValue}\",\"RuntimeIdentifier\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"SelfContained\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"UseAppHost\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"ArtifactsPathLocationType\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"}}");
+                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseAppHost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
         }
 
         [CoreMSBuildOnlyFact]
@@ -57,15 +57,13 @@ namespace Microsoft.NET.Build.Tests
             var result = buildCommand
                 .Execute(TelemetryTestLogger);
 
-            var netTfmHashValue = Sha256Hasher.HashWithNormalizedCasing($".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}");
-            var net46TfmHashValue = Sha256Hasher.HashWithNormalizedCasing(".NETFramework,Version=v4.6");
             result
                 .StdOut.Should()
                 .Contain(
-                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\"{net46TfmHashValue}\",\"RuntimeIdentifier\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"SelfContained\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"UseAppHost\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"ArtifactsPathLocationType\":\"null\"}}")
+                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseAppHost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}")
                 .And
                 .Contain(
-                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\"{netTfmHashValue}\",\"RuntimeIdentifier\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"SelfContained\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"UseAppHost\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"ArtifactsPathLocationType\":\"null\"}}");
+                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseAppHost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -28,11 +28,11 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var buildCommand = new BuildCommand(testAsset);
-
+            var tfmHashValue = Sha256Hasher.HashWithNormalizedCasing($".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}");
             buildCommand
                 .Execute(TelemetryTestLogger)
                 .StdOut.Should()
-                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseAppHost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
+                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\"{tfmHashValue}\",\"RuntimeIdentifier\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"SelfContained\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"UseAppHost\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"ArtifactsPathLocationType\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"}}");
         }
 
         [CoreMSBuildOnlyFact]
@@ -57,13 +57,15 @@ namespace Microsoft.NET.Build.Tests
             var result = buildCommand
                 .Execute(TelemetryTestLogger);
 
+            var netTfmHashValue = Sha256Hasher.HashWithNormalizedCasing($".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}");
+            var net46TfmHashValue = Sha256Hasher.HashWithNormalizedCasing(".NETFramework,Version=v4.6");
             result
                 .StdOut.Should()
                 .Contain(
-                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseAppHost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}")
+                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\"{net46TfmHashValue}\",\"RuntimeIdentifier\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"SelfContained\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"UseAppHost\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"ArtifactsPathLocationType\":\"null\"}}")
                 .And
                 .Contain(
-                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseAppHost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
+                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\"{netTfmHashValue}\",\"RuntimeIdentifier\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"SelfContained\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"UseAppHost\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921\",\"ArtifactsPathLocationType\":\"null\"}}");
         }
     }
 }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             fakeTelemetry.LogEntry.Properties["otherProperty"].Should().Be("otherProperty value");
         }
 
-        // Reproduce https://github.com/dotnet/sdk/issues/3868
+        // This just ensures that the telemetry system is receiving events
         [Fact]
         public void ItCanSendProperties()
         {
@@ -102,14 +102,13 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 EventName = "targetframeworkeval",
                 Properties = new Dictionary<string, string>
                 {
-                    { "TargetFrameworkVersion", ".NETFramework,Version=v4.6"},
-                    { "RuntimeIdentifier", "null"},
-                    { "SelfContained", "null"},
-                    { "UseAppHost", "null"},
-                    { "OutputType", "Library"},
+                    { "TargetFrameworkVersion", "9a871d7066260764d4cb5047e4b10570271d04bd1da275681a4b12bce0b27496"},
+                    { "RuntimeIdentifier", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
+                    { "SelfContained", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
+                    { "UseAppHost", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
+                    { "OutputType", "d77982267d9699c2a57bcab5bb975a1935f6427002f52fd4569762fd72db3a94"},
                 }
             };
-
             MSBuildLogger.FormatAndSend(fakeTelemetry, telemetryEventArgs);
 
             fakeTelemetry.LogEntry.Properties.Should().BeEquivalentTo(new Dictionary<string, string>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             fakeTelemetry.LogEntry.Properties["otherProperty"].Should().Be("otherProperty value");
         }
 
-        // This just ensures that the telemetry system is receiving events
+        // Reproduce https://github.com/dotnet/sdk/issues/3868
         [Fact]
         public void ItCanSendProperties()
         {
@@ -102,22 +102,23 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 EventName = "targetframeworkeval",
                 Properties = new Dictionary<string, string>
                 {
-                    { "TargetFrameworkVersion", "9a871d7066260764d4cb5047e4b10570271d04bd1da275681a4b12bce0b27496"},
-                    { "RuntimeIdentifier", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "SelfContained", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "UseAppHost", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "OutputType", "d77982267d9699c2a57bcab5bb975a1935f6427002f52fd4569762fd72db3a94"},
+                    { "TargetFrameworkVersion", ".NETFramework,Version=v4.6"},
+                    { "RuntimeIdentifier", "null"},
+                    { "SelfContained", "null"},
+                    { "UseAppHost", "null"},
+                    { "OutputType", "Library"},
                 }
             };
+
             MSBuildLogger.FormatAndSend(fakeTelemetry, telemetryEventArgs);
 
             fakeTelemetry.LogEntry.Properties.Should().BeEquivalentTo(new Dictionary<string, string>
                 {
-                    { "TargetFrameworkVersion", "9a871d7066260764d4cb5047e4b10570271d04bd1da275681a4b12bce0b27496"},
-                    { "RuntimeIdentifier", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "SelfContained", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "UseAppHost", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "OutputType", "d77982267d9699c2a57bcab5bb975a1935f6427002f52fd4569762fd72db3a94"},
+                    { "TargetFrameworkVersion", ".NETFramework,Version=v4.6"},
+                    { "RuntimeIdentifier", "null"},
+                    { "SelfContained", "null"},
+                    { "UseAppHost", "null"},
+                    { "OutputType", "Library"},
                 });
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     { "TargetFrameworkVersion", ".NETFramework,Version=v4.6"},
                     { "RuntimeIdentifier", "null"},
                     { "SelfContained", "null"},
-                    { "UseApphost", "null"},
+                    { "UseAppHost", "null"},
                     { "OutputType", "Library"},
                 }
             };
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     { "TargetFrameworkVersion", "9a871d7066260764d4cb5047e4b10570271d04bd1da275681a4b12bce0b27496"},
                     { "RuntimeIdentifier", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
                     { "SelfContained", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "UseApphost", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
+                    { "UseAppHost", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
                     { "OutputType", "d77982267d9699c2a57bcab5bb975a1935f6427002f52fd4569762fd72db3a94"},
                 });
         }


### PR DESCRIPTION
For the Artifacts output path feature we added two new telemetry data points
* was the feature enabled, and
* what mode was the feature using (explicit, implicit, project-local, etc)

Those data points were being collected, but filtered out because we missed another filtering step. This PR

* adds the data points to the filter, then
* fixes a typo in the already-collected `UseAppHost` telemetry value, and
* finally converts the entire `targetframeworkeval` event to use the new declarative hashing feature of the `AllowEmptyTelemetry` task so that we don't need the additional filter in the MSBuild telemetry logger. This change is the most impactful, and we should discuss it.
* I also flipped the defaults to `opt-in` hashing for the telemetry task. This involved annotating the existing usages with Hash=false to keep behavior the same.