### PR TITLE
Rename GenAPI IncludeVisibleOutsideOfAssembly

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
@@ -50,9 +50,9 @@ namespace Microsoft.DotNet.GenAPI.Task
         public string[]? ExcludeAttributesFiles { get; set; }
 
         /// <summary>
-        /// Include internal API's. Default is false.
+        /// If true, includes both internal and public API.
         /// </summary>
-        public bool IncludeVisibleOutsideOfAssembly { get; set; }
+        public bool RespectInternals { get; set; }
 
         /// <summary>
         /// Includes assembly attributes which are values that provide information about an assembly.
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.GenAPI.Task
                 ExceptionMessage,
                 ExcludeApiFiles,
                 ExcludeAttributesFiles,
-                IncludeVisibleOutsideOfAssembly,
+                RespectInternals,
                 IncludeAssemblyAttributes
             ));
         }

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -1,5 +1,6 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
+
   <PropertyGroup>
     <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
     <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and Exists('$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.DotNet.GenAPI.Task.dll')">$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
@@ -49,9 +50,10 @@
       ExceptionMessage="$(GenAPIExceptionMessage)"
       ExcludeApiFiles="@(GenAPIExcludeApiList)"
       ExcludeAttributesFiles="@(GenAPIExcludeAttributesList)"
-      IncludeVisibleOutsideOfAssembly="$(GenAPIIncludeVisibleOutsideOfAssembly)"
+      RespectInternals="$(GenAPIRespectInternals)"
       IncludeAssemblyAttributes="$(GenAPIIncludeAssemblyAttributes)" />
 
     <Message Text="Generated reference assembly source code: $(GenAPITargetPath)" Importance="$(GenAPIVerbosity)" />
   </Target>
+
 </Project>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
@@ -56,8 +56,8 @@ namespace Microsoft.DotNet.GenAPI.Tool
             Option<string?> exceptionMessageOption = new("--exception-message",
                 "If specified - method bodies should throw PlatformNotSupportedException, else `throw null`.");
 
-            Option<bool> includeVisibleOutsideOfAssemblyOption = new("--include-visible-outside",
-                "Include internal API's. Default is false.");
+            Option<bool> respectInternalsOption = new("--respect-internals",
+                "If true, includes both internal and public API.");
 
             Option<bool> includeAssemblyAttributesOption = new("--include-assembly-attributes",
                 "Includes assembly attributes which are values that provide information about an assembly. Default is false.");
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.GenAPI.Tool
             rootCommand.AddGlobalOption(outputPathOption);
             rootCommand.AddGlobalOption(headerFileOption);
             rootCommand.AddGlobalOption(exceptionMessageOption);
-            rootCommand.AddGlobalOption(includeVisibleOutsideOfAssemblyOption);
+            rootCommand.AddGlobalOption(respectInternalsOption);
             rootCommand.AddGlobalOption(includeAssemblyAttributesOption);
 
             rootCommand.SetHandler((InvocationContext context) =>
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.GenAPI.Tool
                     context.ParseResult.GetValue(exceptionMessageOption),
                     context.ParseResult.GetValue(excludeApiFilesOption),
                     context.ParseResult.GetValue(excludeAttributesFilesOption),
-                    context.ParseResult.GetValue(includeVisibleOutsideOfAssemblyOption),
+                    context.ParseResult.GetValue(respectInternalsOption),
                     context.ParseResult.GetValue(includeAssemblyAttributesOption)
                 ));
             });

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.GenAPI
                 string? exceptionMessage,
                 string[]? excludeApiFiles,
                 string[]? excludeAttributesFiles,
-                bool includeVisibleOutsideOfAssembly,
+                bool respectInternals,
                 bool includeAssemblyAttributes)
             {
                 Assemblies = assemblies;
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.GenAPI
                 ExceptionMessage = exceptionMessage;
                 ExcludeApiFiles = excludeApiFiles;
                 ExcludeAttributesFiles = excludeAttributesFiles;
-                IncludeVisibleOutsideOfAssembly = includeVisibleOutsideOfAssembly;
+                RespectInternals = respectInternals;
                 IncludeAssemblyAttributes = includeAssemblyAttributes;
             }
 
@@ -79,9 +79,9 @@ namespace Microsoft.DotNet.GenAPI
             public string[]? ExcludeAttributesFiles { get; }
 
             /// <summary>
