### PR TITLE
Log success or error only for error suppressions

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.ApiCompat
         /// </summary>
         public static void LogApiCompatSuccessOrFailure(bool generateSuppressionFile, ISuppressableLog log)
         {
-            if (log.HasLoggedSuppressions)
+            if (log.HasLoggedErrorSuppressions)
             {
                 if (!generateSuppressionFile)
                 {

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/SuppressableMSBuildLog.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/SuppressableMSBuildLog.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.ApiCompat.Task
         private readonly ISuppressionEngine _suppressionEngine;
 
         /// <inheritdoc />
-        public bool HasLoggedSuppressions { get; private set; }
+        public bool HasLoggedErrorSuppressions { get; private set; }
 
         public SuppressableMSBuildLog(NET.Build.Tasks.Logger log,
             ISuppressionEngine suppressionEngine)
@@ -29,8 +29,8 @@ namespace Microsoft.DotNet.ApiCompat.Task
             if (_suppressionEngine.IsErrorSuppressed(suppression))
                 return false;
 
-            HasLoggedSuppressions = true;
-            base.LogError(code, message);
+            HasLoggedErrorSuppressions = true;
+            LogError(code, message);
 
             return true;
         }
@@ -41,8 +41,7 @@ namespace Microsoft.DotNet.ApiCompat.Task
             if (_suppressionEngine.IsErrorSuppressed(suppression))
                 return false;
 
-            HasLoggedSuppressions = true;
-            base.LogWarning(code, message);
+            LogWarning(code, message);
 
             return true;
         }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/SuppressableConsoleLog.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/SuppressableConsoleLog.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
         private readonly ISuppressionEngine _suppressionEngine;
 
         /// <inheritdoc />
-        public bool HasLoggedSuppressions { get; private set; }
+        public bool HasLoggedErrorSuppressions { get; private set; }
 
         public SuppressableConsoleLog(ISuppressionEngine suppressionEngine,
             MessageImportance messageImportance)
@@ -30,9 +30,9 @@ namespace Microsoft.DotNet.ApiCompat.Tool
         {
             if (_suppressionEngine.IsErrorSuppressed(suppression))
                 return false;
-            
-            HasLoggedSuppressions = true;
-            base.LogError(code, message);
+
+            HasLoggedErrorSuppressions = true;
+            LogError(code, message);
             
             return true;
         }
@@ -43,8 +43,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             if (_suppressionEngine.IsErrorSuppressed(suppression))
                 return false;
             
-            HasLoggedSuppressions = true;
-            base.LogWarning(code, message);
+            LogWarning(code, message);
             
             return true;
         }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressableLog.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressableLog.cs
@@ -11,9 +11,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
     public interface ISuppressableLog : ILog
     {
         /// <summary>
-        /// Reports whether the logger emitted a compatibility suppression.
+        /// Reports whether the logger emitted an error suppression.
         /// </summary>
-        bool HasLoggedSuppressions { get; }
+        bool HasLoggedErrorSuppressions { get; }
 
         /// <summary>
         /// Log an error based on a passed in suppression, code and message.

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SuppressableTestLog.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SuppressableTestLog.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.DotNet.ApiCompatibility.Logging;
 using Microsoft.DotNet.ApiSymbolExtensions.Logging;
@@ -14,11 +13,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         public List<string> warnings = new();
 
         public bool HasLoggedErrors => errors.Count != 0;
-        public bool HasLoggedSuppressions { get; private set; }
+        public bool HasLoggedErrorSuppressions { get; private set; }
 
         public bool LogError(Suppression suppression, string code, string message)
         {
-            HasLoggedSuppressions = true;
+            HasLoggedErrorSuppressions = true;
             errors.Add($"{code} {message}");
 
             return true;
@@ -28,7 +27,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         
         public bool LogWarning(Suppression suppression, string code, string message)
         {
-            HasLoggedSuppressions = true;
             warnings.Add($"{code} {message}");
 
             return true;


### PR DESCRIPTION
APICompat logs a success or error message in case breaking changes are found. It currently also logs an error if a warning is logged. Change that so that a warning doesn't impact the compatibility result.

Example:
```
PS C:\temp\pkgvalidationmultiref> dotnet pack
MSBuild version 17.6.0-preview-23174-01+e7de13307 for .NET
  Determining projects to restore...
  Restored C:\temp\pkgvalidationmultiref\pkgvalidationmultiref.csproj (in 231 ms).
  pkgvalidationmultiref -> C:\temp\pkgvalidationmultiref\bin\Release\net6.0-windows\pkgvalidationmultiref.dll
  pkgvalidationmultiref -> C:\temp\pkgvalidationmultiref\bin\Release\net7.0-windows\pkgvalidationmultiref.dll
  Successfully created package 'C:\temp\pkgvalidationmultiref\bin\Release\pkgvalidationmultiref.1.0.0.nupkg'.
C:\Program Files\dotnet\sdk\8.0.100-preview.3.23178.7\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ApiCompat.ValidatePackage.targets(39,5): warning CP1003: Could not find a reference directory in the provided directories for TargetFramework 'net6.0-windows7.0' when loading 'lib/net6.0-windows7.0/pkgvalidationmultiref.dll'. For more information see: https://aka.ms/dotnetpackagevalidation [C:\temp\pkgvalidationmultiref\pkgvalidationmultiref.csproj]
C:\Program Files\dotnet\sdk\8.0.100-preview.3.23178.7\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ApiCompat.ValidatePackage.targets(39,5): warning CP1003: Could not find a reference directory in the provided directories for TargetFramework 'net7.0-windows7.0' when loading 'lib/net7.0-windows7.0/pkgvalidationmultiref.dll'. For more information see: https://aka.ms/dotnetpackagevalidation [C:\temp\pkgvalidationmultiref\pkgvalidationmultiref.csproj]
  API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true'
```