### PR TITLE
[Containers] Enable multi-RID and multi-project containerization

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/PlatformMapping.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/PlatformMapping.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.NET.Build.Containers;
+
+/// <summary>
+/// Handles mapping between .NET RIDs and Docker platform names/structures
+/// </summary>
+public static class PlatformMapping {
+
+    public static bool TryGetRidForDockerPlatform(string golangPlatform, bool isMuslBased, [NotNullWhen(true)] out string? runtimeIdentifier) {
+        runtimeIdentifier = null;
+
+        runtimeIdentifier = golangPlatform.Split('/') switch {
+            ["linux", "amd64"] when isMuslBased => "linux-musl-x64",
+            ["linux", "amd64"] => "linux-x64",
+
+            ["linux", "amd64", var _amd64Version] when isMuslBased => "linux-musl-x64",
+            ["linux", "amd64", var _amd64Version] => "linux-x64",
+
+            ["linux", "arm64"] when isMuslBased => "linux-musl-arm64",
+            ["linux", "arm64"] => "linux-arm64",
+
+            ["linux", "arm64", var _arm64Version ] when isMuslBased => "linux-musl-arm64",
+            ["linux", "arm64", var _arm64Version ] => "linux-arm64",
+
+            ["linux", "arm" ] or ["linux", "arm", "v7" ] when isMuslBased => "linux-musl-arm",
+            ["linux", "arm" ] or ["linux", "arm", "v7" ] => "linux-arm",
+
+            ["linux", "arm", "v6" ] when isMuslBased => "linux-musl-armv6",
+            ["linux", "arm", "v6" ]   => "linux-armv6",
+
+            ["linux", "riscv64" ] when isMuslBased => "linux-musl-riscv64",
+            ["linux", "riscv64" ] => "linux-riscv64",
+
+            ["linux", "ppc64le" ] when isMuslBased => "linux-musl-ppc64le",
+            ["linux", "ppc64le" ] => "linux-ppc64le",
+
+            ["linux", "s390x" ] when isMuslBased => "linux-musl-s390x",
+            ["linux", "s390x" ] => "linux-s390x",
+
+            ["linux", "386" ] when isMuslBased => "linux-musl-x86",
+            ["linux", "386" ] => "linux-x86",
+
+            ["windows", "amd64"] => "win-x64",
+            ["windows", "arm64"] => "win-arm64",
+
+            _ => null // other golang platforms are not supported
+        };
+        return runtimeIdentifier != null;
+    }
+
+    public static bool TryGetDockerPlatformForRid(string runtimeIdentifier, [NotNullWhen(true)] out string? dockerPlatform) {
+        dockerPlatform = null;
+
+        runtimeIdentifier = runtimeIdentifier.Replace("-musl-", "-"); // we lose musl information in the docker platform name
+
+        dockerPlatform = runtimeIdentifier.Split('-') switch {
+            ["linux", "x64"] => "linux/amd64",
+            ["linux", "arm64"] => "linux/arm64",
+            ["linux", "arm"] => "linux/arm/v7",
+            ["linux", "armv6"] => "linux/arm/v6",
+            ["linux", "riscv64"] => "linux/riscv64",
+            ["linux", "ppc64le"] => "linux/ppc64le",
+            ["linux", "s390x"] => "linux/s390x",
+            ["linux", "x86"] => "linux/386",
+            ["win", "x64"] => "windows/amd64",
+            ["win", "arm64"] => "windows/arm64",
+            _ => null
+        };
+        return dockerPlatform != null;
+    }
+
+    public static bool TryGetDockerImageTagForRid(string runtimeIdentifier, [NotNullWhen(true)] out string? dockerPlatformTag) {
+        dockerPlatformTag = null;
+
+        runtimeIdentifier = runtimeIdentifier.Replace("-musl-", "-"); // we lose musl information in the docker platform name
+
+        dockerPlatformTag = runtimeIdentifier.Split('-') switch {
+            ["linux", "x64"] => "amd64",
+            ["linux", "arm64"] => "arm64v8",
+            ["linux", "arm"] => "arm32v7",
+            ["linux", "armv6"] => "arm32v6",
+            ["linux", "riscv64"] => "riscv64",
+            ["linux", "ppc64le"] => "ppc64le",
+            ["linux", "s390x"] => "s390x",
+            ["linux", "x86"] => "386",
+            _ => null // deliberately not trying to make tag names for windows containers
+        };
+        return dockerPlatformTag != null;
+    }
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -83,6 +83,10 @@ Microsoft.NET.Build.Containers.PlatformInformation.variant.get -> string?
 Microsoft.NET.Build.Containers.PlatformInformation.variant.set -> void
 Microsoft.NET.Build.Containers.PlatformInformation.version.get -> string?
 Microsoft.NET.Build.Containers.PlatformInformation.version.set -> void
+Microsoft.NET.Build.Containers.PlatformMapping
+static Microsoft.NET.Build.Containers.PlatformMapping.TryGetRidForDockerPlatform(string! golangPlatform, bool isMuslBased, out string? runtimeIdentifier) -> bool
+static Microsoft.NET.Build.Containers.PlatformMapping.TryGetDockerPlatformForRid(string! runtimeIdentifier, out string? dockerPlatform) -> bool
+static Microsoft.NET.Build.Containers.PlatformMapping.TryGetDockerImageTagForRid(string! runtimeIdentifier, out string? dockerPlatformTag) -> bool
 Microsoft.NET.Build.Containers.PlatformSpecificManifest
 Microsoft.NET.Build.Containers.PlatformSpecificManifest.digest.get -> string!
 Microsoft.NET.Build.Containers.PlatformSpecificManifest.digest.set -> void
@@ -166,6 +170,13 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolPath.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolPath.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.WorkingDirectory.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.WorkingDirectory.set -> void
+Microsoft.NET.Build.Containers.Tasks.MapRidToDockerPlatform
+Microsoft.NET.Build.Containers.Tasks.MapRidToDockerPlatform.MapRidToDockerPlatform() -> void
+Microsoft.NET.Build.Containers.Tasks.MapRidToDockerPlatform.RuntimeIdentifiers.get -> Microsoft.Build.Framework.ITaskItem![]!
+Microsoft.NET.Build.Containers.Tasks.MapRidToDockerPlatform.RuntimeIdentifiers.set -> void
+Microsoft.NET.Build.Containers.Tasks.MapRidToDockerPlatform.ModifiedRuntimeIdentifiers.get -> Microsoft.Build.Framework.ITaskItem![]!
+Microsoft.NET.Build.Containers.Tasks.MapRidToDockerPlatform.ModifiedRuntimeIdentifiers.set -> void
+override Microsoft.NET.Build.Containers.Tasks.MapRidToDockerPlatform.Execute() -> bool
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ContainerEnvironmentVariables.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ContainerEnvironmentVariables.set -> void

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/MapRidToDockerPlatform.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/MapRidToDockerPlatform.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Containers.Tasks;
+
+public sealed class MapRidToDockerPlatform : Microsoft.Build.Utilities.Task
+{
+    [Required]
+    public ITaskItem[] RuntimeIdentifiers { get; set; }
+
+    [Output]
+    public ITaskItem[] ModifiedRuntimeIdentifiers { get; set; }
+
+    public MapRidToDockerPlatform()
+    {
+        RuntimeIdentifiers = Array.Empty<ITaskItem>();
+        ModifiedRuntimeIdentifiers = Array.Empty<ITaskItem>();
+    }
+    public override bool Execute()
+    {
+        bool result = true;
+        var modifiedRuntimeIdentifiers = new List<ITaskItem>(RuntimeIdentifiers.Length);
+        foreach (ITaskItem rid in RuntimeIdentifiers) {
+            if (PlatformMapping.TryGetDockerImageTagForRid(rid.ItemSpec, out string? dockerPlatform))
+            {
+                rid.SetMetadata("DockerPlatformTag", dockerPlatform);
+                modifiedRuntimeIdentifiers.Add(rid);
+            }
+            else {
+                Log.LogError($"No Docker platform mapping found for RuntimeIdentifier '{rid.ItemSpec}'");
+                result = false;
+            }
+        }
+        ModifiedRuntimeIdentifiers = modifiedRuntimeIdentifiers.ToArray();
+        return result;
+    }
+}

--- a/src/Containers/containerize/ContainerizeCommand.cs
+++ b/src/Containers/containerize/ContainerizeCommand.cs
@@ -3,6 +3,9 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.ComponentModel.Design;
+using System.Diagnostics;
+using System.ComponentModel;
 using System.Text;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.Logging;

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.props
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.props
@@ -17,4 +17,5 @@
     <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateNewImage" AssemblyFile="$(ContainerCustomTasksAssembly)"/>
     <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ParseContainerProperties" AssemblyFile="$(ContainerCustomTasksAssembly)"/>
     <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ComputeDotnetBaseImageTag" AssemblyFile="$(ContainerCustomTasksAssembly)"/>
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.MapRidToDockerPlatform" AssemblyFile="$(ContainerCustomTasksAssembly)"/>
 </Project>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -190,6 +190,7 @@
     </PublishContainerDependsOn>
   </PropertyGroup>
 
+  <!-- Main entrypoint for creating a specific container -->
   <Target Name="PublishContainer" DependsOnTargets="$(PublishContainerDependsOn)">
 
     <PropertyGroup Condition="'$(DOTNET_HOST_PATH)' == ''">
@@ -221,10 +222,69 @@
                     ContainerEnvironmentVariables="@(ContainerEnvironmentVariables)"
                     ContainerRuntimeIdentifier="$(ContainerRuntimeIdentifier)"
                     ContainerUser="$(ContainerUser)"
-                    RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"> <!-- The RID graph path is provided as a property by the SDK. -->
+                    RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)" > <!-- The RID graph path is provided as a property by the SDK. -->
 
       <Output TaskParameter="GeneratedContainerManifest" PropertyName="GeneratedContainerManifest" />
       <Output TaskParameter="GeneratedContainerConfiguration" PropertyName="GeneratedContainerConfiguration" />
     </CreateNewImage>
