### PR TITLE
[release/7.0.3xx] Containers: prefer atomic layer upload

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
@@ -9,32 +9,52 @@ namespace Microsoft.NET.Build.Containers;
 
 internal static class AuthHeaderCache
 {
-
-    private static ConcurrentDictionary<string, AuthenticationHeaderValue> HostAuthenticationCache = new();
+    private static readonly ConcurrentDictionary<string, AuthenticationHeaderValue> s_hostAuthenticationCache = new();
 
     public static bool TryGet(Uri uri, [NotNullWhen(true)] out AuthenticationHeaderValue? header)
     {
-        header = null;
-
-        // observed quirk in Azure Container Registry: if you present a token to blobs/uploads and it's wrong,
-        // it won't give back a www-authenticate header for the reauth mechanism to work. So never return
-        // a cache for that URI pattern
-        string[] segments = uri.Segments;
-        if (segments is [.., "blobs/", "uploads/"])
-        {
-            return false;
-        }
-
-        return HostAuthenticationCache.TryGetValue(GetCacheKey(uri), out header);
+        return s_hostAuthenticationCache.TryGetValue(GetCacheKey(uri), out header); ;
     }
 
     public static AuthenticationHeaderValue AddOrUpdate(Uri uri, AuthenticationHeaderValue header)
     {
-        return HostAuthenticationCache.AddOrUpdate(GetCacheKey(uri), header, (_, _) => header);
+        return s_hostAuthenticationCache.AddOrUpdate(GetCacheKey(uri), header, (_, _) => header);
     }
 
-    private static string GetCacheKey(Uri uri)
+    internal static string GetCacheKey(Uri uri)
     {
-        return uri.Host + uri.AbsolutePath;
+        string finalUri = uri.Host + uri.AbsolutePath;
+
+        //trim uri parameters
+        //cases:
+        //push: 
+        //POST /v2/<name>/blobs/uploads/
+        //HEAD /v2/<name>/blobs/<digest>
+        //GET /v2/<name>/blobs/uploads/<uuid>
+        //PUT /v2/<name>/blobs/uploads/<uuid>?digest=<digest>
+        //PATCH /v2/<name>/blobs/uploads/<uuid>
+        //PUT /v2/<name>/manifests/<reference>
+
+        //pull:
+        //GET /v2/<name>/manifests/<reference>
+        //HEAD /v2/<name>/manifests/<reference>
+        //GET /v2/<name>/blobs/<digest>
+
+        IReadOnlyList<string> possibleUris = new[] { "blobs/uploads/", "blobs/", "manifests/" };
+
+        foreach (string end in possibleUris)
+        {
+            int index = finalUri.IndexOf(end);
+            if (index == -1)
+            {
+                continue;
+            }
+            else
+            {
+                finalUri = finalUri = finalUri.Substring(0, index + end.Length);
+                break;
+            }
+        }
+        return finalUri;
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
@@ -51,7 +51,7 @@ internal static class AuthHeaderCache
             }
             else
             {
-                finalUri = finalUri = finalUri.Substring(0, index + end.Length);
+                finalUri = finalUri.Substring(0, index + end.Length);
                 break;
             }
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
@@ -162,7 +162,8 @@ internal record struct Layer
 
             fs.Position = 0;
 
-            SHA256.HashData(fs, hash);
+            int bW = SHA256.HashData(fs, hash);
+            Debug.Assert(bW == hash.Length);
         }
 
         string contentHash = Convert.ToHexString(hash).ToLowerInvariant();

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -412,7 +412,8 @@ internal sealed class Registry
         HttpResponseMessage patchResponse = await client.SendAsync(patchMessage, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
-        if (patchResponse.StatusCode != HttpStatusCode.Accepted)
+        // Fail the upload if the response code is not Accepted (202) or if uploading to Amazon ECR which returns back Created (201).
+        if (!(patchResponse.StatusCode == HttpStatusCode.Accepted || (IsAmazonECRRegistry && patchResponse.StatusCode == HttpStatusCode.Created)))
         {
             var headers = patchResponse.Headers.ToString();
             var detail = await patchResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -354,7 +354,6 @@ internal sealed class Registry
             int bytesRead = await contents.ReadAsync(chunkBackingStore, cancellationToken).ConfigureAwait(false);
 
             ByteArrayContent content = new (chunkBackingStore, offset: 0, count: bytesRead);
-            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
             content.Headers.ContentLength = bytesRead;
 
             // manual because ACR throws an error with the .NET type {"Range":"bytes 0-84521/*","Reason":"the Content-Range header format is invalid"}
@@ -444,13 +443,14 @@ internal sealed class Registry
     private Task<UriBuilder> UploadBlobContentsAsync(string repository, string digest, Stream contents, HttpClient client, UriBuilder uploadUri, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (SupportsChunkedUpload && s_chunkedUploadEnabled)
-        {
-            return UploadBlobChunkedAsync(repository, digest, contents, client, uploadUri, cancellationToken);
-        }
-        else
+        try
         {
             return UploadBlobWholeAsync(repository, digest, contents, client, uploadUri, cancellationToken);
+        }
+        catch (Exception)
+        {
+            contents.Seek(0, SeekOrigin.Begin);
+            return UploadBlobChunkedAsync(repository, digest, contents, client, uploadUri, cancellationToken);
         }
     }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry.cs
@@ -361,7 +361,12 @@ internal sealed class Registry
             //    content.Headers.Add("Content-Range", $"0-{contents.Length - 1}");
             Debug.Assert(content.Headers.TryAddWithoutValidation("Content-Range", $"{chunkStart}-{chunkStart + bytesRead - 1}"));
 
-            HttpResponseMessage patchResponse = await client.PatchAsync(patchUri, content, cancellationToken).ConfigureAwait(false);
+            HttpRequestMessage patchMessage = new(HttpMethod.Patch, patchUri)
+            {
+                Content = content
+            };
+            patchMessage.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+            HttpResponseMessage patchResponse = await client.SendAsync(patchMessage, cancellationToken).ConfigureAwait(false);
 
             // Fail the upload if the response code is not Accepted (202) or if uploading to Amazon ECR which returns back Created (201).
             if (!(patchResponse.StatusCode == HttpStatusCode.Accepted || (IsAmazonECRRegistry && patchResponse.StatusCode == HttpStatusCode.Created)))
@@ -399,9 +404,13 @@ internal sealed class Registry
     {
         cancellationToken.ThrowIfCancellationRequested();
         StreamContent content = new StreamContent(contents);
-        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
         content.Headers.ContentLength = contents.Length;
-        HttpResponseMessage patchResponse = await client.PatchAsync(uploadUri.Uri, content, cancellationToken).ConfigureAwait(false);
+        HttpRequestMessage patchMessage = new(HttpMethod.Patch, uploadUri.Uri)
+        {
+            Content = content
+        };
+        patchMessage.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+        HttpResponseMessage patchResponse = await client.SendAsync(patchMessage, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
         if (patchResponse.StatusCode != HttpStatusCode.Accepted)

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -10,6 +10,9 @@ using Microsoft.NET.Build.Containers.UnitTests;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework;
+using FakeItEasy;
+using Microsoft.Build.Framework;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
@@ -26,8 +29,7 @@ public class CreateNewImageTests
     [DockerDaemonAvailableFact]
     public void CreateNewImage_Baseline()
     {
-        DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(CreateNewImage_Baseline)));
-
+        DirectoryInfo newProjectDir = new(GetTestDirectoryName());
         if (newProjectDir.Exists)
         {
             newProjectDir.Delete(recursive: true);
@@ -45,28 +47,33 @@ public class CreateNewImageTests
             .Execute()
             .Should().Pass();
 
-        CreateNewImage task = new CreateNewImage();
+        CreateNewImage task = new();
+
+        (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
+        task.BuildEngine = buildEngine;
+
         task.BaseRegistry = "mcr.microsoft.com";
         task.BaseImageName = "dotnet/runtime";
         task.BaseImageTag = "7.0";
 
         task.OutputRegistry = "localhost:5010";
+        task.LocalContainerDaemon = "Docker";
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-arm64", "publish");
-        task.ImageName = "dotnet/testimage";
+        task.ImageName = "dotnet/create-new-image-baseline";
         task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";
         task.ContainerRuntimeIdentifier = "linux-arm64";
         task.Entrypoint = new TaskItem[] { new("dotnet"), new("build") };
         task.RuntimeIdentifierGraphPath = ToolsetUtils.GetRuntimeGraphFilePath();
 
-        Assert.True(task.Execute());
+        Assert.True(task.Execute(), FormatBuildMessages(errors));
         newProjectDir.Delete(true);
     }
 
     [DockerDaemonAvailableFact]
     public void ParseContainerProperties_EndToEnd()
     {
-        DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(ParseContainerProperties_EndToEnd)));
+        DirectoryInfo newProjectDir = new(GetTestDirectoryName());
 
         if (newProjectDir.Exists)
         {
@@ -85,13 +92,16 @@ public class CreateNewImageTests
             .Execute()
             .Should().Pass();
 
-        ParseContainerProperties pcp = new ParseContainerProperties();
+        ParseContainerProperties pcp = new();
+        (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
+        pcp.BuildEngine = buildEngine;
+
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:7.0";
         pcp.ContainerRegistry = "localhost:5010";
         pcp.ContainerImageName = "dotnet/testimage";
         pcp.ContainerImageTags = new[] { "5.0", "latest" };
 
-        Assert.True(pcp.Execute());
+        Assert.True(pcp.Execute(), FormatBuildMessages(errors));
         Assert.Equal("mcr.microsoft.com", pcp.ParsedContainerRegistry);
         Assert.Equal("dotnet/runtime", pcp.ParsedContainerImage);
         Assert.Equal("7.0", pcp.ParsedContainerTag);
@@ -99,7 +109,10 @@ public class CreateNewImageTests
         Assert.Equal("dotnet/testimage", pcp.NewContainerImageName);
         pcp.NewContainerTags.Should().BeEquivalentTo(new[] { "5.0", "latest" });
 
-        CreateNewImage cni = new CreateNewImage();
+        CreateNewImage cni = new();
+        (buildEngine, errors) = SetupBuildEngine();
+        cni.BuildEngine = buildEngine;
+
         cni.BaseRegistry = pcp.ParsedContainerRegistry;
         cni.BaseImageName = pcp.ParsedContainerImage;
         cni.BaseImageTag = pcp.ParsedContainerTag;
@@ -107,12 +120,12 @@ public class CreateNewImageTests
         cni.OutputRegistry = "localhost:5010";
         cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.CurrentTargetFramework);
         cni.WorkingDirectory = "app/";
-        cni.Entrypoint = new TaskItem[] { new("ParseContainerProperties_EndToEnd") };
+        cni.Entrypoint = new TaskItem[] { new(newProjectDir.Name) };
         cni.ImageTags = pcp.NewContainerTags;
         cni.ContainerRuntimeIdentifier = "linux-x64";
         cni.RuntimeIdentifierGraphPath = ToolsetUtils.GetRuntimeGraphFilePath();
 
-        Assert.True(cni.Execute());
+        Assert.True(cni.Execute(), FormatBuildMessages(errors));
         newProjectDir.Delete(true);
     }
 
@@ -122,7 +135,7 @@ public class CreateNewImageTests
     [DockerDaemonAvailableFact]
     public void Tasks_EndToEnd_With_EnvironmentVariable_Validation()
     {
-        DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, nameof(Tasks_EndToEnd_With_EnvironmentVariable_Validation)));
+        DirectoryInfo newProjectDir = new(GetTestDirectoryName());
 
         if (newProjectDir.Exists)
         {
@@ -143,7 +156,10 @@ public class CreateNewImageTests
             .Execute()
             .Should().Pass();
 
-        ParseContainerProperties pcp = new ParseContainerProperties();
+        ParseContainerProperties pcp = new();
+        (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
+        pcp.BuildEngine = buildEngine;
+
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
         pcp.ContainerRegistry = "";
         pcp.ContainerImageName = "dotnet/envvarvalidation";
@@ -154,7 +170,7 @@ public class CreateNewImageTests
 
         pcp.ContainerEnvironmentVariables = new[] { new TaskItem("B@dEnv.Var", dict), new TaskItem("GoodEnvVar", dict) };
 
-        Assert.True(pcp.Execute());
+        Assert.True(pcp.Execute(), FormatBuildMessages(errors));
         Assert.Equal("mcr.microsoft.com", pcp.ParsedContainerRegistry);
         Assert.Equal("dotnet/runtime", pcp.ParsedContainerImage);
         Assert.Equal("6.0", pcp.ParsedContainerTag);
@@ -164,7 +180,10 @@ public class CreateNewImageTests
         Assert.Equal("dotnet/envvarvalidation", pcp.NewContainerImageName);
         Assert.Equal("latest", pcp.NewContainerTags[0]);
 
-        CreateNewImage cni = new CreateNewImage();
+        CreateNewImage cni = new();
+        (buildEngine, errors) = SetupBuildEngine();
+        cni.BuildEngine = buildEngine;
+
         cni.BaseRegistry = pcp.ParsedContainerRegistry;
         cni.BaseImageName = pcp.ParsedContainerImage;
         cni.BaseImageTag = pcp.ParsedContainerTag;
@@ -172,18 +191,33 @@ public class CreateNewImageTests
         cni.OutputRegistry = pcp.NewContainerRegistry;
         cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.CurrentTargetFramework, "linux-x64");
         cni.WorkingDirectory = "/app";
-        cni.Entrypoint = new TaskItem[] { new("/app/Tasks_EndToEnd_With_EnvironmentVariable_Validation") };
+        cni.Entrypoint = new TaskItem[] { new($"/app/{newProjectDir.Name}") };
         cni.ImageTags = pcp.NewContainerTags;
         cni.ContainerEnvironmentVariables = pcp.NewContainerEnvironmentVariables;
         cni.ContainerRuntimeIdentifier = "linux-x64";
         cni.RuntimeIdentifierGraphPath = ToolsetUtils.GetRuntimeGraphFilePath();
         cni.LocalContainerDaemon = global::Microsoft.NET.Build.Containers.KnownDaemonTypes.Docker;
 
-        Assert.True(cni.Execute());
+        Assert.True(cni.Execute(), FormatBuildMessages(errors));
 
         new RunExeCommand(_testOutput, "docker", "run", "--rm", $"{pcp.NewContainerImageName}:latest")
             .Execute()
             .Should().Pass()
             .And.HaveStdOut("Foo");
     }
+
+    private static (IBuildEngine buildEngine, List<string?> errors) SetupBuildEngine()
+    {
+        List<string?> errors = new();
+        IBuildEngine buildEngine = A.Fake<IBuildEngine>();
+        A.CallTo(() => buildEngine.LogWarningEvent(A<BuildWarningEventArgs>.Ignored)).Invokes((BuildWarningEventArgs e) => errors.Add(e.Message));
+        A.CallTo(() => buildEngine.LogErrorEvent(A<BuildErrorEventArgs>.Ignored)).Invokes((BuildErrorEventArgs e) => errors.Add(e.Message));
+        A.CallTo(() => buildEngine.LogMessageEvent(A<BuildMessageEventArgs>.Ignored)).Invokes((BuildMessageEventArgs e) => errors.Add(e.Message));
+
+        return (buildEngine, errors);
+    }
+
+    private static string GetTestDirectoryName([CallerMemberName]string testName = "DefaultTest") => Path.Combine(TestSettings.TestArtifactsDirectory, testName + "_" + DateTime.Now.ToString("yyyyMMddHHmmss"));
+
+    private static string FormatBuildMessages(List<string?> messages) => string.Join("\r\n", messages);
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/AuthHeaderCacheTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/AuthHeaderCacheTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Xunit;
+
+namespace Microsoft.NET.Build.Containers.UnitTests;
+
+public class AuthHeaderCacheTests
+{
+    [Theory]
+    [InlineData("https://mcr.microsoft.com/v2/dotnet/runtime/manifests/7.0", "mcr.microsoft.com/v2/dotnet/runtime/manifests/")]
+    [InlineData("https://mcr.microsoft.com/v2/dotnet/runtime/manifests/sha256:aa5e231e0f9a11220e10530899b489fc33182ed1168bc684949ab0cd83debd4a", "mcr.microsoft.com/v2/dotnet/runtime/manifests/")]
+    [InlineData("https://mcr.microsoft.com/v2/dotnet/runtime/blobs/sha256:ae2858f05eb4a525b320c2b2c702cda9924e58aae19a6b040eca4eee565c71e5", "mcr.microsoft.com/v2/dotnet/runtime/blobs/")]
+    [InlineData("https://public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/", "public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/")]
+    [InlineData("https://public.ecr.aws/token/", "public.ecr.aws/token/")]
+    [InlineData("https://public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/e9c6cb4a-da5a-4a45-b1db-1f17ce0d21f7", "public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/")]
+    [InlineData("https://public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/e9c6cb4a-da5a-4a45-b1db-1f17ce0d21f7?&digest=sha256%3Ad981f2c20c93e1c57a46cd87bc5b9a554be5323072a0d0ab4b354aabd237bbcf", "public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/")]
+    [InlineData("https://public.ecr.aws/v2/abcdef12/sdk-containers-test/manifests/sha256:d1f6df587a3da02b668ef33566a348374eb1500c9c050680c47295b7c0a35616", "public.ecr.aws/v2/abcdef12/sdk-containers-test/manifests/")]
+    public void DerivesCacheKeyCorrectly(string uri, string expectedKey)
+    {
+        Assert.Equal(expectedKey, AuthHeaderCache.GetCacheKey(new Uri(uri)));
+    }
+}


### PR DESCRIPTION
Ports the https://github.com/dotnet/sdk/pull/33500 and https://github.com/dotnet/sdk/pull/32890 to release/7.0.3xx
- prefer atomic upload of layer over chunked. Chunked upload is only attempted when atomic fails
- adds `Accept-Encoding` headers to PATCH requests
- adds missing auth tokens to various requests
- added handling of `Created` status code sent by AWS ECR for whole upload
- added additional check for hash creation
- [tests] improved previously false-negative tests

## Customer Impact
High:
- switch to upload the layer atomically brings up to 5x performance benefit - this is a common user complaint, especially for Azure Container Registry users
- fixes the upload to AWS ECR, now broken and intermittent issues with other registries

## Regression?
- [ ] Yes
- [X] No

## Risk
- [ ] High
- [ ] Medium
- [X] Low
The fixes are straightforward and unlikely to introduce a new regression.
Those are aligned with how docker (and other commonly-used golang container libraries like `regclient`) communicates with registries.

## Verification

- [X] Manual (required)
- [x] Automated
