### PR TITLE
Add explicit System.Text.Json dependency

### DIFF
--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -28,7 +28,7 @@
       Explicit System.Text.Json package reference is required for source-build to pick up the live package.
       Avoids picking up an old version via transitive dependency from Microsoft.Build or Microsoft.CodeAnalysis.Workspaces.MSBuild.
     -->
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(DotnetBuildFromSource)' == 'true'" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
 
     <Compile Include="$(RepoRoot)src\Common\PathUtilities.cs" LinkBase="Common" />
   </ItemGroup>

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -23,6 +23,13 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion)" />
+
+    <!--
+      Explicit System.Text.Json package reference is required for source-build to pick up the live package.
+      Avoids picking up an old version via transitive dependency from Microsoft.Build or Microsoft.CodeAnalysis.Workspaces.MSBuild.
+    -->
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(DotnetBuildFromSource)' == 'true'" />
+
     <Compile Include="$(RepoRoot)src\Common\PathUtilities.cs" LinkBase="Common" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3540

In source-build, `Microsoft.Build` package dependency is pulling a transitive `System.Text.Json` dependency from PSB. The fix is to simply add an explicit `System.Text.Json` dependency.