+  </Target>
+
+  <!-- Secondary entrypoint, either from solution-level `/t:Containerize` or project-level `/t:Containerize` -->
+  <Target Name="Containerize" Condition="'$(EnableSdkContainerSupport)' == 'true'">
+    <PropertyGroup>
+      <!-- We have to build Publish AND PublishContainer because PublishContainer (and other
+          PublishProfile-delivered targets) don't have an explicit Publish dependency. -->
+      <_RequiredContainerPublishTargets>Publish;PublishContainer</_RequiredContainerPublishTargets>
+    </PropertyGroup>
+
+    <!-- Strategy here is that we will figure out what project(s) to build the containerization targets(s) for
+         based on project state. We use `AdditionalProperties` to customize the outputs of each of the builds. -->
+
+    <!-- Properties set here:
+      * TargetFramework - multitargeting - changes inference for base image based on TFM
+      * ContainerImageTag - this is a rough cut
+      * ContainerRuntimeIdentifier - if we're building for a specific RID, we need to set this so that the
+                                     containerization targets know what RID to build for
+      * RuntimeIdentifier - if we're building for a specific RID, we need to set this so that we get optimized
+                            RID-specific assets in the publish output
+
+      NOTE: we could get away with setting `RuntimeIdentfier` here to control `ContainerRuntimeIdentifier` inference
+            but this is also nice and explicit.
+     -->
+
+    <!-- TFMs but no TF -> multitarget, making image for each TFM -->
+    <ItemGroup Condition="'$(TargetFrameworks)' != ''
+                          and '$(TargetFramework)' == ''" >
+      <_TFMItems Include="$(TargetFrameworks)" />
+      <_SingleContainerPublish Include="$(MSBuildProjectFullPath)"
+        AdditionalProperties="TargetFramework=%(_TFMItems.Identity);
+                              ContainerImageTag=$([MSBuild]::GetTargetFrameworkVersion('%(_TFMItems.Identity)', 2))" />
+    </ItemGroup>
+
+    <!-- TF but no TFMs -> single image (aka the default pathway) up until now -->
+    <ItemGroup Condition="'$(TargetFramework)' != ''
+                          and '$(RuntimeIdentifiers)' == ''">
+        <_SingleContainerPublish Include="$(MSBuildProjectFullPath)" />
+    </ItemGroup>
+
+    <!-- TF with RIDs -> multi-arch, single image per arch -->
+    <ItemGroup Condition="'$(TargetFramework)' != ''
+                          and '$(RuntimeIdentifiers)' != ''">
+      <_RIDItems Include="$(RuntimeIdentifiers)" />
+    </ItemGroup>
+    <MapRidToDockerPlatform Condition="'$(TargetFramework)' != ''
+                                      and '$(RuntimeIdentifiers)' != ''"
+                            RuntimeIdentifiers="@(_RIDItems)">
+      <Output TaskParameter="ModifiedRuntimeIdentifiers" ItemName="_RIDItemsWithDockerPlatformTag" />
+    </MapRidToDockerPlatform>
+    <ItemGroup Condition="'$(TargetFramework)' != ''
+                          and '$(RuntimeIdentifiers)' != ''">
+      <_SingleContainerPublish Include="$(MSBuildProjectFullPath)"
+          AdditionalProperties="ContainerRuntimeIdentifier=%(_RIDItemsWithDockerPlatformTag.Identity);
+                                RuntimeIdentifier=%(_RIDItemsWithDockerPlatformTag.Identity);
+                                ContainerImageTag=$(Version)-%(_RIDItemsWithDockerPlatformTag.DockerPlatformTag);" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(_SingleContainerPublish)" Targets="$(_RequiredContainerPublishTargets)" BuildInParallel="true" />
   </Target>
 </Project>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -235,6 +235,9 @@
       <!-- We have to build Publish AND PublishContainer because PublishContainer (and other
           PublishProfile-delivered targets) don't have an explicit Publish dependency. -->
       <_RequiredContainerPublishTargets>Publish;PublishContainer</_RequiredContainerPublishTargets>
