### PR TITLE
[release/7.0.4xx] excluded containerize from source-build 

### DIFF
--- a/source-build.slnf
+++ b/source-build.slnf
@@ -19,7 +19,6 @@
       "src\\Cli\\Microsoft.TemplateEngine.Cli\\Microsoft.TemplateEngine.Cli.csproj",
       "src\\Cli\\dotnet\\dotnet.csproj",
       "src\\Containers\\Microsoft.NET.Build.Containers\\Microsoft.NET.Build.Containers.csproj",
-      "src\\Containers\\containerize\\containerize.csproj",
       "src\\Containers\\packaging\\package.csproj",
       "src\\Layout\\redist\\redist.csproj",
       "src\\Layout\\tool_fsharp\\tool_fsc.csproj",

--- a/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -95,4 +95,9 @@
     </ItemGroup>
   </Target>
 
+  <!-- Copy to *.csproj for using in sanity checks integration tests. -->
+  <Target Name="CopyCsprojToTestExecutionDirectory" AfterTargets="Build">
+    <Copy SourceFiles="$(MSBuildThisFileFullPath)" DestinationFiles="$(ArtifactsTmpDir)Container\ProjectFiles\$(MSBuildThisFileName).csproj" />
+  </Target>
+
 </Project>

--- a/src/Containers/containerize/containerize.csproj
+++ b/src/Containers/containerize/containerize.csproj
@@ -24,4 +24,9 @@
     </ItemGroup>
     <Copy SourceFiles="@(ContainerizeFiles)" DestinationFiles="@(ContainerizeFiles->'$(ArtifactsTmpDir)Container\containerize\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
+
+  <!-- Copy to *.csproj for using in sanity checks integration tests. -->
+  <Target Name="CopyCsprojToTestExecutionDirectory" AfterTargets="Build">
+    <Copy SourceFiles="$(MSBuildThisFileFullPath)" DestinationFiles="$(ArtifactsTmpDir)Container\ProjectFiles\$(MSBuildThisFileName).csproj" />
+  </Target>
 </Project>

--- a/src/Containers/containerize/containerize.csproj
+++ b/src/Containers/containerize/containerize.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
     <SignAssembly>true</SignAssembly>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Containers/packaging/package.csproj
+++ b/src/Containers/packaging/package.csproj
@@ -28,12 +28,15 @@
                           SetTargetFramework="TargetFramework=$(TargetFramework)"
                           OutputItemType="ContainerLibraryOutput"/>
 
+        <ProjectReference Include="../../Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj"
+                          SetTargetFramework="TargetFramework=$(TargetFramework)"
+                          OutputItemType="DotNetCliUtilsLibraryOutput"/>
+
         <ProjectReference Include="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj"
                           SetTargetFramework="TargetFramework=$(VSCompatTargetFramework)"
                           OutputItemType="ContainerLibraryOutputNet472" Condition="'$(DotNetBuildFromSource)' != 'true'" />
 
-        <ProjectReference Include="../containerize/containerize.csproj" PrivateAssets="all" IncludeAssets="runtime" ReferenceOutputAssembly="true" />
-        <PackageReference Include="System.CommandLine" PrivateAssets="all" IncludeAssets="runtime" Version="$(SystemCommandLineVersion)"/>
+        <ProjectReference Include="../containerize/containerize.csproj" PrivateAssets="all" IncludeAssets="runtime" ReferenceOutputAssembly="true" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     </ItemGroup>
 
     <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">
@@ -48,18 +51,12 @@
             <Output TaskParameter="TargetOutputs" ItemName="_AllNet472ContainerTaskDependencies" />
         </MSBuild>
         <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-          <NecessaryNet472ContainerTaskDependencies
-            Include="@(_AllNet472ContainerTaskDependencies)"
-            Condition="(
-                        $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('NuGet')) or
-                        $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('Newtonsoft'))
-                       ) and
-                       %(_AllNet472ContainerTaskDependencies.NuGetIsFrameworkReference) != true" />
-        </ItemGroup>
-        <ItemGroup>
-            <!-- root folder -->
-            <Content Include="README.md" Pack="true" PackagePath="" />
-
+            <NecessaryNet472ContainerTaskDependencies Include="@(_AllNet472ContainerTaskDependencies)" Condition="(
+                                $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('NuGet')) or
+                                $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('Newtonsoft'))
+                            ) and
+                            %(_AllNet472ContainerTaskDependencies.NuGetIsFrameworkReference) != true" />
+            
             <!-- containerize folder -->
             <Content Include="$(OutDir)containerize.dll" Pack="true" PackagePath="containerize/" />
             <Content Include="$(OutDir)containerize.runtimeconfig.json" Pack="true" PackagePath="containerize/" />
