### PR TITLE
[release/7.0.4xx] bug fixes related to AWS ECR

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
@@ -162,7 +162,8 @@ internal record struct Layer
 
             fs.Position = 0;
 
-            SHA256.HashData(fs, hash);
+            int bW = SHA256.HashData(fs, hash);
+            Debug.Assert(bW == hash.Length);
         }
 
         string contentHash = Convert.ToHexString(hash).ToLowerInvariant();

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -421,7 +421,8 @@ internal sealed class Registry
         HttpResponseMessage patchResponse = await client.PatchAsync(uploadUri.Uri, content, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
-        if (patchResponse.StatusCode != HttpStatusCode.Accepted)
+        // Fail the upload if the response code is not Accepted (202) or if uploading to Amazon ECR which returns back Created (201).
+        if (!(patchResponse.StatusCode == HttpStatusCode.Accepted || (IsAmazonECRRegistry && patchResponse.StatusCode == HttpStatusCode.Created)))
         {
             var headers = patchResponse.Headers.ToString();
             var detail = await patchResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -10,6 +10,9 @@ using Microsoft.NET.Build.Containers.UnitTests;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework;
+using FakeItEasy;
+using Microsoft.Build.Framework;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
@@ -26,8 +29,7 @@ public class CreateNewImageTests
     [DockerDaemonAvailableFact]
     public void CreateNewImage_Baseline()
     {
-        DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(CreateNewImage_Baseline)));
-
+        DirectoryInfo newProjectDir = new(GetTestDirectoryName());
         if (newProjectDir.Exists)
         {
             newProjectDir.Delete(recursive: true);
@@ -46,28 +48,33 @@ public class CreateNewImageTests
             .Execute()
             .Should().Pass();
 
-        CreateNewImage task = new CreateNewImage();
+        CreateNewImage task = new();
+
+        (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
+        task.BuildEngine = buildEngine;
+
         task.BaseRegistry = "mcr.microsoft.com";
         task.BaseImageName = "dotnet/runtime";
         task.BaseImageTag = "7.0";
 
         task.OutputRegistry = "localhost:5010";
+        task.LocalContainerDaemon = "Docker";
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-arm64", "publish");
-        task.Repository = "dotnet/testimage";
+        task.Repository = "dotnet/create-new-image-baseline";
         task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";
         task.ContainerRuntimeIdentifier = "linux-arm64";
         task.Entrypoint = new TaskItem[] { new("dotnet"), new("build") };
         task.RuntimeIdentifierGraphPath = ToolsetUtils.GetRuntimeGraphFilePath();
 
-        Assert.True(task.Execute());
+        Assert.True(task.Execute(), FormatBuildMessages(errors));
         newProjectDir.Delete(true);
     }
 
     [DockerDaemonAvailableFact]
     public void ParseContainerProperties_EndToEnd()
     {
-        DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(ParseContainerProperties_EndToEnd)));
+        DirectoryInfo newProjectDir = new(GetTestDirectoryName());
 
         if (newProjectDir.Exists)
         {
@@ -87,13 +94,16 @@ public class CreateNewImageTests
             .Execute()
             .Should().Pass();
 
-        ParseContainerProperties pcp = new ParseContainerProperties();
+        ParseContainerProperties pcp = new();
+        (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
+        pcp.BuildEngine = buildEngine;
+
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:7.0";
         pcp.ContainerRegistry = "localhost:5010";
         pcp.ContainerRepository = "dotnet/testimage";
         pcp.ContainerImageTags = new[] { "5.0", "latest" };
 
-        Assert.True(pcp.Execute());
+        Assert.True(pcp.Execute(), FormatBuildMessages(errors));
         Assert.Equal("mcr.microsoft.com", pcp.ParsedContainerRegistry);
         Assert.Equal("dotnet/runtime", pcp.ParsedContainerImage);
         Assert.Equal("7.0", pcp.ParsedContainerTag);
@@ -101,7 +111,10 @@ public class CreateNewImageTests
         Assert.Equal("dotnet/testimage", pcp.NewContainerRepository);
         pcp.NewContainerTags.Should().BeEquivalentTo(new[] { "5.0", "latest" });
 
-        CreateNewImage cni = new CreateNewImage();
+        CreateNewImage cni = new();
+        (buildEngine, errors) = SetupBuildEngine();
+        cni.BuildEngine = buildEngine;
+
         cni.BaseRegistry = pcp.ParsedContainerRegistry;
         cni.BaseImageName = pcp.ParsedContainerImage;
         cni.BaseImageTag = pcp.ParsedContainerTag;
@@ -109,12 +122,12 @@ public class CreateNewImageTests
         cni.OutputRegistry = "localhost:5010";
         cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.CurrentTargetFramework);
         cni.WorkingDirectory = "app/";
-        cni.Entrypoint = new TaskItem[] { new("ParseContainerProperties_EndToEnd") };
+        cni.Entrypoint = new TaskItem[] { new(newProjectDir.Name) };
         cni.ImageTags = pcp.NewContainerTags;
         cni.ContainerRuntimeIdentifier = "linux-x64";
         cni.RuntimeIdentifierGraphPath = ToolsetUtils.GetRuntimeGraphFilePath();
 
-        Assert.True(cni.Execute());
+        Assert.True(cni.Execute(), FormatBuildMessages(errors));
         newProjectDir.Delete(true);
     }
 
@@ -124,7 +137,7 @@ public class CreateNewImageTests
     [DockerDaemonAvailableFact]
     public void Tasks_EndToEnd_With_EnvironmentVariable_Validation()
     {
-        DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(Tasks_EndToEnd_With_EnvironmentVariable_Validation)));
+        DirectoryInfo newProjectDir = new(GetTestDirectoryName());
 
         if (newProjectDir.Exists)
         {
@@ -146,7 +159,10 @@ public class CreateNewImageTests
             .Execute()
             .Should().Pass();
 
-        ParseContainerProperties pcp = new ParseContainerProperties();
+        ParseContainerProperties pcp = new();
+        (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
+        pcp.BuildEngine = buildEngine;
+
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
         pcp.ContainerRegistry = "";
         pcp.ContainerRepository = "dotnet/envvarvalidation";
@@ -157,7 +173,7 @@ public class CreateNewImageTests
 
         pcp.ContainerEnvironmentVariables = new[] { new TaskItem("B@dEnv.Var", dict), new TaskItem("GoodEnvVar", dict) };
 
-        Assert.True(pcp.Execute());
+        Assert.True(pcp.Execute(), FormatBuildMessages(errors));
         Assert.Equal("mcr.microsoft.com", pcp.ParsedContainerRegistry);
         Assert.Equal("dotnet/runtime", pcp.ParsedContainerImage);
         Assert.Equal("6.0", pcp.ParsedContainerTag);
@@ -167,7 +183,10 @@ public class CreateNewImageTests
         Assert.Equal("dotnet/envvarvalidation", pcp.NewContainerRepository);
         Assert.Equal("latest", pcp.NewContainerTags[0]);
 
-        CreateNewImage cni = new CreateNewImage();
+        CreateNewImage cni = new();
+        (buildEngine, errors) = SetupBuildEngine();
+        cni.BuildEngine = buildEngine;
+
         cni.BaseRegistry = pcp.ParsedContainerRegistry;
         cni.BaseImageName = pcp.ParsedContainerImage;
         cni.BaseImageTag = pcp.ParsedContainerTag;
@@ -175,18 +194,33 @@ public class CreateNewImageTests
         cni.OutputRegistry = pcp.NewContainerRegistry;
         cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.CurrentTargetFramework, "linux-x64");
         cni.WorkingDirectory = "/app";
-        cni.Entrypoint = new TaskItem[] { new("/app/Tasks_EndToEnd_With_EnvironmentVariable_Validation") };
+        cni.Entrypoint = new TaskItem[] { new($"/app/{newProjectDir.Name}") };
         cni.ImageTags = pcp.NewContainerTags;
         cni.ContainerEnvironmentVariables = pcp.NewContainerEnvironmentVariables;
         cni.ContainerRuntimeIdentifier = "linux-x64";
         cni.RuntimeIdentifierGraphPath = ToolsetUtils.GetRuntimeGraphFilePath();
         cni.LocalContainerDaemon = global::Microsoft.NET.Build.Containers.KnownDaemonTypes.Docker;
 
-        Assert.True(cni.Execute());
+        Assert.True(cni.Execute(), FormatBuildMessages(errors));
 
         new RunExeCommand(_testOutput, "docker", "run", "--rm", $"{pcp.NewContainerRepository}:latest")
             .Execute()
             .Should().Pass()
             .And.HaveStdOut("Foo");
     }
