### PR TITLE
Fix feature bands for side-by-side manifests

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -54,14 +54,12 @@ namespace Microsoft.DotNet.Cli
                 return;
             }
 
+            var manifestInfoDict =  workloadInfoHelper.WorkloadResolver.GetInstalledManifests().ToDictionary(info => info.Id, StringComparer.OrdinalIgnoreCase);
 
             foreach (var workload in installedWorkloads.AsEnumerable())
             {
                 var workloadManifest = workloadInfoHelper.WorkloadResolver.GetManifestFromWorkload(new WorkloadId(workload.Key));
-                var workloadFeatureBand = new WorkloadManifestInfo(
-                    workloadManifest.Id,
-                    workloadManifest.Version,
-                    Path.GetDirectoryName(workloadManifest.ManifestPath)!).ManifestFeatureBand;
+                var workloadFeatureBand = manifestInfoDict[workloadManifest.Id].ManifestFeatureBand;
 
                 const int align = 10;
                 const string separator = "   ";

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Parsing;
@@ -81,6 +82,8 @@ namespace Microsoft.DotNet.Workloads.Workload.List
             }
             else
             {
+                var manifestInfoDict = _workloadListHelper.WorkloadResolver.GetInstalledManifests().ToDictionary(info => info.Id, StringComparer.OrdinalIgnoreCase);
+
                 InstalledWorkloadsCollection installedWorkloads = _workloadListHelper.AddInstalledVsWorkloads(installedList);
                 Reporter.WriteLine();
                 PrintableTable<KeyValuePair<string, string>> table = new();
@@ -88,8 +91,8 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 table.AddColumn(InformationStrings.WorkloadManfiestVersionColumn, workload =>
                 {
                     var m = _workloadListHelper.WorkloadResolver.GetManifestFromWorkload(new WorkloadId(workload.Key));
-                    return m.Version + "/" +
-                    new WorkloadManifestInfo(m.Id, m.Version, Path.GetDirectoryName(m.ManifestPath)!).ManifestFeatureBand;
+                    var manifestInfo = manifestInfoDict[m.Id];
+                    return m.Version + "/" + manifestInfo.ManifestFeatureBand;
                 });
                 table.AddColumn(InformationStrings.WorkloadSourceColumn, workload => workload.Value);
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ReadableWorkloadManifest.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ReadableWorkloadManifest.cs
@@ -18,16 +18,19 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         public string ManifestPath { get; }
 
+        public string ManifestFeatureBand { get; }
+
         readonly Func<Stream> _openManifestStreamFunc;
 
 
         readonly Func<Stream?> _openLocalizationStream;
 
-        public ReadableWorkloadManifest(string manifestId, string manifestDirectory, string manifestPath, Func<Stream> openManifestStreamFunc, Func<Stream?> openLocalizationStream)
+        public ReadableWorkloadManifest(string manifestId, string manifestDirectory, string manifestPath, string manifestFeatureBand, Func<Stream> openManifestStreamFunc, Func<Stream?> openLocalizationStream)
         {
             ManifestId = manifestId;
             ManifestPath = manifestPath;
             ManifestDirectory = manifestDirectory;
+            ManifestFeatureBand = manifestFeatureBand;
             _openManifestStreamFunc = openManifestStreamFunc;
             _openLocalizationStream = openLocalizationStream;
         }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
@@ -37,6 +37,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     manifestId,
                     workloadManifestDirectory,
                     workloadManifestPath,
+                    _sdkVersionBand,
                     () => File.OpenRead(workloadManifestPath),
                     () => WorkloadManifestReader.TryOpenLocalizationCatalogForManifest(workloadManifestPath)
                 );

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestInfo.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestInfo.cs
@@ -12,12 +12,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
     public class WorkloadManifestInfo
     {
-        public WorkloadManifestInfo(string id, string version, string manifestDirectory)
+        public WorkloadManifestInfo(string id, string version, string manifestDirectory, string manifestFeatureBand)
         {
             Id = id;
             Version = version;
             ManifestDirectory = manifestDirectory;
-            ManifestFeatureBand = Path.GetFileName(Path.GetDirectoryName(manifestDirectory))!;
+            ManifestFeatureBand = manifestFeatureBand;
         }
 
         public string Id { get; }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
@@ -71,7 +71,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         public static WorkloadSet FromJson(string json, SdkFeatureBand defaultFeatureBand)
         {
 #if USE_SYSTEM_TEXT_JSON
-            return FromDictionaryForJson(JsonSerializer.Deserialize<IDictionary<string, string>>(json)!, defaultFeatureBand);
+            var jsonSerializerOptions = new JsonSerializerOptions()
+            {
+                AllowTrailingCommas = true,
+                ReadCommentHandling = JsonCommentHandling.Skip
+            };
+            return FromDictionaryForJson(JsonSerializer.Deserialize<IDictionary<string, string>>(json, jsonSerializerOptions)!, defaultFeatureBand);
 #else
             return FromDictionaryForJson(JsonConvert.DeserializeObject<IDictionary<string, string>>(json)!, defaultFeatureBand);
 #endif

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
@@ -26,8 +26,6 @@ namespace ManifestReaderTests
             _filePaths = filePaths;
         }
 
-        public IEnumerable<string> GetManifestDirectories() => throw new NotImplementedException();
-
         public IEnumerable<ReadableWorkloadManifest> GetManifests()
         {
             foreach (var filePath in _filePaths)
@@ -36,6 +34,7 @@ namespace ManifestReaderTests
                     Path.GetFileNameWithoutExtension(filePath.manifest),
                     Path.GetDirectoryName(filePath.manifest)!,
                     filePath.manifest,
+                    "8.0.100",
                     () => new FileStream(filePath.manifest, FileMode.Open, FileAccess.Read),
                     () => filePath.localizationCatalog != null ? new FileStream(filePath.localizationCatalog, FileMode.Open, FileAccess.Read) : null
                 );
@@ -50,13 +49,13 @@ namespace ManifestReaderTests
         readonly List<(string id, byte[] content)> _manifests = new List<(string, byte[])>();
 
         public void Add(string id, string content) => _manifests.Add((id, Encoding.UTF8.GetBytes(content)));
-        public IEnumerable<string> GetManifestDirectories() => throw new NotImplementedException();
 
         public IEnumerable<ReadableWorkloadManifest> GetManifests()
             => _manifests.Select(m => new ReadableWorkloadManifest(
                 m.id,
                 $@"C:\fake\{m.id}",
                 $@"C:\fake\{m.id}\WorkloadManifest.json",
+                "8.0.100",
                 (Func<Stream>)(() => new MemoryStream(m.content)),
                 (Func<Stream?>)(() => null)
             ));

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -202,6 +202,32 @@ namespace ManifestReaderTests
                 .BeEquivalentTo("ios: 11.0.2/8.0.100", "android: 33.0.2-rc.1/8.0.200", "maui: 15.0.1-rc.456/8.0.200-rc.2");
         }
 
