### PR TITLE
Disabled `--version` option for `dotnet new details`

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/details/DetailsCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/details/DetailsCommand.cs
@@ -17,7 +17,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             : base(hostBuilder, "details", SymbolStrings.Command_Details_Description)
         {
             Arguments.Add(NameArgument);
-            // Options.Add(VersionOption);
             Options.Add(InteractiveOption);
             Options.Add(AddSourceOption);
         }
@@ -28,7 +27,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Arity = new ArgumentArity(1, 1)
         };
 
-        //internal static CliOption<string> VersionOption { get; } = new Option<string>(new string[] { "-version", "--version" })
+        // Option disabled until https://github.com/dotnet/templating/issues/6811 is solved
+        //internal static CliOption<string> VersionOption { get; } = new("-version", "--version")
         //{
         //    Description = LocalizableStrings.DetailsCommand_Option_Version,
         //    Arity = new ArgumentArity(1, 1)

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/details/DetailsCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/details/DetailsCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             : base(hostBuilder, "details", SymbolStrings.Command_Details_Description)
         {
             Arguments.Add(NameArgument);
-            Options.Add(VersionOption);
+            // Options.Add(VersionOption);
             Options.Add(InteractiveOption);
             Options.Add(AddSourceOption);
         }
@@ -28,11 +28,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Arity = new ArgumentArity(1, 1)
         };
 
-        internal static CliOption<string> VersionOption { get; } = new("--version", "-version")
-        {
-            Description = LocalizableStrings.DetailsCommand_Option_Version,
-            Arity = new ArgumentArity(1, 1)
-        };
+        //internal static CliOption<string> VersionOption { get; } = new Option<string>(new string[] { "-version", "--version" })
+        //{
+        //    Description = LocalizableStrings.DetailsCommand_Option_Version,
+        //    Arity = new ArgumentArity(1, 1)
+        //};
 
         internal virtual CliOption<bool> InteractiveOption { get; } = SharedOptions.InteractiveOption;
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/details/DetailsCommandArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/details/DetailsCommandArgs.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 ?? throw new ArgumentException($"{nameof(parseResult)} should contain one argument for {nameof(DetailsCommand.NameArgument)}", nameof(parseResult));
 
             NameCriteria = nameCriteria;
-            VersionCriteria = parseResult.GetValueForOptionOrNull(DetailsCommand.VersionOption);
+            VersionCriteria = null;
             Interactive = parseResult.GetValue(detailsCommand.InteractiveOption);
             AdditionalSources = parseResult.GetValue(detailsCommand.AddSourceOption);
         }

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.DetailsCommand_GetAllSuggestions.verified.txt
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.DetailsCommand_GetAllSuggestions.verified.txt
@@ -19,19 +19,5 @@
     SortText: --nuget-source,
     InsertText: --nuget-source,
     Detail: Specifies a NuGet source to use.
-  },
-  {
-    Label: --version,
-    Kind: Keyword,
-    SortText: --version,
-    InsertText: --version,
-    Detail: Specifies a concrete version for displaying details. If not specified the last is taken.
-  },
-  {
-    Label: -version,
-    Kind: Keyword,
-    SortText: -version,
-    InsertText: -version,
-    Detail: Specifies a concrete version for displaying details. If not specified the last is taken.
   }
 ]

--- a/src/Tests/dotnet-new.Tests/DotnetNewDetailsTest.Approval.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewDetailsTest.Approval.cs
@@ -12,7 +12,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
     {
         private const string _nuGetPackageId = "Uno.ProjectTemplates.Dotnet";
 
-        [Fact]
+#pragma warning disable xUnit1004 // Test methods should not be skipped
+        [Fact(Skip = "https://github.com/dotnet/templating/issues/6811")]
+#pragma warning restore xUnit1004 // Test methods should not be skipped
         public Task CanDisplayDetails_RemotePackage_NuGetFeedWithVersion()
         {
             CommandResult commandResult = new DotnetNewCommand(_log, "details", _nuGetPackageId, "--version", "4.8.0-dev.604")
@@ -42,7 +44,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             return Verify(commandResult.StdOut);
         }
 
-        [Fact]
+#pragma warning disable xUnit1004 // Test methods should not be skipped
+        [Fact(Skip = "https://github.com/dotnet/templating/issues/6811")]
+#pragma warning restore xUnit1004 // Test methods should not be skipped
         public Task CanDisplayDetails_RemotePackage_OtherFeedWithVersion()
         {
             CommandResult commandResult = new DotnetNewCommand(_log, "details", "Microsoft.Azure.WebJobs.ItemTemplates", "--version", "4.0.2288")
@@ -86,7 +90,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .ExitWith(0)
                 .And.NotHaveStdErr();
 
-            CommandResult commandResult = new DotnetNewCommand(_log, "details", "Microsoft.TemplateEngine.TestTemplates", "-version", "1.0.0")
+            CommandResult commandResult = new DotnetNewCommand(_log, "details", "Microsoft.TemplateEngine.TestTemplates")
                 .WithCustomHive(home)
                 .WithoutBuiltInTemplates()
                 .WithWorkingDirectory(CreateTemporaryFolder())


### PR DESCRIPTION
Disabled `--version` option for `dotnet new details` as discussed in this issue: https://github.com/dotnet/templating/issues/6811.