### PR TITLE
Move wait and result calls to the thread pool to avoid deadlocks.

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli.Utils
@@ -69,8 +70,8 @@ namespace Microsoft.DotNet.Cli.Utils
                 var taskErr = _stdErr?.BeginRead(_process.StandardError);
                 _process.WaitForExit();
 
-                taskOut?.Wait();
-                taskErr?.Wait();
+                Task.Run(() => taskOut)?.Wait();
+                Task.Run(() => taskErr)?.Wait();
             }
 
             var exitCode = _process.ExitCode;

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -70,8 +70,8 @@ namespace Microsoft.DotNet.Cli.Utils
                 var taskErr = _stdErr?.BeginRead(_process.StandardError);
                 _process.WaitForExit();
 
-                Task.Run(() => taskOut)?.Wait();
-                Task.Run(() => taskErr)?.Wait();
+                Task.Run(() => taskOut?.Wait());
+                Task.Run(() => taskErr?.Wait());
             }
 
             var exitCode = _process.ExitCode;

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessStartInfoExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessStartInfoExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -55,8 +56,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
                 process.WaitForExit();
 
-                taskOut.Wait();
-                taskErr.Wait();
+                Task.Run(() => taskOut).Wait();
+                Task.Run(() => taskErr).Wait();
 
                 stdOut = outStream.CapturedOutput;
                 stdErr = errStream.CapturedOutput;

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessStartInfoExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessStartInfoExtensions.cs
@@ -56,8 +56,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
                 process.WaitForExit();
 
-                Task.Run(() => taskOut).Wait();
-                Task.Run(() => taskErr).Wait();
+                Task.Run(() => taskOut.Wait());
+                Task.Run(() => taskErr.Wait());
 
                 stdOut = outStream.CapturedOutput;
                 stdErr = errStream.CapturedOutput;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.TabCompletion.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.TabCompletion.cs
@@ -159,7 +159,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 if (constraintEvaluationTask.IsCompletedSuccessfully)
                 {
                     //return only allowed templates
-                    return constraintEvaluationTask.Result;
+                    return Task.Run(() => constraintEvaluationTask).Result;
                 }
                 //if evaluation task fails, all the templates in a group are considered as allowed.
                 //in case the template may not be run, it will fail during instantiation.

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -213,7 +213,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 }
             }
 
-            return instantiateTask.Result;
+            return Task.Run(() => instantiateTask).Result;
         }
 
         private void DisplayConstraintResults(IReadOnlyList<TemplateConstraintResult> constraintResults, TemplateCommandArgs templateArgs)

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/MSBuildProject.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/MSBuildProject.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
 using Microsoft.DotNet.Cli.Utils;
 using NuGet.Frameworks;
@@ -159,8 +160,8 @@ namespace Microsoft.DotNet.CommandFactory
             var lockFilePath = GetLockFilePathFromProjectLockFileProperty() ??
                 GetLockFilePathFromIntermediateBaseOutputPath();
 
-            return new LockFileFormat()
-                .ReadWithLock(lockFilePath)
+            return Task.Run(() => new LockFileFormat()
+                .ReadWithLock(lockFilePath))
                 .Result;
         }
 
@@ -181,8 +182,8 @@ namespace Microsoft.DotNet.CommandFactory
                 return false;
             }
 
-            lockFile = new LockFileFormat()
-                .ReadWithLock(lockFilePath)
+            lockFile = Task.Run(() => new LockFileFormat()
+                .ReadWithLock(lockFilePath))
                 .Result;
             return true;
         }

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
@@ -270,8 +270,8 @@ namespace Microsoft.DotNet.CommandFactory
 
             try
             {
-                lockFile = new LockFileFormat()
-                    .ReadWithLock(lockFilePath)
+                lockFile = Task.Run(() => new LockFileFormat()
+                    .ReadWithLock(lockFilePath))
                     .Result;
             }
             catch (FileFormatException)

--- a/src/Cli/dotnet/DotNetCommandFactory.cs
+++ b/src/Cli/dotnet/DotNetCommandFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.CommandFactory;
 using NuGet.Frameworks;
@@ -43,7 +44,7 @@ namespace Microsoft.DotNet.Cli
             var command = Parser.GetBuiltInCommand(commandName);
             if (command != null && command.Handler != null)
             {
-                commandFunc = (args) => command.Handler.InvokeAsync(new InvocationContext(Parser.Instance.Parse(args))).Result;
+                commandFunc = (args) => Task.Run(() => command.Handler.InvokeAsync(new InvocationContext(Parser.Instance.Parse(args)))).Result;
                 return true;
             }
             commandFunc = null;

