### PR TITLE
Containers: Registry: support pulling from quay.io.

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -17,6 +17,7 @@ namespace Microsoft.NET.Build.Containers;
 internal sealed class Registry
 {
     private const string DockerManifestV2 = "application/vnd.docker.distribution.manifest.v2+json";
+    private const string OciManifestV1 = "application/vnd.oci.image.manifest.v1+json"; // https://containers.gitbook.io/build-containers-the-hard-way/#registry-format-oci-image-manifest
     private const string DockerManifestListV2 = "application/vnd.docker.distribution.manifest.list.v2+json";
     private const string DockerContainerV1 = "application/vnd.docker.container.image.v1+json";
     private const string DockerHubRegistry1 = "registry-1.docker.io";
@@ -157,7 +158,7 @@ internal sealed class Registry
 
         return initialManifestResponse.Content.Headers.ContentType?.MediaType switch
         {
-            DockerManifestV2 => await ReadSingleImageAsync(
+            DockerManifestV2 or OciManifestV1 => await ReadSingleImageAsync(
                 repositoryName,
                 await initialManifestResponse.Content.ReadFromJsonAsync<ManifestV2>(cancellationToken: cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false),
@@ -555,6 +556,7 @@ internal sealed class Registry
         request.Headers.Accept.Add(new("application/json"));
         request.Headers.Accept.Add(new(DockerManifestListV2));
         request.Headers.Accept.Add(new(DockerManifestV2));
+        request.Headers.Accept.Add(new(OciManifestV1));
         request.Headers.Accept.Add(new(DockerContainerV1));
     }
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.NET.Build.Containers.UnitTests;
+using Xunit;
+
+namespace Microsoft.NET.Build.Containers.IntegrationTests;
+
+[Collection("Docker tests")]
+public class DockerRegistryTests
+{
+    [DockerAvailableFact]
+    public async Task GetFromRegistry()
+    {
+        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
+        var ridgraphfile = ToolsetUtils.GetRuntimeGraphFilePath();
+
+        // Don't need rid graph for local registry image pulls - since we're only pushing single image manifests (not manifest lists)
+        // as part of our setup, we could put literally anything in here. The file at the passed-in path would only get read when parsing manifests lists.
+        ImageBuilder? downloadedImage = await registry.GetImageManifestAsync(
+            DockerRegistryManager.RuntimeBaseImage,
+            DockerRegistryManager.Net6ImageTag,
+            "linux-x64",
+            ridgraphfile,
+            cancellationToken: default).ConfigureAwait(false);
+
+        Assert.NotNull(downloadedImage);
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
@@ -6,27 +6,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
-[Collection("Docker tests")]
 public class RegistryTests
 {
-    [DockerAvailableFact]
-    public async Task GetFromRegistry()
-    {
-        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
-        var ridgraphfile = ToolsetUtils.GetRuntimeGraphFilePath();
-
-        // Don't need rid graph for local registry image pulls - since we're only pushing single image manifests (not manifest lists)
-        // as part of our setup, we could put literally anything in here. The file at the passed-in path would only get read when parsing manifests lists.
-        ImageBuilder? downloadedImage = await registry.GetImageManifestAsync(
-            DockerRegistryManager.RuntimeBaseImage,
-            DockerRegistryManager.Net6ImageTag,
-            "linux-x64",
-            ridgraphfile,
-            cancellationToken: default).ConfigureAwait(false);
-
-        Assert.NotNull(downloadedImage);
-    }
-
     [InlineData("quay.io/centos/centos")]
     [InlineData("registry.access.redhat.com/ubi8/dotnet-70")]
     [Theory]

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
@@ -28,6 +28,7 @@ public class RegistryTests
     }
 
     [InlineData("quay.io/centos/centos")]
+    [InlineData("registry.access.redhat.com/ubi8/dotnet-70")]
     [Theory]
     public async Task CanReadManifestFromRegistry(string fullyQualifiedContainerName)
     {

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
@@ -26,4 +26,34 @@ public class RegistryTests
 
         Assert.NotNull(downloadedImage);
     }
+
+    [InlineData("quay.io/centos/centos")]
+    [Theory]
+    public async Task CanReadManifestFromRegistry(string fullyQualifiedContainerName)
+    {
+        bool parsed = ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedContainerName,
+                                                                           out string? containerRegistry,
+                                                                           out string? containerName,
+                                                                           out string? containerTag,
+                                                                           out string? containerDigest,
+                                                                           out bool isRegistrySpecified);
+        Assert.True(parsed);
+        Assert.True(isRegistrySpecified);
+        Assert.NotNull(containerRegistry);
+        Assert.NotNull(containerName);
+        containerTag ??= "latest";
+
+        Registry registry = new Registry(new Uri($"https://{containerRegistry}"));
+
+        var ridgraphfile = ToolsetUtils.GetRuntimeGraphFilePath();
+
+        ImageBuilder? downloadedImage = await registry.GetImageManifestAsync(
+            containerName,
+            containerTag,
+            "linux-x64",
+            ridgraphfile,
+            cancellationToken: default).ConfigureAwait(false);
+
+        Assert.NotNull(downloadedImage);
+    }
 }


### PR DESCRIPTION
quay.io returns 'application/vnd.oci.image.manifest.v1+json' which we can treat the same as 'application/vnd.docker.distribution.manifest.v2+json'.

@baronfel ptal.