### PR TITLE
Update ValleySoft.DockerCredsProvider to get better support for podman authentication

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -34,7 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nuget.Packaging" Version="$(NuGetPackagingPackageVersion)" />
-    <PackageReference Include="Valleysoft.DockerCredsProvider" Version="2.1.0" />
+    <PackageReference Include="Valleysoft.DockerCredsProvider" Version="2.2.0" />
   </ItemGroup>
 
   <!-- net472 builds manually import files to compile -->


### PR DESCRIPTION
@tmds contributed better support for probing podman authentication, so we should update that to take advantage of it in the 7.0.400 SDKs. While this won't provide the _full_ first-class podman support that has been added in 8.0.1xx, it will enable podman-as-docker usage to be more correct.