### PR TITLE
adjust item templates to langVersion changes in Roslyn

### DIFF
--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.class.verified/class/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.class.verified/class/TestItem1.cs
@@ -1,7 +1,6 @@
-﻿namespace ClassLib
-{
-    public class TestItem1
-    {
+﻿namespace ClassLib;
 
-    }
+public class TestItem1
+{
+
 }

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.targetFramework=netstandard2.0.verified/ClassLib.csproj
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.targetFramework=netstandard2.0.verified/ClassLib.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.targetFramework=netstandard2.0.verified/enum/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.targetFramework=netstandard2.0.verified/enum/TestItem1.cs
@@ -1,0 +1,7 @@
+﻿namespace ClassLib
+{
+    public enum TestItem1
+    {
+
+    }
+}

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.targetFramework=netstandard2.0.verified/std-streams/stdout.txt
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.targetFramework=netstandard2.0.verified/std-streams/stdout.txt
@@ -1,0 +1,1 @@
+﻿The template "Enum" was created successfully.

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.verified/enum/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.enum.verified/enum/TestItem1.cs
@@ -1,7 +1,6 @@
-﻿namespace ClassLib
-{
-    public enum TestItem1
-    {
+﻿namespace ClassLib;
 
-    }
+public enum TestItem1
+{
+
 }

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.interface.verified/interface/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.interface.verified/interface/TestItem1.cs
@@ -1,7 +1,6 @@
-﻿namespace ClassLib
-{
-    public interface TestItem1
-    {
+﻿namespace ClassLib;
 
-    }
+public interface TestItem1
+{
+
 }

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.record.verified/record/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.record.verified/record/TestItem1.cs
@@ -1,9 +1,6 @@
-﻿namespace ClassLib
-{
-    //Record was added in C# 9 and later, so Class was used instead. 
-    //See more info: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record
-    public class TestItem1
-    {
+﻿namespace ClassLib;
 
-    }
+public record class TestItem1
+{
+
 }

--- a/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.struct.verified/struct/TestItem1.cs
+++ b/src/Tests/dotnet-new.Tests/Approvals/DotnetCSharpClassTemplatesTest.struct.verified/struct/TestItem1.cs
@@ -1,7 +1,6 @@
-﻿namespace ClassLib
-{
-    public struct TestItem1
-    {
+﻿namespace ClassLib;
 
-    }
+public struct TestItem1
+{
+
 }

--- a/src/Tests/dotnet-new.Tests/DotnetClassTemplateTests.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetClassTemplateTests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         [InlineData("enum", "10", "net6.0")]
         [InlineData("enum", "", "net7.0")]
         [InlineData("enum", "9.0", "netstandard2.0")]
+        [InlineData("enum", "", "netstandard2.0")]
         public async void DotnetCSharpClassTemplatesTest(
             string templateShortName,
             string langVersion = "",
@@ -91,7 +92,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                        content
                        .UnixifyNewlines()
                        .ScrubAndReplace(
-                           "Warning: Failed to evaluate bind symbol \'langVersion\', it will be skipped.",
+                           "Warning: Failed to evaluate bind symbol \'evaluatedLangVersion\', it will be skipped.",
                            string.Empty);
 
                        content.ScrubAndReplace("\n", string.Empty);
@@ -171,7 +172,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                        content
                        .UnixifyNewlines()
                        .ScrubAndReplace(
-                           "Warning: Failed to evaluate bind symbol \'langVersion\', it will be skipped.",
+                           "Warning: Failed to evaluate bind symbol \'evaluatedLangVersion\', it will be skipped.",
                            string.Empty);
 
                        content.ScrubAndReplace("\n", string.Empty);

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Class-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Class-CSharp/.template.config/template.json
@@ -35,10 +35,25 @@
       "datatype": "string",
       "defaultValue": "disable"
     },
-    "langVersion": {
+    "evaluatedLangVersion": {
       "type": "bind",
       "binding": "msbuild:LangVersion",
       "dataType": "string"
+    },
+    "latestLangVersion": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "latest"
+      }
+    },
+    "langVersion": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "evaluatedLangVersion",
+        "fallbackVariableName": "latestLangVersion"
+      }
     },
     "csharp9orOlder": {
       "type": "generated",

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Enum-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Enum-CSharp/.template.config/template.json
@@ -29,10 +29,25 @@
       "binding": "msbuild:RootNamespace",
       "replaces": "Company.ClassLibrary1"
     },
-    "langVersion": {
+    "evaluatedLangVersion": {
       "type": "bind",
       "binding": "msbuild:LangVersion",
       "dataType": "string"
+    },
+    "latestLangVersion": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "latest"
+      }
+    },
+    "langVersion": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "evaluatedLangVersion",
+        "fallbackVariableName": "latestLangVersion"
+      }
     },
     "csharp9orOlder": {
       "type": "generated",

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Interface-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Interface-CSharp/.template.config/template.json
@@ -35,10 +35,25 @@
       "datatype": "string",
       "defaultValue": "disable"
     },
-    "langVersion": {
+    "evaluatedLangVersion": {
       "type": "bind",
       "binding": "msbuild:LangVersion",
       "dataType": "string"
+    },
+    "latestLangVersion": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "latest"
+      }
+    },
+    "langVersion": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "evaluatedLangVersion",
+        "fallbackVariableName": "latestLangVersion"
+      }
     },
     "csharp9orOlder": {
       "type": "generated",

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Record-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Record-CSharp/.template.config/template.json
@@ -42,10 +42,25 @@
         "source": "TargetFramework"
       }
     },
-    "langVersion": {
+    "evaluatedLangVersion": {
       "type": "bind",
       "binding": "msbuild:LangVersion",
       "dataType": "string"
+    },
+    "latestLangVersion": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "latest"
+      }
+    },
+    "langVersion": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "evaluatedLangVersion",
+        "fallbackVariableName": "latestLangVersion"
+      }
     },
     "csharp8orOlder": {
       "type": "generated",

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Struct-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Struct-CSharp/.template.config/template.json
@@ -35,10 +35,25 @@
       "datatype": "string",
       "defaultValue": "disable"
     },
-    "langVersion": {
+    "evaluatedLangVersion": {
       "type": "bind",
       "binding": "msbuild:LangVersion",
       "dataType": "string"
+    },
+    "latestLangVersion": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "latest"
+      }
+    },
+    "langVersion": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "evaluatedLangVersion",
+        "fallbackVariableName": "latestLangVersion"
+      }
     },
     "csharp9orOlder": {
       "type": "generated",


### PR DESCRIPTION
## Problem 
https://github.com/dotnet/templating/issues/6781

## Solution
After removing the evaluation of the default LangVersion, it was decided to adjust item templates and introduce a default value for the lang version in them.