@@ -70,24 +67,36 @@
             <Content Include="$(OutDir)Valleysoft.DockerCredsProvider.dll" Pack="true" PackagePath="containerize/" />
             <Content Include="@(ContainerLibraryOutput)" Pack="true" PackagePath="containerize/" />
 
+            <!-- net472 tasks -->
+            <!-- dependencies -->
+            <Content Include="@(NecessaryNet472ContainerTaskDependencies)" Pack="true" PackagePath="tasks/$(VSCompatTargetFramework)/" />
+            <!-- actual DLL  -->
+            <Content Include="@(ContainerLibraryOutputNet472)" Pack="true" PackagePath="tasks/$(VSCompatTargetFramework)/" />
+        </ItemGroup>
+        <MSBuild Projects="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj" Properties="TargetFramework=$(TargetFramework)" Targets="ResolveAssemblyReferences">
+            <Output TaskParameter="TargetOutputs" ItemName="_AllNetContainerTaskDependencies" />
+        </MSBuild>
+        <ItemGroup>
+             <NecessaryNetContainerTaskDependencies Include="@(_AllNetContainerTaskDependencies)" Condition="(
+                                $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('NuGet')) or
+                                $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('Newtonsoft')) or
+                                $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('Valleysoft'))
+                            ) and
+                            %(_AllNetContainerTaskDependencies.NuGetIsFrameworkReference) != true" />
+
+            <!-- root folder -->
+            <Content Include="README.md" Pack="true" PackagePath="" />
+
             <!-- tasks folder -->
             <!-- net7.0 tasks -->
             <!-- dependencies -->
-            <Content Include="$(OutDir)Valleysoft.DockerCredsProvider.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
-            <Content Include="$(OutDir)NuGet.*.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
-            <Content Include="$(OutDir)Newtonsoft.Json.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
-            <Content Include="$(OutDir)Microsoft.DotNet.Cli.Utils.dll" Pack="true" PackagePath="tasks/$(TargetFramework)" />
+            <Content Include="@(NecessaryNetContainerTaskDependencies)" Pack="true" PackagePath="tasks/$(TargetFramework)/" />
+            <Content Include="@(DotNetCliUtilsLibraryOutput)" Pack="true" PackagePath="tasks/$(TargetFramework)/" />
+
             <!-- runtime deps json -->
             <Content Include="$(ArtifactsDir)bin/Microsoft.NET.Build.Containers/$(Configuration)/$(TargetFramework)/Microsoft.NET.Build.Containers.deps.json" Pack="true" PackagePath="tasks/$(TargetFramework)" />
             <!-- actual DLL  -->
             <Content Include="@(ContainerLibraryOutput)" Pack="true" PackagePath="tasks/$(TargetFramework)/" />
-
-            <!-- net472 tasks -->
-            <!-- dependencies -->
-            <Content Include="@(NecessaryNet472ContainerTaskDependencies)" Pack="true" PackagePath="tasks/$(VSCompatTargetFramework)/" Condition="'$(DotNetBuildFromSource)' != 'true'" />
-            <!-- runtime deps json isn't valid for netfx -->
-            <!-- actual DLL  -->
-            <Content Include="@(ContainerLibraryOutputNet472)" Pack="true" PackagePath="tasks/$(VSCompatTargetFramework)/" Condition="'$(DotNetBuildFromSource)' != 'true'" />
 
             <!-- build folder -->
             <Content Include="build/**" Pack="true" PackagePath="build/" />

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -207,7 +207,8 @@
     <MSBuild
       Targets="Publish"
       Projects="$(RepoRoot)/src/Containers/containerize/containerize.csproj"