+
+        [Fact]
+        public void WorkloadSetCanHaveTrailingCommasInJson()
+        {
+            Initialize("8.0.200");
+
+            CreateMockManifest(_manifestRoot, "8.0.100", "ios", "11.0.2", true);
+            CreateMockManifest(_manifestRoot, "8.0.200", "android", "33.0.2-rc.1", true);
+            CreateMockManifest(_manifestRoot, "8.0.200-rc.2", "maui", "15.0.1-rc.456", true);
+
+            CreateMockWorkloadSet(_manifestRoot, "8.0.200", "8.0.200", """
+                {
+                "ios": "11.0.2/8.0.100",
+                "android": "33.0.2-rc.1/8.0.200",
+                "maui": "15.0.1-rc.456/8.0.200-rc.2",
+                }
+                """);
+
+            var sdkDirectoryWorkloadManifestProvider
+                = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "8.0.200", userProfileDir: null, globalJsonPath: null);
+
+            GetManifestContents(sdkDirectoryWorkloadManifestProvider)
+                .Should()
+                .BeEquivalentTo("ios: 11.0.2/8.0.100", "android: 33.0.2-rc.1/8.0.200", "maui: 15.0.1-rc.456/8.0.200-rc.2");
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -1183,7 +1183,7 @@ Microsoft.Net.Workload.Emscripten.net7"
                        $"NotInIncudedWorkloadsFile: 1/{currentSdkVersion}");
         }
 
