### PR TITLE
Unblock sln add for a shared project

### DIFF
--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojFiles/Shared/Shared.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojFiles/Shared/Shared.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Shared
+{
+    internal class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojFiles/Shared/Shared.projitems
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojFiles/Shared/Shared.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>de9cf769-c210-4262-b612-164469266aa0</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Class1.cs" />
+  </ItemGroup>
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojFiles/Shared/Shared.shproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojFiles/Shared/Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>de9cf769-c210-4262-b612-164469266aa0</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props')"/>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props')"/>
+  <PropertyGroup />
+  <Import Project="Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets')"/>
+</Project>

--- a/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/ProjectTypeGuids.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/ProjectTypeGuids.cs
@@ -9,5 +9,6 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
         public const string FSharpProjectTypeGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
         public const string VBProjectTypeGuid = "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}";
         public const string SolutionFolderGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
+        public const string SharedProjectGuid = "{D954291E-2A0B-460D-934E-DC6B0785DB48}";
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -281,11 +281,6 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             }
         }
 
-        public bool AreBuildConfigurationsApplicable()
-        {
-            return Path.GetExtension(_filePath) == ".shproj";
-        }
-
         public int Line { get; private set; }
         internal bool Processed { get; set; }
 

--- a/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -281,6 +281,11 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             }
         }
 
+        public bool AreBuildConfigurationsApplicable()
+        {
+            return Path.GetExtension(_filePath) == ".shproj";
+        }
+
         public int Line { get; private set; }
         internal bool Processed { get; set; }
 

--- a/src/Cli/dotnet/ProjectInstanceExtensions.cs
+++ b/src/Cli/dotnet/ProjectInstanceExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Tools.Common
         public static string GetDefaultProjectTypeGuid(this ProjectInstance projectInstance)
         {
             string projectTypeGuid = projectInstance.GetPropertyValue("DefaultProjectTypeGuid");
-            if (string.IsNullOrEmpty(projectTypeGuid) && projectInstance.FullPath.EndsWith(".shproj"))
+            if (string.IsNullOrEmpty(projectTypeGuid) && projectInstance.FullPath.EndsWith(".shproj", StringComparison.OrdinalIgnoreCase))
             {
                 projectTypeGuid = ProjectTypeGuids.SharedProjectGuid;
             }

--- a/src/Cli/dotnet/ProjectInstanceExtensions.cs
+++ b/src/Cli/dotnet/ProjectInstanceExtensions.cs
@@ -22,7 +22,12 @@ namespace Microsoft.DotNet.Tools.Common
 
         public static string GetDefaultProjectTypeGuid(this ProjectInstance projectInstance)
         {
-            return projectInstance.GetPropertyValue("DefaultProjectTypeGuid");
+            string projectTypeGuid = projectInstance.GetPropertyValue("DefaultProjectTypeGuid");
+            if (string.IsNullOrEmpty(projectTypeGuid) && projectInstance.FullPath.EndsWith(".shproj"))
+            {
+                projectTypeGuid = ProjectTypeGuids.SharedProjectGuid;
+            }
+            return projectTypeGuid;
         }
 
         public static IEnumerable<string> GetPlatforms(this ProjectInstance projectInstance)

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Tools.Common
                 // section comes first we need to add it first. This doesn't affect correctness but does
                 // stop VS from re-ordering things later on. Since we are keeping the SlnFile class low-level
                 // it shouldn't care about the VS implementation details. That's why we handle this here.
-                if (AreBuildConfigurationsApplicable(relativeProjectPath)) {
+                if (AreBuildConfigurationsApplicable(slnProject.TypeGuid)) {
                     slnFile.AddDefaultBuildConfigurations();
 
                     slnFile.MapSolutionConfigurationsToProject(
@@ -90,6 +90,11 @@ namespace Microsoft.DotNet.Tools.Common
                 Reporter.Output.WriteLine(
                     string.Format(CommonLocalizableStrings.ProjectAddedToTheSolution, relativeProjectPath));
             }
+        }
+
+        private static bool AreBuildConfigurationsApplicable(string projectTypeGuid)
+        {
+            return !projectTypeGuid.Equals(ProjectTypeGuids.SharedProjectGuid, StringComparison.OrdinalIgnoreCase);
         }
 
         private static void SetupSolutionFolders(SlnFile slnFile, IList<string> solutionFolders, string relativeProjectPath, SlnProject slnProject)
@@ -121,11 +126,6 @@ namespace Microsoft.DotNet.Tools.Common
                 // Even if we added a solution folder above for a duplicate, we still need to add the expected folder for the current project
                 slnFile.AddSolutionFolders(slnProject, solutionFolders);
             }
-        }
-
-        private static bool AreBuildConfigurationsApplicable(string projectFilePath)
-        {
-            return !Path.GetExtension(projectFilePath).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void AddDefaultBuildConfigurations(this SlnFile slnFile)

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -123,9 +123,9 @@ namespace Microsoft.DotNet.Tools.Common
             }
         }
 
