### PR TITLE
Allow MSBuild to use BinaryFormatter

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -438,6 +438,9 @@
     <PropertyGroup>
       <ReplacementPattern>"version": ".*"</ReplacementPattern>
       <ReplacementString>"version": "$(MicrosoftNETCoreAppRuntimePackageVersion)"</ReplacementString>
+
+      <DisabledBinaryFormatterPattern>"System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false</DisabledBinaryFormatterPattern>
+      <EnableBinaryFormatterString>"System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": true</EnableBinaryFormatterString>
     </PropertyGroup>
     <ItemGroup>
       <!-- Exclude F# from retargeting: https://github.com/dotnet/toolset/issues/2866 -->
@@ -452,6 +455,14 @@
       DestinationFiles="@(ToolRuntimeConfigPath)"
       ReplacementPatterns="$(ReplacementPattern)"
       ReplacementStrings="$(ReplacementString)" />
+
+    <!-- Work around https://github.com/dotnet/msbuild/issues/6215 by opting back into net7 behavior -->
+    <ReplaceFileContents
+      InputFiles="@(ToolRuntimeConfigPath)"
+      DestinationFiles="@(ToolRuntimeConfigPath)"
+      ReplacementPatterns="$(DisabledBinaryFormatterPattern)"
+      ReplacementStrings="$(EnableBinaryFormatterString)"
+      Condition=" '%(ToolRuntimeConfigPath.FileName)' == 'MSBuild.runtimeconfig'" />
 
     <Move
       SourceFiles="@(MSBuild15Items)"


### PR DESCRIPTION
With EnableUnsafeBinaryFormatterSerialization=false, MSBuild can crash
instead of passing along an error, dotnet/msbuild#8786. Temporarily
opt back into the old behavior while fixing this in MSBuild.
