### PR TITLE
[APICompat - PackageValidation] Enable baseline assembly references

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
@@ -69,7 +69,8 @@ namespace Microsoft.DotNet.ApiCompat
                     enableStrictMode: enableStrictModeForBaselineValidation,
                     enqueueApiCompatWorkItems: runApiCompat,
                     executeApiCompatWorkItems: false,
-                    baselinePackage: Package.Create(baselinePackagePath, baselinePackageAssemblyReferences)));
+                    // Use the current package assembly references if baseline package assembly references aren't provided.
+                    baselinePackage: Package.Create(baselinePackagePath, baselinePackageAssemblyReferences ?? packageAssemblyReferences)));
             }
 
             if (runApiCompat)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
@@ -69,8 +69,7 @@ namespace Microsoft.DotNet.ApiCompat
                     enableStrictMode: enableStrictModeForBaselineValidation,
                     enqueueApiCompatWorkItems: runApiCompat,
                     executeApiCompatWorkItems: false,
-                    // Use the current package assembly references if baseline package assembly references aren't provided.
-                    baselinePackage: Package.Create(baselinePackagePath, baselinePackageAssemblyReferences ?? packageAssemblyReferences)));
+                    baselinePackage: Package.Create(baselinePackagePath, baselinePackageAssemblyReferences)));
             }
 
             if (runApiCompat)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
