### PR TITLE
Add a unique error message when workloads are disabled but a customer is trying to use workloads

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -900,7 +900,7 @@ You may need to build the project on another operating system or architecture, o
     <comment>{StrBegin="NETSDK1205: "}{Locked="Microsoft.Net.Compilers.Toolset.Framework"}{Locked="BuildWithNetFrameworkHostedCompiler"}</comment>
   </data>
   <data name="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled" xml:space="preserve">
-    <value>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</value>
+    <value>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</value>
     <comment>{StrBegin="NETSDK1208: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -899,4 +899,8 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1205: The Microsoft.Net.Compilers.Toolset.Framework package should not be set directly. Set the property 'BuildWithNetFrameworkHostedCompiler' to 'true' instead if you need it.</value>
     <comment>{StrBegin="NETSDK1205: "}{Locked="Microsoft.Net.Compilers.Toolset.Framework"}{Locked="BuildWithNetFrameworkHostedCompiler"}</comment>
   </data>
+  <data name="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled" xml:space="preserve">
+    <value>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</value>
+    <comment>{StrBegin="NETSDK1208: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: Identifikátor cílové platformy {0} se nerozpoznal.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: K sestavování desktopových aplikací pro Windows se vyžaduje Microsoft.NET.Sdk.WindowsDesktop. Aktuální verze sady SDK nepodporuje hodnoty UseWpf a UseWindowsForms.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: Der Zielplattformbezeichner "{0}" wurde nicht erkannt.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Für das Erstellen von Windows-Desktopanwendungen ist Microsoft.NET.Sdk.WindowsDesktop erforderlich. "UseWpf" und "UseWindowsForms" werden vom aktuellen SDK nicht unterstützt.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: No se reconoció el identificador de la plataforma de destino {0}.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Se requiere Microsoft.NET.Sdk.WindowsDesktop para compilar las aplicaciones de escritorio de Windows. El SDK actual no admite "UseWpf" ni "UseWindowsForms".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: L'identificateur de la plateforme cible {0} n'a pas été reconnu.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: vous devez disposer de Microsoft.NET.Sdk.WindowsDesktop pour générer des applications de bureau Windows. 'UseWpf' et 'UseWindowsForms' ne sont pas pris en charge par le kit SDK actuel.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: l'identificatore di piattaforma di destinazione {0} non è stato riconosciuto.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: per compilare applicazioni desktop di Windows, è necessario Microsoft.NET.Sdk.WindowsDesktop. 'UseWpf' e 'UseWindowsForms' non sono supportati dall'SDK corrente.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: ターゲット プラットフォーム識別子 {0} は認識されませんでした。</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Windows デスクトップ アプリケーションを作成するには、Microsoft.NET.Sdk.WindowsDesktop が必要です。現在の SDK では、'UseWpf' と 'UseWindowsForms' はサポートされていません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: 대상 플랫폼 식별자 {0}을(를) 인식할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop을 사용하려면 Windows 데스크톱 애플리케이션을 빌드해야 합니다. 'UseWpf' 및 'UseWindowsForms'는 현재 SDK에서 지원하지 않습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: nie rozpoznano identyfikatora platformy docelowej {0}.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Do kompilowania aplikacji klasycznych systemu Windows konieczny jest zestaw Microsoft.NET.Sdk.WindowsDesktop. Właściwości „UseWpf” i „UseWindowsForms” nie są obsługiwane przez bieżący zestaw SDK.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: o identificador de plataforma de destino {0} não foi reconhecido.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop é necessário para compilar aplicativos da área de trabalho do Windows. Não há suporte para 'UseWpf' e 'UseWindowsForms' no SDK atual.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: не удалось распознать идентификатор целевой платформы {0}.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: для сборки классических приложений для Windows требуется Microsoft.NET.Sdk.WindowsDesktop. "UseWpf" и "UseWindowsForms" не поддерживаются текущим пакетом SDK.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: {0} hedef platform tanımlayıcısı tanınmadı.</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: Windows Masaüstü uygulamalarını derlemek için Microsoft.NET.Sdk.WindowsDesktop gereklidir. 'UseWpf' ve 'UseWindowsForms' geçerli SDK tarafından desteklenmiyor.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: 无法识别目标平台标识符 {0}。</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: 要构建 Windows 桌面应用程序，需使用 Microsoft.NET.Sdk.WindowsDesktop。当前 SDK 不支持 "UseWpf" 和 "UseWindowsForms"。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -930,6 +930,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1139: 無法辨識目標平台識別碼 {0}。</target>
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
+      <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <note>{StrBegin="NETSDK1208: "}</note>
+      </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
         <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
         <target state="translated">NETSDK1107: 需有 Microsoft.NET.Sdk.WindowsDesktop 才能建置 Windows 傳統型應用程式。目前的 SDK 不支援 'UseWpf' 和 'UseWindowsForms'。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -931,8 +931,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1139: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled">
-        <source>NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</source>
-        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. Please ensure that MSBuildEnableWorkloadResolver is set to true and .NET workloads are enabled</target>
+        <source>NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</source>
+        <target state="new">NETSDK1208: The target platform identifier {0} was not recognized. This is because MSBuildEnableWorkloadResolver is set to false which disables .NET SDK Workloads which is required for this identifer. Unset this environment variable or MSBuild property to enable workloads.</target>
         <note>{StrBegin="NETSDK1208: "}</note>
       </trans-unit>
       <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -109,8 +109,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TargetPlatformSupported Condition="'$(TargetPlatformIdentifier)' == 'Windows'">true</TargetPlatformSupported>
     </PropertyGroup>
 
-    <NETSdkError Condition="'$(TargetPlatformSupported)' != 'true'"
+    <UseWorkloadsSpecificError Condition="($(TargetPlatformIdentifier.StartsWith('ios')) or $(TargetPlatformIdentifier.StartsWith('tvos')) or $(TargetPlatformIdentifier.StartsWith('maccatalyst')) or $(TargetPlatformIdentifier.StartsWith('android')) or $(TargetPlatformIdentifier.StartsWith('browser'))) and '$(MSBuildEnableWorkloadResolver)' != 'true'">true</UseWorkloadsSpecificError>
+
+    <NETSdkError Condition="'$(TargetPlatformSupported)' != 'true' and '$(UseWorkloadsSpecificError)' != 'true'"
                  ResourceName="UnsupportedTargetPlatformIdentifier"
+                 FormatArguments="$(TargetPlatformIdentifier)" />
+
+    <NETSdkError Condition="'$(TargetPlatformSupported)' != 'true' and '$(UseWorkloadsSpecificError)' == 'true'"
+                 ResourceName="UnsupportedTargetPlatformIdentifierWithWorkloadsDisabled"
                  FormatArguments="$(TargetPlatformIdentifier)" />
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -107,7 +107,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <TargetPlatformSupported Condition="'$(TargetPlatformIdentifier)' == 'Windows'">true</TargetPlatformSupported>
-      <UseWorkloadsSpecificError Condition="($(TargetPlatformIdentifier.StartsWith('ios')) or $(TargetPlatformIdentifier.StartsWith('tvos')) or $(TargetPlatformIdentifier.StartsWith('maccatalyst')) or $(TargetPlatformIdentifier.StartsWith('android')) or $(TargetPlatformIdentifier.StartsWith('browser'))) and '$(MSBuildEnableWorkloadResolver)' != 'true'">true</UseWorkloadsSpecificError>
+      <UseWorkloadsSpecificError Condition="($(TargetPlatformIdentifier) == 'ios' or $(TargetPlatformIdentifier) == 'tvos' or $(TargetPlatformIdentifier) == 'maccatalyst' or $(TargetPlatformIdentifier) == 'android' or $(TargetPlatformIdentifier.StartsWith('browser'))) and '$(MSBuildEnableWorkloadResolver)' != 'true'">true</UseWorkloadsSpecificError>
     </PropertyGroup>
 
     <NETSdkError Condition="'$(TargetPlatformSupported)' != 'true' and '$(UseWorkloadsSpecificError)' != 'true'"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -107,9 +107,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <TargetPlatformSupported Condition="'$(TargetPlatformIdentifier)' == 'Windows'">true</TargetPlatformSupported>
+      <UseWorkloadsSpecificError Condition="($(TargetPlatformIdentifier.StartsWith('ios')) or $(TargetPlatformIdentifier.StartsWith('tvos')) or $(TargetPlatformIdentifier.StartsWith('maccatalyst')) or $(TargetPlatformIdentifier.StartsWith('android')) or $(TargetPlatformIdentifier.StartsWith('browser'))) and '$(MSBuildEnableWorkloadResolver)' != 'true'">true</UseWorkloadsSpecificError>
     </PropertyGroup>
-
-    <UseWorkloadsSpecificError Condition="($(TargetPlatformIdentifier.StartsWith('ios')) or $(TargetPlatformIdentifier.StartsWith('tvos')) or $(TargetPlatformIdentifier.StartsWith('maccatalyst')) or $(TargetPlatformIdentifier.StartsWith('android')) or $(TargetPlatformIdentifier.StartsWith('browser'))) and '$(MSBuildEnableWorkloadResolver)' != 'true'">true</UseWorkloadsSpecificError>
 
     <NETSdkError Condition="'$(TargetPlatformSupported)' != 'true' and '$(UseWorkloadsSpecificError)' != 'true'"
                  ResourceName="UnsupportedTargetPlatformIdentifier"

--- a/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -171,20 +171,20 @@ namespace Microsoft.NET.Build.Tests
             var testProject = new TestProject()
             {
                 Name = "WorkloadTest",
-                TargetFrameworks = $"{ToolsetInfo.CurrentTargetFramework}-workloadtestplatform"
+                TargetFrameworks = $"{ToolsetInfo.CurrentTargetFramework}-android"
             };
 
             var testAsset = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            //  NETSDK1139: The target platform identifier workloadtestplatform was not recognized.
+            //  NETSDK1208: The target platform identifier android was not recognized.
             new BuildCommand(testAsset)
                 .WithEnvironmentVariable("MSBuildEnableWorkloadResolver", "false")
                 .Execute()
                 .Should()
                 .Fail()
                 .And
-                .HaveStdOutContaining("NETSDK1139");
+                .HaveStdOutContaining("NETSDK1208");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/33395

Not sure how common this will be or if it's worth it but it'll prevent some confusion and was easy enough to implement.