-        private void CreateMockManifest(string manifestRoot, string featureBand, string manifestId, string manifestVersion, bool useVersionFolder = false)
+        private void CreateMockManifest(string manifestRoot, string featureBand, string manifestId, string manifestVersion, bool useVersionFolder = false, string? manifestContents = null)
         {
             var manifestDirectory = Path.Combine(manifestRoot, featureBand, manifestId);
             if (useVersionFolder)
@@ -1196,7 +1196,12 @@ Microsoft.Net.Workload.Emscripten.net7"
                 Directory.CreateDirectory(manifestDirectory);
             }
 
-            File.WriteAllText(Path.Combine(manifestDirectory, "WorkloadManifest.json"), $"{manifestId}: {manifestVersion}/{featureBand}");
+            if (manifestContents == null)
+            {
+                manifestContents = $"{manifestId}: {manifestVersion}/{featureBand}";
+            }
+
+            File.WriteAllText(Path.Combine(manifestDirectory, "WorkloadManifest.json"), manifestContents);
         }
 
         private void CreateMockWorkloadSet(string manifestRoot, string featureBand, string workloadSetVersion, string workloadSetContents)
@@ -1243,7 +1248,99 @@ Microsoft.Net.Workload.Emscripten.net7"
             GetManifestContents(sdkDirectoryWorkloadManifestProvider)
                 .Should()
                 .BeEquivalentTo("iOS: iOS-6.0.100");
+        }
 
+        [Fact]
+        public void WorkloadResolverUsesManifestsFromWorkloadSet()
+        {
+            Initialize("8.0.200");
+
+            string manifestContents1 = """
+    {
+        "version": "11.0.1",
+        "workloads": {
+            "ios": {
+                "description": "iOS workload",
+                "kind": "dev",
+                "packs": [ "Microsoft.NET.iOS.Workload" ]
+            },
+        },
+        "packs": {
+            "Microsoft.NET.iOS.Workload" : {
+                "kind": "sdk",
+                "version": "1"
+            }
+        }
+    }
+    """;
+
+            string manifestContents2 = """
+    {
+        "version": "11.0.2",
+        "workloads": {
+            "ios": {
+                "description": "iOS workload",
+                "kind": "dev",
+                "packs": [ "Microsoft.NET.iOS.Workload" ]
+            },
+        },
+        "packs": {
+            "Microsoft.NET.iOS.Workload" : {
+                "kind": "sdk",
+                "version": "2"
+            }
+        }
+    }
+    """;
+
+            string manifestContents3 = """
+    {
+        "version": "12.0.1",
+        "workloads": {
+            "ios": {
+                "description": "iOS workload",
+                "kind": "dev",
+                "packs": [ "Microsoft.NET.iOS.Workload" ]
+            },
+        },
+        "packs": {
+            "Microsoft.NET.iOS.Workload" : {
+                "kind": "sdk",
+                "version": "3"
+            }
+        }
+    }
+    """;
+
+            CreateMockManifest(_manifestRoot, "8.0.100", "ios", "11.0.1", true, manifestContents1);
+            CreateMockManifest(_manifestRoot, "8.0.100", "ios", "11.0.2", true, manifestContents2);
+            CreateMockManifest(_manifestRoot, "8.0.200", "ios", "12.0.1", true, manifestContents3);
+
+            CreateMockWorkloadSet(_manifestRoot, "8.0.200", "8.0.200", """
+                {
+                  "ios": "11.0.2/8.0.100"
+                }
+                """);
+
+            var sdkDirectoryWorkloadManifestProvider
+                = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "8.0.200", userProfileDir: null, globalJsonPath: null);
+
+            var workloadResolver = WorkloadResolver.CreateForTests(sdkDirectoryWorkloadManifestProvider, _fakeDotnetRootDirectory);
+
+            var workloads = workloadResolver.GetAvailableWorkloads();
+            workloads.Count().Should().Be(1);
+            var expectedPackId = new WorkloadPackId("Microsoft.NET.iOS.Workload");
+            workloadResolver.GetPacksInWorkload(workloads.Single().Id).Should().BeEquivalentTo(new[] { expectedPackId });
+            var packInfo = workloadResolver.TryGetPackInfo(expectedPackId);
+            packInfo.Should().NotBeNull();
+            packInfo!.Version.Should().Be("2");
+
+            workloadResolver.GetInstalledManifests().Count().Should().Be(1);
+            var manifestInfo = workloadResolver.GetInstalledManifests().Single();
+            manifestInfo.Id.Should().Be("ios");
+            manifestInfo.Version.Should().Be("11.0.2");
+            manifestInfo.ManifestFeatureBand.Should().Be("8.0.100");
+            manifestInfo.ManifestDirectory.Should().Be(Path.Combine(_manifestRoot, "8.0.100", "ios", "11.0.2"));
         }
 
         private IEnumerable<string> GetManifestContents(SdkDirectoryWorkloadManifestProvider manifestProvider)

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -192,10 +192,13 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 File.WriteAllText(Path.Combine(AdManifestPath, "AdvertisedManifestFeatureBand.txt"), currentFeatureBand);
             }
 