-      Properties="Configuration=$(Configuration);PublishDir=$(OutputPath)/Containers/containerize" />
+      Properties="Configuration=$(Configuration);PublishDir=$(OutputPath)/Containers/containerize"
+      Condition="'$(DotNetBuildFromSource)' != 'true'" />
   </Target>
   
   <Target Name="PublishBuiltInTools"

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.IO.Compression;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.DotNet.Cli.Utils;
+using Xunit;
+
+namespace Microsoft.NET.Build.Containers.IntegrationTests;
+
+public class PackageTests
+{
+    [Fact]
+    public void SanityTest_ContainerizeDependencies()
+    {
+        IReadOnlyList<string> knownPackageReferences = new List<string>()
+        {
+            "System.CommandLine"
+        };
+        IReadOnlyList<string> knownProjectReferences = new List<string>()
+        {
+            "..\\Microsoft.NET.Build.Containers\\Microsoft.NET.Build.Containers.csproj"
+        };
+
+        string projectFilePath = Path.Combine(TestContext.Current.TestExecutionDirectory, "Container", "ProjectFiles", "containerize.csproj");
+        XDocument project = XDocument.Load(projectFilePath);
+        XNamespace ns = project.Root?.Name.Namespace ?? throw new InvalidOperationException("Project file is empty");
+
+        IEnumerable<string?> packageReferences = project.Descendants().Where(element => element.Name.Equals(ns + "PackageReference")).Select(element => element.Attribute("Include")?.Value);
+        packageReferences.Should().BeEquivalentTo(knownPackageReferences, $"Known package references for containerize project are different from actual. Check if this is expected. If the new package reference is expected, add it to {nameof(knownPackageReferences)} and verify they are included to NuGet package in package.csproj correctly");
+
+        IEnumerable<string?> projectReferences = project.Descendants().Where(element => element.Name.Equals(ns + "ProjectReference")).Select(element => element.Attribute("Include")?.Value);
+        projectReferences.Should().BeEquivalentTo(knownProjectReferences, $"Known project references for containerize project are different from actual. Check if this is expected. If the new project reference is expected, add it to {nameof(knownProjectReferences)} and verify they are included to NuGet package in package.csproj correctly");
+    }
+
+    [Fact]
+    public void SanityTest_NET_Build_ContainersDependencies()
+    {
+        IReadOnlyList<string> knownPackageReferences = new List<string>()
+        {
+            "Microsoft.Build.Utilities.Core",
+            "Microsoft.CodeAnalysis.PublicApiAnalyzers",
+            "Nuget.Packaging",
+            "Valleysoft.DockerCredsProvider"
+        };
+        IReadOnlyList<string> knownProjectReferences = new List<string>()
+        {
+            "..\\..\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj"
+        };
+
+        string projectFilePath = Path.Combine(TestContext.Current.TestExecutionDirectory, "Container", "ProjectFiles", "Microsoft.NET.Build.Containers.csproj");
+        XDocument project = XDocument.Load(projectFilePath);
+        XNamespace ns = project.Root?.Name.Namespace ?? throw new InvalidOperationException("Project file is empty");
+
+        IEnumerable<string?> packageReferences = project.Descendants().Where(element => element.Name.Equals(ns + "PackageReference")).Select(element => element.Attribute("Include")?.Value);
+        packageReferences.Should().BeEquivalentTo(knownPackageReferences, $"Known package references for Microsoft.NET.Build.Containers project are different from actual. Check if this is expected. If the new package reference is expected, add it to {nameof(knownPackageReferences)} and verify they are included to NuGet package in package.csproj correctly");
+
+        IEnumerable<string?> projectReferences = project.Descendants().Where(element => element.Name.Equals(ns + "ProjectReference")).Select(element => element.Attribute("Include")?.Value);
+        projectReferences.Should().BeEquivalentTo(knownProjectReferences, $"Known project references for Microsoft.NET.Build.Containers project are different from actual. Check if this is expected. If the new project reference is expected, add it to {nameof(knownProjectReferences)} and verify they are included to NuGet package in package.csproj correctly");
+    }
+
+    [Fact]
+    public void PackageContentTest()
+    {
+        string ignoredZipFileEntriesPrefix = "package/services/metadata";
+
+        IReadOnlyList<string> packageContents = new List<string>()
+        {
+              "_rels/.rels",
+              "[Content_Types].xml",
+              "build/Microsoft.NET.Build.Containers.props",
+              "build/Microsoft.NET.Build.Containers.targets",
+              "containerize/containerize.dll",
+              "containerize/containerize.runtimeconfig.json",
+              "containerize/Microsoft.DotNet.Cli.Utils.dll",
+              "containerize/Microsoft.NET.Build.Containers.dll",
+              "containerize/Newtonsoft.Json.dll",
+              "containerize/NuGet.Common.dll",
+              "containerize/NuGet.Configuration.dll",
+              "containerize/NuGet.DependencyResolver.Core.dll",
+              "containerize/NuGet.Frameworks.dll",
+              "containerize/NuGet.LibraryModel.dll",
+              "containerize/NuGet.Packaging.dll",
+              "containerize/NuGet.ProjectModel.dll",
+              "containerize/NuGet.Protocol.dll",
+              "containerize/NuGet.Versioning.dll",
+              "containerize/System.CommandLine.dll",
+              "containerize/Valleysoft.DockerCredsProvider.dll",
+              "Icon.png",
+              "Microsoft.NET.Build.Containers.nuspec",
+              "README.md",
+              "tasks/net472/Microsoft.NET.Build.Containers.dll",
+              "tasks/net472/Newtonsoft.Json.dll",
+              "tasks/net472/NuGet.Common.dll",
+              "tasks/net472/NuGet.Configuration.dll",
+              "tasks/net472/NuGet.DependencyResolver.Core.dll",
+              "tasks/net472/NuGet.Frameworks.dll",
+              "tasks/net472/NuGet.LibraryModel.dll",
+              "tasks/net472/NuGet.Packaging.Core.dll",
+              "tasks/net472/NuGet.Packaging.dll",
+              "tasks/net472/NuGet.ProjectModel.dll",
+              "tasks/net472/NuGet.Protocol.dll",
+              "tasks/net472/NuGet.Versioning.dll",
+              "tasks/net7.0/Microsoft.DotNet.Cli.Utils.dll",
+              "tasks/net7.0/Microsoft.NET.Build.Containers.deps.json",
+              "tasks/net7.0/Microsoft.NET.Build.Containers.dll",
+              "tasks/net7.0/Newtonsoft.Json.dll",
+              "tasks/net7.0/NuGet.Common.dll",
+              "tasks/net7.0/NuGet.Configuration.dll",
+              "tasks/net7.0/NuGet.DependencyResolver.Core.dll",
+              "tasks/net7.0/NuGet.Frameworks.dll",
+              "tasks/net7.0/NuGet.LibraryModel.dll",
+              "tasks/net7.0/NuGet.Packaging.dll",
+              "tasks/net7.0/NuGet.ProjectModel.dll",
+              "tasks/net7.0/NuGet.Protocol.dll",
+              "tasks/net7.0/NuGet.Versioning.dll",
+              "tasks/net7.0/Valleysoft.DockerCredsProvider.dll"
+        };
+
+        string packageFilePath = Path.Combine(TestContext.Current.TestExecutionDirectory, "Container", "package", $"Microsoft.NET.Build.Containers.{Product.Version}.nupkg");
+        using ZipArchive archive = new(File.OpenRead(packageFilePath), ZipArchiveMode.Read, false);
+
+        archive.Entries
+                .Select(e => e.FullName)
+                .Where(e => !e.StartsWith(ignoredZipFileEntriesPrefix, StringComparison.InvariantCultureIgnoreCase))
+                .Should()
+                .BeEquivalentTo(packageContents, $"Microsoft.NET.Build.Containers.{Product.Version}.nupkg content differs from expected. Please add the entry to the list, if the addition is expected.");
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
@@ -114,6 +114,7 @@ public class PackageTests
               "tasks/net7.0/NuGet.Frameworks.dll",
               "tasks/net7.0/NuGet.LibraryModel.dll",
               "tasks/net7.0/NuGet.Packaging.dll",
+              "tasks/net7.0/NuGet.Packaging.Core.dll",
               "tasks/net7.0/NuGet.ProjectModel.dll",
               "tasks/net7.0/NuGet.Protocol.dll",
               "tasks/net7.0/NuGet.Versioning.dll",


### PR DESCRIPTION
fixes https://github.com/dotnet/sdk-container-builds/issues/440

excluded containerize from source-build. This CLI tool is only needed for full framework version of MSBuild task.

Furthermore, the PR changes how packaging for containers works. Previously it was relying on containerize outputs, now it can work independently.

Also PR adds sanity tests for packages changing. I hope they will help us to avoid the problems in future.