### PR TITLE
[Blazor] Support loading the Blazor WebAssembly SDK when targeting net8.0-browser

### DIFF
--- a/src/Assets/TestProjects/RazorComponentAppMultitarget/ComponentApp.csproj
+++ b/src/Assets/TestProjects/RazorComponentAppMultitarget/ComponentApp.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(AspNetTestTfm);$(AspNetTestTfm)-browser1.0</TargetFrameworks>
+    <EnableSdkContainerSupport>false</EnableSdkContainerSupport>
+
+    <!-- Until we have support for it, pretend it supports it -->
+    <TargetPlatformSupported>true</TargetPlatformSupported>
+  </PropertyGroup>
+
+  <!-- Until we have support for it, pretend it supports it -->
+  <ItemGroup>
+    <SdkSupportedTargetPlatformVersion Include="1.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- We don't want to run build server when not running as tests. -->
+    <UseRazorBuildServer>false</UseRazorBuildServer>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0-preview.4.23260.4" />
+  </ItemGroup>
+
+  <Target Name="_IntrospectGetCopyToOutputDirectoryItems">
+    <Message Text="AllItemsFullPathWithTargetPath: %(AllItemsFullPathWithTargetPath.TargetPath)" Importance="High" />
+  </Target>
+
+  <Target Name="_IntrospectWatchItems" DependsOnTargets="_RazorSdkCustomCollectWatchItems">
+    <Message Text="Watch: %(Watch.FileName)%(Watch.Extension)" Importance="High" />
+  </Target>
+
+  <Target Name="_IntrospectRazorGenerateComponentDesignTime" DependsOnTargets="RazorGenerateComponentDesignTime">
+    <Message Text="RazorComponentWithTargetPath: %(RazorComponentWithTargetPath.FileName) %(RazorComponentWithTargetPath.TargetPath)" Importance="High" />
+  </Target>
+
+  <Target Name="_IntrospectReferences" AfterTargets="ResolveAssemblyReferences">
+      <PropertyGroup>
+        <_ReferencesFilePath>$(IntermediateOutputPath)captured-references.txt</_ReferencesFilePath>
+      </PropertyGroup>
+      <ItemGroup>
+        <_CapturedReferences Include="@(ReferencePath->'%(Identity)')"/>
+    </ItemGroup>
+
+    <WriteLinesToFile
+        File="$(_ReferencesFilePath)"
+        Lines="@(_CapturedReferences)"
+        Overwrite="true"/>
+
+  </Target>
+</Project>

--- a/src/Assets/TestProjects/RazorComponentAppMultitarget/Program.cs
+++ b/src/Assets/TestProjects/RazorComponentAppMultitarget/Program.cs
@@ -1,0 +1,9 @@
+
+namespace ComponentApp;
+
+public static class Program
+{
+    public static void Main(string[] arguments)
+    {
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorMultitargetIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorMultitargetIntegrationTest.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text.Json;
+using System.Xml.Linq;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using static Microsoft.NET.Sdk.BlazorWebAssembly.Tests.ServiceWorkerAssert;
+using Microsoft.NET.Sdk.WebAssembly;
+
+namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
+{
+    public class BlazorMultitargetIntegrationTest : AspNetSdkTest
+    {
+        public BlazorMultitargetIntegrationTest(ITestOutputHelper log) : base(log) { }
+
+        [Fact]
+        public void MultiTargetApp_LoadsTheCorrectSdkBasedOnTfm()
+        {
+            // Arrange
+            var testAppName = "RazorComponentAppMultitarget";
+            var testInstance = CreateMultitargetAspNetSdkTestAsset(testAppName);
+
+            var buildCommand = new BuildCommand(testInstance);
+            buildCommand.WithWorkingDirectory(testInstance.Path);
+            buildCommand.Execute("/bl").Should().Pass();
+
+            var serverDependencies = buildCommand.GetIntermediateDirectory(DefaultTfm);
+            var browserDependencies = buildCommand.GetIntermediateDirectory($"{DefaultTfm}-browser1.0");
+
+            serverDependencies.File("captured-references.txt").Should().NotContain("Microsoft.AspNetCore.Components.WebAssembly.dll");
+            serverDependencies.File("captured-references.txt").Should().Contain("Microsoft.AspNetCore.Components.Server.dll");
+
+            browserDependencies.File("captured-references.txt").Should().Contain("Microsoft.AspNetCore.Components.WebAssembly.dll");
+            browserDependencies.File("captured-references.txt").Should().NotContain("Microsoft.AspNetCore.Components.Server.dll");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/AspNetSdkTest.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/AspNetSdkTest.cs
@@ -47,5 +47,25 @@ namespace Microsoft.NET.TestFramework
                 });
             return projectDirectory;
         }
+
+        public TestAsset CreateMultitargetAspNetSdkTestAsset(
+            string testAsset,
+            [CallerMemberName] string callerName = "",
+            string subdirectory = "",
+            string overrideTfm = null,
+            string identifier = null)
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset(testAsset, callingMethod: callerName, testAssetSubdirectory: subdirectory, identifier: identifier)
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var targetFramework = project.Descendants()
+                       .Single(e => e.Name.LocalName == "TargetFrameworks");
+                    targetFramework.Value = targetFramework.Value.Replace("$(AspNetTestTfm)", overrideTfm ?? DefaultTfm);
+                });
+            return projectDirectory;
+        }
     }
 }

