### PR TITLE
Enable MSBuild TerminalLogger by default

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli.Utils
             };
 
         private readonly IEnumerable<string> _msbuildRequiredParameters =
-            new List<string> { "-maxcpucount", "-verbosity:m" };
+            new List<string> { "-maxcpucount", "-verbosity:m", "-terminallogger:auto" };
 
         public MSBuildForwardingAppWithoutLogging(IEnumerable<string> argsToForward, string msbuildPath = null)
         {


### PR DESCRIPTION
Opt all MSBuild invocations into TerminalLogger in auto mode. This should not affect any CI invocations, because auto
will fall back to the console logger when it detects redirected output.
