### PR TITLE
Set PlatformName and other properties early enough in outer build

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -32,7 +32,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultAssemblyInfo.targets" Condition="'$(UsingNETSdkDefaults)' == 'true'"/>
 
   <!--
-    Apply the same default output paths as Microsoft.Common.targets now since we're running before them,
+    Apply these defaults from Microsoft.Common.CurrentVersion.targets now since we're running before them,
     but need to adjust them and/or make decisions in terms of them.
    -->
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets
@@ -11,6 +11,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!--
+    Apply these defaults from Microsoft.Common.CurrentVersion.targets now since we're running before them,
+    but need to adjust them and/or make decisions in terms of them.
+   -->
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
+    <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
+  </PropertyGroup>
+  
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultAssemblyInfo.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultOutputPaths.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Workloads.CrossTargeting.targets" />


### PR DESCRIPTION
Fix #32971

As part of the support for the artifacts output path format (#31454), I moved setting default values for `Configuration`, `Platform`, and `PlatformName` from `Microsoft.NET.DefaultOutputPaths.targets` to `Microsoft.NET.Sdk.BeforeCommon.targets`.

I missed that `Microsoft.NET.DefaultOutputPaths.targets` was also imported from `Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets`, so these properties were not defaulted correctly in the outer build anymore.  This resulted in the `OutputPath` for the outer build having a doubled backslash in it, which impacted NuGet pack scenarios.

This copies the defaults for those properties to `Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets`, fixing the issue.