### PR TITLE
Don't set UseApphost or SelfContained to true for PublishAot

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -69,8 +69,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                              $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '8.0')) and
                               (
                                   '$(PublishTrimmed)' == 'true' or
-                                  '$(PublishSingleFile)' == 'true' or
-                                  '$(PublishAot)' == 'true'
+                                  '$(PublishSingleFile)' == 'true'
                               )">
     <PublishSelfContained>true</PublishSelfContained>
   </PropertyGroup>
@@ -173,6 +172,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               $([MSBuild]::VersionLessThan($(_TargetFrameworkVersionWithoutV), '8.0'))">true</SelfContained>
     
     <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
+    <SelfContained Condition="'$(PublishAot)' == 'true' and '$(_IsPublishing)' == 'true'">false</SelfContained>
     <_RuntimeIdentifierUsesAppHost Condition="$(RuntimeIdentifier.StartsWith('ios')) or $(RuntimeIdentifier.StartsWith('tvos')) or $(RuntimeIdentifier.StartsWith('maccatalyst')) or $(RuntimeIdentifier.StartsWith('android')) or $(RuntimeIdentifier.StartsWith('browser'))">false</_RuntimeIdentifierUsesAppHost>
     <_RuntimeIdentifierUsesAppHost Condition="'$(_RuntimeIdentifierUsesAppHost)' == ''">true</_RuntimeIdentifierUsesAppHost>
     <UseAppHost Condition="'$(UseAppHost)' == '' and
@@ -181,6 +181,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                             ('$(RuntimeIdentifier)' != '' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1') or
                             '$(_TargetFrameworkVersionWithoutV)' >= '3.0')">true</UseAppHost>
     <UseAppHost Condition="'$(UseAppHost)' == ''">false</UseAppHost>
+    <UseAppHost Condition="'$(PublishAot)' == 'true' and '$(_IsPublishing)' == 'true'">false</UseAppHost>
   </PropertyGroup>
 
   <!-- Only use the default apphost if building without a RID and without a deps file path (used by GenerateDeps.proj for CLI tools). -->

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -275,13 +275,11 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData("PublishReadyToRun", true)]
         [InlineData("PublishSingleFile", true)]
         [InlineData("PublishTrimmed", true)]
-        [InlineData("PublishAot", true)]
         [InlineData("PublishReadyToRun", false)]
         [InlineData("PublishSingleFile", false)]
         [InlineData("PublishTrimmed", false)]
         public void SomePublishPropertiesInferSelfContained(string property, bool useFrameworkDependentDefaultTargetFramework)
         {
-            // Note: there is a bug with PublishAot I think where this test will fail for Aot if the testname is too long. Do not make it longer.
             var tfm = useFrameworkDependentDefaultTargetFramework ? ToolsetInfo.CurrentTargetFramework : "net7.0"; // net 7 is the last non FDD default TFM at the time of this PR.
             var testProject = new TestProject()
             {


### PR DESCRIPTION
Fixes dotnet/runtime#79575.

`UseAppHost` doesn't make any sense for `PublishAot`, and neither do the behaviors around `SelfContained` - if `SelfContained` is true, the bin directory gets populated with a ton of garbage files we don't need during publish, and the publish process starts to have opinions about whether UseAppHost=true should be specified.

Cc @dotnet/ilc-contrib @ViktorHofer 