### PR TITLE
Update .gitignore to ignore .env files

### DIFF
--- a/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from `dotnet new gitignore`
 
+# dotenv files
+.env
+
 # User-specific files
 *.rsuser
 *.suo

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from `dotnet new gitignore`
 
+# dotenv files
+.env
+
 # User-specific files
 *.rsuser
 *.suo


### PR DESCRIPTION
dotenv is a very common convention in other ecosystems for allowing user-specific env var values without doing crazy custom configurations. We're talking about things in https://github.com/dotnet/sdk/issues/33241 that might lead to .NET apps doing more with dotenv, so let's get ahead of the game and pre-emptively don't commit these files.

A longer-term change would sync this with github/gitignore, but wanted to get this flag in the ground first.