### PR TITLE
[release/7.0.4xx] containers: add read support for oci manifest v1

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/HttpExtensions.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/HttpExtensions.cs
@@ -15,6 +15,7 @@ internal static class HttpExtensions
         request.Headers.Accept.Add(new("application/json"));
         request.Headers.Accept.Add(new(SchemaTypes.DockerManifestListV2));
         request.Headers.Accept.Add(new(SchemaTypes.DockerManifestV2));
+        request.Headers.Accept.Add(new(SchemaTypes.OciManifestV1));
         request.Headers.Accept.Add(new(SchemaTypes.DockerContainerV1));
         return request;
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -98,7 +98,7 @@ internal sealed class Registry
 
         return initialManifestResponse.Content.Headers.ContentType?.MediaType switch
         {
-            SchemaTypes.DockerManifestV2 => await ReadSingleImageAsync(
+            SchemaTypes.DockerManifestV2 or SchemaTypes.OciManifestV1 => await ReadSingleImageAsync(
                 repositoryName,
                 await initialManifestResponse.Content.ReadFromJsonAsync<ManifestV2>(cancellationToken: cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false),

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/SchemaTypes.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/SchemaTypes.cs
@@ -9,4 +9,5 @@ internal class SchemaTypes
     internal const string DockerContainerV1 = "application/vnd.docker.container.image.v1+json";
     internal const string DockerManifestListV2 = "application/vnd.docker.distribution.manifest.list.v2+json";
     internal const string DockerManifestV2 = "application/vnd.docker.distribution.manifest.v2+json";
+    internal const string OciManifestV1 = "application/vnd.oci.image.manifest.v1+json"; // https://containers.gitbook.io/build-containers-the-hard-way/#registry-format-oci-image-manifest
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/RegistryTests.cs
@@ -44,4 +44,33 @@ public class RegistryTests : IDisposable
 
         Assert.NotNull(downloadedImage);
     }
+
+    [InlineData("quay.io/centos/centos")]
+    [InlineData("registry.access.redhat.com/ubi8/dotnet-70")]
+    [DockerDaemonAvailableTheory]
+    public async Task CanReadManifestFromRegistry(string fullyQualifiedContainerName)
+    {
+        bool parsed = ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedContainerName,
+                                                                           out string? containerRegistry,
+                                                                           out string? containerName,
+                                                                           out string? containerTag,
+                                                                           out string? containerDigest);
+        Assert.True(parsed);
+        Assert.NotNull(containerRegistry);
+        Assert.NotNull(containerName);
+        containerTag ??= "latest";
+
+        ILogger logger = _loggerFactory.CreateLogger(nameof(CanReadManifestFromRegistry));
+        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(containerRegistry), logger);
+
+        var ridgraphfile = ToolsetUtils.GetRuntimeGraphFilePath();
+
+        ImageBuilder? downloadedImage = await registry.GetImageManifestAsync(
+            containerName,
+            containerTag,
+            "linux-x64",
+            ridgraphfile,
+            cancellationToken: default).ConfigureAwait(false);
+        Assert.NotNull(downloadedImage);
+    }
 }


### PR DESCRIPTION
Adds support for reading oci manifest v1 `application/vnd.oci.image.manifest.v1+json`

Integrates code from #33266 