@@ -115,10 +115,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
             ApiCompatRunnerOptions options,
             out bool resolvedExternallyProvidedAssemblyReferences)
         {
-            // In order to enable reference support for baseline suppression we need a better way
-            // to resolve references for the baseline package. Let's not enable it for now.
             string[] aggregatedReferences = metadataInformation.Where(m => m.References != null).SelectMany(m => m.References!).Distinct().ToArray();
-            resolvedExternallyProvidedAssemblyReferences = !options.IsBaselineComparison && aggregatedReferences.Length > 0;
+            resolvedExternallyProvidedAssemblyReferences = aggregatedReferences.Length > 0;
 
             IAssemblySymbolLoader loader = _assemblySymbolLoaderFactory.Create(resolvedExternallyProvidedAssemblyReferences);
             if (resolvedExternallyProvidedAssemblyReferences)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
@@ -46,13 +46,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
 
             foreach (ApiCompatRunnerWorkItem workItem in _workItems)
             {
-                IReadOnlyList<ElementContainer<IAssemblySymbol>> leftContainerList = CreateAssemblySymbols(workItem.Left, out bool resolvedExternallyProvidedAssemblyReferences);
+                IReadOnlyList<ElementContainer<IAssemblySymbol>> leftContainerList = CreateAssemblySymbols(workItem.Left, workItem.Options, out bool resolvedExternallyProvidedAssemblyReferences);
                 bool runWithReferences = resolvedExternallyProvidedAssemblyReferences;
 
                 List<IEnumerable<ElementContainer<IAssemblySymbol>>> rightContainersList = new(workItem.Right.Count);
                 foreach (IReadOnlyList<MetadataInformation> right in workItem.Right)
                 {
-                    IReadOnlyList<ElementContainer<IAssemblySymbol>> rightContainers = CreateAssemblySymbols(right.ToImmutableArray(), out resolvedExternallyProvidedAssemblyReferences);
+                    IReadOnlyList<ElementContainer<IAssemblySymbol>> rightContainers = CreateAssemblySymbols(right.ToImmutableArray(), workItem.Options, out resolvedExternallyProvidedAssemblyReferences);
                     rightContainersList.Add(rightContainers);
                     runWithReferences &= resolvedExternallyProvidedAssemblyReferences;
                 }
@@ -112,6 +112,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
         }
 
         private IReadOnlyList<ElementContainer<IAssemblySymbol>> CreateAssemblySymbols(IReadOnlyList<MetadataInformation> metadataInformation,
+            ApiCompatRunnerOptions options,
             out bool resolvedExternallyProvidedAssemblyReferences)
         {
             string[] aggregatedReferences = metadataInformation.Where(m => m.References != null).SelectMany(m => m.References!).Distinct().ToArray();

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
@@ -46,13 +46,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
 
             foreach (ApiCompatRunnerWorkItem workItem in _workItems)
             {
-                IReadOnlyList<ElementContainer<IAssemblySymbol>> leftContainerList = CreateAssemblySymbols(workItem.Left, workItem.Options, out bool resolvedExternallyProvidedAssemblyReferences);
+                IReadOnlyList<ElementContainer<IAssemblySymbol>> leftContainerList = CreateAssemblySymbols(workItem.Left, out bool resolvedExternallyProvidedAssemblyReferences);
                 bool runWithReferences = resolvedExternallyProvidedAssemblyReferences;
 
                 List<IEnumerable<ElementContainer<IAssemblySymbol>>> rightContainersList = new(workItem.Right.Count);
                 foreach (IReadOnlyList<MetadataInformation> right in workItem.Right)
                 {
-                    IReadOnlyList<ElementContainer<IAssemblySymbol>> rightContainers = CreateAssemblySymbols(right.ToImmutableArray(), workItem.Options, out resolvedExternallyProvidedAssemblyReferences);
+                    IReadOnlyList<ElementContainer<IAssemblySymbol>> rightContainers = CreateAssemblySymbols(right.ToImmutableArray(), out resolvedExternallyProvidedAssemblyReferences);
                     rightContainersList.Add(rightContainers);
                     runWithReferences &= resolvedExternallyProvidedAssemblyReferences;
                 }
@@ -112,7 +112,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
         }
 
         private IReadOnlyList<ElementContainer<IAssemblySymbol>> CreateAssemblySymbols(IReadOnlyList<MetadataInformation> metadataInformation,
-            ApiCompatRunnerOptions options,
             out bool resolvedExternallyProvidedAssemblyReferences)
         {
             string[] aggregatedReferences = metadataInformation.Where(m => m.References != null).SelectMany(m => m.References!).Distinct().ToArray();

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/ApiCompatRunnerExtensions.cs
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/ApiCompatRunnerExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.DotNet.ApiCompatibility;
 using Microsoft.DotNet.ApiCompatibility.Logging;
@@ -25,19 +26,13 @@ namespace Microsoft.DotNet.PackageValidation
             Package leftPackage,
             Package? rightPackage = null)
         {
+            Debug.Assert(leftContentItems.Count > 0);
+            Debug.Assert(rightContentItems.Count > 0);
+
             // Don't enqueue duplicate items (if no right package is supplied and items match)
-            if (rightPackage == null && ContentItemCollectionEquals(leftContentItems, rightContentItems))
+            if (rightPackage is null && ContentItemCollectionEquals(leftContentItems, rightContentItems))
             {
                 return;
-            }
-
-            MetadataInformation[] left = new MetadataInformation[leftContentItems.Count];
-            for (int leftIndex = 0; leftIndex < leftContentItems.Count; leftIndex++)
-            {
-                left[leftIndex] = GetMetadataInformation(log,
-                    leftPackage,
-                    leftContentItems[leftIndex],
-                    options.IsBaselineComparison ? Resources.Baseline + " " + leftContentItems[leftIndex].Path : null);
             }
 
             MetadataInformation[] right = new MetadataInformation[rightContentItems.Count];
@@ -48,30 +43,46 @@ namespace Microsoft.DotNet.PackageValidation
                     rightContentItems[rightIndex]);
             }
 
+            MetadataInformation[] left = new MetadataInformation[leftContentItems.Count];
+            for (int leftIndex = 0; leftIndex < leftContentItems.Count; leftIndex++)
+            {
+                left[leftIndex] = GetMetadataInformation(log,
+                    leftPackage,
+                    leftContentItems[leftIndex],
+                    displayString: options.IsBaselineComparison ? Resources.Baseline + " " + leftContentItems[leftIndex].Path : null,
+                    // Use the assembly references from the right package if the left package doesn't provide them.
+                    assemblyReferences: rightPackage is not null ? right[right.Length > leftIndex ? leftIndex : 0].References : null);
+            }
+
             apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, options, right));
         }
 
         private static MetadataInformation GetMetadataInformation(ISuppressableLog log,
             Package package,
             ContentItem item,
-            string? displayString = null)
+            string? displayString = null,
+            IEnumerable<string>? assemblyReferences = null)
         {
             displayString ??= item.Path;
-            string[]? assemblyReferences = null;
 
             if (item.Properties.TryGetValue("tfm", out object? tfmObj))
             {
-                // Find the nearest set of assembly references for the package item (assembly).
-                NuGetFramework targetFramework = ((NuGetFramework)tfmObj);
-                assemblyReferences = package.FindBestAssemblyReferencesForFramework(targetFramework);
+                string targetFramework = ((NuGetFramework)tfmObj).GetShortFolderName();
 
-                if (package.AssemblyReferences != null && assemblyReferences is null)
+                if (package.AssemblyReferences != null)
                 {
-                    log.LogWarning(new Suppression(DiagnosticIds.SearchDirectoriesNotFoundForTfm) { Target = displayString },
-                        DiagnosticIds.SearchDirectoriesNotFoundForTfm,
-                        string.Format(Resources.MissingSearchDirectory,
-                            targetFramework.GetShortFolderName(),
-                            displayString));
+                    if (package.AssemblyReferences.TryGetValue(targetFramework, out string[]? assemblyReferencesRaw))
+                    {
+                        assemblyReferences = assemblyReferencesRaw;
+                    }
+                    else
+                    {
+                        log.LogWarning(new Suppression(DiagnosticIds.SearchDirectoriesNotFoundForTfm) { Target = displayString },
+                           DiagnosticIds.SearchDirectoriesNotFoundForTfm,
+                           string.Format(Resources.MissingSearchDirectory,
+                               targetFramework,
+                               displayString));
+                    }
                 }
             }
 

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/ApiCompatRunnerExtensions.cs
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/ApiCompatRunnerExtensions.cs
@@ -61,14 +61,16 @@ namespace Microsoft.DotNet.PackageValidation
 
             if (item.Properties.TryGetValue("tfm", out object? tfmObj))
             {
-                string targetFramework = ((NuGetFramework)tfmObj).GetShortFolderName();
+                // Find the nearest set of assembly references for the package item (assembly).
+                NuGetFramework targetFramework = ((NuGetFramework)tfmObj);
+                assemblyReferences = package.FindBestAssemblyReferencesForFramework(targetFramework);
 
-                if (package.AssemblyReferences != null && !package.AssemblyReferences.TryGetValue(targetFramework, out assemblyReferences))
+                if (package.AssemblyReferences != null && assemblyReferences is null)
                 {
                     log.LogWarning(new Suppression(DiagnosticIds.SearchDirectoriesNotFoundForTfm) { Target = displayString },
                         DiagnosticIds.SearchDirectoriesNotFoundForTfm,
                         string.Format(Resources.MissingSearchDirectory,
-                            targetFramework,
+                            targetFramework.GetShortFolderName(),
                             displayString));
                 }
             }

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.PackageValidation
         }
 
         /// <summary>
