### PR TITLE
ApiCompat log breaking changes footer as error

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -45,8 +45,7 @@ namespace Microsoft.DotNet.ApiCompat
             {
                 if (!generateSuppressionFile)
                 {
-                    log.LogMessage(MessageImportance.High,
-                        Resources.BreakingChangesFoundRegenerateSuppressionFileCommandHelp);
+                    log.LogError(Resources.BreakingChangesFoundRegenerateSuppressionFileCommandHelp);
                 }
             }
             else


### PR DESCRIPTION
When breaking changes are found in APICompat, log the message as an error instead of with high importance as otherwise the message would be lost in the build log. Errors are propagated into the build summary when using msbuild.