### PR TITLE
Align EnableStrictModeForCompatibleTfms default between frontends

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
@@ -67,17 +67,17 @@ namespace Microsoft.DotNet.ApiCompat.Task
         public bool RunApiCompat { get; set; } = true;
 
         /// <summary>
-        /// Enables strict mode api comparison checks enqueued by the compatible tfm validator.
+        /// Validates api compatibility in strict mode for contract and implementation assemblies for all compatible target frameworks.
         /// </summary>
-        public bool EnableStrictModeForCompatibleTfms { get; set; }
+        public bool EnableStrictModeForCompatibleTfms { get; set; } = true;
 
         /// <summary>
-        /// Enables strict mode api comparison checks enqueued by the compatible framework in package validator.
+        /// Validates api compatibility in strict mode for assemblies that are compatible based on their target framework.
         /// </summary>
         public bool EnableStrictModeForCompatibleFrameworksInPackage { get; set; }
 
         /// <summary>
-        /// Enables strict mode api comparison checks enqueued by the baseline package validator.
+        /// Validates api compatibility in strict mode for package baseline checks.
         /// </summary>
         public bool EnableStrictModeForBaselineValidation { get; set; }
 

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -364,12 +364,12 @@ namespace Microsoft.DotNet.ApiCompat.Tool
 
         private static Dictionary<NuGetFramework, IEnumerable<string>>? ParsePackageAssemblyReferenceArgument(ArgumentResult argumentResult)
         {
-            const string invalidPackageAssemblyReferenceFormatMessage = "Invalid package assembly reference format {TargetFrameworkMoniker(+TargetPlatformMoniker)=assembly1,assembly2,assembly3,...}";
+            const string invalidPackageAssemblyReferenceFormatMessage = "Invalid package assembly reference format {TargetFrameworkMoniker(+TargetPlatformMoniker)|assembly1,assembly2,assembly3,...}";
 
             Dictionary<NuGetFramework, IEnumerable<string>> packageAssemblyReferencesDict = new(argumentResult.Tokens.Count);
             foreach (var token in argumentResult.Tokens)
             {
-                string[] parts = token.Value.Split(';');
+                string[] parts = token.Value.Split('|');
                 if (parts.Length != 2)
                 {
                     argumentResult.AddError(invalidPackageAssemblyReferenceFormatMessage);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -225,7 +225,8 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             };
             CliOption<bool> enableStrictModeForCompatibleTfmsOption = new("--enable-strict-mode-for-compatible-tfms")
             {
-                Description = "Validates api compatibility in strict mode for contract and implementation assemblies for all compatible target frameworks."
+                Description = "Validates api compatibility in strict mode for contract and implementation assemblies for all compatible target frameworks.",
+                DefaultValueFactory = _ => true
             };
             CliOption<bool> enableStrictModeForCompatibleFrameworksInPackageOption = new("--enable-strict-mode-for-compatible-frameworks-in-package")
             {
@@ -368,7 +369,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             Dictionary<NuGetFramework, IEnumerable<string>> packageAssemblyReferencesDict = new(argumentResult.Tokens.Count);
             foreach (var token in argumentResult.Tokens)
             {
-                string[] parts = token.Value.Split('=');
+                string[] parts = token.Value.Split(';');
                 if (parts.Length != 2)
                 {
                     argumentResult.AddError(invalidPackageAssemblyReferenceFormatMessage);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -45,7 +45,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ExcludeAttributesFiles="@(ApiCompatExcludeAttributesFile)"
       EnableRuleCannotChangeParameterName="$(ApiCompatEnableRuleCannotChangeParameterName)"
       RunApiCompat="$(RunApiCompat)"
-      EnableStrictModeForCompatibleTfms="$([MSBuild]::ValueOrDefault('$(EnableStrictModeForCompatibleTfms)', 'true'))"
+      EnableStrictModeForCompatibleTfms="$(EnableStrictModeForCompatibleTfms)"
       EnableStrictModeForCompatibleFrameworksInPackage="$(EnableStrictModeForCompatibleFrameworksInPackage)"
       EnableStrictModeForBaselineValidation="$(EnableStrictModeForBaselineValidation)"
       GenerateSuppressionFile="$(ApiCompatGenerateSuppressionFile)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/33011

Make sure that the CLI and MSBuild frontend have the same default value for the
EnableStrictModeForCompatibleTfms/--enable-strict-mode-for-compatible-tfms option.

Also bring the description of the parameters in sync again.