--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -12,9 +12,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Imports the .NET, Razor, and other web related SDKs on projects that target server scenarios. -->
-  <Import Project="../Targets/Sdk.Server.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
+  <Import Project="..\Targets\Sdk.Server.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 
   <!-- Delegates to the Blazor Webassembly SDK on projects that target browser scenarios -->
-  <Import Project="../Targets/Sdk.Browser.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
+  <Import Project="..\Targets\Sdk.Browser.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
 
 </Project>

--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -13,7 +13,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--
       Indicate to other targets that Microsoft.NET.Sdk.Web is being used.
     -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'">
     <UsingMicrosoftNETSdkWeb>true</UsingMicrosoftNETSdkWeb>
     <EnableRazorSdkContent>true</EnableRazorSdkContent>
   </PropertyGroup>
@@ -23,19 +23,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
   </PropertyGroup>
 
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
 
-  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.props" />
+  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
+
+  <Import Sdk="Microsoft.NET.Sdk.Blazor" Project="Sdk.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' == 'browser'" />
 
   <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.props" />
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.props" />
 
-  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DisableImplicitAspNetCoreAnalyzers)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
     <Analyzer
       Include="$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..))\analyzers\cs\Microsoft.AspNetCore.Analyzers.dll"
       Condition="'$(Language)'=='C#'"
@@ -51,7 +53,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DisableImplicitComponentsAnalyzers)' != 'true' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true'
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(DisableImplicitComponentsAnalyzers)' != 'true' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true'
       And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
       And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
       And $([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '6.0'))">
@@ -61,7 +63,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
     <Using Include="System.Net.Http.Json" />
     <Using Include="Microsoft.AspNetCore.Builder" />
     <Using Include="Microsoft.AspNetCore.Hosting" />

--- a/src/WebSdk/Web/Sdk/Sdk.props
+++ b/src/WebSdk/Web/Sdk/Sdk.props
@@ -13,7 +13,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--
       Indicate to other targets that Microsoft.NET.Sdk.Web is being used.
     -->
-  <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'">
+  <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'">
     <UsingMicrosoftNETSdkWeb>true</UsingMicrosoftNETSdkWeb>
     <EnableRazorSdkContent>true</EnableRazorSdkContent>
   </PropertyGroup>
@@ -23,21 +23,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
   </PropertyGroup>
 
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 
-  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 
-  <Import Sdk="Microsoft.NET.Sdk.Blazor" Project="Sdk.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' == 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk.BlazorWebAssembly" Project="Sdk.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
 
   <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.props" />
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.props" />
 
-  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser' And '$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
     <Analyzer
       Include="$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..))\analyzers\cs\Microsoft.AspNetCore.Analyzers.dll"
       Condition="'$(Language)'=='C#'"
@@ -53,7 +53,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(DisableImplicitComponentsAnalyzers)' != 'true' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true'
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser' And '$(DisableImplicitComponentsAnalyzers)' != 'true' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true'
       And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
       And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
       And $([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '6.0'))">
@@ -63,7 +63,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser' And '$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
     <Using Include="System.Net.Http.Json" />
     <Using Include="Microsoft.AspNetCore.Builder" />
     <Using Include="Microsoft.AspNetCore.Hosting" />

--- a/src/WebSdk/Web/Sdk/Sdk.targets
+++ b/src/WebSdk/Web/Sdk/Sdk.targets
@@ -12,9 +12,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Imports the .NET, Razor, and other web related SDKs on projects that target server scenarios. -->
-  <Import Project="../Targets/Sdk.Server.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
+  <Import Project="..\Targets\Sdk.Server.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 
   <!-- Delegates to the Blazor Webassembly SDK on projects that target browser scenarios -->
-  <Import Project="../Targets/Sdk.Browser.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
+  <Import Project="..\Targets\Sdk.Browser.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
 
 </Project>