--- a/src/Cli/dotnet/Installer/Windows/PipeStreamMessageDispatcherBase.cs
+++ b/src/Cli/dotnet/Installer/Windows/PipeStreamMessageDispatcherBase.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Installer.Windows
                 if (_pipeStream is NamedPipeServerStream)
                 {
                     Task connectTask = Task.Factory.StartNew(() => ((NamedPipeServerStream)_pipeStream).WaitForConnection());
-                    connectTask.Wait(ConnectionTimeout);
+                    Task.Run(() => connectTask).Wait(ConnectionTimeout);
 
                     if (!connectTask.IsCompleted)
                     {

--- a/src/Cli/dotnet/Installer/Windows/PipeStreamMessageDispatcherBase.cs
+++ b/src/Cli/dotnet/Installer/Windows/PipeStreamMessageDispatcherBase.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Installer.Windows
                 if (_pipeStream is NamedPipeServerStream)
                 {
                     Task connectTask = Task.Factory.StartNew(() => ((NamedPipeServerStream)_pipeStream).WaitForConnection());
-                    Task.Run(() => connectTask).Wait(ConnectionTimeout);
+                    Task.Run(() => connectTask.Wait(ConnectionTimeout));
 
                     if (!connectTask.IsCompleted)
                     {

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                 return Path.Combine(repository.PackageSource.Source, $"{packageId}.{resolvedPackageVersion}.nupkg");
             }
 
-            ServiceIndexResourceV3 serviceIndexResource = repository.GetResourceAsync<ServiceIndexResourceV3>().Result;
+            ServiceIndexResourceV3 serviceIndexResource = Task.Run(() => repository.GetResourceAsync<ServiceIndexResourceV3>()).Result;
             IReadOnlyList<Uri> packageBaseAddress =
                 serviceIndexResource?.GetServiceEntryUris(ServiceTypes.PackageBaseAddress);
 

--- a/src/Cli/dotnet/Telemetry/Telemetry.cs
+++ b/src/Cli/dotnet/Telemetry/Telemetry.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 return;
             }
 
-            _trackEventTask.Wait();
+            Task.Run(() => _trackEventTask).Wait();
         }
 
         // Adding dispose on graceful shutdown per https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152#issuecomment-518742922

--- a/src/Cli/dotnet/Telemetry/Telemetry.cs
+++ b/src/Cli/dotnet/Telemetry/Telemetry.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 return;
             }
 
-            Task.Run(() => _trackEventTask).Wait();
+            Task.Run(() => _trackEventTask.Wait());
         }
 
         // Adding dispose on graceful shutdown per https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152#issuecomment-518742922

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.Add.PackageReference;
 using LocalizableStrings = Microsoft.DotNet.Tools.Add.PackageReference.LocalizableStrings;
@@ -85,10 +86,10 @@ namespace Microsoft.DotNet.Cli
             try
             {
                 using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-                var response = httpClient.GetAsync($"https://api-v2v3search-0.nuget.org/autocomplete?q={match}&skip=0&take=100", cancellation.Token)
+                var response = Task.Run(() => httpClient.GetAsync($"https://api-v2v3search-0.nuget.org/autocomplete?q={match}&skip=0&take=100", cancellation.Token))
                                          .Result;
 
-                result = response.Content.ReadAsStreamAsync().Result;
+                result = Task.Run(() => response.Content.ReadAsStreamAsync()).Result;
             }
             catch (Exception)
             {

--- a/src/Cli/dotnet/commands/dotnet-sdk/check/ProductCollectionProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-sdk/check/ProductCollectionProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Tools.Sdk.Check
         {
             try
             {
-                return product.GetReleasesAsync().Result;
+                return Task.Run(() => product.GetReleasesAsync()).Result;
             }
             catch (Exception e)
             {

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
@@ -7,6 +7,7 @@ using System.CommandLine;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
@@ -147,7 +148,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                             NuGetFramework.Parse(_framework);
                     }
 
-                    string appHostSourceDirectory = _shellShimTemplateFinder.ResolveAppHostSourceDirectoryAsync(_architectureOption, framework, RuntimeInformation.ProcessArchitecture).Result;
+                    string appHostSourceDirectory = Task.Run(() => _shellShimTemplateFinder.ResolveAppHostSourceDirectoryAsync(_architectureOption, framework, RuntimeInformation.ProcessArchitecture)).Result;
                     IShellShimRepository shellShimRepository = _createShellShimRepository(appHostSourceDirectory, toolPath);
 
                     foreach (var command in package.Commands)

--- a/src/Cli/dotnet/commands/dotnet-tool/search/ToolSearchCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/ToolSearchCommand.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.NugetSearch;
@@ -30,8 +31,8 @@ namespace Microsoft.DotNet.Tools.Tool.Search
             var isDetailed = _parseResult.GetValue(ToolSearchCommandParser.DetailOption);
             NugetSearchApiParameter nugetSearchApiParameter = new NugetSearchApiParameter(_parseResult);
             IReadOnlyCollection<SearchResultPackage> searchResultPackages =
-                NugetSearchApiResultDeserializer.Deserialize(
-                    _nugetToolSearchApiRequest.GetResult(nugetSearchApiParameter).GetAwaiter().GetResult());
+                NugetSearchApiResultDeserializer.Deserialize(Task.Run(() => 
+                    _nugetToolSearchApiRequest.GetResult(nugetSearchApiParameter)).Result);
 
             _searchResultPrinter.Print(isDetailed, searchResultPackages);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -845,8 +845,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             if (offlineCache == null || !offlineCache.HasValue)
             {
                 Reporter.WriteLine($"Downloading {packageId} ({packageVersion})");
-                packagePath = _nugetPackageDownloader.DownloadPackageAsync(new PackageId(packageId), new NuGetVersion(packageVersion),
-                    _packageSourceLocation).Result;
+                packagePath = Task.Run(() => _nugetPackageDownloader.DownloadPackageAsync(new PackageId(packageId), new NuGetVersion(packageVersion),
+                    _packageSourceLocation)).Result;
                 Log?.LogMessage($"Downloaded {packageId} ({packageVersion}) to '{packagePath}");
             }
             else
@@ -865,7 +865,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             string extractionDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(extractionDirectory);
             Log?.LogMessage($"Extracting '{packageId}' to '{extractionDirectory}'");
-            _ = _nugetPackageDownloader.ExtractPackageAsync(packagePath, new DirectoryPath(extractionDirectory)).Result;
+            _ = Task.Run(() => _nugetPackageDownloader.ExtractPackageAsync(packagePath, new DirectoryPath(extractionDirectory))).Result;
 
             return extractionDirectory;
         }
@@ -987,7 +987,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 throw installTask.Exception.InnerException;
             }
 
