### PR TITLE
Add `--disable-build-servers` to Run and Store CLI commands

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -70,6 +70,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(CommonOptions.VerbosityOption);
             command.AddOption(CommonOptions.ArchitectureOption);
             command.AddOption(CommonOptions.OperatingSystemOption);
+            command.AddOption(CommonOptions.DisableBuildServersOption);
 
             command.AddArgument(ApplicationArguments);
 

--- a/src/Cli/dotnet/commands/dotnet-store/StoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-store/StoreCommandParser.cs
@@ -88,7 +88,8 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription));
             command.AddOption(CommonOptions.RuntimeOption.WithHelpDescription(command, LocalizableStrings.RuntimeOptionDescription));
             command.AddOption(CommonOptions.VerbosityOption);
-			command.AddOption(CommonOptions.CurrentRuntimeOption(LocalizableStrings.CurrentRuntimeOptionDescription));
+            command.AddOption(CommonOptions.CurrentRuntimeOption(LocalizableStrings.CurrentRuntimeOptionDescription));
+            command.AddOption(CommonOptions.DisableBuildServersOption);
 
             command.SetHandler(StoreCommand.Run);
 

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetMSBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetMSBuildInvocation.cs
@@ -9,17 +9,13 @@ using Xunit;
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     [Collection(TestConstants.UsesStaticTelemetryState)]
-
     public class GivenDotnetMSBuildInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        const string ExpectedPrefix = "-maxcpucount -verbosity:m";
-       
-        private static readonly string WorkingDirectory =
-            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetPackInvocation));
+        private const string ExpectedPrefix = "-maxcpucount -verbosity:m";
+        private static readonly string WorkingDirectory = TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetPackInvocation));
 
         [Theory]
         [InlineData(new string[] { "--disable-build-servers" }, "-p:UseRazorBuildServer=false -p:UseSharedCompilation=false /nodeReuse:false")]
-
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetRunInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetRunInvocation.cs
@@ -22,8 +22,9 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "-p", "prop1=true", "-p", "prop2=false" }, new string[] { "-p:prop1=true", "-p:prop2=false" })]
         [InlineData(new string[] { "-p:prop1=true;prop2=false" }, new string[] { "-p:prop1=true;prop2=false" })]
         [InlineData(new string[] { "-p", "MyProject.csproj", "-p:prop1=true" }, new string[] { "-p:prop1=true" })]
-        [InlineData(new string[] { "--property", "MyProject.csproj", "-p:prop1=true" }, // The longhand --property option should never be treated as a project
-            new string[] { "-p:MyProject.csproj", "-p:prop1=true" })]
+        // The longhand --property option should never be treated as a project
+        [InlineData(new string[] { "--property", "MyProject.csproj", "-p:prop1=true" }, new string[] { "-p:MyProject.csproj", "-p:prop1=true" })]
+        [InlineData(new string[] { "--disable-build-servers" }, new string[] { "-p:UseRazorBuildServer=false", "-p:UseSharedCompilation=false", "/nodeReuse:false" })]
         public void MsbuildInvocationIsCorrect(string[] args, string[] expectedArgs)
         {
             CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
@@ -39,6 +39,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--use-current-runtime" }, "-property:UseCurrentRuntimeIdentifier=True")]
         [InlineData(new string[] { "--ucr" }, "-property:UseCurrentRuntimeIdentifier=True")]
         [InlineData(new string[] { "--manifest", "one.xml", "--manifest", "two.xml", "--manifest", "three.xml" }, @"-property:AdditionalProjects=<cwd>one.xml%3B<cwd>two.xml%3B<cwd>three.xml")]
+        [InlineData(new string[] { "--disable-build-servers" }, "-p:UseRazorBuildServer=false -p:UseSharedCompilation=false /nodeReuse:false")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetTestInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetTestInvocation.cs
@@ -11,10 +11,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetTestInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        private const string ExpectedPrefix =
-            "-maxcpucount -verbosity:m -restore -target:VSTest -nodereuse:false -nologo";
-        private static readonly string WorkingDirectory =
-            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetTestInvocation));
+        private const string ExpectedPrefix = "-maxcpucount -verbosity:m -restore -target:VSTest -nodereuse:false -nologo";
+        private static readonly string WorkingDirectory = TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetTestInvocation));
 
         [Theory]
         [InlineData(new string[] { "--disable-build-servers" }, "-p:UseRazorBuildServer=false -p:UseSharedCompilation=false /nodeReuse:false -property:VSTestArtifactsProcessingMode=collect -property:VSTestSessionCorrelationId=<testSessionCorrelationId>")]
@@ -30,7 +28,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 var testSessionCorrelationId = "<testSessionCorrelationId>";
                 var msbuildPath = "<msbuildpath>";
-               
+
                 TestCommand.FromArgs(args, testSessionCorrelationId, msbuildPath)
                     .GetArgumentsToMSBuild()
                     .Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/31651

## Summary
The `--disable-build-servers` option is present for the following CLI commands:
- Build
- Clean
- MSBuild
- Pack
- Publish
- Restore
- Test

This is because each of these commands invokes MSBuild. I investigated the commands that invoke MSBuild that are missing this option. The two I found were:
- Run
- Store

I've added `--disable-build-servers` option these commands. I've also added an inline data entry to test this option on these commands. Lastly, did some minor formatting cleanup for MSBuild and Test invocation unit tests, since I was looking at these from [this follow-up PR](https://github.com/dotnet/sdk/pull/22472) that added this option for some commands and created these test files. *Note*: [Here's the PR](https://github.com/dotnet/sdk/pull/22472) that added this feature.