### PR TITLE
Update MSBuildLocator version

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -11,12 +11,9 @@
          https://github.com/dotnet/source-build/issues/3356 -->
     <UsagePattern IdentityGlob="Microsoft.*.App.Ref/*6.0*" />
 
-    <!-- TODO: SBRPs or updates
-         https://github.com/dotnet/source-build/issues/3357 -->
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.AnalyzerUtilities/*3.3.0*" />
-
-    <!-- This may be coming in transitively from aspnetcore. Needs evaluation.
+    <!-- These are coming in transitively from verious repos (aspnetcore & format). Needs evaluation.
          https://github.com/dotnet/source-build/issues/3358. -->
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.AnalyzerUtilities/*3.3.0*" />
     <UsagePattern IdentityGlob="System.Text.Json/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Text.Encodings.Web/*8.0.0*" />
   </IgnorePatterns>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,21 +1,20 @@
 <UsageData>
   <IgnorePatterns>
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
-    
+
     <!-- TODO: Ignore needed until https://github.com/NuGet/Home/issues/11059 is addressed. -->
     <UsagePattern IdentityGlob="Nuget.*/*" />
     <UsagePattern IdentityGlob="Microsoft.Build.NuGetSdkResolver/*" />
-    
+
     <!-- TODO: Figure out what to do about the netcoreapp ref packages (these are probably being pulled
          in via implicit versions and net6 targeting projects (e.g. tests)
          https://github.com/dotnet/source-build/issues/3356 -->
     <UsagePattern IdentityGlob="Microsoft.*.App.Ref/*6.0*" />
-    
+
     <!-- TODO: SBRPs or updates
          https://github.com/dotnet/source-build/issues/3357 -->
-    <UsagePattern IdentityGlob="Microsoft.Build.Locator/*1.5.3*" />
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.AnalyzerUtilities/*3.3.0*" />
-    
+
     <!-- This may be coming in transitively from aspnetcore. Needs evaluation.
          https://github.com/dotnet/source-build/issues/3358. -->
     <UsagePattern IdentityGlob="System.Text.Json/*8.0.0*" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -165,7 +165,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Manually updated">
     <!-- Dependencies from https://github.com/microsoft/MSBuildLocator -->
-    <MicrosoftBuildLocatorPackageVersion>1.5.3</MicrosoftBuildLocatorPackageVersion>
+    <MicrosoftBuildLocatorPackageVersion>1.5.5</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerPinnedVersionPackageVersion>4.0.1</MicrosoftCodeAnalysisCSharpAnalyzerPinnedVersionPackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3356

Source-build only builds once version of MSBuildLocator and that is 1.5.5 (used by format and roslyn).  It would be nice if we could centralize on a single version so that we can avoid having to carry around reference packages for multiple versions.

I am not sure who are the correct folks to code review this.  @nagilson - you were the last one to update this version.