-            error = installTask.Result;
+            error = Task.Run(() => installTask).Result;
 
             if (!Error.Success(error))
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     var existingWorkloads = GetInstalledWorkloads(false);
                     var workloadsToDownload = existingWorkloads.Union(_workloadIds.Select(id => new WorkloadId(id))).ToList();
 
-                    DownloadToOfflineCacheAsync(workloadsToDownload, new DirectoryPath(_downloadToCacheOption), _skipManifestUpdate, _includePreviews).Wait();
+                    Task.Run(() => DownloadToOfflineCacheAsync(workloadsToDownload, new DirectoryPath(_downloadToCacheOption), _skipManifestUpdate, _includePreviews)).Wait();
                 }
                 catch (Exception e)
                 {
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 }
                 workloadIds = workloadIds.Concat(installedWorkloads).Distinct();
 
-                _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache).Wait();
+                Task.Run(() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache)).Wait();
                 manifestsToUpdate = string.IsNullOrWhiteSpace(_fromRollbackDefinition) ?
                     _workloadManifestUpdater.CalculateManifestUpdates().Select(m => m.manifestUpdate) :
                     _workloadManifestUpdater.CalculateManifestRollbacks(_fromRollbackDefinition);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     var existingWorkloads = GetInstalledWorkloads(false);
                     var workloadsToDownload = existingWorkloads.Union(_workloadIds.Select(id => new WorkloadId(id))).ToList();
 
-                    Task.Run(() => DownloadToOfflineCacheAsync(workloadsToDownload, new DirectoryPath(_downloadToCacheOption), _skipManifestUpdate, _includePreviews)).Wait();
+                    Task.Run(() => DownloadToOfflineCacheAsync(workloadsToDownload, new DirectoryPath(_downloadToCacheOption), _skipManifestUpdate, _includePreviews).Wait());
                 }
                 catch (Exception e)
                 {
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 }
                 workloadIds = workloadIds.Concat(installedWorkloads).Distinct();
 
