### PR TITLE
Containers: rename "Docker daemon" to "local registry".

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -12,11 +12,11 @@ using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers;
 
-internal sealed class LocalDocker : ILocalDaemon
+internal sealed class DockerCli : ILocalRegistry
 {
     private readonly Action<string> logger;
 
-    public LocalDocker(Action<string> logger)
+    public DockerCli(Action<string> logger)
     {
         this.logger = logger;
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalRegistry.cs
@@ -4,23 +4,22 @@
 namespace Microsoft.NET.Build.Containers;
 
 /// <summary>
-/// Abstracts over the concept of a local container runtime of some kind. Currently this is only modeled by Docker,
-/// but users have expressed desires for Podman, nerdctl, etc as well so this kind of abstraction makes sense to have.
+/// Abstracts over the concept of a local registry storeof some kind.
 /// </summary>
-internal interface ILocalDaemon {
+internal interface ILocalRegistry {
 
     /// <summary>
-    /// Loads an image (presumably from a tarball) into the local container runtime.
+    /// Loads an image (presumably from a tarball) into the local registry.
     /// </summary>
     public Task LoadAsync(BuiltImage image, ImageReference sourceReference, ImageReference destinationReference, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Checks to see if the local container runtime is available. This is used to give nice errors to the user.
+    /// Checks to see if the local registry is available. This is used to give nice errors to the user.
     /// </summary>
     public Task<bool> IsAvailableAsync(CancellationToken cancellationToken);
 
     /// <summary>
-    /// Checks to see if the local container runtime is available. This is used to give nice errors to the user.
+    /// Checks to see if the local registry is available. This is used to give nice errors to the user.
     /// See <see cref="IsAvailableAsync(CancellationToken)"/> for async version.
     /// </summary>
     public bool IsAvailable();

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/KnownLocalRegistryTypes.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/KnownLocalRegistryTypes.cs
@@ -3,8 +3,9 @@
 
 namespace Microsoft.NET.Build.Containers;
 
-public static class KnownDaemonTypes
+public static class KnownLocalRegistryTypes
 {
     public const string Docker = nameof(Docker);
-    public static readonly string[] SupportedLocalDaemonTypes = new [] { Docker };
+
+    public static readonly string[] SupportedLocalRegistryTypes = new [] { Docker };
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -53,8 +53,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageTags.get -> string![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageTags.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Labels.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Labels.set -> void
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalContainerDaemon.get -> string!
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalContainerDaemon.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalRegistry.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalRegistry.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,8 +1,8 @@
-﻿const Microsoft.NET.Build.Containers.KnownDaemonTypes.Docker = "Docker" -> string!
+﻿const Microsoft.NET.Build.Containers.KnownLocalRegistryTypes.Docker = "Docker" -> string!
 Microsoft.NET.Build.Containers.BaseImageNotFoundException
 Microsoft.NET.Build.Containers.Constants
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ComputeDotnetBaseImageTag() -> void
-static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! publishDirectory, string! workingDir, string! baseRegistry, string! baseImageName, string! baseImageTag, string![]! entrypoint, string![]? entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, System.Collections.Generic.Dictionary<string!, string!>! labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, System.Collections.Generic.Dictionary<string!, string!>! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, string? containerUser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>!
+static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! publishDirectory, string! workingDir, string! baseRegistry, string! baseImageName, string! baseImageTag, string![]! entrypoint, string![]? entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, System.Collections.Generic.Dictionary<string!, string!>! labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, System.Collections.Generic.Dictionary<string!, string!>! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localRegistry, string? containerUser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>!
 static readonly Microsoft.NET.Build.Containers.Constants.Version -> string!
 Microsoft.NET.Build.Containers.ContainerBuilder
 Microsoft.NET.Build.Containers.ContainerHelpers
@@ -28,7 +28,7 @@ Microsoft.NET.Build.Containers.Descriptor.UncompressedDigest.get -> string?
 Microsoft.NET.Build.Containers.Descriptor.UncompressedDigest.init -> void
 Microsoft.NET.Build.Containers.Descriptor.Urls.get -> string![]?
 Microsoft.NET.Build.Containers.Descriptor.Urls.init -> void
-Microsoft.NET.Build.Containers.KnownDaemonTypes
+Microsoft.NET.Build.Containers.KnownLocalRegistryTypes
 Microsoft.NET.Build.Containers.ManifestConfig
 Microsoft.NET.Build.Containers.ManifestConfig.digest.get -> string!
 Microsoft.NET.Build.Containers.ManifestConfig.digest.set -> void
@@ -143,8 +143,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageTags.get -> string![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageTags.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Labels.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Labels.set -> void
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalContainerDaemon.get -> string!
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalContainerDaemon.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalRegistry.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalRegistry.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.get -> string!
@@ -183,4 +183,4 @@ override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Execute() -> bool
 override Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.Execute() -> bool
 static Microsoft.NET.Build.Containers.ContainerHelpers.TryParsePort(string! input, out Microsoft.NET.Build.Containers.Port? port, out Microsoft.NET.Build.Containers.ContainerHelpers.ParsePortError? error) -> bool
 static Microsoft.NET.Build.Containers.ContainerHelpers.TryParsePort(string? portNumber, string? portType, out Microsoft.NET.Build.Containers.Port? port, out Microsoft.NET.Build.Containers.ContainerHelpers.ParsePortError? error) -> bool
-static readonly Microsoft.NET.Build.Containers.KnownDaemonTypes.SupportedLocalDaemonTypes -> string![]!
+static readonly Microsoft.NET.Build.Containers.KnownLocalRegistryTypes.SupportedLocalRegistryTypes -> string![]!

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Resource.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Resource.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Build.Containers.Resources
     /// </summary>
     /// <remarks>
     /// Codes used for warnings/errors:
-    /// CONTAINER1xxx: HTTP or local daemon related failures
+    /// CONTAINER1xxx: HTTP or local registry related failures
     /// CONTAINER2xxx: Invalid/missing data related failures
     /// CONTAINER3xxx: Docker process related failures
     /// CONTAINER4xxx: Invalid command line parameters

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -205,7 +205,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}.
+        ///   Looks up a localized string similar to CONTAINER1009: Failed to load image to local registry. stdout: {0}.
         /// </summary>
         internal static string ImageLoadFailed {
             get {
@@ -214,7 +214,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER1010: Pulling images from local Docker daemon is not supported..
+        ///   Looks up a localized string similar to CONTAINER1010: Pulling images from local registry is not supported..
         /// </summary>
         internal static string ImagePullNotSupported {
             get {
@@ -331,11 +331,11 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again..
+        ///   Looks up a localized string similar to CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.
         /// </summary>
-        internal static string LocalDaemonNotAvailable {
+        internal static string LocalRegistryNotAvailable {
             get {
-                return ResourceManager.GetString("LocalDaemonNotAvailable", resourceCulture);
+                return ResourceManager.GetString("LocalRegistryNotAvailable", resourceCulture);
             }
         }
         
@@ -439,11 +439,11 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER2002: Unknown local container daemon type &apos;{0}&apos;. Valid local container daemon types are {1}..
+        ///   Looks up a localized string similar to CONTAINER2002: Unknown local registry type &apos;{0}&apos;. Valid local container registry types are {1}..
         /// </summary>
-        internal static string UnknownDaemonType {
+        internal static string UnknownLocalRegistryType {
             get {
-                return ResourceManager.GetString("UnknownDaemonType", resourceCulture);
+                return ResourceManager.GetString("UnknownLocalRegistryType", resourceCulture);
             }
         }
         

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -162,7 +162,7 @@
     <comment>{StrBegin="CONTAINER3001: "}</comment>
   </data>
   <data name="ImagePullNotSupported" xml:space="preserve">
-    <value>CONTAINER1010: Pulling images from local Docker daemon is not supported.</value>
+    <value>CONTAINER1010: Pulling images from local registry is not supported.</value>
     <comment>{StrBegin="CONTAINER1010: "}</comment>
   </data>
   <data name="EmptyOrWhitespacePropertyIgnored" xml:space="preserve">
@@ -181,7 +181,7 @@
     <value>No host object detected.</value>
   </data>
   <data name="ImageLoadFailed" xml:space="preserve">
-    <value>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</value>
+    <value>CONTAINER1009: Failed to load image from local registry. stdout: {0}</value>
     <comment>{StrBegin="CONTAINER1009: "}</comment>
   </data>
   <data name="InvalidContainerImageName" xml:space="preserve">
@@ -232,8 +232,8 @@
     <value>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</value>
     <comment>{StrBegin="CONTAINER4005: "}</comment>
   </data>
-  <data name="LocalDaemonNotAvailable" xml:space="preserve">
-    <value>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</value>
+  <data name="LocalRegistryNotAvailable" xml:space="preserve">
+    <value>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</value>
     <comment>{StrBegin="CONTAINER1012: "}</comment>
   </data>
   <data name="MissingLinkToRegistry" xml:space="preserve">
@@ -279,8 +279,8 @@
     <value>CONTAINER1006: Too many retries, stopping.</value>
     <comment>{StrBegin="CONTAINER1006: "}</comment>
   </data>
-  <data name="UnknownDaemonType" xml:space="preserve">
-    <value>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</value>
+  <data name="UnknownLocalRegistryType" xml:space="preserve">
+    <value>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</value>
     <comment>{StrBegin="CONTAINER2002: "}</comment>
   </data>
   <data name="UnknownMediaType" xml:space="preserve">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: Nepovedlo se načíst image do místního procesu démon Dockeru. stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: Nepovedlo se načíst image do místního procesu démon Dockeru. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="new">CONTAINER1010: Pulling images from local Docker daemon is not supported.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="new">CONTAINER1010: Pulling images from local registry is not supported.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: Položka '{0}' obsahuje položky bez metadat 'Value' a budou ignorovány.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="new">CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: Příliš mnoho opakovaných pokusů, zastavuje se.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: Neznámý typ procesu démon místního kontejneru '{0}'. Platné typy procesu démon místního kontejneru jsou {1}.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: Fehler beim Laden des Images in den lokalen Docker-Daemon. stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: Fehler beim Laden des Images in den lokalen Docker-Daemon. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="new">CONTAINER1010: Pulling images from local Docker daemon is not supported.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="new">CONTAINER1010: Pulling images from local registry is not supported.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: Das Element „{0}“ enthält Elemente ohne Metadatum „Value“. Diese werden ignoriert.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="new">CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: Zu viele Wiederholungsversuche, Vorgang wird beendet.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: Unbekannter lokaler Containerdaemontyp „{0}“. Gültige lokale Containerdaemontypen sind {1}.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: No se pudo cargar la imagen en el demonio de Docker local. stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: No se pudo cargar la imagen en el demonio de Docker local. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="translated">CONTAINER1010: No se admite la extracción de imágenes del demonio de Docker local.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="needs-review-translation">CONTAINER1010: No se admite la extracción de imágenes del demonio de Docker local.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: El elemento "{0}" contiene elementos sin metadatos "Value" y se omitirán.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="translated">CONTAINER1012: El demonio de Docker local no está disponible, pero se solicitó la inserción en un demonio de Docker local. Inicie el demonio e inténtelo de nuevo.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: Demasiados reintentos, deteniendo.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: Tipo "{0}" de demonio de contenedor local desconocido. Los tipos de demonio de contenedor local válidos son {1}.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: échec du chargement de l’image dans le démon Docker local. stdout : {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: échec du chargement de l’image dans le démon Docker local. stdout : {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="new">CONTAINER1010: Pulling images from local Docker daemon is not supported.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="new">CONTAINER1010: Pulling images from local registry is not supported.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: l’élément '{0}' contient des éléments sans métadonnées 'Value'. Ils seront ignorés.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="new">CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: trop de tentatives, arrêt.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: type de démon de conteneur local inconnu '{0}'. Les types de démon de conteneur local valides sont {1}.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: non è stato possibile caricare l'immagine nel daemon Docker locale. stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: non è stato possibile caricare l'immagine nel daemon Docker locale. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="new">CONTAINER1010: Pulling images from local Docker daemon is not supported.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="new">CONTAINER1010: Pulling images from local registry is not supported.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: l'elemento '{0}' contiene elementi senza 'Value' di metadati e tali elementi verranno ignorati.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="new">CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: troppi tentativi, arresto.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: tipo di daemon '{0}' sconosciuto per il contenitore locale. I tipi di daemon validi per i contenitori locali sono {1}.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: ローカル Docker デーモンにイメージを読み込めませんでした。stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: ローカル Docker デーモンにイメージを読み込めませんでした。stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="translated">CONTAINER1010: ローカル Docker デーモンからのイメージのプルはサポートされていません。</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="needs-review-translation">CONTAINER1010: ローカル Docker デーモンからのイメージのプルはサポートされていません。</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: 項目 '{0}' にメタデータ 'Value' のない項目が含まれており、これらは無視されます。</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="translated">CONTAINER1012: ローカル Docker デーモンは使用できませんが、ローカル Docker デーモンへのプッシュが要求されました。 デーモンを起動して、もう一度お試しください。</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: 再試行回数が多すぎます。停止しています。</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: 不明なローカル コンテナー デーモンの種類 '{0}'。有効なローカル コンテナー デーモンの種類は {1} です。</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: 로컬 Docker 디먼에 이미지를 로드하지 못했습니다. 표준 출력: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: 로컬 Docker 디먼에 이미지를 로드하지 못했습니다. 표준 출력: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="translated">CONTAINER1010: 로컬 Docker 디먼에서 이미지 끌어오기가 지원되지 않습니다.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="needs-review-translation">CONTAINER1010: 로컬 Docker 디먼에서 이미지 끌어오기가 지원되지 않습니다.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: 항목 '{0}'에는 메타데이터 '값'이 없는 항목이 포함되어 있으며 무시됩니다.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="translated">CONTAINER1012: 로컬 Docker 디먼을 사용할 수 없지만 로컬 Docker 디먼으로 푸시가 요청되었습니다. 디먼을 시작하고 다시 시도하세요.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: 다시 시도가 너무 많아 중지 중입니다.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: 알 수 없는 로컬 컨테이너 디먼 유형 '{0}'. 유효한 로컬 컨테이너 디먼 유형은 {1}입니다.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: nie można załadować obrazu do lokalnego demona platformy Docker. stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: nie można załadować obrazu do lokalnego demona platformy Docker. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="translated">CONTAINER1010: ściąganie obrazów z lokalnego demona platformy Docker nie jest obsługiwane.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="needs-review-translation">CONTAINER1010: ściąganie obrazów z lokalnego demona platformy Docker nie jest obsługiwane.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: Element „{0}” zawiera elementy bez metadanych „Value” i zostaną zignorowane.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="translated">CONTAINER1012: lokalny demon platformy Docker jest niedostępny, ale zażądano wypchnięcia do lokalnego demona platformy Docker. Uruchom demona i spróbuj ponownie.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: zbyt wiele ponownych prób, zatrzymywanie.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: nieznany typ demona kontenera lokalnego „{0}”. Prawidłowe typy demonów kontenerów lokalnych to {1}.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: falha ao carregar a imagem no daemon do Docker local. stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: falha ao carregar a imagem no daemon do Docker local. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="translated">CONTAINER1010: não há suporte para a extração de imagens do daemon do Docker local.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="needs-review-translation">CONTAINER1010: não há suporte para a extração de imagens do daemon do Docker local.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: O item '{0}' contém itens sem metadados 'Valor' e eles serão ignorados.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="translated">CONTAINER1012: o daemon do Docker local não está disponível, mas o push para um daemon do Docker local foi solicitado. Inicie o daemon e tente novamente.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: Muitas tentativas, parando.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: Tipo de daemon de contêiner local desconhecido '{0}'. Os tipos de daemon de contêiner local válidos são {1}.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: не удалось загрузить образ в локальную управляющую программу Docker. StdOut:{0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: не удалось загрузить образ в локальную управляющую программу Docker. StdOut:{0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="translated">CONTAINER1010: извлечение образов из локальной управляющей программы Docker не поддерживается.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="needs-review-translation">CONTAINER1010: извлечение образов из локальной управляющей программы Docker не поддерживается.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: элемент "{0}" содержит элементы без метаданных "Value", и они будут пропущены.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="translated">CONTAINER1012: локальная управляющая программа Docker недоступна, но запрошена отправка в локальную управляющую программу Docker. Запустите управляющую программу и повторите попытку.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: слишком много повторных попыток, остановка.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: неизвестный тип управляющей программы локального контейнера "{0}". Допустимыми типами управляющих программ локального контейнера являются {1}.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: Görüntü yerel Docker daemon'a yüklenemedi. stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: Görüntü yerel Docker daemon'a yüklenemedi. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="new">CONTAINER1010: Pulling images from local Docker daemon is not supported.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="new">CONTAINER1010: Pulling images from local registry is not supported.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: '{0}' öğesi 'Value' meta verileri olmayan öğeler içeriyor ve yoksayılacak.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="new">CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: Çok fazla yeniden deneme, durduruluyor.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: Bilinmeyen yerel kapsayıcı daemon türü ('{0}'). Geçerli yerel kapsayıcı daemon türleri {1}.</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: 未能将映像加载到本地 Docker 守护程序。stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: 未能将映像加载到本地 Docker 守护程序。stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="new">CONTAINER1010: Pulling images from local Docker daemon is not supported.</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="new">CONTAINER1010: Pulling images from local registry is not supported.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: 项 "{0}" 包含没有元数据 "Value" 的项，它们将被忽略。</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="new">CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: 重试次数过多，正在停止。</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: 未知的本地容器守护程序类型“{0}”。有效的本地容器守护程序类型为 {1}。</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -78,13 +78,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: 無法將映像載入至本機 Docker 精靈。stdout: {0}</target>
+        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+        <target state="needs-review-translation">CONTAINER1009: 無法將映像載入至本機 Docker 精靈。stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local Docker daemon is not supported.</source>
-        <target state="translated">CONTAINER1010: 不支援從本機 Docker 精靈提取映像。</target>
+        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+        <target state="needs-review-translation">CONTAINER1010: 不支援從本機 Docker 精靈提取映像。</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidContainerImageName">
@@ -147,9 +147,9 @@
         <target state="translated">CONTAINER4005: 項目 '{0}' 包含沒有中繼資料 'Value' 的項目，將忽略這些項目。</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
-      <trans-unit id="LocalDaemonNotAvailable">
-        <source>CONTAINER1012: The local Docker daemon is not available, but pushing to a local Docker daemon was requested. Please start the daemon and try again.</source>
-        <target state="translated">CONTAINER1012: 無法使用本機 Docker 精靈，但已要求推送至本機 Docker 精靈。請啟動精靈，然後再試一次。</target>
+      <trans-unit id="LocalRegistryNotAvailable">
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="new">CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
@@ -207,9 +207,9 @@
         <target state="translated">CONTAINER1006: 重試太多次，正在停止。</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
-      <trans-unit id="UnknownDaemonType">
-        <source>CONTAINER2002: Unknown local container daemon type '{0}'. Valid local container daemon types are {1}.</source>
-        <target state="translated">CONTAINER2002: 未知的本機容器精靈類型 '{0}'。有效的本機容器精靈類型為 {1}。</target>
+      <trans-unit id="UnknownLocalRegistryType">
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="new">CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -46,10 +46,10 @@ partial class CreateNewImage
     public string OutputRegistry { get; set; }
 
     /// <summary>
-    /// The kind of local daemon to use, if any.
+    /// The kind of local registry to use, if any.
     /// </summary>
     [Required]
-    public string LocalContainerDaemon { get; set; }
+    public string LocalRegistry { get; set; }
 
     /// <summary>
     /// The name of the output image that will be pushed to the registry.
@@ -151,7 +151,7 @@ partial class CreateNewImage
         ContainerEnvironmentVariables = Array.Empty<ITaskItem>();
         ContainerRuntimeIdentifier = "";
         RuntimeIdentifierGraphPath = "";
-        LocalContainerDaemon = "";
+        LocalRegistry = "";
         ContainerUser = "";
 
         GeneratedContainerConfiguration = "";

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -124,9 +124,9 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
         {
             builder.AppendSwitchIfNotNull("--outputregistry ", OutputRegistry);
         }
-        if (!string.IsNullOrWhiteSpace(LocalContainerDaemon))
+        if (!string.IsNullOrWhiteSpace(LocalRegistry))
         {
-            builder.AppendSwitchIfNotNull("--localcontainerdaemon ", LocalContainerDaemon);
+            builder.AppendSwitchIfNotNull("--localregistry ", LocalRegistry);
         }
 
         if (EntrypointArgs.Any(e => string.IsNullOrWhiteSpace(e.ItemSpec)))

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
@@ -18,7 +18,7 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
     public string FullyQualifiedBaseImageName { get; set; }
 
     /// <summary>
-    /// The registry to push the new container to. This will be null if the container is to be pushed to a local daemon.
+    /// The registry to push the new container to. This will be null if the container is to be pushed to a local registry.
     /// </summary>
     public string ContainerRegistry { get; set; }
 

--- a/src/Containers/containerize/ContainerizeCommand.cs
+++ b/src/Containers/containerize/ContainerizeCommand.cs
@@ -79,10 +79,10 @@ internal class ContainerizeCommand : RootCommand
                 AllowMultipleArgumentsPerToken = true
             };
 
-    internal Option<string> LocalContainerDaemonOption { get; } = new Option<string>(
-            name: "--localcontainerdaemon",
-            description: "The local daemon type to push to")
-        .AcceptOnlyFromAmong(KnownDaemonTypes.SupportedLocalDaemonTypes);
+    internal Option<string> LocalRegistryOption { get; } = new Option<string>(
+            name: "--localregistry",
+            description: "The local registry to push to")
+        .AcceptOnlyFromAmong(KnownLocalRegistryTypes.SupportedLocalRegistryTypes);
 
     internal Option<Dictionary<string, string>> LabelsOption { get; } = new(
             name: "--labels",
@@ -184,7 +184,7 @@ internal class ContainerizeCommand : RootCommand
         this.AddOption(EnvVarsOption);
         this.AddOption(RidOption);
         this.AddOption(RidGraphPathOption);
-        this.AddOption(LocalContainerDaemonOption);
+        this.AddOption(LocalRegistryOption);
         this.AddOption(ContainerUserOption);
 
         this.SetHandler(async (context) =>
@@ -204,7 +204,7 @@ internal class ContainerizeCommand : RootCommand
             Dictionary<string, string> _envVars = context.ParseResult.GetValue(EnvVarsOption) ?? new Dictionary<string, string>();
             string _rid = context.ParseResult.GetValue(RidOption)!;
             string _ridGraphPath = context.ParseResult.GetValue(RidGraphPathOption)!;
-            string _localContainerDaemon = context.ParseResult.GetValue(LocalContainerDaemonOption)!;
+            string _localRegistry = context.ParseResult.GetValue(LocalRegistryOption)!;
             string? _containerUser = context.ParseResult.GetValue(ContainerUserOption);
             await ContainerBuilder.ContainerizeAsync(
                 _publishDir,
@@ -222,7 +222,7 @@ internal class ContainerizeCommand : RootCommand
                 _envVars,
                 _rid,
                 _ridGraphPath,
-                _localContainerDaemon,
+                _localRegistry,
                 _containerUser,
                 context.GetCancellationToken()).ConfigureAwait(false);
         });

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -71,11 +71,11 @@
 
     <!-- Container Defaults -->
     <PropertyGroup>
-      <!-- An empty ContainerRegistry implies pushing to the local daemon, putting this here for documentation purposes -->
+      <!-- An empty ContainerRegistry implies pushing to the local registry, putting this here for documentation purposes -->
       <!-- <ContainerRegistry></ContainerRegistry> -->
 
-      <!-- Set which local container daemon to use. We only explicitly support Docker (or things that mimic Docker APIs and binary names) at the moment. -->
-      <LocalContainerDaemon Condition="'$(LocalContainerDaemon)' == ''">Docker</LocalContainerDaemon>
+      <!-- Set which local container registry to use. We only explicitly support Docker (or things that mimic Docker APIs and binary names) at the moment. -->
+      <LocalRegistry Condition="'$(LocalRegistry)' == ''">Docker</LocalRegistry>
 
       <!-- Note: spaces will be replaced with '-' in ContainerImageName and ContainerImageTag -->
       <ContainerImageName Condition="'$(ContainerImageName)' == ''">$(AssemblyName)</ContainerImageName>
@@ -199,7 +199,7 @@
                     BaseRegistry="$(ContainerBaseRegistry)"
                     BaseImageName="$(ContainerBaseName)"
                     BaseImageTag="$(ContainerBaseTag)"
-                    LocalContainerDaemon="$(LocalContainerDaemon)"
+                    LocalRegistry="$(LocalRegistry)"
                     OutputRegistry="$(ContainerRegistry)"
                     ImageName="$(ContainerImageName)"
                     ImageTags="@(ContainerImageTags)"

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -23,7 +23,7 @@ public class CreateNewImageTests
         _testOutput = testOutput;
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public void CreateNewImage_Baseline()
     {
         DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(CreateNewImage_Baseline)));
@@ -64,7 +64,7 @@ public class CreateNewImageTests
         newProjectDir.Delete(true);
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public void ParseContainerProperties_EndToEnd()
     {
         DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(ParseContainerProperties_EndToEnd)));
@@ -121,7 +121,7 @@ public class CreateNewImageTests
     /// <summary>
     /// Creates a console app that outputs the environment variable added to the image.
     /// </summary>
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public void Tasks_EndToEnd_With_EnvironmentVariable_Validation()
     {
         DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(Tasks_EndToEnd_With_EnvironmentVariable_Validation)));
@@ -180,7 +180,7 @@ public class CreateNewImageTests
         cni.ContainerEnvironmentVariables = pcp.NewContainerEnvironmentVariables;
         cni.ContainerRuntimeIdentifier = "linux-x64";
         cni.RuntimeIdentifierGraphPath = ToolsetUtils.GetRuntimeGraphFilePath();
-        cni.LocalContainerDaemon = global::Microsoft.NET.Build.Containers.KnownDaemonTypes.Docker;
+        cni.LocalRegistry = global::Microsoft.NET.Build.Containers.KnownLocalRegistryTypes.Docker;
 
         Assert.True(cni.Execute());
 
@@ -190,7 +190,7 @@ public class CreateNewImageTests
             .And.HaveStdOut("Foo");
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public async System.Threading.Tasks.Task CreateNewImage_RootlessBaseImage()
     {
         const string RootlessBase ="dotnet/rootlessbase";

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryManager.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryManager.cs
@@ -25,8 +25,8 @@ public class DockerRegistryManager
     public static void StartAndPopulateDockerRegistry(ITestOutputHelper testOutput)
     {
         testOutput.WriteLine("Spawning local registry");
-        if (!new LocalDocker(testOutput.WriteLine).IsAvailable()) {
-            throw new InvalidOperationException("Docker daemon is not started, tests cannot run");
+        if (!new DockerCli(testOutput.WriteLine).IsAvailable()) {
+            throw new InvalidOperationException("Docker is not available, tests cannot run");
         }
         CommandResult processResult = ContainerCli.RunCommand(testOutput, "--rm", "--publish", "5010:5000", "--detach", "docker.io/library/registry:2").Execute();
         processResult.Should().Pass().And.HaveStdOut();

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchInlineData.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchInlineData.cs
@@ -75,7 +75,7 @@ public class DockerSupportsArchInlineData : DataAttribute
     {
         // the config json has an OSType property that is either "linux" or "windows" -
         // we can't use this for linux arch detection because that isn't enough information.
-        var config = LocalDocker.GetConfig();
+        var config = DockerCli.GetConfig();
         if (config.RootElement.TryGetProperty("OSType", out JsonElement osTypeProperty))
         {
             return osTypeProperty.GetString() == "windows";

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -35,7 +35,7 @@ public class EndToEndTests
         return callerMemberName;
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public async Task ApiEndToEndWithRegistryPushAndPull()
     {
         string publishDirectory = BuildLocalApp();
@@ -78,7 +78,7 @@ public class EndToEndTests
             .Should().Pass();
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public async Task ApiEndToEndWithLocalLoad()
     {
         string publishDirectory = BuildLocalApp(tfm: "net8.0");
@@ -103,11 +103,11 @@ public class EndToEndTests
 
         BuiltImage builtImage = imageBuilder.Build();
 
-        // Load the image into the local Docker daemon
+        // Load the image into the local registry
         var sourceReference = new ImageReference(registry, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net7ImageTag);
         var destinationReference = new ImageReference(registry, NewImageName(), "latest");
 
-        await new LocalDocker(Console.WriteLine).LoadAsync(builtImage, sourceReference, destinationReference, default).ConfigureAwait(false);
+        await new DockerCli(Console.WriteLine).LoadAsync(builtImage, sourceReference, destinationReference, default).ConfigureAwait(false);
 
         // Run the image
         ContainerCli.RunCommand(_testOutput, "--rm", "--tty", $"{NewImageName()}:latest")
@@ -148,7 +148,7 @@ public class EndToEndTests
         return publishDirectory;
     }
 
-    [DockerDaemonAvailableTheory]
+    [DockerAvailableTheory]
     [InlineData(false)]
     [InlineData(true)]
     public async Task EndToEnd_NoAPI_Web(bool addPackageReference)
@@ -302,7 +302,7 @@ public class EndToEndTests
         privateNuGetAssets.Delete(true);
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public void EndToEnd_NoAPI_Console()
     {
         DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, "CreateNewImageTest"));
@@ -397,7 +397,7 @@ public class EndToEndTests
     [DockerSupportsArchInlineData("linux/386", "linux-x86", "/app", Skip = "There's no apphost for linux-x86 so we can't execute self-contained, and there's no .NET runtime base image for linux-x86 so we can't execute framework-dependent.")]
     [DockerSupportsArchInlineData("windows/amd64", "win-x64", "C:\\app")]
     [DockerSupportsArchInlineData("linux/amd64", "linux-x64", "/app")]
-    [DockerDaemonAvailableTheory]
+    [DockerAvailableTheory]
     public async Task CanPackageForAllSupportedContainerRIDs(string dockerPlatform, string rid, string workingDir)
     {
         string publishDirectory = BuildLocalApp(tfm: ToolsetInfo.CurrentTargetFramework, rid: rid);
@@ -423,10 +423,10 @@ public class EndToEndTests
 
         BuiltImage builtImage = imageBuilder.Build();
 
-        // Load the image into the local Docker daemon
+        // Load the image into the local registry
         var sourceReference = new ImageReference(registry, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net7ImageTag);
         var destinationReference = new ImageReference(registry, NewImageName(), rid);
-        await new LocalDocker(Console.WriteLine).LoadAsync(builtImage, sourceReference, destinationReference, default).ConfigureAwait(false);
+        await new DockerCli(Console.WriteLine).LoadAsync(builtImage, sourceReference, destinationReference, default).ConfigureAwait(false);
 
         // Run the image
         ContainerCli.RunCommand(

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 [Collection("Docker tests")]
 public class ParseContainerPropertiesTests
 {
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public void Baseline()
     {
         var (project, _, d) = ProjectInitializer.InitProject(new () {
@@ -35,7 +35,7 @@ public class ParseContainerPropertiesTests
         instance.GetItems("ProjectCapability").Select(i => i.EvaluatedInclude).ToArray().Should().BeEquivalentTo(new[] { "NetSdkOCIImageBuild" });
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public void SpacesGetReplacedWithDashes()
     {
          var (project, _, d) = ProjectInitializer.InitProject(new () {
@@ -51,7 +51,7 @@ public class ParseContainerPropertiesTests
         Assert.Equal("7.0", instance.GetPropertyValue(ContainerBaseTag));
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public void RegexCatchesInvalidContainerNames()
     {
          var (project, logs, d) = ProjectInitializer.InitProject(new () {
@@ -66,7 +66,7 @@ public class ParseContainerPropertiesTests
         Assert.Contains(logs.Messages, m => m.Message?.Contains("'ContainerImageName' was not a valid container image name, it was normalized to 'dotnet-testimage'") == true);
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public void RegexCatchesInvalidContainerTags()
     {
         var (project, logs, d) = ProjectInitializer.InitProject(new () {
@@ -83,7 +83,7 @@ public class ParseContainerPropertiesTests
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2007);
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public void CanOnlySupplyOneOfTagAndTags()
     {
         var (project, logs, d) = ProjectInitializer.InitProject(new () {

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.Build.Containers.IntegrationTests;
 [Collection("Docker tests")]
 public class RegistryTests
 {
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public async Task GetFromRegistry()
     {
         Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerAvailableUtils.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerAvailableUtils.cs
@@ -5,26 +5,26 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Containers.UnitTests;
 
-public class DockerDaemonAvailableTheoryAttribute : TheoryAttribute
+public class DockerAvailableTheoryAttribute : TheoryAttribute
 {
-    private static bool IsDaemonAvailable = new LocalDocker(Console.WriteLine).IsAvailable();
-    public DockerDaemonAvailableTheoryAttribute()
+    private static bool IsAvailable = new DockerCli(Console.WriteLine).IsAvailable();
+    public DockerAvailableTheoryAttribute()
     {
-        if (!IsDaemonAvailable)
+        if (!IsAvailable)
         {
             base.Skip = "Skipping test because Docker is not available on this host.";
         }
     }
 }
 
-public class DockerDaemonAvailableFactAttribute : FactAttribute
+public class DockerAvailableFactAttribute : FactAttribute
 {
     // tiny optimization - since there are many instances of this attribute we should only get
     // the daemon status once
-    private static bool IsDaemonAvailable = new LocalDocker(Console.WriteLine).IsAvailable();
-    public DockerDaemonAvailableFactAttribute()
+    private static bool IsAvailable = new DockerCli(Console.WriteLine).IsAvailable();
+    public DockerAvailableFactAttribute()
     {
-        if (!IsDaemonAvailable)
+        if (!IsAvailable)
         {
             base.Skip = "Skipping test because Docker is not available on this host.";
         }

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerDaemonTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerDaemonTests.cs
@@ -13,21 +13,21 @@ public class DaemonTestsCollection
 [Collection("Daemon Tests")]
 public class DockerDaemonTests
 {
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public async Task Can_detect_when_no_daemon_is_running() {
         // mimic no daemon running by setting the DOCKER_HOST to a nonexistent socket
         try {
             System.Environment.SetEnvironmentVariable("DOCKER_HOST", "tcp://123.123.123.123:12345");
-            var available = await new LocalDocker(Console.WriteLine).IsAvailableAsync(default).ConfigureAwait(false);
+            var available = await new DockerCli(Console.WriteLine).IsAvailableAsync(default).ConfigureAwait(false);
             Assert.False(available, "No daemon should be listening at that port");
         } finally {
             System.Environment.SetEnvironmentVariable("DOCKER_HOST", null);
         }
     }
 
-    [DockerDaemonAvailableFact]
+    [DockerAvailableFact]
     public async Task Can_detect_when_daemon_is_running() {
-        var available = await new LocalDocker(Console.WriteLine).IsAvailableAsync(default).ConfigureAwait(false);
+        var available = await new DockerCli(Console.WriteLine).IsAvailableAsync(default).ConfigureAwait(false);
         Assert.True(available, "Should have found a working daemon");
     }
 }


### PR DESCRIPTION
The container tooling supports working with the local registry provided by the the 'docker' cli.

The implementation and messages refer to this as the "Docker/local daemon". This changes to use "local registry" instead. This makes the naming appropriate also for a daemonless implementation like 'podman'.

@baronfel ptal.

This PR is about renaming things. I will make a separate PR that is specifically about adding 'podman' support.