### PR TITLE
Handle when the target graph is TF/RID to pull out the TF piece

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1520,7 +1520,8 @@ namespace Microsoft.NET.Build.Tasks
                         log.LibraryId == package.Name &&
                         log.TargetGraphs.Any(tg =>
                         {
-                            var parsedTargetGraph = NuGetFramework.Parse(tg);
+                            var parts = tg.Split(Path.AltDirectorySeparatorChar);
+                            var parsedTargetGraph = NuGetFramework.Parse(parts[0]);
                             var alias = _lockFile.PackageSpec.TargetFrameworks
                                 .FirstOrDefault(tf => tf.FrameworkName == parsedTargetGraph)
                                 ?.TargetAlias ?? tg;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1520,7 +1520,7 @@ namespace Microsoft.NET.Build.Tasks
                         log.LibraryId == package.Name &&
                         log.TargetGraphs.Any(tg =>
                         {
-                            var parts = tg.Split(Path.AltDirectorySeparatorChar);
+                            var parts = tg.Split(LockFile.DirectorySeparatorChar);
                             var parsedTargetGraph = NuGetFramework.Parse(parts[0]);
                             var alias = _lockFile.PackageSpec.TargetFrameworks
                                 .FirstOrDefault(tf => tf.FrameworkName == parsedTargetGraph)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -820,7 +820,9 @@ class Program
             buildCommand
                 .Execute()
                 .Should()
-                .Pass();
+                .Pass()
+                .And
+                .HaveStdOutContaining("NU1603");
         }
 
         [WindowsOnlyFact]

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -26,6 +26,7 @@ using Microsoft.NET.Build.Tasks;
 using NuGet.Versioning;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+using Xunit.Sdk;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -798,6 +799,28 @@ class Program
             packageReferences
                 .Should()
                 .BeEmpty();
+        }
+
+        [WindowsOnlyFact]
+        public void ItResolvesPackageAssetsMultiTargetingNetStandard()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "MultiTargetedPackageReference",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework +";netstandard2.1",
+                RuntimeIdentifier = "win-x64",
+                IsExe = true
+            };
+            testProject.PackageReferences.Add(new TestPackageReference("Nuget.Common","6.5.7"));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
         }
 
         [WindowsOnlyFact]


### PR DESCRIPTION
This was being reported as an issue by vendors against a specific test application where 2.1/win-x64 was being passed through to nuget and throwing an exception.