### PR TITLE
[wasm] Override versions of previous runtime packs

### DIFF
--- a/src/Layout/redist/targets/BuildToolsetTasks.targets
+++ b/src/Layout/redist/targets/BuildToolsetTasks.targets
@@ -26,5 +26,6 @@
   <UsingTask TaskName="GetCurrentRuntimeInformation" AssemblyFile="$(ToolsetTaskDll)"/>
   <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(ToolsetTaskDll)"/>
   <UsingTask TaskName="OverrideAndCreateBundledNETCoreAppPackageVersion" AssemblyFile="$(ToolsetTaskDll)"/>
+  <UsingTask TaskName="OverrideWasmRuntimePackVersions" AssemblyFile="$(ToolsetTaskDll)"/>
 
 </Project>

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -68,6 +68,9 @@
       <WasmWorkloads Include="microsoft.net.workload.emscripten.current" Version="$(EmscriptenWorkloadManifestVersion)/$(EmscriptenWorkloadFeatureBand)"/>
 	    <WasmWorkloads Include="microsoft.net.workload.emscripten.net6" Version="$(EmscriptenWorkloadManifestVersion)/$(EmscriptenWorkloadFeatureBand)"/>
 	    <WasmWorkloads Include="microsoft.net.workload.emscripten.net7" Version="$(EmscriptenWorkloadManifestVersion)/$(EmscriptenWorkloadFeatureBand)"/>
+
+      <WasmRuntimePackVersion Include="_RuntimePackInWorkloadVersion6" Version="$(_RuntimePackInWorkloadVersion6)" />
+      <WasmRuntimePackVersion Include="_RuntimePackInWorkloadVersion7" Version="$(_RuntimePackInWorkloadVersion7)" />
     </ItemGroup>
 
     <!-- Create a rollback file for installing workloads during the build  -->
@@ -93,6 +96,9 @@
     <Exec Condition="Exists('$(RedistLayoutPath)TestRollback.json')"
           Command="$(RedistLayoutPath)dotnet workload update --from-rollback-file $(RedistLayoutPath)TestRollback.json"
           EnvironmentVariables="DOTNET_CLI_HOME=$(ArtifactsTmpDir)"/>
+
+    <OverrideWasmRuntimePackVersions Properties="@(WasmRuntimePackVersion)" 
+      WorkloadManifestPath="$(RedistLayoutPath)\sdk-manifests\$(MonoWorkloadFeatureBand)\microsoft.net.workload.mono.toolchain.current\WorkloadManifest.targets" />
   </Target>
 
 

--- a/src/Layout/toolset-tasks/OverrideWasmRuntimePackVersions.cs
+++ b/src/Layout/toolset-tasks/OverrideWasmRuntimePackVersions.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// </summary>
+    public sealed class OverrideWasmRuntimePackVersions : Task
+    {
+        [Required]
+        public ITaskItem[] Properties { get; set; }
+
+        [Required]
+        public string WorkloadManifestPath { get; set; }
+
+        public override bool Execute()
+        {
+            var document = XDocument.Load(WorkloadManifestPath);
+            if (document != null)
+            {
+                foreach (var property in Properties)
+                {
+                    string propertyName = property.ItemSpec;
+                    string targetVersion = property.GetMetadata("Version");
+
+                    var xmlProperty = document.Descendants(propertyName).Single();
+                    xmlProperty.Value = targetVersion;
+                }
+
+                document.Save(WorkloadManifestPath);
+
+                return true;
+            }
+            
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Override value of properties `_RuntimePackInWorkloadVersion6` and `_RuntimePackInWorkloadVersion7` to match versions in SDK.

Fixes https://github.com/dotnet/sdk/issues/32864