### PR TITLE
VS Shortcut: Use version number file

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -93,9 +93,10 @@ function CreateVSShortcut()
     return
   }
 
-  # Note: The VS version in this call would need to be updated as new VS major versions release.
-  $vsVersion = 17.0
-  $devenvPath = (& "$installerPath\vswhere.exe" -all -prerelease -latest -version $vsVersion -find Common7\IDE\devenv.exe) | Select-Object -First 1
+  $versionFilePath = Join-Path $RepoRoot 'src\Layout\redist\minimumMSBuildVersion'
+  # Gets the first digit (ex. 17) and appends '.0' to it.
+  $vsMajorVersion = "$(((Get-Content $versionFilePath).Split('.'))[0]).0"
+  $devenvPath = (& "$installerPath\vswhere.exe" -all -prerelease -latest -version $vsMajorVersion -find Common7\IDE\devenv.exe) | Select-Object -First 1
   if(-Not $devenvPath)
   {
     return


### PR DESCRIPTION
## Summary

Upon investigating a build issue I'm having on my machine, I noticed there is this `minimumMSBuildVersion` file. This seems to contain the version of VS (which is also the MSBuild version) used by the `redist.csproj` project. I noticed this being updated semi-regularly, which is good enough for this shortcut mechanism to know which VS version it should locate. Therefore, I no longer need a hard-coded version in the script. Now, I acquire it from this file.

The file's current value is `17.6.0` which becomes `17.0` for the purposes of finding the latest VS version of that major release on the system.