### PR TITLE
[iOS] Add HybridGlobalization flag in dotnet/sdk

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -513,6 +513,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Value="$(InvariantGlobalization)"
                                     Trim="true" />
 
+    <RuntimeHostConfigurationOption Include="System.Globalization.Hybrid"
+                                    Condition="'$(HybridGlobalization)' != ''"
+                                    Value="$(HybridGlobalization)"
+                                    Trim="true" />
+
     <RuntimeHostConfigurationOption Include="System.Globalization.PredefinedCulturesOnly"
                                     Condition="'$(PredefinedCulturesOnly)' != ''"
                                     Value="$(PredefinedCulturesOnly)"


### PR DESCRIPTION
Add HybridGlobalization flag in SDK. 
This will allow to load icudt_hybrid.dat file when HybridGlobalization is on and call native functions on apple platforms.


Contributes to https://github.com/dotnet/runtime/issues/80689

cc @SamMonoRT 