### PR TITLE
Fix CmdOption name and aliases

### DIFF
--- a/src/Containers/containerize/ContainerizeCommand.cs
+++ b/src/Containers/containerize/ContainerizeCommand.cs
@@ -85,7 +85,7 @@ internal class ContainerizeCommand : CliRootCommand
         AllowMultipleArgumentsPerToken = true
     };
 
-    internal CliOption<string[]> CmdOption { get; } = new CliOption<string[]>("--cmd",new[] {"--entrypointargs", "--cmd"})
+    internal CliOption<string[]> CmdOption { get; } = new CliOption<string[]>("--cmd")
     {
         Description = "The Cmd of the container image.",
         AllowMultipleArgumentsPerToken = true


### PR DESCRIPTION
The `EntrypointArgsOption` option is already using `--entrypointargs` as it's name

https://github.com/dotnet/sdk/blob/6483a69e9a26df4f0fd598a523f6f09fab9e1c10/src/Containers/containerize/ContainerizeCommand.cs#L70
