### PR TITLE
Normalize line endings in GenAPI consistently

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -80,8 +80,7 @@ namespace Microsoft.DotNet.GenAPI
             SyntaxNode compilationUnit = _syntaxGenerator.CompilationUnit(namespaceSyntaxNodes)
                 .WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation)
                 .Rewrite(new TypeDeclarationCSharpSyntaxRewriter())
-                .Rewrite(new BodyBlockCSharpSyntaxRewriter(_exceptionMessage))
-                .NormalizeWhitespace();
+                .Rewrite(new BodyBlockCSharpSyntaxRewriter(_exceptionMessage));
 
             if (_includeAssemblyAttributes)
             {
@@ -89,6 +88,7 @@ namespace Microsoft.DotNet.GenAPI
             }
 
             compilationUnit = GenerateForwardedTypeAssemblyAttributes(assemblySymbol, compilationUnit);
+            compilationUnit = compilationUnit.NormalizeWhitespace(eol: Environment.NewLine);
 
             Document document = project.AddDocument(assemblySymbol.Name, compilationUnit);
             document = Simplifier.ReduceAsync(document).Result;

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -4,6 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+#if !NET
+using System.Text.RegularExpressions;
+#endif
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiSymbolExtensions;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
@@ -198,9 +201,17 @@ namespace Microsoft.DotNet.GenAPI
 
             """;
 
-            return !string.IsNullOrEmpty(headerFile) ?
+            string header = !string.IsNullOrEmpty(headerFile) ?
                 File.ReadAllText(headerFile) :
                 defaultFileHeader;
+
+#if NET
+            header = header.ReplaceLineEndings();
+#else
+            header = Regex.Replace(header, @"\r\n|\n\r|\n|\r", Environment.NewLine);
+#endif
+
+            return header;
         }
     }
 }


### PR DESCRIPTION
Normalize line endings for the license header and the assembly attributes.

Fixes https://github.com/dotnet/sdk/issues/33289