### PR TITLE
BlazorWasmSdk: Fix duplicate imports

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.5_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.5_0.targets
@@ -10,10 +10,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0">
-  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />
-  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" />
-  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
-
   <PropertyGroup>
     <EnableDefaultContentItems Condition=" '$(EnableDefaultContentItems)' == '' ">true</EnableDefaultContentItems>
 


### PR DESCRIPTION
`Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets` unconditionally imports:

```xml
  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />
  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" />
  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
```

.. *after* which it can import
`Microsoft.NET.Sdk.BlazorWebAssembly.5_0.targets`, which then unconditionally imports:

```xml
  <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />
  <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" />
  <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
```

.. which produces warning:

```
[2023/05/24 07:06:03][INFO] /home/helixbot/work/BAA509D0/p/dotnet/sdk/8.0.100-preview.5.23273.2/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/targets/Microsoft.NET.Sdk.BlazorWebAssembly.5_0.targets(13,3): warning MSB4011: "/home/helixbot/work/BAA509D0/p/dotnet/sdk/8.0.100-preview.5.23273.2/Sdks/Microsoft.NET.Sdk.Razor/Sdk/Sdk.targets" cannot be imported again. It was already imported at "/home/helixbot/work/BAA509D0/p/dotnet/sdk/8.0.100-preview.5.23273.2/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets (25,3)". This is most likely a build authoring error. This subsequent import will be ignored.
```

.. and the same for `Microsoft.NET.Sdk.Web.ProjectSystem`, and `Microsoft.NET.Sdk.Publish`.

Since the `5_0.targets` is only ever imported from the `Current.targets`, it does not need to import the same SDKs again.

This was introduced in:
```
commit 3e34299dff61129227b539b792973a7f7ad60d57
Author: Marek Fišera <mara@neptuo.com>
Date:   Tue Mar 28 15:47:55 2023 +0200

    Split WebAssembly SDK from Blazor SDK (#31154)
```

.. and the blazor scenario perf runs have been broken since it got merged.