### PR TITLE
Stabilize branding for the 7.0.400 release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,11 +12,11 @@
   <!-- Repo Version Information -->
   <PropertyGroup>
     <VersionPrefix>7.0.400</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
     <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <!-- Production Dependencies -->

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
@@ -153,7 +153,7 @@ public class PackageTests
               "tasks/net7.0/Valleysoft.DockerCredsProvider.dll"
         };
 
-        string packageFilePath = Path.Combine(TestContext.Current.TestExecutionDirectory, "Container", "package", $"Microsoft.NET.Build.Containers.{Product.Version}.nupkg");
+        (string packageFilePath, string packageVersion) = ToolsetUtils.GetContainersPackagePath();
         using ZipArchive archive = new(File.OpenRead(packageFilePath), ZipArchiveMode.Read, false);
 
         IEnumerable<string> actualEntries = archive.Entries
@@ -163,6 +163,6 @@ public class PackageTests
 
         actualEntries
                 .Should()
-                .BeEquivalentTo(packageContents, $"Microsoft.NET.Build.Containers.{Product.Version}.nupkg content differs from expected. Please add the entry to the list, if the addition is expected.");
+                .BeEquivalentTo(packageContents, $"{Path.GetFileName(packageFilePath)} content differs from expected. Please add the entry to the list, if the addition is expected.");
     }
 }


### PR DESCRIPTION
7.0.4xx will be shipping its final preview next week and so putting out the PR to stabilize branding in preparation for GA release. This PR should wait till the runtime in SDK has been updated to 7.0.9 on Tuesday I think.