--- a/src/WebSdk/Web/Sdk/Sdk.targets
+++ b/src/WebSdk/Web/Sdk/Sdk.targets
@@ -11,24 +11,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- We can't add it here because the OutputPath and other msbuild properties are not evaluated.-->
-  <!--<Import Sdk="Microsoft.NET.Sdk.Publish" Project="ImportPublishProfile.targets" />-->
+  <!-- Imports the .NET, Razor, and other web related SDKs on projects that target server scenarios. -->
+  <Import Project="../Targets/Sdk.Server.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
+  <!-- Delegates to the Blazor Webassembly SDK on projects that target browser scenarios -->
+  <Import Project="../Targets/Sdk.Browser.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
 
-  <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'">
-    <!--
-      Configure the Razor SDK to add support for the MVC configuration unless the project configured it or the user opted out of the implicit reference to
-      Microsoft.AspNetCore.App. This needs to happen after the .NET SDK has evaluated TFMs.
-     -->
-    <AddRazorSupportForMvc Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser' And '$(DisableImplicitFrameworkReferences)' != 'true' And '$(AddRazorSupportForMvc)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">true</AddRazorSupportForMvc>
-  </PropertyGroup>
-
-  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
-
-  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
-
-  <Import Sdk="Microsoft.NET.Sdk.BlazorWebAssembly" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
-
-  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 </Project>

--- a/src/WebSdk/Web/Sdk/Sdk.targets
+++ b/src/WebSdk/Web/Sdk/Sdk.targets
@@ -14,19 +14,21 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- We can't add it here because the OutputPath and other msbuild properties are not evaluated.-->
   <!--<Import Sdk="Microsoft.NET.Sdk.Publish" Project="ImportPublishProfile.targets" />-->
 
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'">
     <!--
       Configure the Razor SDK to add support for the MVC configuration unless the project configured it or the user opted out of the implicit reference to
       Microsoft.AspNetCore.App. This needs to happen after the .NET SDK has evaluated TFMs.
      -->
-    <AddRazorSupportForMvc Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(AddRazorSupportForMvc)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">true</AddRazorSupportForMvc>
+    <AddRazorSupportForMvc Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(DisableImplicitFrameworkReferences)' != 'true' And '$(AddRazorSupportForMvc)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">true</AddRazorSupportForMvc>
   </PropertyGroup>
 
-  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />
+  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
 
-  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" />
+  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
 
-  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
+  <Import Sdk="Microsoft.NET.Sdk.BlazorWebAssembly" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' == 'browser'" />
+
+  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
 </Project>

--- a/src/WebSdk/Web/Sdk/Sdk.targets
+++ b/src/WebSdk/Web/Sdk/Sdk.targets
@@ -14,21 +14,21 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- We can't add it here because the OutputPath and other msbuild properties are not evaluated.-->
   <!--<Import Sdk="Microsoft.NET.Sdk.Publish" Project="ImportPublishProfile.targets" />-->
 
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 
-  <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'">
+  <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'">
     <!--
       Configure the Razor SDK to add support for the MVC configuration unless the project configured it or the user opted out of the implicit reference to
       Microsoft.AspNetCore.App. This needs to happen after the .NET SDK has evaluated TFMs.
      -->
-    <AddRazorSupportForMvc Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser' And '$(DisableImplicitFrameworkReferences)' != 'true' And '$(AddRazorSupportForMvc)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">true</AddRazorSupportForMvc>
+    <AddRazorSupportForMvc Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser' And '$(DisableImplicitFrameworkReferences)' != 'true' And '$(AddRazorSupportForMvc)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">true</AddRazorSupportForMvc>
   </PropertyGroup>
 
-  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 
-  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 
-  <Import Sdk="Microsoft.NET.Sdk.BlazorWebAssembly" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' == 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk.BlazorWebAssembly" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
 
-  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($TargetFramework))' != 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
 </Project>

--- a/src/WebSdk/Web/Targets/Sdk.Browser.props
+++ b/src/WebSdk/Web/Targets/Sdk.Browser.props
@@ -11,10 +11,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Imports the .NET, Razor, and other web related SDKs on projects that target server scenarios. -->
-  <Import Project="../Targets/Sdk.Server.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
-
-  <!-- Delegates to the Blazor Webassembly SDK on projects that target browser scenarios -->
-  <Import Project="../Targets/Sdk.Browser.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk.BlazorWebAssembly" Project="Sdk.props" />
 
 </Project>

--- a/src/WebSdk/Web/Targets/Sdk.Browser.targets
+++ b/src/WebSdk/Web/Targets/Sdk.Browser.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Sdk.props
+Sdk.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -11,10 +11,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Imports the .NET, Razor, and other web related SDKs on projects that target server scenarios. -->
-  <Import Project="../Targets/Sdk.Server.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'browser'" />
-
-  <!-- Delegates to the Blazor Webassembly SDK on projects that target browser scenarios -->
-  <Import Project="../Targets/Sdk.Browser.props" Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'" />
+  <Import Sdk="Microsoft.NET.Sdk.BlazorWebAssembly" Project="Sdk.targets" />
 
 </Project>

