### PR TITLE
Fix R2R map generation on OSX

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -78,18 +78,6 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private bool IsTargetLinux
-        {
-            get
-            {
-                // Crossgen2 V6 and above always has TargetOS metadata available
-                if (ReadyToRunUseCrossgen2 && !string.IsNullOrEmpty(Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS))) 
-                    return Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "linux";
-                else
-                    return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-            }
-        }
-
         protected override void ExecuteCore()
         {
             if (ReadyToRunUseCrossgen2)
@@ -170,7 +158,7 @@ namespace Microsoft.NET.Build.Tasks
                         outputPDBImageRelativePath = Path.ChangeExtension(outputR2RImageRelativePath, "ni.pdb");
                         crossgen1CreatePDBCommand = $"/CreatePDB \"{Path.GetDirectoryName(outputPDBImage)}\"";
                     }
-                    else if (IsTargetLinux)
+                    else
                     {
                         string perfmapExtension;
                         if (ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5 && _perfmapFormatVersion >= 1)
@@ -275,7 +263,7 @@ namespace Microsoft.NET.Build.Tasks
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.pdb");
                         compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
                     }
-                    else if (IsTargetLinux)
+                    else
                     {
                         string perfmapExtension = (_perfmapFormatVersion >= 1 ? ".ni.r2rmap" : ".ni.{composite}.map");
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, perfmapExtension);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -281,7 +281,7 @@ namespace Microsoft.NET.Build.Tasks
                             compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
                         }
                     }
-                    else if (!_crossgen2IsVersion5 || IsTargetLinux)
+                    else if ((ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5) || IsTargetLinux)
                     {
                         string perfmapExtension = (_perfmapFormatVersion >= 1 ? ".ni.r2rmap" : ".ni.{composite}.map");
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, perfmapExtension);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -173,7 +173,7 @@ namespace Microsoft.NET.Build.Tasks
                             crossgen1CreatePDBCommand = $"/CreatePDB \"{Path.GetDirectoryName(outputPDBImage)}\"";
                         }
                     }
-                    else if (!_crossgen2IsVersion5 || IsTargetLinux)
+                    else if ((ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5) || IsTargetLinux)
                     {
                         string perfmapExtension;
                         if (ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5 && _perfmapFormatVersion >= 1)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -152,11 +152,14 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (EmitSymbols)
                 {
-                    if (IsTargetWindows && hasValidDiaSymReaderLib)
+                    if (IsTargetWindows)
                     {
-                        outputPDBImage = Path.ChangeExtension(outputR2RImage, "ni.pdb");
-                        outputPDBImageRelativePath = Path.ChangeExtension(outputR2RImageRelativePath, "ni.pdb");
-                        crossgen1CreatePDBCommand = $"/CreatePDB \"{Path.GetDirectoryName(outputPDBImage)}\"";
+                        if (hasValidDiaSymReaderLib)
+                        {
+                            outputPDBImage = Path.ChangeExtension(outputR2RImage, "ni.pdb");
+                            outputPDBImageRelativePath = Path.ChangeExtension(outputR2RImageRelativePath, "ni.pdb");
+                            crossgen1CreatePDBCommand = $"/CreatePDB \"{Path.GetDirectoryName(outputPDBImage)}\"";
+                        }
                     }
                     else
                     {
@@ -258,10 +261,13 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     string compositePDBImage = null;
                     string compositePDBRelativePath = null;
-                    if (IsTargetWindows && hasValidDiaSymReaderLib)
+                    if (IsTargetWindows)
                     {
-                        compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.pdb");
-                        compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
+                        if (hasValidDiaSymReaderLib)
+                        {
+                            compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.pdb");
+                            compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
+                        }
                     }
                     else
                     {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -281,7 +281,7 @@ namespace Microsoft.NET.Build.Tasks
                             compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
                         }
                     }
-                    else if ((ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5) || IsTargetLinux)
+                    else
                     {
                         string perfmapExtension = (_perfmapFormatVersion >= 1 ? ".ni.r2rmap" : ".ni.{composite}.map");
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, perfmapExtension);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -78,6 +78,18 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
+        private bool IsTargetLinux
+        {
+            get
+            {
+                // Crossgen2 V6 and above always has TargetOS metadata available
+                if (ReadyToRunUseCrossgen2 && !string.IsNullOrEmpty(Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS))) 
+                    return Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "linux";
+                else
+                    return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+        }
+
         protected override void ExecuteCore()
         {
             if (ReadyToRunUseCrossgen2)
@@ -161,7 +173,7 @@ namespace Microsoft.NET.Build.Tasks
                             crossgen1CreatePDBCommand = $"/CreatePDB \"{Path.GetDirectoryName(outputPDBImage)}\"";
                         }
                     }
-                    else
+                    else if (!_crossgen2IsVersion5 || IsTargetLinux)
                     {
                         string perfmapExtension;
                         if (ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5 && _perfmapFormatVersion >= 1)
@@ -269,7 +281,7 @@ namespace Microsoft.NET.Build.Tasks
                             compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
                         }
                     }
