### PR TITLE
Expose EnableComHosting to analyzers

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -127,6 +127,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Used for analyzer to match namespace to folder structure -->
     <CompilerVisibleProperty Include="RootNamespace" />
     <CompilerVisibleProperty Include="ProjectDir" />
+    <!--
+      Used by the analyzers in the Microsoft.Interop.ComInterfaceGenerator to detect combinations
+      of built-in and source generated COM interop
+    -->
+    <CompilerVisibleProperty Include="EnableComHosting" />
   </ItemGroup>
 
   <!-- C# Code Style Analyzers -->


### PR DESCRIPTION
This is used by the COM interop analyzers from dotnet/runtime.