### PR TITLE
Containers: add mappings for s390x and ppc64le platform architectures to corresponding rids.

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -264,8 +264,6 @@ internal sealed class Registry
     private static string? CreateRidForPlatform(PlatformInformation platform)
     {
         // we only support linux and windows containers explicitly, so anything else we should skip past.
-        // there are theoretically other platforms/architectures that Docker supports (s390x?), but we are
-        // deliberately ignoring them without clear user signal.
         var osPart = platform.os switch
         {
             "linux" => "linux",
@@ -285,6 +283,8 @@ internal sealed class Registry
             "x386" => "x86",
             "arm" => $"arm{(platform.variant != "v7" ? platform.variant : "")}",
             "arm64" => "arm64",
+            "ppc64le" => "ppc64le",
+            "s390x" => "s390x",
             _ => null
         };
 


### PR DESCRIPTION
Rids for these architectures are defined in the rid graph, and Red Hat provides images for them, like [ubi8/dotnet-70-runtime](https://catalog.redhat.com/software/containers/ubi8/dotnet-70-runtime/633c2b3f7f3af1e4ef67fa27).

@baronfel ptal.