### PR TITLE
[Blazor WASM] Don't apply hot reload deltas if Blazor has not been initialized

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -131,20 +131,25 @@ setTimeout(async function () {
     }
 
     let applyFailed = false;
-    deltas.forEach(d => {
-      try {
-        window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta)
-      } catch (error) {
-        console.warn(error);
-        applyFailed = true;
-      }
-    });
+    if (window.Blazor?._internal?.applyHotReload) {
+      // Only apply hot reload deltas if Blazor has been initialized.
+      // It's possible for Blazor to start after the initial page load, so we don't consider skipping this step
+      // to be a failure. These deltas will get applied later, when Blazor completes initialization.
+      deltas.forEach(d => {
+        try {
+          window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta)
+        } catch (error) {
+          console.warn(error);
+          applyFailed = true;
+        }
+      }); 
+    }
 
     fetch('/_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: JSON.stringify(deltas) })
       .then(response => {
         if (response.status == 200) {
           const etag = response.headers['etag'];
-          window.sessionStorage.setItem('blazor-webasssembly-cache', { etag, deltas });
+          window.sessionStorage.setItem('blazor-webassembly-cache', { etag, deltas });
         }
       });
 


### PR DESCRIPTION
## [Blazor WASM] Don't apply hot reload deltas if Blazor has not been initialized

Fixes an issue where if Blazor hot reload deltas are received before Blazor is initialized, hot reload fails. VS interprets this case as a fatal error, requiring the customer to restart the app to get hot reload working again.

## Description

This fix works by added a check to see if `window.Blazor._internal.applyHotReload` is defined before attempting to apply hot reload deltas. Upon first glance, it might seem that this means Blazor won't ever receive the skipped deltas, but this is not the case because Blazor applies all existing deltas after it boots.

Another possible fix for this would be for VS to not interpret the "delta not applied" case as fatal. However, I think it's preferable to apply the fix in `WebSocketScriptInjection.js` because there still might be cases where exceptions thrown from Blazor's JS implementation are "fatal" in nature. I think it's natural for `WebSocketScriptInjection.js` to differentiate between cases where deltas were intentionally skipped vs. deltas could not be applied.

We could alternatively report the "skipped" case differently from the "success" case so that we can get insight via telemetry about how often this happens.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1779975