+      <_IsMultiTargetTfm Condition="'$(TargetFrameworks)' != ''and '$(TargetFramework)' == ''">true</_IsMultiTargetTfm>
+      <_IsSingleTargetTfmNoRids Condition="'$(TargetFramework)' != '' and '$(RuntimeIdentifiers)' == ''">true</_IsSingleTargetTfmNoRids>
+      <_IsSingleTargetAndMultiRid Condition="'$(TargetFramework)' != '' and '$(RuntimeIdentifiers)' != ''">true</_IsSingleTargetAndMultiRid>
     </PropertyGroup>
 
     <!-- Strategy here is that we will figure out what project(s) to build the containerization targets(s) for
@@ -253,8 +256,7 @@
      -->
 
     <!-- TFMs but no TF -> multitarget, making image for each TFM -->
-    <ItemGroup Condition="'$(TargetFrameworks)' != ''
-                          and '$(TargetFramework)' == ''" >
+    <ItemGroup Condition="'$(_IsMultiTargetTfm)' == 'true'" >
       <_TFMItems Include="$(TargetFrameworks)" />
       <_SingleContainerPublish Include="$(MSBuildProjectFullPath)"
         AdditionalProperties="TargetFramework=%(_TFMItems.Identity);
@@ -262,23 +264,25 @@
     </ItemGroup>
 
     <!-- TF but no TFMs -> single image (aka the default pathway) up until now -->