-        /// Finds the best compile time assset for a specific framework.
+        /// Finds the best compile time asset for a specific framework.
         /// </summary>
         /// <param name="framework">The framework where the package needs to be installed.</param>
         /// <returns>A ContentItem representing the best compile time asset.</returns>
@@ -223,6 +223,24 @@ namespace Microsoft.DotNet.PackageValidation
             return items != null ?
                 new ReadOnlyCollection<ContentItem>(items) :
                 null;
+        }
+
+        /// <summary>
+        /// Finds the best assembly references for a specific framework.
+        /// </summary>
+        /// <param name="framework">The framework where the package needs to be installed.</param>
+        /// <returns>The assembly references for the specified framework.</returns>
+        public string[]? FindBestAssemblyReferencesForFramework(NuGetFramework framework)
+        {
+            if (AssemblyReferences is null)
+                return null;
+
+            string? nearestTfm = NuGetFrameworkUtility.GetNearest(AssemblyReferences.Keys, framework, (key) => NuGetFramework.ParseFolder(key));
+
+            if (nearestTfm is null || !AssemblyReferences.TryGetValue(nearestTfm, out string[]? assemblyReferences))
+                return null;
+
+            return assemblyReferences;
         }
     }
 }

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
@@ -224,23 +224,5 @@ namespace Microsoft.DotNet.PackageValidation
                 new ReadOnlyCollection<ContentItem>(items) :
                 null;
         }
-
-        /// <summary>
-        /// Finds the best assembly references for a specific framework.
-        /// </summary>
-        /// <param name="framework">The framework where the package needs to be installed.</param>
-        /// <returns>The assembly references for the specified framework.</returns>
-        public string[]? FindBestAssemblyReferencesForFramework(NuGetFramework framework)
-        {
-            if (AssemblyReferences is null)
-                return null;
-
-            string? nearestTfm = NuGetFrameworkUtility.GetNearest(AssemblyReferences.Keys, framework, (key) => NuGetFramework.ParseFolder(key));
-
-            if (nearestTfm is null || !AssemblyReferences.TryGetValue(nearestTfm, out string[]? assemblyReferences))
-                return null;
-
-            return assemblyReferences;
-        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/32922, https://github.com/dotnet/sdk/issues/18676, https://github.com/dotnet/sdk/issues/31271

If assembly references aren't provided for the baseline package via the MSBuild task or the CLI frontend, use the current package's assembly references as an approximation.

As current assembly references are grouped by TFMs, use the nearest compatible TFM for which assembly references are provided. This guarantees that assembly references from current are used even if TFMs don't match.

@ericstj what do you think about the assembly reference change related to picking the nearest compatible TFM? Do we want a baseline package with a `lib/net7.0/a.dll` asset to use the assembly references from the current package `lib/net8.0/a.dll` asset? Note that the current assembly symbol loader ignored versions.