### PR TITLE
Enable interceptors compiler feature when RDG is enabled

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -42,6 +42,7 @@ namespace Microsoft.NET.Build.Tests
                 });
 
             VerifyRequestDelegateGeneratorIsUsed(asset, isEnabled);
+            VerifyInterceptorsFeatureEnabled(asset, isEnabled);
         }
 
         [Fact]
@@ -57,6 +58,7 @@ namespace Microsoft.NET.Build.Tests
                 });
 
             VerifyRequestDelegateGeneratorIsUsed(asset, expectEnabled: true);
+            VerifyInterceptorsFeatureEnabled(asset, expectEnabled: true);
         }
 
         private void VerifyRequestDelegateGeneratorIsUsed(TestAsset asset, bool? expectEnabled)
@@ -76,6 +78,25 @@ namespace Microsoft.NET.Build.Tests
             var analyzers = command.GetValues();
 
             Assert.Equal(expectEnabled ?? false, analyzers.Any(analyzer => analyzer.Contains("Microsoft.AspNetCore.Http.RequestDelegateGenerator.dll")));
+        }
+
+        private void VerifyInterceptorsFeatureEnabled(TestAsset asset, bool? expectEnabled)
+        {
+            var command = new GetValuesCommand(
+                Log,
+                asset.Path,
+                ToolsetInfo.CurrentTargetFramework,
+                "Features",
+                GetValuesCommand.ValueType.Property);
+
+            command
+                .WithWorkingDirectory(asset.Path)
+                .Execute()
+                .Should().Pass();
+
+            var features = command.GetValues();
+
+            Assert.Equal(expectEnabled ?? false, features.Any(feature => feature.Contains("InterceptorsPreview")));
         }
 
         [Theory]

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.BeforeCommon.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.BeforeCommon.targets
@@ -16,5 +16,5 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Enable EventSource support because it is disabled by default in aot'd apps. -->
     <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">true</EventSourceSupport>
   </PropertyGroup>
-  
+
 </Project>

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -58,6 +58,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableConfigurationBindingGenerator Condition="'$(EnableConfigurationBindingGenerator)' == ''">true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 
+  <!-- Enable the interceptors compiler feature by default for projects that use the RequestDelegateGenerator. -->
+  <PropertyGroup Condition="'$(EnableRequestDelegateGenerator)' == 'true'">
+    <Features>$(Features);InterceptorsPreview</Features>
+  </PropertyGroup>
+
   <!--
     Newer versions of Visual Studio ship the designtime related properties in a targets file and all future design time only elements should be added there. If that file does not
     exist, it falls back to the default set of values defined here.


### PR DESCRIPTION
The interceptors compiler feature will be hidden behind a compiler feature flag. To smooth out the user experience, we want to automatically enable this feature flag to projects that are using the RequestDelegateGenerator.

Although the interceptors feature is not in, it's necessary to get this code change in first so that we can flow a version of the SDK that enables this feature flag into the repo once the interceptors implementation lands.