### PR TITLE
Fix StaticWebAssets Brotli asset deduplication

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ResolveCompressedAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ResolveCompressedAssets.cs
@@ -78,21 +78,31 @@ public class ResolveCompressedAssets : Task
                 }
 
                 var assetTraitValue = asset.GetMetadata("AssetTraitValue");
+                string assetFormat;
 
-                if (!IsValidCompressionAssetTraitValue(assetTraitValue))
+                if (string.Equals(assetTraitValue, GzipAssetTraitValue, StringComparison.OrdinalIgnoreCase))
+                {
+                    assetFormat = GzipFormatName;
+                }
+                else if (string.Equals(assetTraitValue, BrotliAssetTraitValue, StringComparison.OrdinalIgnoreCase))
+                {
+                    assetFormat = BrotliFormatName;
+                }
+                else
                 {
                     Log.LogError(
                         "The asset '{0}' has an unknown compression format '{1}'.",
                         asset.ItemSpec,
                         assetTraitValue);
+                    continue;
                 }
 
                 Log.LogMessage(
                     "The asset '{0}' with related asset '{1}' was detected as already compressed with format '{2}'.",
                     asset.ItemSpec,
                     relatedAssetItemSpec,
-                    assetTraitValue);
-                existingFormats.Add(assetTraitValue);
+                    assetFormat);
+                existingFormats.Add(assetFormat);
             }
         }
 
@@ -198,10 +208,6 @@ public class ResolveCompressedAssets : Task
 
     private static bool IsCompressedAsset(ITaskItem asset)
         => string.Equals("Content-Encoding", asset.GetMetadata("AssetTraitName"));
-
-    private static bool IsValidCompressionAssetTraitValue(string assetTraitValue)
-        => string.Equals(GzipAssetTraitValue, assetTraitValue, StringComparison.OrdinalIgnoreCase)
-        || string.Equals(BrotliAssetTraitValue, assetTraitValue, StringComparison.OrdinalIgnoreCase);
 
     private static string[] SplitPattern(string pattern)
         => string.IsNullOrEmpty(pattern) ? Array.Empty<string>() : pattern

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/ResolveCompressedAssetsTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/ResolveCompressedAssetsTest.cs
@@ -46,10 +46,7 @@ public class ResolveCompressedAssetsTest
         }.ToTaskItem();
 
         var gzipExplicitAsset = new TaskItem(asset.ItemSpec, asset.CloneCustomMetadata());
-        gzipExplicitAsset.SetMetadata("ConfigurationName", "BuildCompressionGzip");
-
         var brotliExplicitAsset = new TaskItem(asset.ItemSpec, asset.CloneCustomMetadata());
-        brotliExplicitAsset.SetMetadata("ConfigurationName", "BuildCompressionBrotli");
 
         var task = new ResolveCompressedAssets()
         {
@@ -156,10 +153,7 @@ public class ResolveCompressedAssetsTest
         }.ToTaskItem();
 
         var gzipExplicitAsset = new TaskItem(asset.ItemSpec, asset.CloneCustomMetadata());
-        gzipExplicitAsset.SetMetadata("ConfigurationName", "BuildCompressionGzip");
-
         var brotliExplicitAsset = new TaskItem(asset.ItemSpec, asset.CloneCustomMetadata());
-        brotliExplicitAsset.SetMetadata("ConfigurationName", "BuildCompressionBrotli");
 
         var buildTask = new ResolveCompressedAssets()
         {
@@ -182,7 +176,7 @@ public class ResolveCompressedAssetsTest
     }
 
     [Fact]
-    public void IgnoresAssetsCompressedInPreviousTaskRun()
+    public void IgnoresAssetsCompressedInPreviousTaskRun_Gzip()
     {
         // Arrange
         var errorMessages = new List<string>();
@@ -214,7 +208,6 @@ public class ResolveCompressedAssetsTest
         task1.AssetsToCompress[0].ItemSpec.Should().EndWith(".gz");
 
         var brotliExplicitAsset = new TaskItem(asset.ItemSpec, asset.CloneCustomMetadata());
-        brotliExplicitAsset.SetMetadata("ConfigurationName", "BuildCompressionBrotli");
 
         var task2 = new ResolveCompressedAssets()
         {
@@ -231,5 +224,56 @@ public class ResolveCompressedAssetsTest
         result2.Should().BeTrue();
         task2.AssetsToCompress.Should().HaveCount(1);
         task2.AssetsToCompress[0].ItemSpec.Should().EndWith(".br");
+    }
+
+    [Fact]
+    public void IgnoresAssetsCompressedInPreviousTaskRun_Brotli()
+    {
+        // Arrange
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var asset = new StaticWebAsset()
+        {
+            Identity = ItemSpec,
+            OriginalItemSpec = OriginalItemSpec,
+            RelativePath = Path.GetFileName(ItemSpec),
+        }.ToTaskItem();
+
+        // Act/Assert
+        var task1 = new ResolveCompressedAssets()
+        {
+            OutputPath = OutputBasePath,
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = new[] { asset },
+            IncludePatterns = "**\\*.tmp",
+            Formats = "brotli",
+        };
+
+        var result1 = task1.Execute();
+
+        result1.Should().BeTrue();
+        task1.AssetsToCompress.Should().HaveCount(1);
+        task1.AssetsToCompress[0].ItemSpec.Should().EndWith(".br");
+
+        var gzipExplicitAsset = new TaskItem(asset.ItemSpec, asset.CloneCustomMetadata());
+
+        var task2 = new ResolveCompressedAssets()
+        {
+            OutputPath = OutputBasePath,
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = new[] { asset, task1.AssetsToCompress[0] },
+            IncludePatterns = "**\\*.tmp",
+            ExplicitAssets = new[] { gzipExplicitAsset },
+            Formats = "gzip;brotli"
+        };
+
+        var result2 = task2.Execute();
+
+        result2.Should().BeTrue();
+        task2.AssetsToCompress.Should().HaveCount(1);
+        task2.AssetsToCompress[0].ItemSpec.Should().EndWith(".gz");
     }
 }


### PR DESCRIPTION
# Fix StaticWebAssets Brotli asset deduplication

While messing around with the new StaticWebAssets compression APIs, I noticed that Brotli assets were not correctly deduplicated if Brotli compression is enabled for both Build and Publish. This resulted in errors like:

```
Conflicting assets with the same target path 'foo.br'
```

The problem was that we were treating the `Content-Encoding` value ("br") as the format name ("brotli"). This PR fixes the issue by correctly mapping `Content-Encoding` value to format name for deduplication.