### PR TITLE
[release/7.0.4xx] Backport '[Blazor WASM] Don't apply hot reload deltas if Blazor has not been initialized'

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -131,20 +131,25 @@ setTimeout(async function () {
     }
 
     let applyFailed = false;
-    deltas.forEach(d => {
-      try {
-        window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta)
-      } catch (error) {
-        console.warn(error);
-        applyFailed = true;
-      }
-    });
+    if (window.Blazor?._internal?.applyHotReload) {
+      // Only apply hot reload deltas if Blazor has been initialized.
+      // It's possible for Blazor to start after the initial page load, so we don't consider skipping this step
+      // to be a failure. These deltas will get applied later, when Blazor completes initialization.
+      deltas.forEach(d => {
+        try {
+          window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta)
+        } catch (error) {
+          console.warn(error);
+          applyFailed = true;
+        }
+      }); 
+    }
 
     fetch('/_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: JSON.stringify(deltas) })
       .then(response => {
         if (response.status == 200) {
           const etag = response.headers['etag'];
-          window.sessionStorage.setItem('blazor-webasssembly-cache', { etag, deltas });
+          window.sessionStorage.setItem('blazor-webassembly-cache', { etag, deltas });
         }
       });
 


### PR DESCRIPTION
# [Blazor WASM] Don't apply hot reload deltas if Blazor has not been initialized

Backport of #33122.

Fixes an issue where hot reload fails if the browser receives hot reload deltas before Blazor WebAssembly initializes.

## Description

If this bug occurs when debugging with Visual Studio, an exception message like the following gets shown:

![screenshot](https://github.com/dotnet/sdk/assets/10456961/a46fb3e8-9db6-4a15-9536-366bfc1b132f)

This forces the customer to restart the app for hot reload to continue working.

The fix simply ignores the received deltas if Blazor has not been initialized to the point where it's ready to apply hot reload updates. Blazor already has logic to apply all previously received hot reload updates upon initialization, so the changes will take effect anyway as soon as Blazor completes its boot procedure.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1779975

## Customer Impact

Moderate. This exception can be triggered easily when debugging web apps that load Blazor WebAssembly only on specific pages. For apps completely written in Blazor WebAssembly, the exception is more difficult to encounter.

If the bug is encountered, a full app restart is required to use hot reload again.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix is straightforward and unlikely to introduce a new regression.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A