### PR TITLE
Add additional dependencies for PVP flow

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -381,15 +381,17 @@
       <Sha>27e584661980ee6d82c419a2a471ae505b7d122e</Sha>
       <SourceBuild RepoName="symreader" ManagedOnly="true" />
     </Dependency>
-    <!-- Dependencies required for flowing correct package versions in source-build, using PVP flow. -->
+    <!-- Dependency required for flowing correct package version in source-build, using PVP flow. -->
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="6.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
     </Dependency>
+    <!-- Dependency required for flowing correct package version in source-build, using PVP flow. -->
     <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
     </Dependency>
+    <!-- Dependency required for flowing correct package version in source-build, using PVP flow. -->
     <Dependency Name="System.ServiceProcess.ServiceController" Version="7.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -381,6 +381,19 @@
       <Sha>27e584661980ee6d82c419a2a471ae505b7d122e</Sha>
       <SourceBuild RepoName="symreader" ManagedOnly="true" />
     </Dependency>
+    <!-- Dependencies required for flowing correct package versions in source-build, using PVP flow. -->
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+    </Dependency>
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23309.8">


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3043

PVP flow is a method of flowing dependencies in source build that only overrides versions of packages that the repo has a declared dependency on in `Version.Details.xml`. This means that the package flow is closer to the Microsoft's way of building .NET.

To enable this for `sdk`, we've added `nuget.client` and `vstest` dependencies with https://github.com/dotnet/sdk/pull/33039. However, 3 dependencies are needed to prevent introduction of reference assemblies and runtime issues. This PR adds these additional dependencies. Patch for this change is being added to existing PR in `installer`: https://github.com/dotnet/installer/pull/16633

To fully enable PVP flow, the repo project in the VMR will need to set `<PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>` once these changes flow in.