### PR TITLE
Update default TrimMode for WebSDK projects

### DIFF
--- a/src/Tests/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NET.Sdk.Web.Tests
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}").Should().Pass();
 
             var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework);
-            buildProperties["TrimMode"].Should().Be("full");
+            buildProperties["TrimMode"].Should().Be("");
 
             string outputDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
             string runtimeConfigFile = Path.Combine(outputDirectory, $"{projectName}.runtimeconfig.json");
@@ -73,7 +73,7 @@ namespace Microsoft.NET.Sdk.Web.Tests
 
             var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework);
             buildProperties["PublishTrimmed"].Should().Be("true");
-            buildProperties["TrimMode"].Should().Be("full");
+            buildProperties["TrimMode"].Should().Be("");
             buildProperties["PublishIISAssets"].Should().Be("false");
             var ucrRid = buildProperties["NETCoreSdkPortableRuntimeIdentifier"];
 

--- a/src/Tests/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NET.Sdk.Web.Tests
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}").Should().Pass();
 
             var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework);
-            buildProperties["TrimMode"].Should().Be("partial");
+            buildProperties["TrimMode"].Should().Be("full");
 
             string outputDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
             string runtimeConfigFile = Path.Combine(outputDirectory, $"{projectName}.runtimeconfig.json");
@@ -73,7 +73,7 @@ namespace Microsoft.NET.Sdk.Web.Tests
 
             var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework);
             buildProperties["PublishTrimmed"].Should().Be("true");
-            buildProperties["TrimMode"].Should().Be("");
+            buildProperties["TrimMode"].Should().Be("full");
             buildProperties["PublishIISAssets"].Should().Be("false");
             var ucrRid = buildProperties["NETCoreSdkPortableRuntimeIdentifier"];
 

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -94,9 +94,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <EFSQLScriptsFolderName Condition="$(EFSQLScriptsFolderName) == ''">EFSQLScripts</EFSQLScriptsFolderName>
 
-    <!-- If TrimMode has not already been set, default to partial trimming, as AspNet is not currently fully trim-compatible -->
-    <!-- We allow the full trimming default with PublishAot enabled, because the parts that are not trim-compatible are not aot-compatible either -->
-    <TrimMode Condition="'$(TrimMode)' == '' and '$(PublishTrimmed)' == 'true' and '$(PublishAot)' != 'true'">partial</TrimMode>
+    <TrimMode Condition="'$(TrimMode)' == '' and '$(PublishTrimmed)' == 'true'">full</TrimMode>
   </PropertyGroup>
 
   <!--

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -93,8 +93,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PublishIntermediateOutputPath Condition="'$(DockerPublish)' == 'true'">obj/Docker/publish/</PublishIntermediateOutputPath>
 
     <EFSQLScriptsFolderName Condition="$(EFSQLScriptsFolderName) == ''">EFSQLScripts</EFSQLScriptsFolderName>
-
-    <TrimMode Condition="'$(TrimMode)' == '' and '$(PublishTrimmed)' == 'true'">full</TrimMode>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Set `TrimMode=full` for web projects where `PublishTrimmed=true`.

Note: we could achieve the same effect by removing the property all together and relying on the defaults the linker targets set but I like the explicitness of this approach.