### PR TITLE
Add back legacy JS hot reload function

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -1,3 +1,7 @@
+export function receiveHotReload() {
+  return BINDING.js_to_mono_obj(new Promise((resolve) => receiveHotReloadAsync().then(resolve(0))));
+}
+
 export async function receiveHotReloadAsync() {
   const cache = window.sessionStorage.getItem('blazor-webassembly-cache');
   let headers;


### PR DESCRIPTION
We recently removed the legacy JS `receiveHotReload` function in favor of `receiveHotReloadAsync` in an effort to esliminate usage of legacy interop. However, projects targeting a framework version of 7.0 and earlier will continue to use legacy interop, and we want those projects to still work with hot reload when using the .NET 8 SDK.

This change adds back the legacy `receiveHotReload` method. Projects targeting a framework version of 8.0 and later will continue to use the new `receiveHotReloadAsync` method, avoiding use of the legacy interop mechanism when possible.

Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/2087