### PR TITLE
Backport oci manifest reads

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/HttpExtensions.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/HttpExtensions.cs
@@ -15,6 +15,7 @@ internal static class HttpExtensions
         request.Headers.Accept.Add(new("application/json"));
         request.Headers.Accept.Add(new(SchemaTypes.DockerManifestListV2));
         request.Headers.Accept.Add(new(SchemaTypes.DockerManifestV2));
+        request.Headers.Accept.Add(new(SchemaTypes.OciManifestV1));
         request.Headers.Accept.Add(new(SchemaTypes.DockerContainerV1));
         return request;
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -98,7 +98,7 @@ internal sealed class Registry
 
         return initialManifestResponse.Content.Headers.ContentType?.MediaType switch
         {
-            SchemaTypes.DockerManifestV2 => await ReadSingleImageAsync(
+            SchemaTypes.DockerManifestV2 or SchemaTypes.OciManifestV1 => await ReadSingleImageAsync(
                 repositoryName,
                 await initialManifestResponse.Content.ReadFromJsonAsync<ManifestV2>(cancellationToken: cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false),

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/SchemaTypes.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/SchemaTypes.cs
@@ -9,4 +9,5 @@ internal class SchemaTypes
     internal const string DockerContainerV1 = "application/vnd.docker.container.image.v1+json";
     internal const string DockerManifestListV2 = "application/vnd.docker.distribution.manifest.list.v2+json";
     internal const string DockerManifestV2 = "application/vnd.docker.distribution.manifest.v2+json";
+    internal const string OciManifestV1 = "application/vnd.oci.image.manifest.v1+json"; // https://containers.gitbook.io/build-containers-the-hard-way/#registry-format-oci-image-manifest
 }


### PR DESCRIPTION
Backports https://github.com/dotnet/sdk/pull/33266 from main to 7.0.4xx based on user request and limited impact.