### PR TITLE
Explicitly enable BF for WinForms and WPF in Microsoft.NET.Sdk.targets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -165,6 +165,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- controls warn as error -->
     <_BinaryFormatterObsoleteAsError>true</_BinaryFormatterObsoleteAsError>
     <!-- controls runtime behavior (AppContext & trimming) -->
+    <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == '' AND '$(_ProjectTypeRequiresBinaryFormatter)' == 'true'">true</EnableUnsafeBinaryFormatterSerialization>
     <EnableUnsafeBinaryFormatterSerialization Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) AND '$(_ProjectTypeRequiresBinaryFormatter)' != 'true'">false</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/sdk/issues/32941.

The _\*.runtimeconfig.json_ files are being picked up from the shared framework builds and included as part of the .NET 8 installers. Since the shared framework is itself not a WinForms or WPF application, it results in "explicitly disable BF" being hardcoded into the config file, which is then distributed to customers' machines via the installer. This is resulting in BF disablement for _all_ project types starting with Preview 5, even though that was not our intent.

The proposed fix here special-cases WinForms and WPF within the .targets file where we made the initial change, and it forces those project types to re-enable BF if the developer has not set a different value in the .csproj. One downside of this change is that if a WinForms or WPF application is published against .NET 8, the "enable BF" policy will be carried within that app's _runtimeconfig.json_ file, which means that if the app is rolled forward it won't honor the .NET 9 "disabled absolutely everywhere" default setting once that change is checked in. But after talking with some folks here, that seems like an acceptable risk to unblock this scenario.