### PR TITLE
Don't run helix tests if the build fails

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -76,6 +76,7 @@ jobs:
                     /p:Test=false
                     $(_InternalRuntimeDownloadArgs)
                     $(_OfficialBuildArgs)
+          continueOnError: false
           displayName: Build
           env:
             BuildConfig: $(_BuildConfig)
@@ -106,6 +107,7 @@ jobs:
                     $(_OfficialBuildIdArgs)
                     $(_InternalRuntimeDownloadArgs)
                     /p:Test=false
+          continueOnError: false
           displayName: Build
           env:
             BuildConfig: $(_BuildConfig)
@@ -149,6 +151,7 @@ jobs:
                     $(_OfficialBuildIdArgs)
                     $(_InternalRuntimeDownloadArgs)
                     -p:Test=false
+          continueOnError: false
           displayName: Build
           env:
             BuildConfig: $(_BuildConfig)
@@ -251,6 +254,7 @@ jobs:
                     $(_OfficialBuildIdArgs)
                     /p:Test=false
                     $(_InternalRuntimeDownloadArgs)
+          continueOnError: false
           displayName: Build
           env:
             BuildConfig: $(_BuildConfig)


### PR DESCRIPTION
I noticed there was a PR where the build failed but we still tried to run helix tests. That doesn't make sense to me as it's just wasting resources. This was for Windows NT, Full Framework, Ubuntu, and Darwin legs that I saw.

See an example here: https://dev.azure.com/dnceng-public/public/_build/results?buildId=295957&view=results

<img width="1334" alt="image" src="https://github.com/dotnet/sdk/assets/12663534/a7e73ef7-a2c3-46a4-bb21-0f3f50eab969">