-        private static bool AreBuildConfigurationsApplicable(string path)
+        private static bool AreBuildConfigurationsApplicable(string projectFilePath)
         {
-            return !Path.GetExtension(path).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
+            return !Path.GetExtension(projectFilePath).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void AddDefaultBuildConfigurations(this SlnFile slnFile)

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -75,11 +75,13 @@ namespace Microsoft.DotNet.Tools.Common
                 // section comes first we need to add it first. This doesn't affect correctness but does
                 // stop VS from re-ordering things later on. Since we are keeping the SlnFile class low-level
                 // it shouldn't care about the VS implementation details. That's why we handle this here.
-                slnFile.AddDefaultBuildConfigurations();
+                if (slnProject.AreBuildConfigurationsApplicable()) {
+                    slnFile.AddDefaultBuildConfigurations();
 
-                slnFile.MapSolutionConfigurationsToProject(
-                    projectInstance,
-                    slnFile.ProjectConfigurationsSection.GetOrCreatePropertySet(slnProject.Id));
+                    slnFile.MapSolutionConfigurationsToProject(
+                        projectInstance,
+                        slnFile.ProjectConfigurationsSection.GetOrCreatePropertySet(slnProject.Id));
+                }
 
                 SetupSolutionFolders(slnFile, solutionFolders, relativeProjectPath, slnProject);
 

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Tools.Common
                 // section comes first we need to add it first. This doesn't affect correctness but does
                 // stop VS from re-ordering things later on. Since we are keeping the SlnFile class low-level
                 // it shouldn't care about the VS implementation details. That's why we handle this here.
-                if (slnFile.AreBuildConfigurationsApplicable(relativeProjectPath)) {
+                if (AreBuildConfigurationsApplicable(relativeProjectPath)) {
                     slnFile.AddDefaultBuildConfigurations();
 
                     slnFile.MapSolutionConfigurationsToProject(
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Tools.Common
             }
         }
 
-        private static bool AreBuildConfigurationsApplicable(this SlnFile slnFile, string path)
+        private static bool AreBuildConfigurationsApplicable(string path)
         {
             return !Path.GetExtension(path).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
         }

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.Tools.Common
 
         private static bool AreBuildConfigurationsApplicable(this SlnFile slnFile, string path)
         {
-            return !Path.GetExtension(path).Equals(".shproj", StringComparison.CurrentCultureIgnoreCase);
+            return !Path.GetExtension(path).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void AddDefaultBuildConfigurations(this SlnFile slnFile)

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Tools.Common
                 // section comes first we need to add it first. This doesn't affect correctness but does
                 // stop VS from re-ordering things later on. Since we are keeping the SlnFile class low-level
                 // it shouldn't care about the VS implementation details. That's why we handle this here.
-                if (slnProject.AreBuildConfigurationsApplicable()) {
+                if (slnFile.AreBuildConfigurationsApplicable(relativeProjectPath)) {
                     slnFile.AddDefaultBuildConfigurations();
 
                     slnFile.MapSolutionConfigurationsToProject(
@@ -121,6 +121,11 @@ namespace Microsoft.DotNet.Tools.Common
                 // Even if we added a solution folder above for a duplicate, we still need to add the expected folder for the current project
                 slnFile.AddSolutionFolders(slnProject, solutionFolders);
             }
+        }
+
+        private static bool AreBuildConfigurationsApplicable(this SlnFile slnFile, string path)
+        {
+            return !Path.GetExtension(path).Equals(".shproj", StringComparison.CurrentCultureIgnoreCase);
         }
 
         private static void AddDefaultBuildConfigurations(this SlnFile slnFile)

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -75,7 +75,8 @@ namespace Microsoft.DotNet.Tools.Common
                 // section comes first we need to add it first. This doesn't affect correctness but does
                 // stop VS from re-ordering things later on. Since we are keeping the SlnFile class low-level
                 // it shouldn't care about the VS implementation details. That's why we handle this here.
-                if (AreBuildConfigurationsApplicable(slnProject.TypeGuid)) {
+                if (AreBuildConfigurationsApplicable(slnProject.TypeGuid))
+                {
                     slnFile.AddDefaultBuildConfigurations();
 
                     slnFile.MapSolutionConfigurationsToProject(

--- a/src/Tests/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
+++ b/src/Tests/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
@@ -712,6 +712,27 @@ EndGlobal
             slnFile.Sections.GetSection("NestedProjects").Should().BeNull();
         }
 
+        [Fact]
+        public void WhenSharedProjectAddedShouldStillBuild()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndCsprojFiles")
+                .WithSource()
+                .Path;
+
+            var projectToAdd = Path.Combine("Shared", "Shared.shproj");
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"sln", "App.sln", "add", projectToAdd);
+            cmd.Should().Pass();
+            cmd.StdErr.Should().BeEmpty();
+
+            cmd = new DotnetBuildCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute();
+            cmd.Should().Pass();
+        }
+
         [Theory]
         [InlineData(".")]
         [InlineData("")]


### PR DESCRIPTION
Replaces #33834 as git did something very odd with that one.

This is an updated version of #22954. I couldn't update that branch as it was main and I couldn't push to the users fork so updating here. @01xOfFoo is welcome to just add these commits into his own branch if he'd rather do that.

Fixes #22921

If we don't find a project guid and detect it's a shared project, default to that guidtype
update the shared project check for when to add the configuration settings to go off of project type
Add a test