### PR TITLE
Update dotnet tool update command: Download tool packages from nuget when update global tools

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -78,3 +78,8 @@
 /src/Tests/Microsoft.DotNet.ApiCompatibility*/ @dotnet/area-infrastructure-libraries
 /src/Tests/Microsoft.DotNet.ApiCompat*/ @dotnet/area-infrastructure-libraries
 /src/Tests/Microsoft.DotNet.PackageValidation*/ @dotnet/area-infrastructure-libraries
+
+# Area-GenAPI
+/src/GenAPI/ @andriipatsula @dotnet/area-infrastructure-libraries
+/src/Tests/Microsoft.DotNet.GenAPI/ @andriipatsula @dotnet/area-infrastructure-libraries
+/src/Microsoft.DotNet.ApiSymbolExtensions/ @andriipatsula @dotnet/area-infrastructure-libraries

--- a/documentation/general/workloads/README.md
+++ b/documentation/general/workloads/README.md
@@ -19,3 +19,4 @@ Other documentation for workloads is in this repo:
 - [Workload description localization](https://github.com/dotnet/sdk/pull/21189)
 - [Grouping multiple packs into one MSI](https://github.com/dotnet/sdk/issues/21741)
 - [Handling workload assets across major .NET versions](cross-version-workloads.md)
+- [Workload Clean Command](workload-clean.md)

--- a/documentation/general/workloads/workload-clean.md
+++ b/documentation/general/workloads/workload-clean.md
@@ -1,0 +1,31 @@
+# Workload Clean
+
+## Introduction & Background 
+`dotnet workload clean` is a command that was designed in .NET 8. 
+
+Sometimes if uninstalls are interrupted, or other unknown issues occur, workload packs can become orphaned on a developer machine.
+Customers have reported many broken states -- some with their manifest files, others because of potential orphaned packs.
+These orphaned packs that the SDK did not correctly remove can reside on the file system directly, or in the registry as garbage registry keys.
+
+The point of this command is to help users:
+- Clean up residue on their system, saving disk space.
+- Help potentially restore their machine into a working state with workloads.
+
+We considered `workload clean` as an option to "clean" or restore manifests to known SDK states, however, because of the existence of `workload repair`, we decided that has poor UX and can be done in that command.
+
+## Command Spec
+
+`dotnet workload clean`:
+
+Runs workload [garbage collection](https://github.com/dotnet/designs/blob/main/accepted/2021/workloads/workload-installation.md#workload-pack-installation-records-and-garbage-collection) for either file-based or MSI-based workloads.
+Under this mode, garbage collection behaves as normally, cleaning only the orphaned packs themselves, and not their records. This means it will clean up orphaned packs from uninstalled versions of the .NET SDK, or packs where installation records for the pack no longer exist.
+This will only impact packs of feature bands below or at the current feature band number of the SDK running `workload clean`, as the overall workload pack structural design may change in later versions.
+
+Lists all Visual Studio Workloads installed on the machine and warns that they must be uninstalled via Visual Studio instead of the .NET SDK CLI.
+This is to provide clarity as to why some workloads are not cleaned/uninstalled after running `dotnet workload clean`. 
+
+`dotnet workload clean --all`:
+
+Unlike workload clean, `workload clean --all` runs garbage collection irregularly, meaning that it cleans every existing pack on the machine that is not from VS, and is of the current SDK workload installation type. (Either File-Based or MSI-Based.)
+
+Because of this, it also removes all workload installation records for the running .NET SDK feature band and below. `workload clean` does not yet remove installation records, as the manifests are currently the only way to map a pack to the workload ID, but the manifest files may not exist for orphaned packs. 

--- a/documentation/general/workloads/workload-clean.md
+++ b/documentation/general/workloads/workload-clean.md
@@ -1,25 +1,25 @@
 # Workload Clean
 
 ## Introduction & Background 
-`dotnet workload clean` is a command that was designed in .NET 8. 
+`dotnet workload clean` is a command designed in .NET 8. 
 
-Sometimes if uninstalls are interrupted, or other unknown issues occur, workload packs can become orphaned on a developer machine.
-Customers have reported many broken states -- some with their manifest files, others because of potential orphaned packs.
-These orphaned packs that the SDK did not correctly remove can reside on the file system directly, or in the registry as garbage registry keys.
+Sometimes if uninstalls are interrupted or other unknown issues occur, workload packs can become orphaned on a developer machine.
+Customers have reported many broken states -- some with their manifest files, others because of the potential orphaned pack(s).
+These orphaned packs that the SDK did not correctly remove can reside on the file system directly or in the registry as garbage registry keys.
 
 The point of this command is to help users:
 - Clean up residue on their system, saving disk space.
-- Help potentially restore their machine into a working state with workloads.
+- Help potentially restore their machine to a working state with workloads.
 
-We considered `workload clean` as an option to "clean" or restore manifests to known SDK states, however, because of the existence of `workload repair`, we decided that has poor UX and can be done in that command.
+We considered `workload clean` as an option to "clean" or restore manifests to known SDK states; however, because of the existence of `workload repair`, we decided that is poor UX and can be done in that command.
 
 ## Command Spec
 
 `dotnet workload clean`:
 
 Runs workload [garbage collection](https://github.com/dotnet/designs/blob/main/accepted/2021/workloads/workload-installation.md#workload-pack-installation-records-and-garbage-collection) for either file-based or MSI-based workloads.
-Under this mode, garbage collection behaves as normally, cleaning only the orphaned packs themselves, and not their records. This means it will clean up orphaned packs from uninstalled versions of the .NET SDK, or packs where installation records for the pack no longer exist.
-This will only impact packs of feature bands below or at the current feature band number of the SDK running `workload clean`, as the overall workload pack structural design may change in later versions.
+Under this mode, garbage collection behaves as normal, cleaning only the orphaned packs themselves and not their records. This means it will clean up orphaned packs from uninstalled versions of the .NET SDK or packs where installation records for the pack no longer exist.
+This will only impact packs of feature bands below, or at the current feature band number of the SDK running `workload clean`, as the overall workload pack structural design may change in later versions.
 
 Lists all Visual Studio Workloads installed on the machine and warns that they must be uninstalled via Visual Studio instead of the .NET SDK CLI.
 This is to provide clarity as to why some workloads are not cleaned/uninstalled after running `dotnet workload clean`. 

--- a/documentation/general/workloads/workload-clean.md
+++ b/documentation/general/workloads/workload-clean.md
@@ -10,6 +10,7 @@ These orphaned packs that the SDK did not correctly remove can reside on the fil
 The point of this command is to help users:
 - Clean up residue on their system, saving disk space.
 - Help potentially restore their machine to a working state with workloads.
+- Mass uninstall every workload in one swoop.
 
 We considered `workload clean` as an option to "clean" or restore manifests to known SDK states; however, because of the existence of `workload repair`, we decided that is poor UX and can be done in that command.
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -105,9 +105,9 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>b84ca7373557c5725836697f81786ed22e20ead5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.6.0-preview-20230213-02">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.6.0-preview-20230213-04">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>b6a8c3b174380a5d57059428d8d3840915325373</Sha>
+      <Sha>4bb2af558ce5bea6b8822135fa88fa6ae035b408</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.2.23114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -261,22 +261,22 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23110.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23113.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>96d8be74c39a4765ec919ff9bebf9e0c875fc195</Sha>
+      <Sha>7b0fb0ad52d106185432b8437b9defefa1cca9d4</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23110.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23113.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>96d8be74c39a4765ec919ff9bebf9e0c875fc195</Sha>
+      <Sha>7b0fb0ad52d106185432b8437b9defefa1cca9d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SignTool" Version="8.0.0-beta.23110.3">
+    <Dependency Name="Microsoft.DotNet.SignTool" Version="8.0.0-beta.23113.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>96d8be74c39a4765ec919ff9bebf9e0c875fc195</Sha>
+      <Sha>7b0fb0ad52d106185432b8437b9defefa1cca9d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.23110.3">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.23113.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>96d8be74c39a4765ec919ff9bebf9e0c875fc195</Sha>
+      <Sha>7b0fb0ad52d106185432b8437b9defefa1cca9d4</Sha>
     </Dependency>
     <Dependency Name="System.Reflection.MetadataLoadContext" Version="8.0.0-preview.2.23114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -93,13 +93,13 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>73338d92270b9f26982eca2e8872037a0214b912</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="6.6.0-preview.2.21">
       <Uri>https://github.com/nuget/nuget.client</Uri>
@@ -153,50 +153,50 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>c14237626efed2c7138feca38de2c6625856df70</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.8.0" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.8.0" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
       <SourceBuild RepoName="aspnetcore" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="dotnet-dev-certs" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-jwts" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="dotnet-user-jwts" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="dotnet-user-secrets" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Analyzers" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.Analyzers" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.SdkAnalyzers" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.Components.SdkAnalyzers" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Analyzers" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Analyzers" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="7.0.0-preview.23107.1">
       <Uri>https://github.com/dotnet/razor</Uri>
@@ -215,21 +215,21 @@
       <Uri>https://github.com/dotnet/razor</Uri>
       <Sha>23245e6bf9f65ef800009909a5de3e3ebb3f075e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.JSInterop" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>7d29bfae60a8f109da85cf927066e73e461a1593</Sha>
+      <Sha>c42902459618afe114f189e23708fa1a35b6be74</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Web.Xdt" Version="7.0.0-preview.22423.2" Pinned="true">
       <Uri>https://github.com/dotnet/xdt</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -254,9 +254,9 @@
       <Sha>8374d5fca634a93458c84414b1604c12f765d1ab</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23110.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23113.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>1dab45a5eb1c4cbeb31348f97c8b9898c6e5a6ec</Sha>
+      <Sha>6fb713b77c31fb7f49240e0ec26e7581b4150dde</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,41 +6,41 @@
       <Sha>9baf928a75e271b925dfd2445308656a7fb357e1</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.8.0" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.8.0" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.TargetingPack.x64.8.0" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="VS.Redist.Common.NetCore.TargetingPack.x64.8.0" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.NET.HostModel" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="17.6.0-preview-23114-04">
       <Uri>https://github.com/dotnet/msbuild</Uri>
@@ -109,29 +109,29 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>4bb2af558ce5bea6b8822135fa88fa6ae035b408</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="8.0.100-1.23067.1">
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>c790896f128957acd2999208f44f09ae1e826c8c</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="System.CodeDom" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="System.Resources.Extensions" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="8.0.0-preview.2.23112.1">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
@@ -278,9 +278,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>7b0fb0ad52d106185432b8437b9defefa1cca9d4</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="8.0.0-preview.2.23114.1">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="8.0.0-preview.2.23114.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54972b75762f800fddbe1abfe5fce544ae671033</Sha>
+      <Sha>8a96ee761d457fc8f0fcb3b1727151e34d9a2682</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23108.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
     <SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
     <SystemReflectionMetadataVersion>6.0.0</SystemReflectionMetadataVersion>
-    <MicrosoftDotNetSignToolVersion>8.0.0-beta.23110.3</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetSignToolVersion>8.0.0-beta.23113.1</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>7.0.0-preview.22423.2</MicrosoftWebXdtPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>8.0.0-preview.2.23114.1</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
@@ -184,7 +184,7 @@
   <PropertyGroup>
     <FluentAssertionsVersion>6.9.0</FluentAssertionsVersion>
     <FluentAssertionsJsonVersion>6.1.0</FluentAssertionsJsonVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.23110.3</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.23113.1</MicrosoftDotNetXUnitExtensionsVersion>
     <MoqPackageVersion>4.8.2</MoqPackageVersion>
     <MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>6.0.0-beta.22262.1</MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -80,7 +80,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/vstest -->
-    <MicrosoftNETTestSdkPackageVersion>17.6.0-preview-20230213-02</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>17.6.0-preview-20230213-04</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,12 +35,12 @@
     <SystemReflectionMetadataVersion>6.0.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>8.0.0-beta.23113.1</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>7.0.0-preview.22423.2</MicrosoftWebXdtPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>8.0.0-preview.2.23114.1</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>8.0.0-preview.2.23114.2</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
     <SystemTextJsonVersion>6.0.0</SystemTextJsonVersion>
-    <SystemReflectionMetadataLoadContextVersion>8.0.0-preview.2.23114.1</SystemReflectionMetadataLoadContextVersion>
+    <SystemReflectionMetadataLoadContextVersion>8.0.0-preview.2.23114.2</SystemReflectionMetadataLoadContextVersion>
     <SystemManagementPackageVersion>4.6.0</SystemManagementPackageVersion>
     <SystemCommandLineVersion>2.0.0-beta4.22564.1</SystemCommandLineVersion>
     <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview5.1.22263.1</MicrosoftDeploymentDotNetReleasesVersion>
@@ -48,17 +48,17 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.2.23114.1</MicrosoftNETCoreAppRefPackageVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>8.0.0-preview.2.23114.1</VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>8.0.0-preview.2.23114.1</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.2.23114.2</MicrosoftNETCoreAppRefPackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>8.0.0-preview.2.23114.2</VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>8.0.0-preview.2.23114.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>8.0.0-preview.2.23114.1</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>8.0.0-preview.2.23114.1</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>8.0.0-preview.2.23114.1</MicrosoftNETHostModelVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>8.0.0-preview.2.23114.2</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>8.0.0-preview.2.23114.2</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>8.0.0-preview.2.23114.2</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>6.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftNETILLinkTasksPackageVersion>8.0.0-preview.2.23114.1</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>8.0.0-preview.2.23114.2</MicrosoftNETILLinkTasksPackageVersion>
     <SystemServiceProcessServiceControllerVersion>7.0.0</SystemServiceProcessServiceControllerVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -86,9 +86,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <SystemCodeDomPackageVersion>8.0.0-preview.2.23114.1</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>8.0.0-preview.2.23114.1</SystemTextEncodingCodePagesPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>8.0.0-preview.2.23114.1</SystemResourcesExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>8.0.0-preview.2.23114.2</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>8.0.0-preview.2.23114.2</SystemTextEncodingCodePagesPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>8.0.0-preview.2.23114.2</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/format -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -149,12 +149,12 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>8.0.0-preview.2.23114.1</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
-    <MicrosoftAspNetCoreComponentsSdkAnalyzersPackageVersion>8.0.0-preview.2.23114.1</MicrosoftAspNetCoreComponentsSdkAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreMvcAnalyzersPackageVersion>8.0.0-preview.2.23114.1</MicrosoftAspNetCoreMvcAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>8.0.0-preview.2.23114.1</MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreAnalyzersPackageVersion>8.0.0-preview.2.23114.1</MicrosoftAspNetCoreAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>8.0.0-preview.2.23114.1</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>8.0.0-preview.2.23114.2</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
+    <MicrosoftAspNetCoreComponentsSdkAnalyzersPackageVersion>8.0.0-preview.2.23114.2</MicrosoftAspNetCoreComponentsSdkAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreMvcAnalyzersPackageVersion>8.0.0-preview.2.23114.2</MicrosoftAspNetCoreMvcAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>8.0.0-preview.2.23114.2</MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreAnalyzersPackageVersion>8.0.0-preview.2.23114.2</MicrosoftAspNetCoreAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>8.0.0-preview.2.23114.2</MicrosoftAspNetCoreTestHostPackageVersion>
   </PropertyGroup>
   <!-- Dependencies from https://github.com/dotnet/razor -->
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23110.3",
-    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23110.3"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23113.1",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23113.1"
   }
 }

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.ToolPackage;
+using Microsoft.DotNet.Tools;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.Packaging;
+using NuGet.Versioning;
+
+
+namespace Microsoft.DotNet.Cli.ToolPackage
+{
+    internal class ToolPackageDownloader
+    {
+        private readonly INuGetPackageDownloader _nugetPackageDownloader;
+        protected readonly DirectoryPath _tempPackagesDir;
+
+        public ToolPackageDownloader(
+            INuGetPackageDownloader nugetPackageDownloader = null,
+            string tempDirPath = null
+            )
+        {
+            _tempPackagesDir = new DirectoryPath(tempDirPath ?? PathUtilities.CreateTempSubdirectory());
+            _nugetPackageDownloader = nugetPackageDownloader ??
+                                     new NuGetPackageDownloader.NuGetPackageDownloader(_tempPackagesDir);
+        }
+
+        public async Task<IToolPackage> InstallPackageAsync(PackageLocation packageLocation, PackageId packageId,
+            VersionRange versionRange = null,
+            string targetFramework = null,
+            string verbosity = null)
+        { 
+            var tempDirsToDelete = new List<string>();
+            var tempFilesToDelete = new List<string>();
+
+            var packagePath = await _nugetPackageDownloader.DownloadPackageAsync(packageId);
+            tempFilesToDelete.Add(packagePath);
+
+            // Look fo nuget package on disk and read the version 
+            await using FileStream packageStream = File.OpenRead(packagePath);
+            PackageArchiveReader reader = new PackageArchiveReader(packageStream);
+            var version = new NuspecReader(reader.GetNuspec()).GetVersion();
+
+            var tempExtractionDir = Path.GetDirectoryName(packagePath);
+            var tempToolExtractionDir = Path.Combine(tempExtractionDir, packageId.ToString(), version.ToString(), "tools");
+
+            tempDirsToDelete.Add(tempExtractionDir);
+            
+            var filesInPackage = await _nugetPackageDownloader.ExtractPackageAsync(packagePath, new DirectoryPath(tempToolExtractionDir));
+            
+            if (Directory.Exists(packagePath))
+            {
+                throw new ToolPackageException(
+                    string.Format(
+                        CommonLocalizableStrings.ToolPackageConflictPackageId,
+                        packageId,
+                        version.ToNormalizedString()));
+            }
+
+            return new ToolPackageInstance(id: packageId,
+                            version: version,
+                            packageDirectory: new DirectoryPath(tempExtractionDir),
+                            assetsJsonParentDirectory: new DirectoryPath(tempExtractionDir));
+            //cleanup
+            /*foreach (var dir in tempDirsToDelete)
+            {
+                if (Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, true);
+                }
+            }*/
+        
+        }
+    }
+}

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -5,13 +5,26 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools;
 using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.Client;
+using NuGet.Common;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Repositories;
+using NuGet.RuntimeModel;
 using NuGet.Versioning;
+using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
+using static System.Formats.Asn1.AsnWriter;
 
 
 namespace Microsoft.DotNet.Cli.ToolPackage
@@ -20,15 +33,79 @@ namespace Microsoft.DotNet.Cli.ToolPackage
     {
         private readonly INuGetPackageDownloader _nugetPackageDownloader;
         protected readonly DirectoryPath _tempPackagesDir;
+        protected readonly DirectoryPath _storePackagesDir;
 
         public ToolPackageDownloader(
             INuGetPackageDownloader nugetPackageDownloader = null,
-            string tempDirPath = null
-            )
+        string tempDirPath = null
+        )
         {
             _tempPackagesDir = new DirectoryPath(tempDirPath ?? PathUtilities.CreateTempSubdirectory());
+
+            _storePackagesDir = new DirectoryPath ("C:\\Users\\liannie\\.dotnet\\tools\\.store");
             _nugetPackageDownloader = nugetPackageDownloader ??
-                                     new NuGetPackageDownloader.NuGetPackageDownloader(_tempPackagesDir);
+                                     new NuGetPackageDownloader.NuGetPackageDownloader(_storePackagesDir);
+        }
+
+        private static void AddToolsAssets(
+            ManagedCodeConventions managedCodeConventions,
+            LockFileTargetLibrary lockFileLib,
+            ContentItemCollection contentItems,
+            IReadOnlyList<SelectionCriteria> orderedCriteria)
+        {
+            var toolsGroup = GetLockFileItems(
+                orderedCriteria,
+                contentItems,
+                managedCodeConventions.Patterns.ToolsAssemblies);
+
+            lockFileLib.ToolsAssemblies.AddRange(toolsGroup);
+        }
+
+        private static IEnumerable<LockFileItem> GetLockFileItems(
+            IReadOnlyList<SelectionCriteria> criteria,
+            ContentItemCollection items,
+            params PatternSet[] patterns)
+        {
+            return GetLockFileItems(criteria, items, additionalAction: null, patterns);
+        }
+
+        private static IEnumerable<LockFileItem> GetLockFileItems(
+           IReadOnlyList<SelectionCriteria> criteria,
+           ContentItemCollection items,
+           Action<LockFileItem> additionalAction,
+           params PatternSet[] patterns)
+        {
+            // Loop through each criteria taking the first one that matches one or more items.
+            foreach (var managedCriteria in criteria)
+            {
+                var group = items.FindBestItemGroup(
+                    managedCriteria,
+                    patterns);
+
+                if (group != null)
+                {
+                    foreach (var item in group.Items)
+                    {
+                        var newItem = new LockFileItem(item.Path);
+                        object locale;
+                        if (item.Properties.TryGetValue("locale", out locale))
+                        {
+                            newItem.Properties["locale"] = (string)locale;
+                        }
+                        object related;
+                        if (item.Properties.TryGetValue("related", out related))
+                        {
+                            newItem.Properties["related"] = (string)related;
+                        }
+                        additionalAction?.Invoke(newItem);
+                        yield return newItem;
+                    }
+                    // Take only the first group that has items
+                    break;
+                }
+            }
+
+            yield break;
         }
 
         public async Task<IToolPackage> InstallPackageAsync(PackageLocation packageLocation, PackageId packageId,
@@ -39,21 +116,37 @@ namespace Microsoft.DotNet.Cli.ToolPackage
             var tempDirsToDelete = new List<string>();
             var tempFilesToDelete = new List<string>();
 
-            var packagePath = await _nugetPackageDownloader.DownloadPackageAsync(packageId);
+            //var versionFromVersionRange = versionRange?.ToString("N", new VersionRangeFormatter()) ?? "*";
+            Console.WriteLine(versionRange);
+            //Console.WriteLine(versionFromVersionRange);
+            var packageSourceLocation = new PackageSourceLocation(packageLocation.NugetConfig, packageLocation.RootConfigDirectory, null, packageLocation.AdditionalFeeds);
+            var packagePath = await _nugetPackageDownloader.DownloadPackageAsync(packageId, null, packageSourceLocation);
             tempFilesToDelete.Add(packagePath);
+
+            var tempExtractionDir = Path.GetDirectoryName(packagePath);
+            
 
             // Look fo nuget package on disk and read the version 
             await using FileStream packageStream = File.OpenRead(packagePath);
             PackageArchiveReader reader = new PackageArchiveReader(packageStream);
             var version = new NuspecReader(reader.GetNuspec()).GetVersion();
 
-            var tempExtractionDir = Path.GetDirectoryName(packagePath);
+            
+
             var tempToolExtractionDir = Path.Combine(tempExtractionDir, packageId.ToString(), version.ToString(), "tools");
+            var nupkgDir = Path.Combine(tempExtractionDir, packageId.ToString(), version.ToString());
 
             tempDirsToDelete.Add(tempExtractionDir);
             
             var filesInPackage = await _nugetPackageDownloader.ExtractPackageAsync(packagePath, new DirectoryPath(tempToolExtractionDir));
-            
+
+            var packageHash = Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(reader.GetNuspec()));
+            var hashPath = new VersionFolderPathResolver(tempExtractionDir).GetHashPath(packageId.ToString(), version);
+            File.WriteAllText(hashPath, packageHash);
+
+            //Copy nupkg file to hash file folder
+            File.Copy(packagePath, Path.Combine(nupkgDir, Path.GetFileName(packagePath)));
+
             if (Directory.Exists(packagePath))
             {
                 throw new ToolPackageException(
@@ -62,6 +155,60 @@ namespace Microsoft.DotNet.Cli.ToolPackage
                         packageId,
                         version.ToNormalizedString()));
             }
+
+            // create asset files
+
+            // To get runtimeGraph:
+            var runtimeJsonPath = "C:\\Program Files\\dotnet\\sdk\\7.0.200\\RuntimeIdentifierGraph.json";
+            var runtimeGraph = JsonRuntimeFormat.ReadRuntimeGraph(runtimeJsonPath);
+
+            // Create ManagedCodeConventions:
+            var conventions = new ManagedCodeConventions(runtimeGraph);
+
+            //  Create LockFileTargetLibrary
+            var lockFileLib = new LockFileTargetLibrary()
+            { 
+                Name = packageId.ToString(),
+                Version = version,
+                Type = LibraryType.Package,
+                PackageType = new List<PackageType>() { PackageType.DotnetTool }
+            };
+
+            //  Create NuGetv3LocalRepository
+            NuGetv3LocalRepository localRepository = new(tempExtractionDir);
+            Console.WriteLine(tempExtractionDir);
+            var package = localRepository.FindPackage(packageId.ToString(), version);
+
+            var collection = new ContentItemCollection();
+            collection.Load(package.Files);
+
+            //  Create criteria
+            var managedCriteria = new List<SelectionCriteria>(1);
+
+            var currentTargetFramework = NuGetFramework.Parse("net8.0");
+
+            //  Not supporting FallbackFramework for tools
+            var standardCriteria = conventions.Criteria.ForFrameworkAndRuntime(
+                //NuGetFramework.Parse(targetFramework),
+                currentTargetFramework,
+                RuntimeInformation.RuntimeIdentifier);
+            managedCriteria.Add(standardCriteria);
+
+            //  To be implemented
+            if (lockFileLib.PackageType.Contains(PackageType.DotnetTool))
+            {
+                AddToolsAssets(conventions, lockFileLib, collection, managedCriteria);
+            }
+
+            var lockFile = new LockFile();
+            var lockFileTarget = new LockFileTarget()
+            {
+                TargetFramework = currentTargetFramework,
+                RuntimeIdentifier = RuntimeInformation.RuntimeIdentifier
+            };
+            lockFileTarget.Libraries.Add(lockFileLib);
+            lockFile.Targets.Add(lockFileTarget);
+            new LockFileFormat().Write(Path.Combine(tempExtractionDir, "project.assets.json"), lockFile);
 
             return new ToolPackageInstance(id: packageId,
                             version: version,
@@ -75,7 +222,7 @@ namespace Microsoft.DotNet.Cli.ToolPackage
                     Directory.Delete(dir, true);
                 }
             }*/
