### PR TITLE
First-run: Minor code adjustments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,9 +48,9 @@ dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
 
 # Types: use keywords instead of BCL types, and permit var only when the type is clear
-csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_for_built_in_types = false:none
 csharp_style_var_when_type_is_apparent = false:none
-csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_elsewhere = false:none
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/TelemetryEventEntry.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/TelemetryEventEntry.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Utils
         }
     }
 
-    public class PerformanceMeasurement : IDisposable
+    public sealed class PerformanceMeasurement : IDisposable
     {
         private readonly Stopwatch _timer;
         private readonly Dictionary<string, double> _data;

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/TelemetryEventEntry.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/TelemetryEventEntry.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.DotNet.Cli.Utils
@@ -45,6 +46,28 @@ namespace Microsoft.DotNet.Cli.Utils
 
             EntryPosted += Handler;
         }
+    }
+
+    public class PerformanceMeasurement : IDisposable
+    {
+        private readonly Stopwatch _timer;
+        private readonly Dictionary<string, double> _data;
+        private readonly string _name;
+
+        public PerformanceMeasurement(Dictionary<string, double> data, string name)
+        {
+            // Measurement is a no-op if we don't have a dictionary to store the entry.
+            if (data == null)
+            {
+                return;
+            }
+
+            _data = data;
+            _name = name;
+            _timer = Stopwatch.StartNew();
+        }
+
+        public void Dispose() => _data?.Add(_name, _timer.Elapsed.TotalMilliseconds);
     }
 
     public class BlockFilter : ITelemetryFilter

--- a/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Configurer
         public DotnetFirstRunConfiguration(
             bool generateAspNetCertificate,
             bool telemetryOptout,
-            bool addGlobalToolsToPath, 
+            bool addGlobalToolsToPath,
             bool nologo)
         {
             GenerateAspNetCertificate = generateAspNetCertificate;

--- a/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Configurer
                 }
             }
 
-            if (CanGenAspNetCert())
+            if (CanGenerateAspNetCertificate())
             {
                 using (new PerformanceMeasurement(_performanceMeasurements, "GenerateAspNetCertificate Time"))
                 {
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Configurer
             }
         }
 
-        private bool CanGenAspNetCert() =>
+        private bool CanGenerateAspNetCertificate() =>
 #if EXCLUDE_ASPNETCORE
             false;
 #else

