### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/src/Tests/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -402,6 +402,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea
 
 ##
 ## Visual studio for Mac

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -402,6 +402,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea
 
 ##
 ## Visual studio for Mac


### PR DESCRIPTION
fixes #34050 

We could build and run the project without these files just like `.vs`