### PR TITLE
Add test for catching duplicate error codes

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantAGoodErrorExperience.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantAGoodErrorExperience.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.NET.TestFramework;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.Build.Tasks;
+using System.Reflection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenWeWantAGoodErrorExperience : SdkTest
+    {
+        public GivenWeWantAGoodErrorExperience(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void ConfirmNoDuplicateErrorCodes()
+        {
+            Type type = typeof(Strings);
+            var resourceStrings = type.GetRuntimeProperties();
+            List<string> listOfErrorCode = new List<string>();
+            foreach (var resource in resourceStrings )
+            {
+                if ( resource.PropertyType == typeof(string))
+                {
+                    string errorCode = Strings.GetResourceString(resource.Name).Substring(0, 10);
+                    if (errorCode.Contains("NETSDK"))
+                    {
+                        listOfErrorCode.Add(errorCode);
+                    }
+                }
+            }
+            var anyDuplicate = listOfErrorCode.GroupBy(x => x).Where(g => g.Count() > 1);
+            Assert.True(anyDuplicate.Count() == 0,$"Duplicate error code found: {anyDuplicate.First().Key}");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantAGoodErrorExperience.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantAGoodErrorExperience.cs
@@ -23,20 +23,19 @@ namespace Microsoft.NET.Build.Tests
         {
             Type type = typeof(Strings);
             var resourceStrings = type.GetRuntimeProperties();
-            List<string> listOfErrorCode = new List<string>();
+            HashSet<string> listOfErrorCode = new HashSet<string>();
             foreach (var resource in resourceStrings )
             {
                 if ( resource.PropertyType == typeof(string))
                 {
-                    string errorCode = Strings.GetResourceString(resource.Name).Substring(0, 10);
-                    if (errorCode.Contains("NETSDK"))
+                    string resourceString = Strings.GetResourceString(resource.Name);
+                    if (resourceString.StartsWith("NETSDK"))
                     {
-                        listOfErrorCode.Add(errorCode);
+                        string errorCode = resourceString.Substring(0, 10);
+                        Assert.True(listOfErrorCode.Add(errorCode), $"Duplicate error code found: {errorCode}");
                     }
                 }
             }
-            var anyDuplicate = listOfErrorCode.GroupBy(x => x).Where(g => g.Count() > 1);
-            Assert.True(anyDuplicate.Count() == 0,$"Duplicate error code found: {anyDuplicate.First().Key}");
         }
     }
 }


### PR DESCRIPTION
The risk of this test is if two PRs go in in parallel, they could pass in PR but then fail afterwards.  The other risk is if we add a duplicate in a downlevel branch that doesn't have the test.

I'm open to other ways of catching this but I've seen this happen a few times now so it felt like it was worth adding the test. This will fail until https://github.com/dotnet/sdk/pull/33102 is merged and flows.

Fixes #33133