### PR TITLE
Fix workload cache security descriptors

### DIFF
--- a/sdk.sln
+++ b/sdk.sln
@@ -473,6 +473,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Build.Contain
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Build.Containers.UnitTests", "src\Tests\Microsoft.NET.Build.Containers.UnitTests\Microsoft.NET.Build.Containers.UnitTests.csproj", "{E54506B8-0B81-4FC4-99B5-5C67E19D4B09}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SDDLTests", "src\Tests\SDDLTests\SDDLTests.csproj", "{FEA8B7B5-901B-4A3A-948F-7E5F54F09FF5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -887,6 +889,10 @@ Global
 		{E54506B8-0B81-4FC4-99B5-5C67E19D4B09}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E54506B8-0B81-4FC4-99B5-5C67E19D4B09}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E54506B8-0B81-4FC4-99B5-5C67E19D4B09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FEA8B7B5-901B-4A3A-948F-7E5F54F09FF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FEA8B7B5-901B-4A3A-948F-7E5F54F09FF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FEA8B7B5-901B-4A3A-948F-7E5F54F09FF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FEA8B7B5-901B-4A3A-948F-7E5F54F09FF5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1049,6 +1055,7 @@ Global
 		{F04DB812-7278-47F2-913E-225CE2EF150C} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 		{7DCA2BEC-B1E1-4F2B-952A-A26B5110FDA5} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 		{E54506B8-0B81-4FC4-99B5-5C67E19D4B09} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
+		{FEA8B7B5-901B-4A3A-948F-7E5F54F09FF5} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB8F26CE-4DE6-433F-B32A-79183020BBD6}

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.Installer.Windows
                 string packageDirectory = GetPackageDirectory(packageId, packageVersion);
 
                 // Delete the package directory and create a new one. If all the files were properly
