### PR TITLE
Make non-portable RID warning check all available NETCore.App RIDS for the current TFM

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -166,7 +166,6 @@ namespace Microsoft.NET.Build.Tasks
             List<ITaskItem> runtimePacks = new List<ITaskItem>();
             List<ITaskItem> unavailableRuntimePacks = new List<ITaskItem>();
 
-            HashSet<string> knownRuntimeIdentifierPlatforms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             HashSet<string> unrecognizedRuntimeIdentifiers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             bool windowsOnlyErrorLogged = false;
@@ -206,14 +205,6 @@ namespace Microsoft.NET.Build.Tasks
                         {
                             string runtimePackName = runtimePackNamePattern.Replace("**RID**", runtimeIdentifier);
                             preferredPackages.Add(runtimePackName);
-                        }
-
-                        // Update the known runtime identifier platforms based on the selected Microsoft.NETCore.App pack
-                        if (selectedRuntimePack.Value.Name.Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase))
-                        {
-                            int separator = runtimeIdentifier.LastIndexOf('-');
-                            string platform = separator < 0 ? runtimeIdentifier : runtimeIdentifier.Substring(0, separator);
-                            knownRuntimeIdentifierPlatforms.Add(platform);
                         }
                     }
                 }
@@ -449,6 +440,19 @@ namespace Microsoft.NET.Build.Tasks
             if (implicitPackageReferences.Any())
             {
                 ImplicitPackageReferences = implicitPackageReferences.ToArray();
+            }
+
+            // Determine the known runtime identifier platforms based on all available Microsoft.NETCore.App packs
+            HashSet<string> knownRuntimeIdentifierPlatforms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var netCoreAppPacks = knownRuntimePacksForTargetFramework.Where(krp => krp.Name.Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase));
+            foreach (KnownRuntimePack netCoreAppPack in netCoreAppPacks)
+            {
+                foreach (var runtimeIdentifier in netCoreAppPack.RuntimePackRuntimeIdentifiers.Split(';'))
+                {
+                    int separator = runtimeIdentifier.LastIndexOf('-');
+                    string platform = separator < 0 ? runtimeIdentifier : runtimeIdentifier.Substring(0, separator);
+                    knownRuntimeIdentifierPlatforms.Add(platform);
+                }
             }
 
             if (knownRuntimeIdentifierPlatforms.Count > 0)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -935,7 +935,7 @@ class Program
         // Non-portable and portable RIDs should warn
         [InlineData(ToolsetInfo.CurrentTargetFramework, new[] { "ubuntu.22.04-x64", "win7-x86", "unix" }, true, true, null, true)]
         // Portable RIDs only should not warn
-        [InlineData(ToolsetInfo.CurrentTargetFramework, new[] { "win-x86", "linux", "linux-musl-x64", "osx-arm64", "unix" }, true, true, null, false)]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, new[] { "win-x86", "win", "linux", "linux-musl-x64", "osx", "osx-arm64", "unix", "browser", "browser-wasm", "ios-arm64" }, true, true, null, false)]
         // No RID assets should not warn
         [InlineData(ToolsetInfo.CurrentTargetFramework, new string[] { }, false, false, null, false)]
         // Below .NET 8 should not warn


### PR DESCRIPTION
Port of https://github.com/dotnet/sdk/pull/33584 targeting main instead of preview6.

Fixes https://github.com/dotnet/sdk/issues/33579