-            /// Include internal API's. Default is false.
+            /// If true, includes both internal and public API.
             /// </summary>
-            public bool IncludeVisibleOutsideOfAssembly { get; }
+            public bool RespectInternals { get; }
 
             /// <summary>
             /// Includes assembly attributes which are values that provide information about an assembly.
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.GenAPI
         {
             bool resolveAssemblyReferences = context.AssemblyReferences?.Length > 0;
 
-            IAssemblySymbolLoader loader = new AssemblySymbolLoader(resolveAssemblyReferences, context.IncludeVisibleOutsideOfAssembly);
+            IAssemblySymbolLoader loader = new AssemblySymbolLoader(resolveAssemblyReferences, context.RespectInternals);
 
             if (context.AssemblyReferences is not null)
             {
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.GenAPI
             CompositeSymbolFilter compositeSymbolFilter = new CompositeSymbolFilter()
                 .Add(new ImplicitSymbolFilter())
                 .Add(new AccessibilitySymbolFilter(
-                    context.IncludeVisibleOutsideOfAssembly,
+                    context.RespectInternals,
                     includeEffectivelyPrivateSymbols: true,
                     includeExplicitInterfaceImplementationSymbols: true));
 

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoader.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoader.cs
@@ -41,13 +41,13 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         /// <summary>
         /// Creates a new instance of the <see cref="AssemblySymbolLoader"/> class.
         /// </summary>
-        /// <param name="resolveAssemblyReferences">True to attempt to load references for loaded assemblies from the locations specified with <see cref="AddReferenceSearchPaths(string[])"/>.  Default is false.</param>
-        /// <param name="includeInternals">True to include all internal metadata for assemblies loaded.  Default is false which only includes public and some internal metadata.  <seealso cref="MetadataImportOptions"/></param>
-        public AssemblySymbolLoader(bool resolveAssemblyReferences = false, bool includeInternals = false)
+        /// <param name="resolveAssemblyReferences">True to attempt to load references for loaded assemblies from the locations specified with <see cref="AddReferenceSearchPaths(string[])"/>. Default is false.</param>
+        /// <param name="includeInternalSymbols">True to include all internal metadata for assemblies loaded. Default is false which only includes public and some internal metadata. <seealso cref="MetadataImportOptions"/></param>
+        public AssemblySymbolLoader(bool resolveAssemblyReferences = false, bool includeInternalSymbols = false)
         {
             _loadedAssemblies = new Dictionary<string, MetadataReference>();
             CSharpCompilationOptions compilationOptions = new(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable,
-                metadataImportOptions: includeInternals ? MetadataImportOptions.Internal : MetadataImportOptions.Public);
+                metadataImportOptions: includeInternalSymbols ? MetadataImportOptions.Internal : MetadataImportOptions.Public);
             _cSharpCompilation = CSharpCompilation.Create($"AssemblyLoader_{DateTime.Now:MM_dd_yy_HH_mm_ss_FFF}", options: compilationOptions);
             _resolveReferences = resolveAssemblyReferences;
         }

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoaderFactory.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoaderFactory.cs
@@ -8,18 +8,18 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
     /// </summary>
     public sealed class AssemblySymbolLoaderFactory : IAssemblySymbolLoaderFactory
     {
-        private readonly bool _includeInternals;
+        private readonly bool _includeInternalSymbols;
 
         /// <summary>
         /// Creates a new AssemblySymbolLoaderFactory
         /// </summary>
-        /// <param name="includeInternals">True to include internal API when reading assemblies from the <see cref="AssemblySymbolLoader"/> created.</param>
-        public AssemblySymbolLoaderFactory(bool includeInternals = false)
+        /// <param name="includeInternalSymbols">True to include internal API when reading assemblies from the <see cref="AssemblySymbolLoader"/> created.</param>
+        public AssemblySymbolLoaderFactory(bool includeInternalSymbols = false)
         {
-            _includeInternals = includeInternals;
+            _includeInternalSymbols = includeInternalSymbols;
         }
 
         /// <inheritdoc />
-        public IAssemblySymbolLoader Create(bool shouldResolveReferences) => new AssemblySymbolLoader(shouldResolveReferences, _includeInternals);
+        public IAssemblySymbolLoader Create(bool shouldResolveReferences) => new AssemblySymbolLoader(shouldResolveReferences, _includeInternalSymbols);
     }
 }

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
@@ -53,8 +53,8 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
             }
         }
 