-    <ItemGroup Condition="'$(TargetFramework)' != ''
-                          and '$(RuntimeIdentifiers)' == ''">
+    <ItemGroup Condition="'$(_IsSingleTargetTfm)' == 'true'">
         <_SingleContainerPublish Include="$(MSBuildProjectFullPath)" />
     </ItemGroup>
 
     <!-- TF with RIDs -> multi-arch, single image per arch -->
-    <ItemGroup Condition="'$(TargetFramework)' != ''
-                          and '$(RuntimeIdentifiers)' != ''">
+    <ItemGroup Condition="'$(_IsSingleTargetAndMultiRid)' == 'true'">
       <_RIDItems Include="$(RuntimeIdentifiers)" />
     </ItemGroup>
-    <MapRidToDockerPlatform Condition="'$(TargetFramework)' != ''
-                                      and '$(RuntimeIdentifiers)' != ''"
-                            RuntimeIdentifiers="@(_RIDItems)">
+    <!-- The tag is defaulted to 'Version' and would overwrite itself for each different architecture, so we need to differentiate them.
+         It's convention to do so by appending platform information to the tag - e.g. bookworm-amd64
+
+         We map from .NET RIDs to container platforms here so we can adhere to that convention. -->
+    <MapRidToDockerPlatform Condition="'$(_IsSingleTargetAndMultiRid)' == 'true'" RuntimeIdentifiers="@(_RIDItems)">
       <Output TaskParameter="ModifiedRuntimeIdentifiers" ItemName="_RIDItemsWithDockerPlatformTag" />
     </MapRidToDockerPlatform>
