### PR TITLE
Do not fail dotnet watch on workspace errors

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationWorkspaceProvider.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationWorkspaceProvider.cs
@@ -41,14 +41,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                 workspace.WorkspaceFailed += (_sender, diag) =>
                 {
-                    if (diag.Diagnostic.Kind == WorkspaceDiagnosticKind.Warning)
-                    {
-                        reporter.Verbose($"MSBuildWorkspace warning: {diag.Diagnostic}");
-                    }
-                    else
-                    {
-                        taskCompletionSource.TrySetException(new ApplicationException($"Failed to create MSBuildWorkspace: {diag.Diagnostic}"));
-                    }
+                    // Errors reported here are not fatal, an exception would be thrown for fatal issues.
+                    reporter.Verbose($"MSBuildWorkspace warning: {diag.Diagnostic}");
                 };
 
                 await workspace.OpenProjectAsync(projectPath, cancellationToken: cancellationToken);


### PR DESCRIPTION
Report all workspace diagnostics only in `--verbose` mode. Any significant issues with incorrectly formed projects would be reported by `dotnet build` before we load the workspace.

Fixes https://github.com/dotnet/sdk/issues/28998