### PR TITLE
Create VS shortcut with SDK build environment automatically loaded

### DIFF
--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -31,7 +31,11 @@ The build script will output a `dotnet` installation to `artifacts\bin\redist\De
 
 As part of the build, some intermediate files will get generated which may run into long-path issues. If you encounter a build failure with an error message similar to `Resource file [filename].resx cannot be found.`, [enable long paths](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd#enable-long-paths-in-windows-10-version-1607-and-later) and try again.
 
-To open the solution in Visual Studio, be sure to build with `build.cmd` and run the generated environment for your shell. If you're using `cmd`, then run `artifacts\sdk-build-env.bat`. If you're using powershell, you need to 'dot source' `artifacts/sdk-build-env.ps1`. Finally, open Visual Studio with `devenv sdk.sln`.
+#### Using Visual Studio
+
+The simple way to launch Visual Studio after building via `build.cmd` is to double-click the `VS with sdk.sln` Windows shortcut in the `artifacts` folder. This will load the generated environment automatically and launch Visual Studio with the `sdk.sln` solution.
+
+Alternatively, to open the solution in Visual Studio, be sure to build with `build.cmd` and run the generated environment for your shell. If you're using `cmd`, then run `artifacts\sdk-build-env.bat`. If you're using PowerShell, you need to 'dot source' `artifacts/sdk-build-env.ps1`. Finally, open Visual Studio with `devenv sdk.sln`.
 
 In addition, Visual Studio must have the following option set:
 

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -28,6 +28,7 @@ function InitializeCustomSDKToolset {
   InstallDotNetSharedFramework "7.0.0"
 
   CreateBuildEnvScripts
+  CreateVSShortcut
   InstallNuget
 }
 
@@ -81,6 +82,40 @@ function killdotnet {
 "@
 
   Out-File -FilePath $scriptPath -InputObject $scriptContents -Encoding ASCII
+}
+
+function CreateVSShortcut()
+{
+  # https://github.com/microsoft/vswhere/wiki/Installing
+  $installerPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+  if(-Not (Test-Path -Path $installerPath))
+  {
+    return
+  }
+
+  # Note: The VS version in this call would need to be updated as new VS major versions release.
+  $vsVersion = 17.0
+  $devenvPath = (& "$installerPath\vswhere.exe" -all -prerelease -latest -version $vsVersion -find Common7\IDE\devenv.exe) | Select-Object -First 1
+  if(-Not $devenvPath)
+  {
+    return
+  }
+
+  $scriptPath = Join-Path $ArtifactsDir 'sdk-build-env.ps1'
+  $slnPath = Join-Path $RepoRoot 'sdk.sln'
+  $commandToLaunch = "& '$scriptPath'; & '$devenvPath' '$slnPath'"
+  $powershellPath = '%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe'
+  $shortcutPath = Join-Path $ArtifactsDir 'VS with sdk.sln.lnk'
+
+  # https://stackoverflow.com/a/9701907/294804
+  # https://learn.microsoft.com/en-us/troubleshoot/windows-client/admin-development/create-desktop-shortcut-with-wsh
+  $wsShell = New-Object -ComObject WScript.Shell
+  $shortcut = $wsShell.CreateShortcut($shortcutPath)
+  $shortcut.TargetPath = $powershellPath
+  $shortcut.Arguments = "-WindowStyle Hidden -Command ""$commandToLaunch"""
+  $shortcut.IconLocation = $devenvPath
+  $shortcut.WindowStyle = 7 # Minimized
+  $shortcut.Save()
 }
 
 function InstallDotNetSharedFramework([string]$version) {


### PR DESCRIPTION
## Summary

Small quality-of-life feature for devs of the repo. Added a function to create a VS shortcut that automatically loads the SDK build environment from the shortcut. That way, you don't need to manually run the `sdk-build-env` script and then run `devenv` afterwards. Just double click the shortcut and it'll open the `sdk.sln` with the right build environment.

![image](https://github.com/dotnet/sdk/assets/17788297/bb07aede-c58f-4746-97d5-0993f3f84a26)