-                // cached, the client would not request this action. 
+                // cached, the client would not request this action.
                 if (Directory.Exists(packageDirectory))
                 {
                     Directory.Delete(packageDirectory, recursive: true);

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Installer.Windows
                 {
                     DirectorySecurity ds = new(path, AccessControlSections.Access);
 
-                    ds.SetAccessRuleProtection(true, false);
+                    ds.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
 
                     foreach (FileSystemAccessRule ace in ds.GetAccessRules(includeExplicit: true,
                         includeInherited: true, typeof(NTAccount)))
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.Installer.Windows
 
                 string packageDirectory = GetPackageDirectory(packageId, packageVersion);
 
-                // Delete the package directory and create a new one. If all the files were properly
+                // Delete the package directory and create a new one that's secure. If all the files were properly
                 // cached, the client would not request this action.
                 if (Directory.Exists(packageDirectory))
                 {
@@ -209,7 +209,6 @@ namespace Microsoft.DotNet.Installer.Windows
         {
             if (!File.Exists(destinationFile))
             {
-
                 FileAccessRetrier.RetryOnMoveAccessFailure(() => File.Move(sourceFile, destinationFile));
 
                 log?.LogMessage($"Moved '{sourceFile}' to '{destinationFile}'");

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -88,41 +88,63 @@ namespace Microsoft.DotNet.Installer.Windows
         }
 
         /// <summary>
-        /// Creates the root package cache directory if it does not exist and configures the directory's ACLs. ACLs are still configured
-        /// if the directory exists.
-        /// </summary>
-        private void CreateRootDirectory()
-        {
-            CreateSecureDirectory(PackageCacheRoot);
-        }
-
-        /// <summary>
-        /// Creates the specified directory and secures it by configuring access rules (ACLs). If the parent
-        /// of the directory does not exist, it recursively walks the path back to ensure each parent directory
-        /// is created with the proper ACLs and inheritance settings.
+        /// Creates the specified directory and secures it by configuring access rules (ACLs) that allow sub-directories
+        /// and files to inherit access control entries. 
         /// </summary>
         /// <param name="path">The path of the directory to create.</param>
-        private void CreateSecureDirectory(string path)
+        /// <param name="resetAccessRules">When <see langword="true"/>, all existing access rules are removed before
+        /// setting up new rules.
+        /// </param>
+        /// <param name="log">The underlying setup log to use.</param>
+        public static void CreateSecureDirectory(string path, bool resetAccessRules = false, ISetupLogger log = null)
         {
             if (!Directory.Exists(path))
             {
-                CreateSecureDirectory(Directory.GetParent(path).FullName);
-
-                DirectorySecurity directorySecurity = new();
-
-                // Only set the owner and use its default group. If the machine is domain joined, this should create
-                // a descriptor like O:BAG:DU by selecting SDDL_DOMAIN_USERS. On non-domain joined machines and Windows Sandbox,
-                // the group SID will be different and the descriptor will end up as O:BAG:S-1-5-21-2047949552-857980807-821054962-513.
-                directorySecurity.SetOwner(s_AdministratorsSid);
-                directorySecurity.SetAccessRule(s_AdministratorRule);
-                directorySecurity.SetAccessRule(s_LocalSystemRule);
-                directorySecurity.SetAccessRule(s_UsersRule);
-                directorySecurity.SetAccessRule(s_EveryoneRule);
-
-                // Don't use Directory.CreateDirectory as that can cause problems with inherited ACEs from
+                // Create the directory with the desired access rights if it doesn't exist. We don't use
+                // Directory.CreateDirectory as that can cause problems with inherited ACEs from
                 // the parent folders as access rules become cumulative. The acccess rules for the directory should all have
                 // object and container inheritance set to ensure access rights are inherited when creating files.
-                directorySecurity.CreateDirectory(path);
+                DirectorySecurity ds = new();
+                ds.SetOwner(s_AdministratorsSid);
+                ds.SetGroup(s_AdministratorsSid);
+                ds.SetAccessRule(s_AdministratorRule);
+                ds.SetAccessRule(s_LocalSystemRule);
+                ds.SetAccessRule(s_UsersRule);
+                ds.SetAccessRule(s_EveryoneRule);
+                ds.CreateDirectory(path);
+            }
+            else if (resetAccessRules)
+            {
+                // Best effort to reset the DACL and remove unnecessary ACEs. This will
+                // help to address some issues that may arise from older .NET versions that created
+                // the cache with permissions that were too restrictive.
+                try
+                {
+                    DirectorySecurity ds = new(path, AccessControlSections.Access);
+
+                    ds.SetAccessRuleProtection(true, false);
+
+                    foreach (FileSystemAccessRule ace in ds.GetAccessRules(includeExplicit: true,
+                        includeInherited: true, typeof(NTAccount)))
+                    {
+                        ds.PurgeAccessRules(ace.IdentityReference);
+                    }
+
+                    ds.SetOwner(s_AdministratorsSid);
+                    ds.SetGroup(s_AdministratorsSid);
+                    ds.SetAccessRule(s_AdministratorRule);
+                    ds.SetAccessRule(s_LocalSystemRule);
+                    ds.SetAccessRule(s_UsersRule);
+                    ds.SetAccessRule(s_EveryoneRule);
+
+                    DirectoryInfo di = new DirectoryInfo(path);
+                    di.SetAccessControl(ds);
+                }
+                catch (Exception ex)
+                {
+                    // Record the error, but don't fail the operation if we couldn't reset the access rules.
+                    log?.LogMessage($"Failed to reset access rules for '{path}'. Error: {ex.Message}");
+                }
             }
         }
 
@@ -143,12 +165,14 @@ namespace Microsoft.DotNet.Installer.Windows
 
             if (IsElevated)
             {
-                CreateRootDirectory();
+                // Create the root directory. If the directory already exists then we'll try to
+                // reset the DACL to conform to our expectations.
+                CreateSecureDirectory(PackageCacheRoot, resetAccessRules: true, Log);
 
                 string packageDirectory = GetPackageDirectory(packageId, packageVersion);
 
-                // Delete the directory and create a new one that's secure. If the files were properly
-                // cached, the client won't request this action.
+                // Delete the package directory and create a new one. If all the files were properly
+                // cached, the client would not request this action. 
                 if (Directory.Exists(packageDirectory))
                 {
                     Directory.Delete(packageDirectory, recursive: true);
@@ -165,8 +189,8 @@ namespace Microsoft.DotNet.Installer.Windows
                 string cachedMsiPath = Path.Combine(packageDirectory, Path.GetFileName(msiPath));
                 string cachedManifestPath = Path.Combine(packageDirectory, Path.GetFileName(manifestPath));
 
-                MoveAndSecureFile(manifestPath, cachedManifestPath);
-                MoveAndSecureFile(msiPath, cachedMsiPath);
+                MoveAndSecureFile(manifestPath, cachedManifestPath, Log);
+                MoveAndSecureFile(msiPath, cachedMsiPath, Log);
             }
             else if (IsClient)
             {
@@ -191,23 +215,24 @@ namespace Microsoft.DotNet.Installer.Windows
         /// </summary>
         /// <param name="sourceFile">The source file to move.</param>
         /// <param name="destinationFile">The destination where the source file will be moved.</param>
-        private void MoveAndSecureFile(string sourceFile, string destinationFile)
+        /// <param name="log">The underlying setup log to use.</param>
+        public static void MoveAndSecureFile(string sourceFile, string destinationFile, ISetupLogger log = null)
         {
             if (!File.Exists(destinationFile))
             {
-                // See https://github.com/dotnet/sdk/issues/28450
+
                 FileAccessRetrier.RetryOnMoveAccessFailure(() => File.Move(sourceFile, destinationFile));
-                Log?.LogMessage($"Moved '{sourceFile}' to '{destinationFile}'");
+
+                log?.LogMessage($"Moved '{sourceFile}' to '{destinationFile}'");
 
                 FileInfo fi = new(destinationFile);
                 FileSecurity fs = new();
 
-                // Only set the owner, everything else should be inherited. Assuming the parent folder was not
-                // modified externally, the file's descriptor should either be
-                // O:BAG:DUD:(A;ID;0x1200a9;;;WD)(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU) or
-                // O:BAG:S-1-5-21-2047949552-857980807-821054962-513D:(A;ID;0x1200a9;;;WD)(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU)
-                // Note that all the access entries include the ID flag indicating they were inherited from the container.
+                // Set the owner and group to built-in administrators (BA). All other ACE values are inherited from
+                // the parent directory. See https://github.com/dotnet/sdk/issues/28450. If the directory's descriptor
+                // is correctly configured, we should end up with an inherited ACE for Everyone: (A;ID;0x1200a9;;;WD)
                 fs.SetOwner(s_AdministratorsSid);
+                fs.SetGroup(s_AdministratorsSid);
                 fi.SetAccessControl(fs);
             }
         }

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -105,12 +105,7 @@ namespace Microsoft.DotNet.Installer.Windows
                 // the parent folders as access rules become cumulative. The acccess rules for the directory should all have
                 // object and container inheritance set to ensure access rights are inherited when creating files.
                 DirectorySecurity ds = new();
-                ds.SetOwner(s_AdministratorsSid);
-                ds.SetGroup(s_AdministratorsSid);
-                ds.SetAccessRule(s_AdministratorRule);
-                ds.SetAccessRule(s_LocalSystemRule);
-                ds.SetAccessRule(s_UsersRule);
-                ds.SetAccessRule(s_EveryoneRule);
+                SetDirectoryAccessRules(ds);
                 ds.CreateDirectory(path);
             }
             else if (resetAccessRules)
@@ -130,13 +125,7 @@ namespace Microsoft.DotNet.Installer.Windows
                         ds.PurgeAccessRules(ace.IdentityReference);
                     }
 
-                    ds.SetOwner(s_AdministratorsSid);
-                    ds.SetGroup(s_AdministratorsSid);
-                    ds.SetAccessRule(s_AdministratorRule);
-                    ds.SetAccessRule(s_LocalSystemRule);
-                    ds.SetAccessRule(s_UsersRule);
-                    ds.SetAccessRule(s_EveryoneRule);
-
+                    SetDirectoryAccessRules(ds);
                     DirectoryInfo di = new DirectoryInfo(path);
                     di.SetAccessControl(ds);
                 }
@@ -288,6 +277,22 @@ namespace Microsoft.DotNet.Installer.Windows
 
             msiPath = possibleMsiPath;
             return true;
+        }
+
+        /// <summary>
+        /// Apply a standard set of access rules to the directory security descriptor. The owner and group will
+        /// be set to built-in Administrators. Full access is granted to built-in administators and SYSTEM with
+        /// read, execute, synchronize permssions for built-in users and Everyone.
+        /// </summary>
+        /// <param name="ds">The security descriptor to update.</param>
+        private static void SetDirectoryAccessRules(DirectorySecurity ds)
+        {
+            ds.SetOwner(s_AdministratorsSid);
+            ds.SetGroup(s_AdministratorsSid);
+            ds.SetAccessRule(s_AdministratorRule);
+            ds.SetAccessRule(s_LocalSystemRule);
+            ds.SetAccessRule(s_UsersRule);
+            ds.SetAccessRule(s_EveryoneRule);
         }
 
         /// <summary>

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -110,6 +110,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SDDLTests"/>
+  </ItemGroup>
+
   <Target Name="LinkVSEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
     <ItemGroup>
       <ReferencePath Condition="'%(ReferencePath.FileName)' == 'Microsoft.VisualStudio.Setup.Configuration.Interop'">

--- a/src/Tests/SDDLTests/Program.cs
+++ b/src/Tests/SDDLTests/Program.cs
@@ -1,0 +1,323 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.Installer.Windows;
+using Xunit;
+
+namespace SDDLTests
+{
+    /// <summary>
+    /// Console application containing a manual test to verify security descriptors used by workloads when caching packages.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public class SDDLTests
+    {
+        /// <summary>
+        /// Directory under the user's %temp% directory where the test asset will be created.
+        /// </summary>
+        private static readonly string s_userTestDirectory = Path.Combine(Path.GetTempPath(), "SDDLTest");
+
+        /// <summary>
+        /// The filename and extension of the test asset.
+        /// </summary>
+        private static readonly string s_testAsset = "test.txt";
+
+        /// <summary>
+        /// Regular expression to capture parts of a security descriptor in SDDL format.
+        /// </summary>
+        private static readonly string s_SDDL_Pattern = @"O:(?<O_SID>.*?(?=G:))G:(?<G_SID>.*?(?=D:|S:|$))(D:(?<DACL_FLAGS>.*?(?=\())(?<DACL>\(.*?\))*)?(S:(?<SACL_FLAGS>.*?(?=\())(?<SACL>\(.*?\))*)?";
+
+        /// <summary>
+        /// The root directory of the cache under ProgramData.
+        /// </summary>
+        private static readonly string s_cacheRootDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "SDDLTest");
+
+        /// <summary>
+        /// The path of the directory under the cache root where the test asset will be placed.
+        /// </summary>
+        private static readonly string s_cacheDirectory = Path.Combine(s_cacheRootDirectory, "a");
+
+        /// <summary>
+        /// The full path to the test asset under the user temp directory.
+        /// </summary>
+        private static readonly string s_userTestAssetPath = Path.Combine(s_userTestDirectory, s_testAsset);
+
+        /// <summary>
+        /// The full path to the test asset under the cache directory.
+        /// </summary>
+        private static readonly string s_cachedTestAssetPath = Path.Combine(s_cacheDirectory, s_testAsset);
+
+        /// <summary>
+        /// Access control sections to retrieve from security descriptors: owner, group and access control lists.
+        /// </summary>
+        private static readonly AccessControlSections s_accessControlSections = AccessControlSections.Group | AccessControlSections.Owner |
+            AccessControlSections.Access;
+
+        /// <summary>
+        /// Writes a message to the console's error stream.
+        /// </summary>
+        /// <param name="message">The message to write.</param>
+        private static void WriteError(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Error.WriteLine(message);
+            Console.ResetColor();
+        }
+
+        /// <summary>
+        /// Extracts the owner, group and DACL (individual ACES) of the security descriptor.
+        /// </summary>
+        /// <param name="sddlDescriptor">The SDDL formatted security descriptor.</param>
+        /// <returns>The owner, group and DACL.</returns>
+        /// <exception cref="FormatException">If the descriptor string cannot be parsed.</exception>
+        private static (string ownerSID, string groupSID, IEnumerable<string> DACL_ACEs) GetDescriptorParts(string sddlDescriptor)
+        {
+            Match m = Regex.Match(sddlDescriptor, s_SDDL_Pattern);
+
+            if (m.Success)
+            {
+                string owner = m.Groups.ContainsKey("O_SID") ? m.Groups["O_SID"].Value : string.Empty;
+                string group = m.Groups.ContainsKey("G_SID") ? m.Groups["G_SID"].Value : string.Empty;
+                IEnumerable<string> aces = m.Groups.ContainsKey("DACL") ? m.Groups["DACL"].Captures.Select(c => c.Value.Trim('(', ')')) :
+                    Enumerable.Empty<string>();
+
+                return (owner, group, aces);
+            }
+
+            throw new FormatException("Invalid SDDL descriptor string.");
+        }
+
+        /// <summary>
+        /// Determines whether the current user has the Administrator role.
+        /// </summary>
+        /// <returns><see langword="true"/> if the user has the Administrator role.</returns>
+        private static bool IsAdministrator()
+        {
+            WindowsPrincipal principal = new(WindowsIdentity.GetCurrent());
+
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+
+        /// <summary>
+        /// Creates a directory in the user's temporary directory along with an empty file. This
+        /// simulates the behavior when a workload pack is downloaded and extracted.
+        /// </summary>
+        /// <returns>
+        /// The full path to the test file under the users temporary directory.
+        /// </returns>
+        private static string CreateTestAsset()
+        {
+            // Always remove previous directories to ensure we're running in a clean state.
+            if (Directory.Exists(s_userTestDirectory))
+            {
+                Directory.Delete(s_userTestDirectory, recursive: true);
+            }
+
+            Directory.CreateDirectory(s_userTestDirectory);
+
+            string testAssetPath = Path.Combine(s_userTestDirectory, "test.txt");
+            using StreamWriter sw = File.CreateText(testAssetPath);
+
+            Console.WriteLine($"Created test asset at: {testAssetPath}");
+
+            // Report the directory and file security descriptors
+            DirectorySecurity ds = new(s_userTestDirectory, s_accessControlSections);
+            FileSecurity fs = new(testAssetPath, s_accessControlSections);
+
+            Console.WriteLine($"Directory descriptor: {ds.GetSecurityDescriptorSddlForm(s_accessControlSections)}");
+            Console.WriteLine($"     File descriptor: {fs.GetSecurityDescriptorSddlForm(s_accessControlSections)}");
+
+            return Path.GetFullPath(testAssetPath);
+        }
+
+        /// <summary>
+        /// Relocate the test asset from the user directory to ProgramData.
+        /// </summary>
+        private static void RelocateAndSecureAsset()
+        {
+            MsiPackageCache.CreateSecureDirectory(s_cacheRootDirectory, true);
+            MsiPackageCache.CreateSecureDirectory(s_cacheDirectory);
+            MsiPackageCache.MoveAndSecureFile(s_userTestAssetPath, s_cachedTestAssetPath);
+        }
+
+        /// <summary>
+        /// Verify a security descriptor against a set of expected values.
+        /// </summary>
+        /// <param name="path">The full path of the directory to verify.</param>
+        /// <param name="expectedOwnerSID">The expected owner SID in SDDL format.</param>
+        /// <param name="expectedGroupSID">The expected group SID in SDDL format.</param>
+        /// <param name="expectedNumberOfACEsInDACL">The number of ACEs to expect in the DACL.</param>
+        /// <param name="expectedACEs">The set of exapected ACEs in SDDL format (no parantheses). This does not have to be the full set.</param>
+        private static void VerifySecurityDescriptor(string sddlDescriptor, string expectedOwnerSID,
+            string expectedGroupSID, int expectedNumberOfACEsInDACL, params string[] expectedACEs)
+        {
+            Console.WriteLine($"Verifying descriptor: {sddlDescriptor}");
+            (string owner, string group, IEnumerable<string> ACEs) d = GetDescriptorParts(sddlDescriptor);
+
+            Assert.True(expectedOwnerSID == d.owner, $"Expected owner SID to be {expectedOwnerSID}. Actual value: {d.owner}");
+            Assert.True(expectedGroupSID == d.group, $"Expected group SID to be {expectedGroupSID}. Actual value: {d.group}");
+            Assert.True(d.ACEs.Count() == expectedNumberOfACEsInDACL, $"Expected {expectedNumberOfACEsInDACL}. Actual: {d.ACEs.Count()}");
+
+            foreach (string ace in expectedACEs)
+            {
+                Assert.True(d.ACEs.Contains(ace), $"Expected DACL to contain {ace}, but it did not.");
+            }
+        }
+
+        /// <summary>
+        /// Verify a directory's security descriptor against a set of expected values.
+        /// </summary>
+        /// <param name="path">The full path of the directory to verify.</param>
+        /// <param name="expectedOwnerSID">The expected owner SID in SDDL format.</param>
+        /// <param name="expectedGroupSID">The expected group SID in SDDL format.</param>
+        /// <param name="expectedNumberOfACEsInDACL">The number of ACEs to expect in the DACL.</param>
+        /// <param name="expectedACEs">The set of exapected ACEs in SDDL format (no parantheses). This does not have to be the full set.</param>
+        private static void VerifyDirectorySecurityDescriptor(string path, string expectedOwnerSID,
+            string expectedGroupSID, int expectedNumberOfACEsInDACL, params string[] expectedACEs)
+        {
+            Console.WriteLine($"Verifying directory expectations for {path}");
+            DirectorySecurity ds = new DirectorySecurity(path, s_accessControlSections);
+            string descriptor = ds.GetSecurityDescriptorSddlForm(s_accessControlSections);
+            VerifySecurityDescriptor(descriptor, expectedOwnerSID, expectedGroupSID, expectedNumberOfACEsInDACL, expectedACEs);
+        }
+
+        /// <summary>
+        /// Verify a files's security descriptor against a set of expected values.
+        /// </summary>
+        /// <param name="path">The full path of the directory to verify.</param>
+        /// <param name="expectedOwnerSID">The expected owner SID in SDDL format.</param>
+        /// <param name="expectedGroupSID">The expected group SID in SDDL format.</param>
+        /// <param name="expectedNumberOfACEsInDACL">The number of ACEs to expect in the DACL.</param>
+        /// <param name="expectedACEs">The set of exapected ACEs in SDDL format (no parantheses). This does not have to be the full set.</param>
+        private static void VerifyFileSecurityDescriptor(string path, string expectedOwnerSID,
+            string expectedGroupSID, int expectedNumberOfACEsInDACL, params string[] expectedACEs)
+        {
+            Console.WriteLine($"Verifying file expectations for {path}");
+            FileSecurity ds = new FileSecurity(path, s_accessControlSections);
+            string descriptor = ds.GetSecurityDescriptorSddlForm(s_accessControlSections);
+            VerifySecurityDescriptor(descriptor, expectedOwnerSID, expectedGroupSID, expectedNumberOfACEsInDACL, expectedACEs);
+        }
+
+        /// <summary>
+        /// Verify file and directory security descriptors against expected values.
+        /// </summary>
+        private static void VerifyDescriptors()
+        {
+            VerifyDirectorySecurityDescriptor(s_cacheRootDirectory, "BA", "BA", 4, "A;OICI;0x1200a9;;;WD", "A;OICI;FA;;;SY", "A;OICI;FA;;;BA", "A;OICI;0x1200a9;;;BU");
+            VerifyDirectorySecurityDescriptor(s_cacheDirectory, "BA", "BA", 4, "A;OICIID;0x1200a9;;;WD", "A;OICIID;FA;;;SY", "A;OICIID;FA;;;BA", "A;OICIID;0x1200a9;;;BU");
+            VerifyFileSecurityDescriptor(s_cachedTestAssetPath, "BA", "BA", 4, "A;ID;0x1200a9;;;WD", "A;ID;FA;;;SY", "A;ID;FA;;;BA", "A;ID;0x1200a9;;;BU");
+        }
+
+        static void Main(string[] args)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                Console.Error.WriteLine("This test is only applicable to Windows.");
+                Environment.Exit(-1);
+            }
+
+            WindowsIdentity identity = WindowsIdentity.GetCurrent();
+
+            Console.WriteLine($"Running tests as {identity.Name}, admin: {IsAdministrator()}, system: {identity.IsSystem}");
+
+            if (IsAdministrator())
+            {
+                if (args.Length > 0 && args[0] == "elevate")
+                {
+                    // SCENARIO 1B: The installer packages from the user's temp directory are being moved to
+                    // the package cache under ProgramData through an elevated process.
+                    try
+                    {
+                        RelocateAndSecureAsset();
+                    }
+                    catch
+                    {
+                        // Return an error if we couldn't move and secure the assets.
+                        Environment.Exit(-2);
+                    }
+                }
+                else if (args.Length == 0)
+                {
+                    try
+                    {
+                        // SCENARIO 2: Full test is running as administrator. This is similar to user running
+                        // a dotnet workload command from an administrator prompt, local SYSTEM or running inside
+                        // Windows Sandbox.
+                        CreateTestAsset();
+                        RelocateAndSecureAsset();
+                        VerifyDescriptors();
+                    }
+                    catch (Exception e)
+                    {
+                        WriteError(e.Message);
+                        Environment.Exit(-1);
+                    }
+                }
+                else
+                {
+                    // Invalid scenario
+                    WriteError("Invalid scenario!");
+                    Environment.Exit(-1);
+                }
+            }
+            else
+            {
+                // SCENARIO 1A: The user is running with normal privileges. Workload packages are downloaded to
+                // the user's temp directory before the CLI elevates and moves the installers into a secured cache
+                // under ProgramData.
+                try
+                {
+                    CreateTestAsset();
+
+                    // Launch the elevated portion of the test.
+                    ProcessStartInfo startInfo = new($@"""{Environment.ProcessPath}""",
+                        $@"""{Assembly.GetExecutingAssembly().Location}"" elevate")
+                    {
+                        Verb = "runas",
+                        UseShellExecute = true,
+                        CreateNoWindow = true,
+                        WindowStyle = ProcessWindowStyle.Hidden
+                    };
+
+                    Process p = new()
+                    {
+                        StartInfo = startInfo,
+                    };
+
+                    if (p.Start())
+                    {
+                        p.WaitForExit();
+
+                        if (p.ExitCode != 0)
+                        {
+                            WriteError($"Elevated process exited with {p.ExitCode}");
+                            Environment.Exit(-1);
+                        }
+
+                        VerifyDescriptors();
+                    }
+                    else
+                    {
+                        WriteError("Failed to start elevated process.");
+                        Environment.Exit(-1);
+                    }
+                }
+                catch (Exception e)
+                {
+                    WriteError(e.Message);
+                    Environment.Exit(-1);
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/SDDLTests/README.md
+++ b/src/Tests/SDDLTests/README.md
@@ -17,7 +17,7 @@ recreating them.
 
 The test will verify the security descriptor for 3 objects.
 - The root directory
-of the cahce in `ProgramData\SDDLTest`. This is the equivalent of `ProgramData\dotnet` used by
+of the cache in `ProgramData\SDDLTest`. This is the equivalent of `ProgramData\dotnet` used by
 workload related commands.
 
 - A sub folder, `ProgramData\SDDLTest\a`. This is equivalent to creating

--- a/src/Tests/SDDLTests/README.md
+++ b/src/Tests/SDDLTests/README.md
@@ -1,0 +1,81 @@
+# Security Descriptor Tests for Windows
+
+The console application contains a number of tests that need to be executed manually. The tests are used to
+verify the behavior of creating files and directories under `ProgramData`, for example, caching
+workload related MSIs. 
+
+## Building and Running Tests
+
+The test can be built either from within Visual Studio or on the commandline,
+but should be executed from a command prompt. To run the test, execute
+`artifacts\sdk-build.env.bat` followed by `dotnet artifacts\SDDLTests\SDDLTests.dll`.
+
+The test will attempt to clean up the test assets from previous runs before
+recreating them.
+
+## Test Expectations
+
+The test will verify the security descriptor for 3 objects.
+- The root directory
+of the cahce in `ProgramData\SDDLTest`. This is the equivalent of `ProgramData\dotnet` used by
+workload related commands.
+
+- A sub folder, `ProgramData\SDDLTest\a`. This is equivalent to creating
+a versioned sub-folder for a workload package inside the cache.
+
+- A file inside the subfolder that was relocated from the user's temporary
+directory. This is equivalent of downloading a workload package and then moving
+its contents to the workload package cache.
+
+The primary owner, group and DACL for each of the aforementioned
+objects are verified.
+
+## Scenarios
+
+Once compiled, the executable can be used to verify a number of scenarios.
+
+1. Launch the test from a non-elevated command prompt. The application will
+elevate before moving the file under `ProgramData`. This is similar to a user
+executing a `dotnet workload` command that downloads, elevates and caches a
+workload related MSI.
+
+1. Launch the test from an administator prompt. The test will not elevate. The
+test asset file will be created under the user's temporary directory before being
+moved to the test directory under `ProgramData`. The test is intended to
+ensure consistent behavior when running in a different context.
+
+1. Launch the test from a command prompt using Windows Sandbox. While the default account,
+`WDAGUtilityAccount`, runs as administrator, Windows Sandbox is not domain joined. The goal here is
+to very code changes that impact descriptors referencing non-existing SIDs.
+
+1. Launch the command running as `nt authority\System` (the local SYSTEM account).
+Although workloads do not currently support offering automatic updates, the Windows Update
+service usually runs under the local SYSTEM account. Since workload packages are
+first downloaded to the user's temporary directory, the test is intended to ensure
+consistent results across different accounts. The [psexec](https://learn.microsoft.com/en-us/sysinternals/downloads/psexec)
+tools can be used to launch a command prompt using the SYSTEM account by running
+`psexec.exe -sid cmd` from an elevated command prompt.
+
+## Previous Errors
+
+Below are two examples of actual scenarios where the permissions were
+too restrictive or where attempts to fix an issue created problems. The test
+is intended to help validate issues such and find potential regressions.
+
+1. In .NET 6, the workload packages ended up with the an ACE associated with the user's SID
+that provided full access while the World SID (Everyone) was not missing. This resulted
+in errors when a machine was shared between multiple users. Once the package was cached,
+subquent attempts to read or execute the package by another user failed.
+
+1. To fix the issue, the `MsiPackageCache` was modified to explicitly provide
+read and execute permissions to the Domain User SID. However, since the SID
+does not exist on Windows Sandbox, testing workload commands would result in an exception.
+
+## Additional Documentation & Tools
+
+1. [Security Descriptor Definition Language](https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-definition-language)
+1. [Descriptor Control Flags](https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-control)
+1. [ACE Ordering Rules](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/dbfdc00c-1e4b-4165-939b-974e8ea23733)
+1. `icacls` is a commandline tool that can be used to create files and folders with specific descriptors.
+1. The `get-acl <path> | format-list` cmdlet in Powershell can be used to examine
+descriptors.

--- a/src/Tests/SDDLTests/SDDLTests.csproj
+++ b/src/Tests/SDDLTests/SDDLTests.csproj
@@ -9,8 +9,12 @@
     <IsUnitTestProject>false</IsUnitTestProject>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Cli\dotnet\dotnet.csproj" />
+    <ProjectReference Include="..\..\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Microsoft.Win32.Msi\Microsoft.Win32.Msi.csproj" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

Fixes the security descriptors for the workload cache under `ProgramData`. This supersedes #30769. Object inheritance on the cache root and subfolders ensures consistent results across multiple account contexts.

The fix addresses a regression that impacted running workload commands inside Windows Sandbox when trying to assign the Domain Users SID. The regression was the result of attempting to fix another issue related to multiple users on the same machine running `dotnet workload` commands. The initial fix assigned the Domain Users SID that does not always exist.

The desired descriptor should provide full access to administrators and SYSTEM while providing read and execute permissions to built-in users and Everyone. Additionally for files inside the cache, the individual descriptors in the DACL should be inherited from the parent directory (the `ID` flag should be present in the ACE).

# Testing

A manual test application with documentation is included in this change. See the test documentation for additional details on the scenarios it verifies.

# Sample results using the manual test application

The sample below is from running inside Windows Sandbox
![image](https://github.com/dotnet/sdk/assets/7409981/fb436f7e-43fb-46d6-9ed6-850f4f20981a)

Running the same test as `nt authority\system` (local SYSTEM account)

![image](https://github.com/dotnet/sdk/assets/7409981/033d17eb-725c-461e-865e-7ad4a3c45d61)
