### PR TITLE
Make GenerateToolsSettingsFileFromBuildProperty incremental

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -64,9 +64,37 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <ToolCommandName Condition=" '$(ToolCommandName)' == '' ">$(TargetName)</ToolCommandName>
     <ToolEntryPoint Condition=" '$(ToolEntryPoint)' == '' ">$(TargetFileName)</ToolEntryPoint>
+    <_GenerateToolsSettingsFileCacheFile Condition="'$(_GenerateToolsSettingsFileCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).toolssettingsinput.cache</_GenerateToolsSettingsFileCacheFile>
+    <_GenerateToolsSettingsFileCacheFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(_GenerateToolsSettingsFileCacheFile)))</_GenerateToolsSettingsFileCacheFile>
   </PropertyGroup>
 
-  <Target Name="GenerateToolsSettingsFileFromBuildProperty" >
+  <Target Name="_GenerateToolsSettingsFileInputCache">
+    <ItemGroup>
+      <_GenerateToolsSettingsFileInputCacheToHash Include="$(ToolEntryPoint)" />
+      <_GenerateToolsSettingsFileInputCacheToHash Include="$(ToolCommandName)" />
+    </ItemGroup>
+
+    <Hash ItemsToHash="@(_GenerateToolsSettingsFileInputCacheToHash)">
+      <Output TaskParameter="HashResult" PropertyName="_GenerateToolsSettingsFileInputCacheHash" />
+    </Hash>
+
+    <WriteLinesToFile
+      Lines="$(_GenerateToolsSettingsFileInputCacheHash)"
+      File="$(_GenerateToolsSettingsFileCacheFile)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+
+    <!-- Don't include the cache file in FileWrites, because there is no support for cleaning
+         intermediate outputs during PackAsTool. Adding it to FileWrites doesn't work because
+         IncrementalClean during PackAsTool would add it to the clean file, but then IncrementalBuild
+         during the Build target on a subsequent run would consider it to be orphaned (because this target
+         which would add it to FileWrites hasn't run yet), and delete it. -->
+  </Target>
+
+  <Target Name="GenerateToolsSettingsFileFromBuildProperty"
+          DependsOnTargets="_GenerateToolsSettingsFileInputCache"
+          Inputs="$(_GenerateToolsSettingsFileCacheFile)"
+          Outputs="$(_ToolsSettingsFilePath)">
     <GenerateToolsSettingsFile
        EntryPointRelativePath="$(ToolEntryPoint)"
        CommandName="$(ToolCommandName)"


### PR DESCRIPTION
The lack of incrementalism in this target was forcing a re-pack of `dotnet-pgo` in the runtime incremental build. Fixing this cuts about 2s off of the incremental runtime build on my machine.

Contributes to https://github.com/dotnet/runtime/issues/47022