-                    else
+                    else if (!_crossgen2IsVersion5 || IsTargetLinux)
                     {
                         string perfmapExtension = (_perfmapFormatVersion >= 1 ? ".ni.r2rmap" : ".ni.{composite}.map");
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, perfmapExtension);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -351,19 +351,9 @@ namespace Microsoft.NET.Publish.Tests
             return TargetOSEnum.Windows;
         }
 
-        private static bool IsTargetOsOsX(string runtimeIdentifier)
-        {
-            return GetTargetOS(runtimeIdentifier) == TargetOSEnum.OsX;
-        }
-
         private static bool IsTargetOsWindows(string runtimeIdentifier)
         {
             return GetTargetOS(runtimeIdentifier) == TargetOSEnum.Windows;
-        }
-
-        private static bool IsTargetOsLinux(string runtimeIdentifier)
-        {
-            return GetTargetOS(runtimeIdentifier) == TargetOSEnum.Linux;
         }
 
         private void TestProjectPublishing_Internal(string projectName,
@@ -484,8 +474,7 @@ public class Program
             {
                 return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.pdb"));
             }
-
-            if (IsTargetOsLinux(runtimeIdentifier))
+            else
             {
                 if (framework.Version.Major >= 6)
                 {

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -411,7 +411,7 @@ namespace Microsoft.NET.Publish.Tests
             else
                 publishDirectory.Should().NotHaveFile("System.Private.CoreLib.dll");
 
-            if (emitNativeSymbols && !IsTargetOsOsX(testProject.RuntimeIdentifier))
+            if (emitNativeSymbols)
             {
                 NuGetFramework framework = NuGetFramework.Parse(targetFramework);
                 Log.WriteLine("Checking for symbol files");

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -351,6 +351,11 @@ namespace Microsoft.NET.Publish.Tests
             return TargetOSEnum.Windows;
         }
 
+        private static bool IsTargetOsOsX(string runtimeIdentifier)
+        {
+            return GetTargetOS(runtimeIdentifier) == TargetOSEnum.OsX;
+        }
+
         private static bool IsTargetOsWindows(string runtimeIdentifier)
         {
             return GetTargetOS(runtimeIdentifier) == TargetOSEnum.Windows;
@@ -401,9 +406,9 @@ namespace Microsoft.NET.Publish.Tests
             else
                 publishDirectory.Should().NotHaveFile("System.Private.CoreLib.dll");
 
-            if (emitNativeSymbols)
+            NuGetFramework framework = NuGetFramework.Parse(targetFramework);
+            if (emitNativeSymbols && (!IsTargetOsOsX(runtimeIdentifier) || framework.Version.Major >= 6))
             {
-                NuGetFramework framework = NuGetFramework.Parse(targetFramework);
                 Log.WriteLine("Checking for symbol files");
                 IEnumerable<string> pdbFiles;
 
@@ -474,7 +479,7 @@ public class Program
             {
                 return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.pdb"));
             }
-            else
+            else if (!IsTargetOsOsX(runtimeIdentifier) || framework.Version.Major >= 6)
             {
                 if (framework.Version.Major >= 6)
                 {

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -407,7 +407,7 @@ namespace Microsoft.NET.Publish.Tests
                 publishDirectory.Should().NotHaveFile("System.Private.CoreLib.dll");
 
             NuGetFramework framework = NuGetFramework.Parse(targetFramework);
-            if (emitNativeSymbols && (!IsTargetOsOsX(runtimeIdentifier) || framework.Version.Major >= 6))
+            if (emitNativeSymbols && (!IsTargetOsOsX(testProject.RuntimeIdentifier) || framework.Version.Major >= 6))
             {
                 Log.WriteLine("Checking for symbol files");
                 IEnumerable<string> pdbFiles;

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -491,8 +491,6 @@ public class Program
                     return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.{" + mvid + "}.map"));
                 }
             }
-
-            return null;
         }
 
         public static bool DoesImageHaveR2RInfo(string path)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -496,6 +496,8 @@ public class Program
                     return Path.GetFileName(Path.ChangeExtension(assemblyFile, "ni.{" + mvid + "}.map"));
                 }
             }
+
+            return null;
         }
 
         public static bool DoesImageHaveR2RInfo(string path)


### PR DESCRIPTION
As @AArnott noticed, Crossgen2 targeting OSX doesn't produce any form of symbol information. I believe it should produce the R2R map (as the only other option - PDB - is Windows-specific and unsupported on non-Windows OSes) but that was blocked in the SDK by upfront checks for the Linux targeting OS. I propose removing these checks so that the R2R map logic can apply for all non-Windows OSes.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 