--- a/src/WebSdk/Web/Targets/Sdk.Server.props
+++ b/src/WebSdk/Web/Targets/Sdk.Server.props
@@ -51,7 +51,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition=" And '$(DisableImplicitComponentsAnalyzers)' != 'true' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true'
+  <ItemGroup Condition="'$(DisableImplicitComponentsAnalyzers)' != 'true' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true'
       And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
       And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
       And $([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '6.0'))">

--- a/src/WebSdk/Web/Targets/Sdk.Server.props
+++ b/src/WebSdk/Web/Targets/Sdk.Server.props
@@ -1,0 +1,75 @@
+<!--
+***********************************************************************************************
+Sdk.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!--
+      Indicate to other targets that Microsoft.NET.Sdk.Web is being used.
+    -->
+  <PropertyGroup>
+    <UsingMicrosoftNETSdkWeb>true</UsingMicrosoftNETSdkWeb>
+    <EnableRazorSdkContent>true</EnableRazorSdkContent>
+  </PropertyGroup>
+
+  <!-- Default properties that shouldn't be replaced by the microsoft.net.sdk.props -->
+  <PropertyGroup>
+    <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.props" />
+
+  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.props" />
+
+  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.props" />
+
+  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DisableImplicitAspNetCoreAnalyzers)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
+    <Analyzer
+      Include="$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..))\analyzers\cs\Microsoft.AspNetCore.Analyzers.dll"
+      Condition="'$(Language)'=='C#'"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Include="$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..))\analyzers\cs\Microsoft.AspNetCore.Mvc.Analyzers.dll"
+      Condition="'$(Language)'=='C#'"
+      IsImplicitlyDefined="true" />
+
+    <Analyzer
+      Include="$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..))\analyzers\cs\Microsoft.AspNetCore.Mvc.Api.Analyzers.dll"
+      Condition="'$(Language)'=='C#' AND '$(IncludeOpenAPIAnalyzers)' == 'true'"
+      IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" And '$(DisableImplicitComponentsAnalyzers)' != 'true' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true'
+      And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+      And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
+      And $([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '6.0'))">
+    <Analyzer
+      Include="$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..))\analyzers\cs\Microsoft.AspNetCore.Components.SdkAnalyzers.dll"
+      Condition="'$(Language)'=='C#'"
+      IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+    <Using Include="System.Net.Http.Json" />
+    <Using Include="Microsoft.AspNetCore.Builder" />
+    <Using Include="Microsoft.AspNetCore.Hosting" />
+    <Using Include="Microsoft.AspNetCore.Http" />
+    <Using Include="Microsoft.AspNetCore.Routing" />
+    <Using Include="Microsoft.Extensions.Configuration" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="Microsoft.Extensions.Hosting" />
+    <Using Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
+</Project>

--- a/src/WebSdk/Web/Targets/Sdk.Server.targets
+++ b/src/WebSdk/Web/Targets/Sdk.Server.targets
@@ -1,0 +1,32 @@
+<!--
+***********************************************************************************************
+Sdk.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- We can't add it here because the OutputPath and other msbuild properties are not evaluated.-->
+  <!--<Import Sdk="Microsoft.NET.Sdk.Publish" Project="ImportPublishProfile.targets" />-->
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <PropertyGroup>
+    <!--
+      Configure the Razor SDK to add support for the MVC configuration unless the project configured it or the user opted out of the implicit reference to
+      Microsoft.AspNetCore.App. This needs to happen after the .NET SDK has evaluated TFMs.
+     -->
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />
+
+  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" />
+
+  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
+</Project>

--- a/src/WebSdk/Web/Tasks/Microsoft.NET.Sdk.Web.Tasks.csproj
+++ b/src/WebSdk/Web/Tasks/Microsoft.NET.Sdk.Web.Tasks.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <AdditionalContent Include="$(WebRoot)\Targets\**\*.*">
       <Pack>true</Pack>
-      <PackagePath>targets</PackagePath>
+      <PackagePath>Targets</PackagePath>
     </AdditionalContent>
 
     <AdditionalContent Include="$(WebRoot)\Sdk\**\*.*">


### PR DESCRIPTION
* As part of Blazor united, the app project targets the web SDK and multitargets to the net8.0 and net8.0-browser TFMs.

```xml
<Project Sdk="Microsoft.NET.Sdk.Web">

  <PropertyGroup>
    <TargetFrameworks>net8.0;net8.0-browser1.0</TargetFrameworks>
  </PropertyGroup>

  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'browser'">
    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0-preview.4.23260.4" />
  </ItemGroup>

</Project>
```

For this to work, we need to update the Web SDK to import the Blazor SDK instead of the other SDKs when targeting net8.0-browser.