-        
+
         }
     }
 }

--- a/src/Cli/dotnet/ToolPackage/ToolPackageFactory.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageFactory.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.ToolPackage
             return new DirectoryPath(CliFolderPathCalculator.ToolsPackagePath);
         }
 
-        private static ToolPackageStoreAndQuery CreateConcreteToolPackageStore(
+        public static ToolPackageStoreAndQuery CreateConcreteToolPackageStore(
             DirectoryPath? nonGlobalLocation = null)
         {
             var toolPackageStore =

--- a/src/Cli/dotnet/ToolPackage/ToolPackageInstaller.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageInstaller.cs
@@ -49,6 +49,7 @@ namespace Microsoft.DotNet.ToolPackage
                 {
                     try
                     {
+                        // create a temp project with a package reference to the tool and download it
                         var stageDirectory = _store.GetRandomStagingDirectory();
                         Directory.CreateDirectory(stageDirectory.Value);
                         rollbackDirectory = stageDirectory.Value;
@@ -76,6 +77,7 @@ namespace Microsoft.DotNet.ToolPackage
 
                         var version = _store.GetStagedPackageVersion(stageDirectory, packageId);
                         var packageDirectory = _store.GetPackageDirectory(packageId, version);
+                        
                         if (Directory.Exists(packageDirectory.Value))
                         {
                             throw new ToolPackageException(
@@ -88,7 +90,8 @@ namespace Microsoft.DotNet.ToolPackage
                         Directory.CreateDirectory(packageRootDirectory.Value);
                         FileAccessRetrier.RetryOnMoveAccessFailure(() => Directory.Move(stageDirectory.Value, packageDirectory.Value));
                         rollbackDirectory = packageDirectory.Value;
-
+                        Console.WriteLine("In toolPackageInstaller the package directory value is: ");
+                        Console.WriteLine(packageDirectory.Value);
                         return new ToolPackageInstance(id: packageId,
                             version: version,
                             packageDirectory: packageDirectory,

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
@@ -98,8 +98,6 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             }
 
             VersionRange versionRange = _parseResult.GetVersionRange();
-            Console.WriteLine("The versionRange at execute is: ");
-            Console.WriteLine(versionRange);
 
             DirectoryPath? toolPath = null;
             if (!string.IsNullOrEmpty(_toolPath))

--- a/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Transactions;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ShellShim;
 using Microsoft.DotNet.ToolPackage;
@@ -110,12 +111,13 @@ namespace Microsoft.DotNet.Tools.Tool.Update
 
                 RunWithHandlingInstallError(() =>
                 {
-                    IToolPackage newInstalledPackage = toolPackageInstaller.InstallPackage(
-                        new PackageLocation(nugetConfig: GetConfigFile(), additionalFeeds: _additionalFeeds),
+                    var toolPackageDownloader = new ToolPackageDownloader(toolPackageStore);
+                    IToolPackage newInstalledPackage = toolPackageDownloader.InstallPackageAsync(
+                    new PackageLocation(nugetConfig: GetConfigFile(), additionalFeeds: _additionalFeeds),
                         packageId: _packageId,
-                        targetFramework: _framework,
                         versionRange: versionRange,
-                        verbosity: _verbosity);
+                        targetFramework: _framework, verbosity: _verbosity
+                    ).GetAwaiter().GetResult();
 
                     EnsureVersionIsHigher(oldPackageNullable, newInstalledPackage);
 

--- a/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
 using System.Transactions;
@@ -13,7 +12,6 @@ using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ShellShim;
 using Microsoft.DotNet.ToolPackage;
-using Microsoft.DotNet.Tools.Tool.Common;
 using Microsoft.DotNet.Tools.Tool.Install;
 using Microsoft.DotNet.Tools.Tool.Uninstall;
 using Microsoft.Extensions.EnvironmentAbstractions;


### PR DESCRIPTION
PR for global tool update for issue https://github.com/dotnet/sdk/issues/31134

Currently, when updating and installing a dotnet tool package, the code restores a temporary project using `toolPackageInstaller`. The changes download tool packages through the NuGet API for global tool update.