### PR TITLE
Update Container User Id to react to changes in dotnet/dotnet-docker#4715

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -112,8 +112,8 @@
     <!-- We only set a default user when the base image is Microsoft-authored, and we're targeting a version of those images that supports a nonroot user -->
     <PropertyGroup Label="ContainerUser Assignment" Condition="$(_ContainerIsUsingMicrosoftDefaultImages) and $(_ContainerIsTargetingNet8TFM) and '$(ContainerUser)' == ''">
       <ContainerUser Condition="$(_ContainerIsTargetingWindows)">ContainerUser</ContainerUser>
-      <!-- For Linux, the MS images have an 'app' user set to user id 64198 but some container runtimes work better with user ids instead of names, so we defer to that -->
-      <ContainerUser Condition="!$(_ContainerIsTargetingWindows)">64198</ContainerUser>
+      <!-- For Linux, the MS images have an 'app' user set to user id 1654 but some container runtimes work better with user ids instead of names, so we defer to that -->
+      <ContainerUser Condition="!$(_ContainerIsTargetingWindows)">1654</ContainerUser>
     </PropertyGroup>
 
     <ParseContainerProperties FullyQualifiedBaseImageName="$(ContainerBaseImage)"

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -185,11 +185,11 @@ public class TargetsTests
         computedTag.Should().Be(expectedTag);
     }
 
-    [InlineData("v8.0", "linux-x64", "64198")]
+    [InlineData("v8.0", "linux-x64", "1654")]
     [InlineData("v8.0", "win-x64", "ContainerUser")]
     [InlineData("v7.0", "linux-x64", null)]
     [InlineData("v7.0", "win-x64", null)]
-    [InlineData("v9.0", "linux-x64", "64198")]
+    [InlineData("v9.0", "linux-x64", "1654")]
     [InlineData("v9.0", "win-x64", "ContainerUser")]
     [Theory]
     public void CanComputeContainerUser(string tfm, string rid, string expectedUser)


### PR DESCRIPTION
https://github.com/dotnet/dotnet-docker/pull/4715 changed the User Id for the Linux images, and we didn't update at the same time.  A longer-term fix would detect and parse the user id from the specified container environment variable if it is present, but we haven't implemented that yet. That work is tracked in https://github.com/dotnet/sdk-container-builds/issues/479.

This error has already been reported by a user in https://github.com/dotnet/dotnet-docker/issues/4766.

Without this change, container images generated by our tooling from preview 6 onwards are broken unless the user

* sets their own ContainerUser value (`<ContainerUser>1654</ContainerUser>`), or
* sets the user for the container explicitly at container runtime (`docker run -u XXXX`)