-        public static bool IsEffectivelySealed(this ITypeSymbol type, bool includeInternals) =>
-            type.IsSealed || !HasVisibleConstructor(type, includeInternals);
+        public static bool IsEffectivelySealed(this ITypeSymbol type, bool includeInternalSymbols) =>
+            type.IsSealed || !HasVisibleConstructor(type, includeInternalSymbols);
 
         /// <summary>
         /// Determines where the symbol is the explicit interface implementation method or property.
@@ -65,13 +65,13 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
             symbol is IMethodSymbol method && method.MethodKind == MethodKind.ExplicitInterfaceImplementation ||
             symbol is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsEmpty;
 
-        private static bool HasVisibleConstructor(ITypeSymbol type, bool includeInternals)
+        private static bool HasVisibleConstructor(ITypeSymbol type, bool includeInternalSymbols)
         {
             if (type is INamedTypeSymbol namedType)
             {
                 foreach (IMethodSymbol constructor in namedType.Constructors)
                 {
-                    if (!constructor.IsStatic && constructor.IsVisibleOutsideOfAssembly(includeInternals, includeEffectivelyPrivateSymbols: true))
+                    if (!constructor.IsStatic && constructor.IsVisibleOutsideOfAssembly(includeInternalSymbols, includeEffectivelyPrivateSymbols: true))
                         return true;
                 }
             }
@@ -94,17 +94,17 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         }
 
         public static bool IsVisibleOutsideOfAssembly(this ISymbol symbol,
-            bool includeInternals,
+            bool includeInternalSymbols,
             bool includeEffectivelyPrivateSymbols = false,
             bool includeExplicitInterfaceImplementationSymbols = false) =>
             symbol.DeclaredAccessibility switch
             {
                 Accessibility.Public => true,
-                Accessibility.Protected => includeEffectivelyPrivateSymbols || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternals),
-                Accessibility.ProtectedOrInternal => includeEffectivelyPrivateSymbols || includeInternals || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternals),
-                Accessibility.ProtectedAndInternal => includeInternals && (includeEffectivelyPrivateSymbols || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternals)),
+                Accessibility.Protected => includeEffectivelyPrivateSymbols || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternalSymbols),
+                Accessibility.ProtectedOrInternal => includeEffectivelyPrivateSymbols || includeInternalSymbols || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternalSymbols),
+                Accessibility.ProtectedAndInternal => includeInternalSymbols && (includeEffectivelyPrivateSymbols || symbol.ContainingType == null || !IsEffectivelySealed(symbol.ContainingType, includeInternalSymbols)),
                 Accessibility.Private => includeExplicitInterfaceImplementationSymbols && IsExplicitInterfaceImplementation(symbol),
-                _ => includeInternals,
+                _ => includeInternalSymbols,
             };
 
         public static bool IsEventAdderOrRemover(this IMethodSymbol method) =>

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 compositeFilter, stringWriter, null, false, MetadataReferences);
 
             using Stream assemblyStream = SymbolFactory.EmitAssemblyStreamFromSyntax(original, enableNullable: true, allowUnsafe: allowUnsafe, assemblyName: assemblyName);
-            AssemblySymbolLoader assemblySymbolLoader = new AssemblySymbolLoader(resolveAssemblyReferences:true, includeInternals: includeInternalSymbols);
+            AssemblySymbolLoader assemblySymbolLoader = new AssemblySymbolLoader(resolveAssemblyReferences: true, includeInternalSymbols: includeInternalSymbols);
             assemblySymbolLoader.AddReferenceSearchPaths(typeof(object).Assembly!.Location!);            
             IAssemblySymbol assemblySymbol = assemblySymbolLoader.LoadAssembly(assemblyName, assemblyStream);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/32258

There's only a single GenAPI consumer yet which is SBRP which doesn't use this option. "IncludeVisibleOutsideOfAssembly" -> "RespectInternals" (which is already used and exposed by APICompat).

Also change "includeInternals" to "includeInternalSymbols" which is used in most cases already.

This consolidates frontends to use the "respectInternals" name while the backend libraries use the "includeInternalSymbols" name.