--- a/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Configurer
         {
             if (_dotnetFirstRunConfiguration.AddGlobalToolsToPath && !_toolPathSentinel.Exists())
             {
-                using (_ = new PerformanceMeasurement(_performanceMeasurements, "AddPackageExecutablePath Time"))
+                using (new PerformanceMeasurement(_performanceMeasurements, "AddPackageExecutablePath Time"))
                 {
                     _pathAdder.AddPackageExecutablePathToUserPath();
                     _toolPathSentinel.Create();
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.Configurer
             var canShowFirstUseMessages = isFirstTimeUse && !_dotnetFirstRunConfiguration.NoLogo;
             if (isFirstTimeUse)
             {
-                using (_ = new PerformanceMeasurement(_performanceMeasurements, "FirstTimeUseNotice Time"))
+                using (new PerformanceMeasurement(_performanceMeasurements, "FirstTimeUseNotice Time"))
                 {
                     // Migrate the NuGet state from earlier SDKs
                     NuGet.Common.Migrations.MigrationRunner.Run();
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Configurer
 
             if (CanGenAspNetCert())
             {
-                using (_ = new PerformanceMeasurement(_performanceMeasurements, "GenerateAspNetCertificate Time"))
+                using (new PerformanceMeasurement(_performanceMeasurements, "GenerateAspNetCertificate Time"))
                 {
                     _aspNetCoreCertificateGenerator.GenerateAspNetCoreDevelopmentCertificate();
                     _aspNetCertificateSentinel.CreateIfNotExists();

--- a/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -14,15 +14,14 @@ namespace Microsoft.DotNet.Configurer
 {
     public class DotnetFirstTimeUseConfigurer
     {
-        private IReporter _reporter;
-        private DotnetFirstRunConfiguration _dotnetFirstRunConfiguration;
-        private IFirstTimeUseNoticeSentinel _firstTimeUseNoticeSentinel;
-        private IAspNetCertificateSentinel _aspNetCertificateSentinel;
-        private IAspNetCoreCertificateGenerator _aspNetCoreCertificateGenerator;
-        private IFileSentinel _toolPathSentinel;
-        private string _cliFallbackFolderPath;
+        private readonly IReporter _reporter;
+        private readonly DotnetFirstRunConfiguration _dotnetFirstRunConfiguration;
+        private readonly IFirstTimeUseNoticeSentinel _firstTimeUseNoticeSentinel;
+        private readonly IAspNetCertificateSentinel _aspNetCertificateSentinel;
+        private readonly IAspNetCoreCertificateGenerator _aspNetCoreCertificateGenerator;
+        private readonly IFileSentinel _toolPathSentinel;
         private readonly IEnvironmentPath _pathAdder;
-        private Dictionary<string, double> _performanceMeasurements;
+        private readonly Dictionary<string, double> _performanceMeasurements;
 
         public DotnetFirstTimeUseConfigurer(
             IFirstTimeUseNoticeSentinel firstTimeUseNoticeSentinel,
@@ -31,7 +30,6 @@ namespace Microsoft.DotNet.Configurer
             IFileSentinel toolPathSentinel,
             DotnetFirstRunConfiguration dotnetFirstRunConfiguration,
             IReporter reporter,
-            string cliFallbackFolderPath,
             IEnvironmentPath pathAdder,
             Dictionary<string, double> performanceMeasurements = null)
         {
@@ -41,152 +39,83 @@ namespace Microsoft.DotNet.Configurer
             _toolPathSentinel = toolPathSentinel;
             _dotnetFirstRunConfiguration = dotnetFirstRunConfiguration;
             _reporter = reporter;
-            _cliFallbackFolderPath = cliFallbackFolderPath;
             _pathAdder = pathAdder ?? throw new ArgumentNullException(nameof(pathAdder));
             _performanceMeasurements ??= performanceMeasurements;
         }
 
         public void Configure()
         {
-            if (ShouldAddPackageExecutablePath())
+            if (_dotnetFirstRunConfiguration.AddGlobalToolsToPath && !_toolPathSentinel.Exists())
             {
-                Stopwatch beforeAddPackageExecutablePath = Stopwatch.StartNew();
-                AddPackageExecutablePath();
-                _performanceMeasurements?.Add("AddPackageExecutablePath Time", beforeAddPackageExecutablePath.Elapsed.TotalMilliseconds);
+                using(_ = new PerformanceMeasurement(_performanceMeasurements, "AddPackageExecutablePath Time"))
+                {
+                    _pathAdder.AddPackageExecutablePathToUserPath();
+                    _toolPathSentinel.Create();
+                }
             }
 
-            var isFirstTimeUse = ShouldPrintFirstTimeUseNotice();
+            var isFirstTimeUse = !_firstTimeUseNoticeSentinel.Exists();
             var canShowFirstUseMessages = isFirstTimeUse && !_dotnetFirstRunConfiguration.NoLogo;
             if (isFirstTimeUse)
             {
-                Stopwatch beforeFirstTimeUseNotice = Stopwatch.StartNew();
-                // Migrate the nuget state from earlier SDKs
-                NuGet.Common.Migrations.MigrationRunner.Run();
-
-                if (canShowFirstUseMessages)
+                using (_ = new PerformanceMeasurement(_performanceMeasurements, "FirstTimeUseNotice Time"))
                 {
-                    PrintFirstTimeMessageWelcome();
-                    if (ShouldPrintTelemetryMessageWhenFirstTimeUseNoticeIsEnabled())
-                    {
-                        PrintTelemetryMessage();
-                    }
-                }
+                    // Migrate the NuGet state from earlier SDKs
+                    NuGet.Common.Migrations.MigrationRunner.Run();
 
-                _firstTimeUseNoticeSentinel.CreateIfNotExists();
-                _performanceMeasurements?.Add("FirstTimeUseNotice Time", beforeFirstTimeUseNotice.Elapsed.TotalMilliseconds);
+                    if (canShowFirstUseMessages)
+                    {
+                        _reporter.WriteLine();
+                        string productVersion = Product.Version;
+                        _reporter.WriteLine(string.Format(LocalizableStrings.FirstTimeMessageWelcome, ParseDotNetVersion(productVersion), productVersion));
+
+                        if (!_dotnetFirstRunConfiguration.TelemetryOptout)
+                        {
+                            _reporter.WriteLine();
+                            _reporter.WriteLine(LocalizableStrings.TelemetryMessage);
+                        }
+                    }
+
+                    _firstTimeUseNoticeSentinel.CreateIfNotExists();
+                }
             }
 
-            if (ShouldGenerateAspNetCertificate())
+            if (CanGenAspNetCert())
             {
-                Stopwatch beforeGenerateAspNetCertificate = Stopwatch.StartNew();
-                GenerateAspNetCertificate();
-
-                if (canShowFirstUseMessages)
+                using (_ = new PerformanceMeasurement(_performanceMeasurements, "GenerateAspNetCertificate Time"))
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    _aspNetCoreCertificateGenerator.GenerateAspNetCoreDevelopmentCertificate();
+                    _aspNetCertificateSentinel.CreateIfNotExists();
+
+                    if (canShowFirstUseMessages)
                     {
-                        // The instructions in this message only apply to Windows and MacOS.
-                        PrintFirstTimeMessageAspNetCertificate();
-                    }
-                    else
-                    {
-                        // The instructions in this message only apply to Linux (various distros).
-                        // OSPlatform.FreeBSD would also see this message, which is acceptable since we have no specific FreeBSD instructions.
-                        PrintFirstTimeMessageAspNetCertificateLinux();
+                        var aspNetCertMessage = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                            // The instructions in this message only apply to Windows and MacOS.
+                            LocalizableStrings.FirstTimeMessageAspNetCertificate :
+                            // The instructions in this message only apply to Linux (various distros).
+                            // OSPlatform.FreeBSD would also see this message, which is acceptable since we have no specific FreeBSD instructions.
+                            LocalizableStrings.FirstTimeMessageAspNetCertificateLinux;
+                        _reporter.WriteLine();
+                        _reporter.WriteLine(aspNetCertMessage);
                     }
                 }
-
-                _performanceMeasurements?.Add("GenerateAspNetCertificate Time", beforeGenerateAspNetCertificate.Elapsed.TotalMilliseconds);
             }
 
             if (canShowFirstUseMessages)
             {
-                PrintFirstTimeMessageMoreInformation();
+                _reporter.WriteLine();
+                _reporter.WriteLine(LocalizableStrings.FirstTimeMessageMoreInformation);
             }
         }
 
-        private void GenerateAspNetCertificate()
-        {
-            _aspNetCoreCertificateGenerator.GenerateAspNetCoreDevelopmentCertificate();
-
-            _aspNetCertificateSentinel.CreateIfNotExists();
-        }
-
-        private bool ShouldGenerateAspNetCertificate()
-        {
+        private bool CanGenAspNetCert() =>
 #if EXCLUDE_ASPNETCORE
-            return false;
+            false;
 #else
-            return _dotnetFirstRunConfiguration.GenerateAspNetCertificate &&
-                !_aspNetCertificateSentinel.Exists();
+            _dotnetFirstRunConfiguration.GenerateAspNetCertificate && !_aspNetCertificateSentinel.Exists();
 #endif
-        }
 
-        private bool ShouldAddPackageExecutablePath()
-        {
-            return _dotnetFirstRunConfiguration.AddGlobalToolsToPath &&
-                !_toolPathSentinel.Exists();
-        }
-
-        private void AddPackageExecutablePath()
-        {
-            _pathAdder.AddPackageExecutablePathToUserPath();
-
-            _toolPathSentinel.Create();
-        }
-
-        private bool ShouldPrintFirstTimeUseNotice()
-        {
-            return !_firstTimeUseNoticeSentinel.Exists();
-        }
-
-        private bool ShouldPrintTelemetryMessageWhenFirstTimeUseNoticeIsEnabled()
-        {
-            return !_dotnetFirstRunConfiguration.TelemetryOptout;
-        }
-
-        private void PrintFirstTimeMessageWelcome()
-        {
-            _reporter.WriteLine();
-            string productVersion = Product.Version;
-            _reporter.WriteLine(string.Format(
-                LocalizableStrings.FirstTimeMessageWelcome,
-                DeriveDotnetVersionFromProductVersion(productVersion),
-                productVersion));
-        }
-
-        private void PrintFirstTimeMessageAspNetCertificate()
-        {
-            _reporter.WriteLine();
-            _reporter.WriteLine(LocalizableStrings.FirstTimeMessageAspNetCertificate);
-        }
-
-        private void PrintFirstTimeMessageAspNetCertificateLinux()
-        {
-            _reporter.WriteLine();
-            _reporter.WriteLine(LocalizableStrings.FirstTimeMessageAspNetCertificateLinux);
-        }
-
-        private void PrintFirstTimeMessageMoreInformation()
-        {
-            _reporter.WriteLine();
-            _reporter.WriteLine(LocalizableStrings.FirstTimeMessageMoreInformation);
-        }
-
-        private void PrintTelemetryMessage()
-        {
-            _reporter.WriteLine();
-            _reporter.WriteLine(LocalizableStrings.TelemetryMessage);
-        }
-
-        internal static string DeriveDotnetVersionFromProductVersion(string productVersion)
-        {
-            if (!NuGetVersion.TryParse(productVersion, out var parsedVersion))
-            {
-                return string.Empty;
-            }
-
-            return $"{parsedVersion.Major}.{parsedVersion.Minor}";
-        }
+        internal static string ParseDotNetVersion(string productVersion) =>
+            NuGetVersion.TryParse(productVersion, out var parsedVersion) ? $"{parsedVersion.Major}.{parsedVersion.Minor}" : string.Empty;
     }
 }

--- a/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Configurer
         {
             if (_dotnetFirstRunConfiguration.AddGlobalToolsToPath && !_toolPathSentinel.Exists())
             {
-                using(_ = new PerformanceMeasurement(_performanceMeasurements, "AddPackageExecutablePath Time"))
+                using (_ = new PerformanceMeasurement(_performanceMeasurements, "AddPackageExecutablePath Time"))
                 {
                     _pathAdder.AddPackageExecutablePathToUserPath();
                     _toolPathSentinel.Create();

--- a/src/Cli/Microsoft.DotNet.Configurer/FirstTimeUseNoticeSentinel.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/FirstTimeUseNoticeSentinel.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Configurer
     {
         public static readonly string SENTINEL = $"{Product.Version}.dotnetFirstUseSentinel";
 
-        private string _dotnetUserProfileFolderPath;
+        private readonly string _dotnetUserProfileFolderPath;
         private readonly IFileSystem _fileSystem;
 
         private string SentinelPath => Path.Combine(_dotnetUserProfileFolderPath, SENTINEL);

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Cli
 
             PerformanceLogEventSource.Log.BuiltInCommandParserStart();
             ParseResult parseResult;
-            using (_ = new PerformanceMeasurement(performanceData, "Parse Time"))
+            using (new PerformanceMeasurement(performanceData, "Parse Time"))
             {
                 parseResult = Parser.Instance.Parse(args);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -55,14 +55,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                                      workloadResolver ?? _workloadResolver, Verbosity, _userProfileDir, VerifySignatures, PackageDownloader, _dotnetPath, TempDirectoryPath,
                                      _packageSourceLocation, RestoreActionConfiguration, elevationRequired: !_printDownloadLinkOnly && string.IsNullOrWhiteSpace(_downloadToCacheOption));
 
-            bool displayManifestUpdates = false;
-            if (Verbosity.IsDetailedOrDiagnostic())
-            {
-                displayManifestUpdates = true;
-            }
             _workloadManifestUpdater = _workloadManifestUpdaterFromConstructor ?? new WorkloadManifestUpdater(Reporter, workloadResolver ?? _workloadResolver, PackageDownloader, _userProfileDir, TempDirectoryPath,
-                _workloadInstaller.GetWorkloadInstallationRecordRepository(), (IWorkloadManifestInstaller)_workloadInstaller, _packageSourceLocation, displayManifestUpdates: displayManifestUpdates);
-
+                _workloadInstaller.GetWorkloadInstallationRecordRepository(), _workloadInstaller, _packageSourceLocation, displayManifestUpdates: Verbosity.IsDetailedOrDiagnostic());
 
             ValidateWorkloadIdsInput();
         }
@@ -74,14 +68,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             {
                 if (!availableWorkloads.Select(workload => workload.Id.ToString()).Contains(workloadId))
                 {
-                    if (_workloadResolver.IsPlatformIncompatibleWorkload(new WorkloadId(workloadId)))
-                    {
-                        throw new GracefulException(string.Format(LocalizableStrings.WorkloadNotSupportedOnPlatform, workloadId), isUserError: false);
-                    }
-                    else
-                    {
-                        throw new GracefulException(string.Format(LocalizableStrings.WorkloadNotRecognized, workloadId), isUserError: false);
-                    }
+                    var exceptionMessage = _workloadResolver.IsPlatformIncompatibleWorkload(new WorkloadId(workloadId)) ?
+                        LocalizableStrings.WorkloadNotSupportedOnPlatform : LocalizableStrings.WorkloadNotRecognized;
+
+                    throw new GracefulException(string.Format(exceptionMessage, workloadId), isUserError: false);
                 }
             }
         }
@@ -208,16 +198,17 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             IEnumerable<PackInfo> workloadPackToInstall = new List<PackInfo>();
             IEnumerable<WorkloadId> newWorkloadInstallRecords = new List<WorkloadId>();
 
-            var transaction = new CliTransaction();
-
-            transaction.RollbackStarted = () =>
+            var transaction = new CliTransaction
             {
-                Reporter.WriteLine(LocalizableStrings.RollingBackInstall);
-            };
-            // Don't hide the original error if roll back fails, but do log the rollback failure
-            transaction.RollbackFailed = ex =>
-            {
-                Reporter.WriteLine(string.Format(LocalizableStrings.RollBackFailedMessage, ex.Message));
+                RollbackStarted = () =>
+                {
+                    Reporter.WriteLine(LocalizableStrings.RollingBackInstall);
+                },
+                // Don't hide the original error if roll back fails, but do log the rollback failure
+                RollbackFailed = ex =>
+                {
+                    Reporter.WriteLine(string.Format(LocalizableStrings.RollBackFailedMessage, ex.Message));
+                }
             };
 
             transaction.Run(

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -200,15 +200,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             var transaction = new CliTransaction
             {
-                RollbackStarted = () =>
-                {
-                    Reporter.WriteLine(LocalizableStrings.RollingBackInstall);
-                },
+                RollbackStarted = () => Reporter.WriteLine(LocalizableStrings.RollingBackInstall),
                 // Don't hide the original error if roll back fails, but do log the rollback failure
-                RollbackFailed = ex =>
-                {
-                    Reporter.WriteLine(string.Format(LocalizableStrings.RollBackFailedMessage, ex.Message));
-                }
+                RollbackFailed = ex => Reporter.WriteLine(string.Format(LocalizableStrings.RollBackFailedMessage, ex.Message))
             };
 
             transaction.Run(

--- a/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
+++ b/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
@@ -17,8 +17,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
 {
     public class GivenADotnetFirstTimeUseConfigurer
     {
-        private const string CliFallbackFolderPath = "some path";
-
         private Mock<IFirstTimeUseNoticeSentinel> _firstTimeUseNoticeSentinelMock;
         private Mock<IAspNetCertificateSentinel> _aspNetCertificateSentinelMock;
         private Mock<IAspNetCoreCertificateGenerator> _aspNetCoreCertificateGeneratorMock;
@@ -54,7 +52,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object);
 
             dotnetFirstTimeUseConfigurer.Configure();
@@ -81,7 +78,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object);
 
             dotnetFirstTimeUseConfigurer.Configure();
@@ -108,7 +104,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object);
 
             dotnetFirstTimeUseConfigurer.Configure();
@@ -135,7 +130,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object);
 
             dotnetFirstTimeUseConfigurer.Configure();
@@ -162,7 +156,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object);
 
             dotnetFirstTimeUseConfigurer.Configure();
@@ -188,7 +181,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object);
 
             dotnetFirstTimeUseConfigurer.Configure();
@@ -214,7 +206,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object);
 
             dotnetFirstTimeUseConfigurer.Configure();
@@ -239,7 +230,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object);
 
             dotnetFirstTimeUseConfigurer.Configure();
@@ -263,7 +253,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object);
 
             dotnetFirstTimeUseConfigurer.Configure();
@@ -291,7 +280,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object,
                 measurements);
 
