### PR TITLE
[release/7.0.4xx] Containers: prefer atomic layer upload and auth fixes

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
@@ -9,32 +9,52 @@ namespace Microsoft.NET.Build.Containers;
 
 internal static class AuthHeaderCache
 {
-
-    private static ConcurrentDictionary<string, AuthenticationHeaderValue> HostAuthenticationCache = new();
+    private static readonly ConcurrentDictionary<string, AuthenticationHeaderValue> s_hostAuthenticationCache = new();
 
     public static bool TryGet(Uri uri, [NotNullWhen(true)] out AuthenticationHeaderValue? header)
     {
-        header = null;
-
-        // observed quirk in Azure Container Registry: if you present a token to blobs/uploads and it's wrong,
-        // it won't give back a www-authenticate header for the reauth mechanism to work. So never return
-        // a cache for that URI pattern
-        string[] segments = uri.Segments;
-        if (segments is [.., "blobs/", "uploads/"])
-        {
-            return false;
-        }
-
-        return HostAuthenticationCache.TryGetValue(GetCacheKey(uri), out header);
+        return s_hostAuthenticationCache.TryGetValue(GetCacheKey(uri), out header); ;
     }
 
     public static AuthenticationHeaderValue AddOrUpdate(Uri uri, AuthenticationHeaderValue header)
     {
-        return HostAuthenticationCache.AddOrUpdate(GetCacheKey(uri), header, (_, _) => header);
+        return s_hostAuthenticationCache.AddOrUpdate(GetCacheKey(uri), header, (_, _) => header);
     }
 
-    private static string GetCacheKey(Uri uri)
+    internal static string GetCacheKey(Uri uri)
     {
-        return uri.Host + uri.AbsolutePath;
+        string finalUri = uri.Host + uri.AbsolutePath;
+
+        //trim uri parameters
+        //cases:
+        //push: 
+        //POST /v2/<name>/blobs/uploads/
+        //HEAD /v2/<name>/blobs/<digest>
+        //GET /v2/<name>/blobs/uploads/<uuid>
+        //PUT /v2/<name>/blobs/uploads/<uuid>?digest=<digest>
+        //PATCH /v2/<name>/blobs/uploads/<uuid>
+        //PUT /v2/<name>/manifests/<reference>
+
+        //pull:
+        //GET /v2/<name>/manifests/<reference>
+        //HEAD /v2/<name>/manifests/<reference>
+        //GET /v2/<name>/blobs/<digest>
+
+        IReadOnlyList<string> possibleUris = new[] { "blobs/uploads/", "blobs/", "manifests/" };
+
+        foreach (string end in possibleUris)
+        {
+            int index = finalUri.IndexOf(end);
+            if (index == -1)
+            {
+                continue;
+            }
+            else
+            {
+                finalUri = finalUri = finalUri.Substring(0, index + end.Length);
+                break;
+            }
+        }
+        return finalUri;
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
@@ -51,7 +51,7 @@ internal static class AuthHeaderCache
             }
             else
             {
-                finalUri = finalUri = finalUri.Substring(0, index + end.Length);
+                finalUri = finalUri.Substring(0, index + end.Length);
                 break;
             }
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -17,7 +17,7 @@ public static class ContainerHelpers
 
     internal const string HostObjectPass = "SDK_CONTAINER_REGISTRY_PWORD";
 
-    internal const string ChunkedUploadEnabled = "SDK_CONTAINER_REGISTRY_CHUNKED_UPLOAD";
+    internal const string ForceChunkedUploadEnabled = "SDK_CONTAINER_DEBUG_REGISTRY_FORCE_CHUNKED_UPLOAD";
     internal const string ChunkedUploadSizeBytes = "SDK_CONTAINER_REGISTRY_CHUNKED_UPLOAD_SIZE_BYTES";
 
     internal const string ParallelUploadEnabled = "SDK_CONTAINER_REGISTRY_PARALLEL_UPLOAD";

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/AuthHeaderCacheTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/AuthHeaderCacheTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Xunit;
+
+namespace Microsoft.NET.Build.Containers.UnitTests;
+
+public class AuthHeaderCacheTests
+{
+    [Theory]
+    [InlineData("https://mcr.microsoft.com/v2/dotnet/runtime/manifests/7.0", "mcr.microsoft.com/v2/dotnet/runtime/manifests/")]
+    [InlineData("https://mcr.microsoft.com/v2/dotnet/runtime/manifests/sha256:aa5e231e0f9a11220e10530899b489fc33182ed1168bc684949ab0cd83debd4a", "mcr.microsoft.com/v2/dotnet/runtime/manifests/")]
+    [InlineData("https://mcr.microsoft.com/v2/dotnet/runtime/blobs/sha256:ae2858f05eb4a525b320c2b2c702cda9924e58aae19a6b040eca4eee565c71e5", "mcr.microsoft.com/v2/dotnet/runtime/blobs/")]
+    [InlineData("https://public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/", "public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/")]
+    [InlineData("https://public.ecr.aws/token/", "public.ecr.aws/token/")]
+    [InlineData("https://public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/e9c6cb4a-da5a-4a45-b1db-1f17ce0d21f7", "public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/")]
+    [InlineData("https://public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/e9c6cb4a-da5a-4a45-b1db-1f17ce0d21f7?&digest=sha256%3Ad981f2c20c93e1c57a46cd87bc5b9a554be5323072a0d0ab4b354aabd237bbcf", "public.ecr.aws/v2/abcdef12/sdk-containers-test/blobs/uploads/")]
+    [InlineData("https://public.ecr.aws/v2/abcdef12/sdk-containers-test/manifests/sha256:d1f6df587a3da02b668ef33566a348374eb1500c9c050680c47295b7c0a35616", "public.ecr.aws/v2/abcdef12/sdk-containers-test/manifests/")]
+    public void DerivesCacheKeyCorrectly(string uri, string expectedKey)
+    {
+        Assert.Equal(expectedKey, AuthHeaderCache.GetCacheKey(new Uri(uri)));
+    }
+}


### PR DESCRIPTION
Ports the following parts of https://github.com/dotnet/sdk/pull/33019:

- prefer atomic upload of layer over chunked. Chunked upload is only attempted when atomic fails
- adds Accept-Encoding headers to PATCH requests
- adds missing auth tokens to various requests
- allows to force chunked upload for testing
