### PR TITLE
Reenable in-test timeout

### DIFF
--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunIsInterrupted.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunIsInterrupted.cs
@@ -143,7 +143,6 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             //  As of porting these tests to dotnet/sdk, it's unclear if the below is still needed
             // A timeout is required to prevent the `Process.WaitForExit` call to hang if `dotnet run` failed to terminate the child on Windows.
             // This is because `Process.WaitForExit()` hangs waiting for the process launched by `dotnet run` to close the redirected I/O pipes (which won't happen).
-            command.TimeoutMiliseconds = WaitTimeout;
 
             Task.Delay(TimeSpan.FromMilliseconds(WaitTimeout)).ContinueWith(t =>
             {

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunIsInterrupted.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunIsInterrupted.cs
@@ -143,15 +143,15 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             //  As of porting these tests to dotnet/sdk, it's unclear if the below is still needed
             // A timeout is required to prevent the `Process.WaitForExit` call to hang if `dotnet run` failed to terminate the child on Windows.
             // This is because `Process.WaitForExit()` hangs waiting for the process launched by `dotnet run` to close the redirected I/O pipes (which won't happen).
-            //command.TimeoutMiliseconds = WaitTimeout;
+            command.TimeoutMiliseconds = WaitTimeout;
 
-            //Task.Delay(TimeSpan.FromMilliseconds(WaitTimeout)).ContinueWith(t =>
-            //{
-            //    if (!killed)
-            //    {
-            //        testProcess.Kill();
-            //    }
-            //});
+            Task.Delay(TimeSpan.FromMilliseconds(WaitTimeout)).ContinueWith(t =>
+            {
+                if (!killed)
+                {
+                    testProcess.Kill();
+                }
+            });
 
 
             command


### PR DESCRIPTION
This test got stuck and killed after the 2hour helix timeout so adding back in code to prevent that.
https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-sdk-refs-pull-33689-merge-81a5096758e94f8995/dotnet.Tests.dll.9/1/console.4bf3f18b.log?helixlogtype=result

   dotnet.Tests: [Long Running Test] 'Microsoft.DotNet.Cli.Run.Tests.GivenDotnetRunIsInterrupted.ItTerminatesTheChildWhenKilled', Elapsed: **01:57:49**
['dotnet.Tests.dll.9' END OF WORK ITEM LOG: Command timed out, and was killed]