### PR TITLE
Remove containerize binaries from packaging and layout for all non-windows-hosted builds

### DIFF
--- a/src/Containers/packaging/package.csproj
+++ b/src/Containers/packaging/package.csproj
@@ -21,6 +21,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>containers;docker;Microsoft.NET.Build.Containers</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <ShouldBuildContainerizeApp Condition="'$(ShouldBuildContainerizeApp)' == '' and $(NETCoreSdkPortableRuntimeIdentifier.StartsWith('win'))">true</ShouldBuildContainerizeApp>
     </PropertyGroup>
 
     <ItemGroup>
@@ -34,9 +35,9 @@
 
         <ProjectReference Include="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj"
                           SetTargetFramework="TargetFramework=$(VSCompatTargetFramework)"
-                          OutputItemType="ContainerLibraryOutputNet472" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+                          OutputItemType="ContainerLibraryOutputNet472" Condition="'$(ShouldBuildContainerizeApp)' == 'true'" />
 
-        <ProjectReference Include="../containerize/containerize.csproj" PrivateAssets="all" IncludeAssets="runtime" ReferenceOutputAssembly="true" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+        <ProjectReference Include="../containerize/containerize.csproj" PrivateAssets="all" IncludeAssets="runtime" ReferenceOutputAssembly="true" Condition="'$(ShouldBuildContainerizeApp)' == 'true'" />
     </ItemGroup>
 
     <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">
@@ -47,16 +48,16 @@
     </Target>
 
     <Target Name="AddItemsForPackaging" AfterTargets="Build">
-        <MSBuild Projects="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj" Properties="TargetFramework=$(VSCompatTargetFramework)" Targets="ResolveAssemblyReferences" Condition="'$(DotNetBuildFromSource)' != 'true'">
+        <MSBuild Projects="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj" Properties="TargetFramework=$(VSCompatTargetFramework)" Targets="ResolveAssemblyReferences" Condition="'$(ShouldBuildContainerizeApp)' == 'true'">
             <Output TaskParameter="TargetOutputs" ItemName="_AllNet472ContainerTaskDependencies" />
         </MSBuild>
-        <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+        <ItemGroup Condition="'$(ShouldBuildContainerizeApp)' == 'true'">
             <NecessaryNet472ContainerTaskDependencies Include="@(_AllNet472ContainerTaskDependencies)" Condition="(
                                 $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('NuGet')) or
                                 $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('Newtonsoft'))
                             ) and
                             %(_AllNet472ContainerTaskDependencies.NuGetIsFrameworkReference) != true" />
-            
+
             <!-- containerize folder -->
             <Content Include="$(OutDir)containerize.dll" Pack="true" PackagePath="containerize/" />
             <Content Include="$(OutDir)containerize.runtimeconfig.json" Pack="true" PackagePath="containerize/" />

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -189,6 +189,9 @@
 
   <Target Name="PublishContainersSdk"
             BeforeTargets="Build">
+    <PropertyGroup>
+      <ShouldBuildContainerizeApp Condition="'$(ShouldBuildContainerizeApp)' == '' and $(NETCoreSdkPortableRuntimeIdentifier.StartsWith('win'))">true</ShouldBuildContainerizeApp>
+    </PropertyGroup>
     <ItemGroup>
       <BuildFiles Include="$(RepoRoot)/src/Containers/packaging/build/Microsoft.NET.Build.Containers.props" />
       <BuildFiles Include="$(RepoRoot)/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets" />
@@ -199,7 +202,7 @@
       Targets="Publish"
       Projects="$(RepoRoot)/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj"
       Properties="Configuration=$(Configuration);PublishDir=$(OutputPath)/Containers/tasks/net472;TargetFramework=net472"
-      Condition="'$(DotNetBuildFromSource)' != 'true'" />
+      Condition="'$(ShouldBuildContainerizeApp)' == 'true'" />
     <MSBuild
       Targets="Publish"
       Projects="$(RepoRoot)/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj"
@@ -208,9 +211,9 @@
       Targets="Publish"
       Projects="$(RepoRoot)/src/Containers/containerize/containerize.csproj"
       Properties="Configuration=$(Configuration);PublishDir=$(OutputPath)/Containers/containerize"
-      Condition="'$(DotNetBuildFromSource)' != 'true'" />
+      Condition="'$(ShouldBuildContainerizeApp)' == 'true'" />
   </Target>
-  
+
   <Target Name="PublishBuiltInTools"
           BeforeTargets="Build">
 


### PR DESCRIPTION
This should solve https://github.com/dotnet/source-build/issues/3510 (again), but this time using a broader brush.  Before, we excluded containerize binaries (and net472 tasks) based on the source-build flags, but what we really should be asking is "what platform is this SDK being built for?" and not building the net472 assets for non-Windows targets.

We _should not_ take this as it currently is - I'm using the horrible hack of comparing the `$(NETCoreSdkPortableRuntimeIdentifier)` and seeing if it contains the `win` platform - instead we should probably have something more regular/regimented like runtime or installer do. Runtime infers a property called `HostOSName` and `OSName`.