-    <ItemGroup Condition="'$(TargetFramework)' != ''
-                          and '$(RuntimeIdentifiers)' != ''">
+
+    <!-- Right now we're using Version - but this will very likely not be set for single-targeted builds yet (this generally happens via PrepareForBuild).
+         We need to figure out a way to ask what the 'root' of the image tag should be and use that. -->
+    <ItemGroup Condition="'$(_IsSingleTargetAndMultiRid)' == 'true'">
       <_SingleContainerPublish Include="$(MSBuildProjectFullPath)"
           AdditionalProperties="ContainerRuntimeIdentifier=%(_RIDItemsWithDockerPlatformTag.Identity);
                                 RuntimeIdentifier=%(_RIDItemsWithDockerPlatformTag.Identity);


### PR DESCRIPTION
Closes part of https://github.com/dotnet/sdk-container-builds/issues/87

This surfaces the containerization targets in another target that orchestrates the creation of zero or more containers.

When called at the solution level, so-called 'traversal' targets are created for each project, and each project's version of this new target is called in parallel.

For each project, there are a few multi-targeting scenarios that have to be addressed:

## How do you containerize a project with a single TFM and no RIDs (but potentially a single RID)?

This is the situation we have today - you just call the existing target.

## How do you containerize with multiple TFMs?

Easy, you ask each TFM to create its own container by calling the existing target once for each TFM.

## How do you containerize with multiple RIDs (and a single TFM)?

This is the novel thing, since we don't have a concept of multi-RID publishing buttoned down. Based on following patterns from MAUI, we can in parallel build the project with a different set of properties, and have those separate builds create containers for each architecture-specific variant of the container. We take the opportunity here to uniquely tag the containers with architecture-specific information, or else the container image names might overlap. Doing this tagging correctly required mapping .NET RIDs to Docker platform monikers, which was pulled out into a new Task for reuse, and also served to remove the need to rely on the RID graph from the SDK.

## Future work

This doesn't create manifest lists, which would 'wrap' each of the architecture-specific images in a wrapper that to external users looks like the same image regardless of architecture used.


## Use Cases

Microservices - now you can containerize an entire solution at once. Using `dotnet build /t:Containerize && docker-compose up` you can build new `latest` images of each of the projects, and if your Compose file is set up to use `image:` instead of `build:` then you are all ready to go!


## TODOs
* [x] re-introduce (limited) RID graph based selection based on constrained RID graphs (not the open-ended model of today) to enable compatibility with source-built SDKs
* [x] consider removing the multi-RID/multi-TFM publishing for now, and instead focus on the core scenario of enabling solution-level publish for all compatible projects
  * I don't think we can remove multi-TFM and multi-RID publishing if we want to support solution-level publish, because at a solution level you can't really control the TFM/RID selection for each and every project in the solution. So it'll have to stay in _some_ fashion, and we'll just have to evolve it responsibly.