-            var manifestDirs = expectedManifestUpdates.Select(manifest => Path.Combine(testDir, "dotnet", "sdk-manifests", manifest.ExistingFeatureBand, manifest.ManifestId.ToString(), "WorkloadManifest.json"))
-                .Concat(expectedManifestNotUpdated.Select(manifest => Path.Combine(testDir, "dotnet", "sdk-manifests", currentFeatureBand, manifest.ToString(), "WorkloadManifest.json")))
+            var manifestInfo = expectedManifestUpdates.Select(
+                    manifest => (manifest.ManifestId.ToString(), Path.Combine(testDir, "dotnet", "sdk-manifests", manifest.ExistingFeatureBand, manifest.ManifestId.ToString(), "WorkloadManifest.json"), manifest.ExistingFeatureBand))
+                .Concat(expectedManifestNotUpdated.Select(
+                    manifestId => (manifestId.ToString(), Path.Combine(testDir, "dotnet", "sdk-manifests", currentFeatureBand, manifestId.ToString(), "WorkloadManifest.json"), currentFeatureBand)))
                 .ToArray();
-            var workloadManifestProvider = new MockManifestProvider(manifestDirs);
+
+            var workloadManifestProvider = new MockManifestProvider(manifestInfo);
             workloadManifestProvider.SdkFeatureBand = new SdkFeatureBand(currentFeatureBand);
             var nugetDownloader = new MockNuGetPackageDownloader(dotnetRoot);
             var workloadResolver = WorkloadResolver.CreateForTests(workloadManifestProvider, dotnetRoot);
@@ -231,7 +234,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             Directory.CreateDirectory(Path.Combine(installedManifestDir6_0_200, testManifestName));
             File.WriteAllText(Path.Combine(installedManifestDir6_0_200, testManifestName, _manifestFileName), GetManifestContent(new ManifestVersion("1.0.0")));
 
-            var workloadManifestProvider = new MockManifestProvider(Path.Combine(installedManifestDir6_0_200, testManifestName, _manifestFileName))
+            string manifestPath = Path.Combine(installedManifestDir6_0_200, testManifestName, _manifestFileName);
+
+            var workloadManifestProvider = new MockManifestProvider((testManifestName, manifestPath, "6.0.200"))
             {
                 SdkFeatureBand = new SdkFeatureBand(sdkFeatureBand)
             };
@@ -309,7 +314,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             Directory.CreateDirectory(Path.Combine(emptyInstalledManifestsDir, testManifestName));
             File.WriteAllText(Path.Combine(emptyInstalledManifestsDir, testManifestName, _manifestFileName), GetManifestContent(new ManifestVersion("1.0.0")));
 