-                Task.Run(() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache)).Wait();
+                Task.Run(() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache).Wait());
                 manifestsToUpdate = string.IsNullOrWhiteSpace(_fromRollbackDefinition) ?
                     _workloadManifestUpdater.CalculateManifestUpdates().Select(m => m.manifestUpdate) :
                     _workloadManifestUpdater.CalculateManifestRollbacks(_fromRollbackDefinition);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -450,7 +450,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             if (Uri.TryCreate(rollbackDefinitionFilePath, UriKind.Absolute, out var rollbackUri) && !rollbackUri.IsFile)
             {
-                fileContent = (new HttpClient()).GetStringAsync(rollbackDefinitionFilePath).Result;
+                fileContent = Task.Run(() => (new HttpClient()).GetStringAsync(rollbackDefinitionFilePath)).Result;
             }
             else
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         internal UpdateAvailableEntry[] GetUpdateAvailable(IEnumerable<WorkloadId> installedList)
         {
             HashSet<WorkloadId> installedWorkloads = installedList.ToHashSet();
-            Task.Run(() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews)).Wait();
+            Task.Run(() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews).Wait());
             var manifestsToUpdate =
                 _workloadManifestUpdater.CalculateManifestUpdates();
 

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -7,6 +7,7 @@ using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.Utils;
@@ -113,7 +114,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         internal UpdateAvailableEntry[] GetUpdateAvailable(IEnumerable<WorkloadId> installedList)
         {
             HashSet<WorkloadId> installedWorkloads = installedList.ToHashSet();
-            _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews).Wait();
+            Task.Run(() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews)).Wait();
             var manifestsToUpdate =
                 _workloadManifestUpdater.CalculateManifestUpdates();
 

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             {
                 try
                 {
-                    Task.Run(() => DownloadToOfflineCacheAsync(new DirectoryPath(_downloadToCacheOption), _includePreviews)).Wait();
+                    Task.Run(() => DownloadToOfflineCacheAsync(new DirectoryPath(_downloadToCacheOption), _includePreviews).Wait());
                 }
                 catch (Exception e)
                 {
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             }
             else if (_adManifestOnlyOption)
             {
-                Task.Run (() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews, string.IsNullOrWhiteSpace(_fromCacheOption) ? null : new DirectoryPath(_fromCacheOption))).Wait();
+                Task.Run (() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews, string.IsNullOrWhiteSpace(_fromCacheOption) ? null : new DirectoryPath(_fromCacheOption)).Wait());
                 Reporter.WriteLine();
                 Reporter.WriteLine(LocalizableStrings.WorkloadUpdateAdManifestsSucceeded);
             }
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             Reporter.WriteLine();
 
             var workloadIds = GetUpdatableWorkloads();
-            Task.Run(() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache)).Wait();
+            Task.Run(() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache).Wait());
 
             var manifestsToUpdate = string.IsNullOrWhiteSpace(_fromRollbackDefinition) ?
                 _workloadManifestUpdater.CalculateManifestUpdates().Select(m => m.manifestUpdate) :

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             {
                 try
                 {
-                    DownloadToOfflineCacheAsync(new DirectoryPath(_downloadToCacheOption), _includePreviews).Wait();
+                    Task.Run(() => DownloadToOfflineCacheAsync(new DirectoryPath(_downloadToCacheOption), _includePreviews)).Wait();
                 }
                 catch (Exception e)
                 {
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             }
             else if (_adManifestOnlyOption)
             {
-                _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews, string.IsNullOrWhiteSpace(_fromCacheOption) ? null : new DirectoryPath(_fromCacheOption)).Wait();
+                Task.Run (() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews, string.IsNullOrWhiteSpace(_fromCacheOption) ? null : new DirectoryPath(_fromCacheOption))).Wait();
                 Reporter.WriteLine();
                 Reporter.WriteLine(LocalizableStrings.WorkloadUpdateAdManifestsSucceeded);
             }
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             Reporter.WriteLine();
 
             var workloadIds = GetUpdatableWorkloads();
-            _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache).Wait();
+            Task.Run(() => _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, offlineCache)).Wait();
 
             var manifestsToUpdate = string.IsNullOrWhiteSpace(_fromRollbackDefinition) ?
                 _workloadManifestUpdater.CalculateManifestUpdates().Select(m => m.manifestUpdate) :

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
@@ -91,8 +92,8 @@ namespace Microsoft.DotNet.GenAPI
             compilationUnit = compilationUnit.NormalizeWhitespace(eol: Environment.NewLine);
 
             Document document = project.AddDocument(assemblySymbol.Name, compilationUnit);
-            document = Simplifier.ReduceAsync(document).Result;
-            document = Formatter.FormatAsync(document, DefineFormattingOptions()).Result;
+            document = Task.Run(() => Simplifier.ReduceAsync(document)).Result;
+            document = Task.Run(() => Formatter.FormatAsync(document, DefineFormattingOptions())).Result;
 
             document.GetSyntaxRootAsync().Result!
                 .Rewrite(new SingleLineStatementCSharpSyntaxRewriter())

--- a/src/StaticWebAssetsSdk/Tool/Program.cs
+++ b/src/StaticWebAssetsSdk/Tool/Program.cs
@@ -69,7 +69,7 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tool
                 });
             });
 
-            return rootCommand.InvokeAsync(args).Result;
+            return Task.Run(() => rootCommand.InvokeAsync(args)).Result;
         }
     }
 }


### PR DESCRIPTION
Fixes #23850. While it doesn't actually make any of the result or wait calls async, it runs them on a separate thread so as to not lock up the main thread.

@baronfel , I haven't finished the GetResult changes as there are lots of ways to fix those and I wanted to talk with you first. Making more calls async is probably the ideal approach but is a lot more churn as that would flow through a lot of different calls. Let's chat.