### PR TITLE
Containers: fix handling of ContainerBaseImage without a registry.

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -31,7 +31,7 @@ public static class ContainerHelpers
     /// DockerRegistry is the default registry used when no registry is specified.
     /// </summary>
     private const string DockerRegistry = "registry-1.docker.io";
-    private const string DockerRegistryAlias = "docker.io";
+    internal const string DockerRegistryAlias = "docker.io";
 
     /// <summary>
     /// Matches if the string is not lowercase or numeric, or ., _, or -.
@@ -196,7 +196,8 @@ public static class ContainerHelpers
                                                             [NotNullWhen(true)] out string? containerRegistry,
                                                             [NotNullWhen(true)] out string? containerName,
                                                             out string? containerTag, // tag is always optional - we can't guarantee anything here
-                                                            out string? containerDigest // digest is always optional - we can't guarantee anything here
+                                                            out string? containerDigest, // digest is always optional - we can't guarantee anything here
+                                                            out bool isRegistrySpecified
                                                             )
     {
 
@@ -208,6 +209,7 @@ public static class ContainerHelpers
             containerName = null;
             containerTag = null;
             containerDigest = null;
+            isRegistrySpecified = false;
             return false;
         }
 
@@ -228,14 +230,9 @@ public static class ContainerHelpers
 
             // safely discover the registry
             var registryPortion = nameMatch.Groups[1];
-            if (registryPortion.Success)
-            {
-                containerRegistry = registryPortion.Value;
-            }
-            else
-            {
-                containerRegistry = DockerRegistryAlias;
-            }
+            isRegistrySpecified = registryPortion.Success;
+            containerRegistry = isRegistrySpecified ? registryPortion.Value
+                                                    : DockerRegistryAlias;
 
             // direct access to the name portion is safe because the regex matched
             var imageNamePortion = nameMatch.Groups[2];
@@ -259,6 +256,7 @@ public static class ContainerHelpers
             containerName = null;
             containerTag = null;
             containerDigest = null;
+            isRegistrySpecified = false;
             return false;
         }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/ReferenceParser.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ReferenceParser.cs
@@ -67,6 +67,8 @@ internal static class ReferenceParser
     /// </summary>
     private static readonly string domainName = expression(
         domainNameComponent,
+        // Require two name domainNameComponents to prevent matching a domain when parsing the short containername: 'ubuntu/runtime'.
+        literal("."), domainNameComponent,
         optional(repeated(literal("."), domainNameComponent))
     );
 
@@ -77,7 +79,7 @@ internal static class ReferenceParser
     /// brackets (excluding zone identifiers as defined by rfc6874 or special
     /// addresses such as IPv4-Mapped).
     /// </summary>
-    private static readonly string host = $"(?:{domainName}|{ipv6address})";
+    private static readonly string host = $"(?:{domainName}|{ipv6address}|localhost)";
 
     /// <summary>
     /// allowed by the URI Host subcomponent on rfc3986 to ensure backwards

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/<image>'..
+        /// </summary>
+        internal static string BaseImageNameRegistryFallback {
+            get {
+                return ResourceManager.GetString("BaseImageNameRegistryFallback", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to CONTAINER1011: Couldn&apos;t find matching base image for {0} that matches RuntimeIdentifier {1}..
         /// </summary>
         internal static string BaseImageNotFound {

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -133,6 +133,10 @@
     <value>CONTAINER2013: {0} had spaces in it, replacing with dashes.</value>
     <comment>{StrBegin="CONTAINER2013: "}</comment>
   </data>
+  <data name="BaseImageNameRegistryFallback" xml:space="preserve">
+    <value>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</value>
+    <comment>{StrBegin="CONTAINER2020: "}</comment>
+  </data>
   <data name="BaseImageNotFound" xml:space="preserve">
     <value>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</value>
     <comment>{StrBegin="CONTAINER1011: "}</comment>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: Nelze analyzovat {0}: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} obsahoval mezery, které se nahradily pomlčkami.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: {0} konnte nicht analysiert werden: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} enthielt Leerzeichen. Diese werden durch Bindestriche ersetzt.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: No se pudo analizar {0}: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} tenía espacios, reemplazando por guiones.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: impossible d’analyser {0} : {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} contenait des espaces, remplacés par des tirets.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: non è stato possibile analizzare {0}: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} conteneva spazi, che verranno sostituiti con trattini.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: {0} を解析できませんでした: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} にスペースが含まれており、ダッシュに置き換えています。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: {0}을(를) 구문 분석할 수 없습니다: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0}에 공백이 있었고 대시로 대체되었습니다.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: nie można przeanalizować {0}: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: element {0} zawierał spacje, zastępując je kreskami.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: não foi possível analisar {0}: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} continha espaços, substituindo por travessões.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: не удалось проанализировать {0}: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} содержит пробелы, замененные на дефисы.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: {0} ayrıştırılamadı: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} boşluklar içeriyor ve çizgilerle değiştiriliyor.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: 无法分析 {0}: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} 中包含空格，替换为短划线。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">CONTAINER2009: 無法剖析 {0}: {1}</target>
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
+      <trans-unit id="BaseImageNameRegistryFallback">
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="new">CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</target>
+        <note>{StrBegin="CONTAINER2020: "}</note>
+      </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
         <target state="translated">CONTAINER2013: {0} 有空格，正在以虛線取代。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