-            var workloadManifestProvider = new MockManifestProvider(Path.Combine(emptyInstalledManifestsDir, testManifestName, _manifestFileName)) 
+            var workloadManifestProvider = new MockManifestProvider((testManifestName, Path.Combine(emptyInstalledManifestsDir, testManifestName, _manifestFileName), "6.0.200")) 
             {
                 SdkFeatureBand = new SdkFeatureBand(sdkFeatureBand)
             };        

--- a/src/Tests/dotnet-workload-install.Tests/MockManifestProvider.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockManifestProvider.cs
@@ -12,36 +12,35 @@ namespace ManifestReaderTests
 {
     internal class MockManifestProvider : IWorkloadManifestProvider
     {
-        readonly (string name, string path)[] _manifests;
+        readonly (string name, string path, string featureBand)[] _manifests;
 
         public MockManifestProvider(params string[] manifestPaths)
         {
             _manifests = Array.ConvertAll(manifestPaths, mp =>
             {
                 string manifestId = Path.GetFileNameWithoutExtension(Path.GetDirectoryName(mp));
-                return (manifestId, mp);
+                return (manifestId, mp, (string)null);
             });
+            SdkFeatureBand = new SdkFeatureBand("6.0.100");
+        }
+
+        public MockManifestProvider(params (string name, string path, string featureBand)[] manifests)
+        {
+            _manifests = manifests;
             SdkFeatureBand = new SdkFeatureBand("6.0.100");
         }
 
         public SdkFeatureBand SdkFeatureBand { get; set; }
 
-        public IEnumerable<string> GetManifestDirectories()
-        {
-            foreach ((_, var filePath) in _manifests)
-            {
-                yield return Path.GetDirectoryName(filePath);
-            }
-        }
-
         public IEnumerable<ReadableWorkloadManifest> GetManifests()
             {
-                foreach ((var id, var path) in _manifests)
+                foreach ((var id, var path, var featureBand) in _manifests)
                 {
                     yield return new(
                         id,
                         Path.GetDirectoryName(path),
                         path,
+                        featureBand ?? SdkFeatureBand.ToString(),
                         () => File.OpenRead(path),
                         () => WorkloadManifestReader.TryOpenLocalizationCatalogForManifest(path)
                     );

--- a/src/Tests/dotnet-workload-list.Tests/GivenDotnetWorkloadList.cs
+++ b/src/Tests/dotnet-workload-list.Tests/GivenDotnetWorkloadList.cs
@@ -66,13 +66,13 @@ namespace Microsoft.DotNet.Cli.Workload.List.Tests
             _reporter.Clear();
             var expectedWorkloads = new List<WorkloadId>() { new WorkloadId("mock-workload-1"), new WorkloadId("mock-workload-2"), new WorkloadId("mock-workload-3") };
             var workloadInstaller = new MockWorkloadRecordRepo(expectedWorkloads);
-            var workloadResolver = WorkloadResolver.CreateForTests(new MockManifestProvider(new[] { _manifestPath }), Directory.GetCurrentDirectory());
+            var workloadResolver = WorkloadResolver.CreateForTests(new MockManifestProvider(("SampleManifest", _manifestPath, "6.0.100")), Directory.GetCurrentDirectory());
             var command = new WorkloadListCommand(_parseResult, _reporter, workloadInstaller, "6.0.100", workloadResolver: workloadResolver);
             command.Execute();
 
             foreach (var workload in expectedWorkloads)
             {
-                _reporter.Lines.Select(line => line.Trim()).Should().Contain($"{workload}            5.0.0/TestProjects      SDK 6.0.100");
+                _reporter.Lines.Select(line => line.Trim()).Should().Contain($"{workload}            5.0.0/6.0.100         SDK 6.0.100");
             }
         }
 


### PR DESCRIPTION
This PR contains two fixes:

- Correctly report manifest feature band for side-by-side manifests in WorkloadResolver.GetInstalledManifests.  Without this, various workload commands such as `dotnet workload update` would fail with side-by-side workload manifests, as the manifest ID would be used for the SDK feature band, and wouldn't parse correctly as a version.
- Allow trailing commas in JSON files for workload sets

We will want to port these to 7.0.4xx (probably via #33643).