+
+    private static (IBuildEngine buildEngine, List<string?> errors) SetupBuildEngine()
+    {
+        List<string?> errors = new();
+        IBuildEngine buildEngine = A.Fake<IBuildEngine>();
+        A.CallTo(() => buildEngine.LogWarningEvent(A<BuildWarningEventArgs>.Ignored)).Invokes((BuildWarningEventArgs e) => errors.Add(e.Message));
+        A.CallTo(() => buildEngine.LogErrorEvent(A<BuildErrorEventArgs>.Ignored)).Invokes((BuildErrorEventArgs e) => errors.Add(e.Message));
+        A.CallTo(() => buildEngine.LogMessageEvent(A<BuildMessageEventArgs>.Ignored)).Invokes((BuildMessageEventArgs e) => errors.Add(e.Message));
+
+        return (buildEngine, errors);
+    }
+
+    private static string GetTestDirectoryName([CallerMemberName]string testName = "DefaultTest") => Path.Combine(TestSettings.TestArtifactsDirectory, testName + "_" + DateTime.Now.ToString("yyyyMMddHHmmss"));
+
+    private static string FormatBuildMessages(List<string?> messages) => string.Join("\r\n", messages);
 }


### PR DESCRIPTION
blocks investigation of https://github.com/dotnet/sdk-container-builds/issues/424
regression caused by https://github.com/dotnet/sdk/pull/32080

- added handling of `Created` status code sent by AWS ECR for whole upload
- added additional check for hash creation
- improved previously false-negative tests