@@ -135,10 +135,16 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
                                                                   out string? outputReg,
                                                                   out string? outputImage,
                                                                   out string? outputTag,
-                                                                  out string? _outputDigest))
+                                                                  out string? _outputDigest,
+                                                                  out bool isRegistrySpecified))
         {
             Log.LogErrorWithCodeFromResources(nameof(Strings.BaseImageNameParsingFailed), nameof(FullyQualifiedBaseImageName), FullyQualifiedBaseImageName);
             return !Log.HasLoggedErrors;
+        }
+
+        if (!isRegistrySpecified)
+        {
+            Log.LogWarningWithCodeFromResources(nameof(Strings.BaseImageNameRegistryFallback), nameof(FullyQualifiedBaseImageName), ContainerHelpers.DockerRegistryAlias);
         }
 
         try

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -39,14 +39,14 @@ public class ParseContainerPropertiesTests
     public void SpacesGetReplacedWithDashes()
     {
          var (project, _, d) = ProjectInitializer.InitProject(new () {
-            [ContainerBaseImage] = "mcr microsoft com/dotnet runtime:7.0",
+            [ContainerBaseImage] = "mcr.microsoft.com/dotnet runtime:7.0",
             [ContainerRegistry] = "localhost:5010"
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
         Assert.True(instance.Build(new[]{ComputeContainerConfig}, null, null, out var outputs));
 
-        Assert.Equal("mcr-microsoft-com",instance.GetPropertyValue(ContainerBaseRegistry));
+        Assert.Equal("mcr.microsoft.com",instance.GetPropertyValue(ContainerBaseRegistry));
         Assert.Equal("dotnet-runtime", instance.GetPropertyValue(ContainerBaseName));
         Assert.Equal("7.0", instance.GetPropertyValue(ContainerBaseTag));
     }

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
@@ -25,29 +25,30 @@ public class ContainerHelpersTests
     }
 
     [Theory]
-    [InlineData("mcr.microsoft.com/dotnet/runtime:6.0", true, "mcr.microsoft.com", "dotnet/runtime", "6.0")]
-    [InlineData("mcr.microsoft.com/dotnet/runtime", true, "mcr.microsoft.com", "dotnet/runtime", null)]
-    [InlineData("mcr.microsoft.com/", false, null, null, null)] // no image = nothing resolves
+    [InlineData("mcr.microsoft.com/dotnet/runtime:6.0", true, "mcr.microsoft.com", "dotnet/runtime", "6.0", true)]
+    [InlineData("mcr.microsoft.com/dotnet/runtime", true, "mcr.microsoft.com", "dotnet/runtime", null, true)]
+    [InlineData("mcr.microsoft.com/", false, null, null, null, false)] // no image = nothing resolves
     // Ports tag along
-    [InlineData("mcr.microsoft.com:54/dotnet/runtime", true, "mcr.microsoft.com:54", "dotnet/runtime", null)]
+    [InlineData("mcr.microsoft.com:54/dotnet/runtime", true, "mcr.microsoft.com:54", "dotnet/runtime", null, true)]
     // Even if nonsensical
-    [InlineData("mcr.microsoft.com:0/dotnet/runtime", true, "mcr.microsoft.com:0", "dotnet/runtime", null)]
+    [InlineData("mcr.microsoft.com:0/dotnet/runtime", true, "mcr.microsoft.com:0", "dotnet/runtime", null, true)]
     // We don't allow hosts with missing ports when a port is anticipated
-    [InlineData("mcr.microsoft.com:/dotnet/runtime", false, null, null, null)]
+    [InlineData("mcr.microsoft.com:/dotnet/runtime", false, null, null, null, false)]
     // Use default registry when no registry specified.
-    [InlineData("ubuntu:jammy", true, DefaultRegistry, "library/ubuntu", "jammy")]
-    [InlineData("ubuntu/runtime:jammy", true, DefaultRegistry, "ubuntu/runtime", "jammy")]
+    [InlineData("ubuntu:jammy", true, DefaultRegistry, "library/ubuntu", "jammy", false)]
+    [InlineData("ubuntu/runtime:jammy", true, DefaultRegistry, "ubuntu/runtime", "jammy", false)]
     // Alias 'docker.io' to Docker registry.
-    [InlineData("docker.io/ubuntu:jammy", true, DefaultRegistry, "library/ubuntu", "jammy")]
-    [InlineData("docker.io/ubuntu/runtime:jammy", true, DefaultRegistry, "ubuntu/runtime", "jammy")]
+    [InlineData("docker.io/ubuntu:jammy", true, DefaultRegistry, "library/ubuntu", "jammy", true)]
+    [InlineData("docker.io/ubuntu/runtime:jammy", true, DefaultRegistry, "ubuntu/runtime", "jammy", true)]
     // 'localhost' registry.
-    [InlineData("localhost/ubuntu:jammy", true, "localhost", "ubuntu", "jammy")]
-    public void TryParseFullyQualifiedContainerName(string fullyQualifiedName, bool expectedReturn, string expectedRegistry, string expectedImage, string expectedTag)
+    [InlineData("localhost/ubuntu:jammy", true, "localhost", "ubuntu", "jammy", true)]
+    public void TryParseFullyQualifiedContainerName(string fullyQualifiedName, bool expectedReturn, string expectedRegistry, string expectedImage, string expectedTag, bool expectedIsRegistrySpecified)
     {
-        Assert.Equal(expectedReturn, ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedName, out string? containerReg, out string? containerName, out string? containerTag, out string? containerDigest));
+        Assert.Equal(expectedReturn, ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedName, out string? containerReg, out string? containerName, out string? containerTag, out string? containerDigest, out bool isRegistrySpecified));
         Assert.Equal(expectedRegistry, containerReg);
         Assert.Equal(expectedImage, containerName);
         Assert.Equal(expectedTag, containerTag);
