### PR TITLE
Fix Source Link cross-targeting targets

### DIFF
--- a/src/Assets/TestProjects/SourceLinkTestApp/SourceLinkTestApp.csproj
+++ b/src/Assets/TestProjects/SourceLinkTestApp/SourceLinkTestApp.csproj
@@ -3,5 +3,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
@@ -13,20 +13,19 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <_SourceLinkSdkSubDir>build</_SourceLinkSdkSubDir>
-    <_SourceLinkSdkSubDir Condition="'$(IsCrossTargetingBuild)' == 'true'">buildMultiTargeting</_SourceLinkSdkSubDir>
-
     <!-- Suppress implicit SourceLink inclusion if any Microsoft.SourceLink package is referenced. -->
     <SuppressImplicitGitSourceLink Condition="'$(PkgMicrosoft_SourceLink_Common)' != ''">true</SuppressImplicitGitSourceLink>
+
+    <_SourceLinkPropsImported>true</_SourceLinkPropsImported>
   </PropertyGroup>
 
   <ImportGroup Condition="'$(SuppressImplicitGitSourceLink)' != 'true'">
-    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\$(_SourceLinkSdkSubDir)\Microsoft.Build.Tasks.Git.props"/>
-    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Common\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Common.props"/>
-    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitHub.props"/>
-    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitLab.props"/>
-    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.AzureRepos.Git.props"/>
-    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Bitbucket.Git.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\build\Microsoft.Build.Tasks.Git.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Common\build\Microsoft.SourceLink.Common.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\build\Microsoft.SourceLink.GitHub.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\build\Microsoft.SourceLink.GitLab.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\build\Microsoft.SourceLink.AzureRepos.Git.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\build\Microsoft.SourceLink.Bitbucket.Git.props"/>
   </ImportGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
@@ -13,17 +13,21 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- C++ projects currently do not import Microsoft.NET.Sdk.props. -->
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.SourceLink.props" Condition="'$(_SourceLinkSdkSubDir)' == ''"/>
-  
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.SourceLink.props" Condition="'$(_SourceLinkPropsImported)' != 'true'"/>
+
   <PropertyGroup>
+    <!-- Workaround for https://github.com/Microsoft/msbuild/issues/3294. -->
+    <_SourceLinkSdkSubDir>build</_SourceLinkSdkSubDir>
+    <_SourceLinkSdkSubDir Condition="'$(IsCrossTargetingBuild)' == 'true'">buildMultiTargeting</_SourceLinkSdkSubDir>
+
     <EmbedUntrackedSources Condition="'$(EmbedUntrackedSources)' == ''">true</EmbedUntrackedSources>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\$(_SourceLinkSdkSubDir)\Microsoft.Build.Tasks.Git.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\build\Microsoft.Build.Tasks.Git.targets"/>
   <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Common\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Common.targets"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitHub.targets"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.GitLab.targets"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.AzureRepos.Git.targets"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\$(_SourceLinkSdkSubDir)\Microsoft.SourceLink.Bitbucket.Git.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitHub\build\Microsoft.SourceLink.GitHub.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.GitLab\build\Microsoft.SourceLink.GitLab.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\build\Microsoft.SourceLink.AzureRepos.Git.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\build\Microsoft.SourceLink.Bitbucket.Git.targets"/>
 
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Text;
@@ -11,6 +12,7 @@ using FluentAssertions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
+using NuGet.Packaging.Core;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -216,6 +218,15 @@ namespace Microsoft.NET.Build.Tests
 
                 ValidatePdb(Path.Combine(intermediateDir.FullName, "SourceLinkTestApp.pdb"), expectedEmbeddedSources: true);
             }
+
+            // check that RepositoryUrl and commit sha is included in the package nuspec:
+            var binDir = buildCommand.GetOutputDirectory(targetFramework: "");
+            using var nupkg = ZipFile.OpenRead(Path.Combine(binDir.FullName, "SourceLinkTestApp.1.0.0.nupkg"));
+            using var nuspec = nupkg.GetEntry("SourceLinkTestApp.nuspec").Open();
+            using var nuspecStream = new MemoryStream();
+            nuspec.CopyTo(nuspecStream);
+            var nuspecStr = Encoding.UTF8.GetString(nuspecStream.ToArray());
+            Assert.Contains(@"repository type=""git"" commit=""1200000000000000000000000000000000000000""", nuspecStr);
         }
 
         [Theory]
@@ -223,7 +234,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(false)]
         public void SuppressImplicitGitSourceLink_SetExplicitly(bool multitarget)
         {
-            string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? ";netstandard2.0" : "");
+            string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? "; netstandard2.0" : "");
 
             var testAsset = _testAssetsManager
                 .CopyTestAsset("SourceLinkTestApp", identifier: multitarget.ToString())

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -190,7 +190,7 @@ namespace Microsoft.NET.Build.Tests
             string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? ";netstandard2.0" : "");
 
             var testAsset = _testAssetsManager
-                .CopyTestAsset("SourceLinkTestApp", identifier: origin + expectedLink + multitarget.ToString())
+                .CopyTestAsset("SourceLinkTestApp", identifier: origin + multitarget.ToString())
                 .WithSource();
 
             if (multitarget)
@@ -234,7 +234,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(false)]
         public void SuppressImplicitGitSourceLink_SetExplicitly(bool multitarget)
         {
-            string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? "; netstandard2.0" : "");
+            string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? ";netstandard2.0" : "");
 
             var testAsset = _testAssetsManager
                 .CopyTestAsset("SourceLinkTestApp", identifier: multitarget.ToString())

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -190,7 +190,7 @@ namespace Microsoft.NET.Build.Tests
             string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? ";netstandard2.0" : "");
 
             var testAsset = _testAssetsManager
-                .CopyTestAsset("SourceLinkTestApp", identifier: origin)
+                .CopyTestAsset("SourceLinkTestApp", identifier: origin + expectedLink + multitarget.ToString())
                 .WithSource();
 
             if (multitarget)

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -219,7 +219,7 @@ namespace Microsoft.NET.Build.Tests
                 ValidatePdb(Path.Combine(intermediateDir.FullName, "SourceLinkTestApp.pdb"), expectedEmbeddedSources: true);
             }
 
-            // check that RepositoryUrl and commit sha is included in the package nuspec:
+            // check that commit sha is included in the package nuspec:
             var binDir = buildCommand.GetOutputDirectory(targetFramework: "");
             using var nupkg = ZipFile.OpenRead(Path.Combine(binDir.FullName, "SourceLinkTestApp.1.0.0.nupkg"));
             using var nuspec = nupkg.GetEntry("SourceLinkTestApp.nuspec").Open();


### PR DESCRIPTION
`IsCrossTargetingBuild` is only defined in `.targets`, not in `.props`.

Only `Microsoft.SourceLink.Common.targets` needs to be imported in cross-targeting build as it contains workaround for https://github.com/Microsoft/msbuild/issues/3294. Once this issue is fixed we can remove cross-targeting specialization entirely.

Related: https://github.com/dotnet/msbuild/pull/8898
Fixes https://github.com/dotnet/sdk/issues/33297