@@ -331,7 +319,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                     nologo: false
                 ),
                 _reporterMock.Object,
-                CliFallbackFolderPath,
                 _pathAdderMock.Object,
                 measurements);
 

--- a/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
+++ b/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
@@ -19,8 +19,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenADotnetFirstTimeUseConfigurerWithStateSetup
     {
-        private const string CliFallbackFolderPath = "some path";
-
         private MockBasicSentinel _firstTimeUseNoticeSentinelMock;
         private MockBasicSentinel _aspNetCertificateSentinelMock;
         private Mock<IAspNetCoreCertificateGenerator> _aspNetCoreCertificateGeneratorMock;
@@ -29,13 +27,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         private Mock<IEnvironmentPath> _pathAdderMock;
         private Mock<IEnvironmentProvider> _environmentProvider;
 
-        private readonly ITestOutputHelper _output;
-
         public GivenADotnetFirstTimeUseConfigurerWithStateSetup(ITestOutputHelper output)
         {
             ResetObjectState();
-
-            _output = output;
         }
 
         private void ResetObjectState()
@@ -113,7 +107,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 = new FirstRunExperienceAction(
                     () => _reporterMock.Lines.Contains(string.Format(
                     Configurer.LocalizableStrings.FirstTimeMessageWelcome,
-                    DotnetFirstTimeUseConfigurer.DeriveDotnetVersionFromProductVersion(Product.Version),
+                    DotnetFirstTimeUseConfigurer.ParseDotNetVersion(Product.Version),
                     Product.Version))
                             && _reporterMock.Lines.Contains(LocalizableStrings.FirstTimeMessageMoreInformation),
                     "printFirstTimeWelcomeMessage");
@@ -254,7 +248,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                      nologo: nologo
                  ),
                  reporter: _reporterMock,
