### PR TITLE
Add a concept of image family to container base image inference

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
@@ -8,6 +8,8 @@ internal static class KnownStrings
     public static class Properties
     {
         public static readonly string ContainerBaseImage = nameof(ContainerBaseImage);
+        public static readonly string ContainerFamily = nameof(ContainerFamily);
+        public static readonly string _ContainerBaseImageTag = nameof(_ContainerBaseImageTag);
         public static readonly string ContainerRegistry = nameof(ContainerRegistry);
         /// <summary>Note that this is deprecated in favor of <see cref="ContainerRepository"/></summary>
         public static readonly string ContainerImageName = nameof(ContainerImageName);
@@ -22,6 +24,8 @@ internal static class KnownStrings
         public static readonly string ContainerPort = nameof(ContainerPort);
         public static readonly string ContainerEnvironmentVariable = nameof(ContainerEnvironmentVariable);
 
+        public static readonly string ComputeContainerBaseImage = nameof(ComputeContainerBaseImage);
+        public static readonly string _ComputeContainerBaseImageTag = nameof(_ComputeContainerBaseImageTag);
         public static readonly string ComputeContainerConfig = nameof(ComputeContainerConfig);
         public static readonly string AssemblyName = nameof(AssemblyName);
         public static readonly string ContainerBaseRegistry = nameof(ContainerBaseRegistry);

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -24,6 +24,8 @@ Microsoft.NET.Build.Containers.PortType.udp = 1 -> Microsoft.NET.Build.Container
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ComputedBaseImageTag.get -> string?
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ComputeDotnetBaseImageTag() -> void
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ContainerFamily.get -> string!
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ContainerFamily.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.SdkVersion.get -> string!
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.SdkVersion.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.TargetFrameworkVersion.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -112,6 +112,8 @@ Microsoft.NET.Build.Containers.PortType
 Microsoft.NET.Build.Containers.PortType.tcp = 0 -> Microsoft.NET.Build.Containers.PortType
 Microsoft.NET.Build.Containers.PortType.udp = 1 -> Microsoft.NET.Build.Containers.PortType
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ContainerFamily.get -> string!
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ContainerFamily.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.SdkVersion.get -> string!
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.SdkVersion.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.TargetFrameworkVersion.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageTag.cs
@@ -25,6 +25,8 @@ public sealed class ComputeDotnetBaseImageTag : Microsoft.Build.Utilities.Task
     [Required]
     public string TargetFrameworkVersion { get; set; }
 
+    public string ContainerFamily { get; set; }
+
     [Output]
     public string? ComputedBaseImageTag { get; private set; }
 
@@ -32,6 +34,7 @@ public sealed class ComputeDotnetBaseImageTag : Microsoft.Build.Utilities.Task
     {
         SdkVersion = "";
         TargetFrameworkVersion = "";
+        ContainerFamily = "";
     }
 
     public override bool Execute()
@@ -39,19 +42,24 @@ public sealed class ComputeDotnetBaseImageTag : Microsoft.Build.Utilities.Task
         if (SemanticVersion.TryParse(TargetFrameworkVersion, out var tfm) && tfm.Major < FirstVersionWithNewTaggingScheme)
         {
             ComputedBaseImageTag = $"{tfm.Major}.{tfm.Minor}";
-            return true;
         }
-
-        if (SemanticVersion.TryParse(SdkVersion, out var version))
+        else if (SemanticVersion.TryParse(SdkVersion, out var version))
         {
             ComputedBaseImageTag = ComputeVersionInternal(version, tfm);
-            return true;
         }
         else
         {
             Log.LogError(Resources.Strings.InvalidSdkVersion, SdkVersion);
-            return false;
+            return !Log.HasLoggedErrors;
         }
+
+        if (!string.IsNullOrWhiteSpace(ContainerFamily))
+        {
+            // for the inferred image tags, 'family' aka 'flavor' comes after the 'version' portion (including any preview/rc segments).
+            // so it's safe to just append here
+            ComputedBaseImageTag += $"-{ContainerFamily}";
+        }
+        return true;
     }
 
 

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -32,7 +32,8 @@
   <Target Name="_ComputeContainerBaseImageTag" Returns="$(_ContainerBaseImageTag)">
     <ComputeDotnetBaseImageTag
       SdkVersion="$(NetCoreSdkVersion)"
-      TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV).0">
+      TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV).0"
+      ContainerFamily="$(ContainerFamily)">
         <Output TaskParameter="ComputedBaseImageTag" PropertyName="_ContainerBaseImageTag" />
     </ComputeDotnetBaseImageTag>
   </Target>


### PR DESCRIPTION
This allows for easily selecting a group of related images (like chiseled or alpine) without having to 'eject' from inference overall. Right now we don't set this value anywhere, but further work might infer various properties and opt into chiseled ubuntu containers, for example. Or detect a musl RID and flip over to the alpine family of images.

Closes https://github.com/dotnet/sdk-container-builds/issues/401

This is pretty crucial for making it easier for users to opt into Chiseled containers for example - with this, a user could add

```xml
<ContainerFamily>jammy-chiseled</ContainerFamily>
```

to their project file and use the new, slim containers.