+        Assert.Equal(expectedIsRegistrySpecified, isRegistrySpecified);
     }
 
     [Theory]

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
@@ -40,6 +40,8 @@ public class ContainerHelpersTests
     // Alias 'docker.io' to Docker registry.
     [InlineData("docker.io/ubuntu:jammy", true, DefaultRegistry, "library/ubuntu", "jammy")]
     [InlineData("docker.io/ubuntu/runtime:jammy", true, DefaultRegistry, "ubuntu/runtime", "jammy")]
+    // 'localhost' registry.
+    [InlineData("localhost/ubuntu:jammy", true, "localhost", "ubuntu", "jammy")]
     public void TryParseFullyQualifiedContainerName(string fullyQualifiedName, bool expectedReturn, string expectedRegistry, string expectedImage, string expectedTag)
     {
         Assert.Equal(expectedReturn, ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedName, out string? containerReg, out string? containerName, out string? containerTag, out string? containerDigest));

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
@@ -7,6 +7,8 @@ namespace Microsoft.NET.Build.Containers.UnitTests;
 
 public class ContainerHelpersTests
 {
+    private const string DefaultRegistry = "registry-1.docker.io";
+
     [Theory]
     // Valid Tests
     [InlineData("mcr.microsoft.com", true)]
@@ -32,7 +34,12 @@ public class ContainerHelpersTests
     [InlineData("mcr.microsoft.com:0/dotnet/runtime", true, "mcr.microsoft.com:0", "dotnet/runtime", null)]
     // We don't allow hosts with missing ports when a port is anticipated
     [InlineData("mcr.microsoft.com:/dotnet/runtime", false, null, null, null)]
-    [InlineData("ubuntu:jammy", true, ContainerHelpers.DefaultRegistry, "ubuntu", "jammy")]
+    // Use default registry when no registry specified.
+    [InlineData("ubuntu:jammy", true, DefaultRegistry, "library/ubuntu", "jammy")]
+    [InlineData("ubuntu/runtime:jammy", true, DefaultRegistry, "ubuntu/runtime", "jammy")]
+    // Alias 'docker.io' to Docker registry.
+    [InlineData("docker.io/ubuntu:jammy", true, DefaultRegistry, "library/ubuntu", "jammy")]
+    [InlineData("docker.io/ubuntu/runtime:jammy", true, DefaultRegistry, "ubuntu/runtime", "jammy")]
     public void TryParseFullyQualifiedContainerName(string fullyQualifiedName, bool expectedReturn, string expectedRegistry, string expectedImage, string expectedTag)
     {
         Assert.Equal(expectedReturn, ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedName, out string? containerReg, out string? containerName, out string? containerTag, out string? containerDigest));


### PR DESCRIPTION
These images are meant to be pulled from Docker Hub.

The wrong hostname was used for the registry ('registry-1.docker.io' vs 'docker.io').

The parsing of names like 'ubuntu/dotnet-runtime' lead to 'ubuntu' being treated as the registry.

This also enables using 'docker.io' as an alias to the Docker registry.

And adds the required 'library/' prefixing for short-names (like 'ubuntu' to 'library/ubuntu').

@baronfel ptal.

Fixes https://github.com/dotnet/sdk-container-builds/issues/445
Fixes https://github.com/dotnet/sdk-container-builds/issues/444
Fixes https://github.com/dotnet/sdk-container-builds/issues/443