-                 cliFallbackFolderPath: CliFallbackFolderPath,
                  pathAdder: _pathAdderMock.Object);
 
             configurer.Configure();

--- a/src/Tests/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/src/Tests/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Tests
                 .Should()
                 .ContainVisuallySameFragment(string.Format(
                     Configurer.LocalizableStrings.FirstTimeMessageWelcome,
-                    DotnetFirstTimeUseConfigurer.DeriveDotnetVersionFromProductVersion(expectedVersion),
+                    DotnetFirstTimeUseConfigurer.ParseDotNetVersion(expectedVersion),
                     expectedVersion))
                 .And.ContainVisuallySameFragment(Configurer.LocalizableStrings.FirstTimeMessageMoreInformation)
                 .And.NotContain("Restore completed in");
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Tests
                 .Should()
                 .ContainVisuallySameFragment(string.Format(
                     Configurer.LocalizableStrings.FirstTimeMessageWelcome,
-                    DotnetFirstTimeUseConfigurer.DeriveDotnetVersionFromProductVersion(expectedVersion),
+                    DotnetFirstTimeUseConfigurer.ParseDotNetVersion(expectedVersion),
                     expectedVersion))
                 .And.ContainVisuallySameFragment(Configurer.LocalizableStrings.FirstTimeMessageMoreInformation);
         }


### PR DESCRIPTION
## Summary
Just a random set of adjustments/cleanup prior to digging into the first-run workload experience changes.

- Set var usage to have no suggestions
  - The team doesn't seem to have an actual preference based on the code I've looked at thus far. So, just turned off the suggested usage.
- Added `PerformanceMeasurement` to replace manual StopWatch creation
- Removed extraneous method usage and other minor cleanup to `DotnetFirstTimeUseConfigurer`
  - Removed `cliFallbackFolderPath` constructor parameter as it was unused
- Other minor code cleanup/adjustments