### PR TITLE
Revert "#30336 Default Dotnet Tool to Run on Latest Runtime - Build time change"

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -42,11 +42,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DotnetCliToolTargetFramework>netcoreapp2.2</DotnetCliToolTargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <PackageType>DotnetTool</PackageType>
-    <RuntimeIdentifiers>$(RuntimeIdentifiers);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
-    <RollForward Condition="'$(RollForward)' == ''">Major</RollForward>
+  <PropertyGroup>
+    <IncludeBuildOutput Condition=" '$(PackAsTool)' == 'true' ">false</IncludeBuildOutput>
+    <PackageType Condition=" '$(PackAsTool)' == 'true' ">DotnetTool</PackageType>
+    <RuntimeIdentifiers Condition=" '$(PackAsTool)' == 'true' ">$(RuntimeIdentifiers);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(EnablePreviewFeatures)' == 'true' And '$(IsNetCoreAppTargetingLatestTFM)' == 'true'">

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -13,10 +13,8 @@ using Xunit.Abstractions;
 using NuGet.Packaging;
 using System.Xml.Linq;
 using System.Runtime.CompilerServices;
-using Microsoft.NET.TestFramework.ProjectConstruction;
 using System;
 using System.Runtime.InteropServices;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NET.ToolPack.Tests
 {
@@ -301,39 +299,6 @@ namespace Microsoft.NET.ToolPack.Tests
             var result = packCommand.Execute();
             result.Should().Fail().And.HaveStdOutContaining("NETSDK1146");
 
-        }
-
-        [Fact]
-        public void WhenPackingAToolItDefaultsRollsForwardToMajor()
-        {
-            var testProject = new TestProject()
-            {
-                Name = "RollForwardDefault",
-                TargetFrameworks = "netcoreapp3.0",
-                IsWinExe = true,
-            };
-            testProject.AdditionalProperties.Add("PackAsTool", "true");
-
-            TestAsset asset = _testAssetsManager.CreateTestProject(testProject);
-            var packCommand = new PackCommand(Log, Path.Combine(asset.Path, testProject.Name));
-
-            packCommand
-                .Execute()
-                .Should()
-                .Pass();
-
-            var outputDirectory = packCommand.GetOutputDirectory(testProject.TargetFrameworks);
-
-            string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.Name + ".runtimeconfig.json");
-            JObject runtimeConfig = ReadRuntimeConfig(runtimeConfigFile);
-            runtimeConfig["runtimeOptions"]["rollForward"].Value<string>()
-                .Should().Be("Major");
-        }
-
-        private JObject ReadRuntimeConfig(string runtimeConfigPath)
-        {
-            string runtimeConfigContents = File.ReadAllText(runtimeConfigPath);
-            return JObject.Parse(runtimeConfigContents);
         }
     }
 }


### PR DESCRIPTION
Reverts dotnet/sdk#31957

Per offline discussion, there was some discomfort with the original change as it might imply a change to our compat bar that was not intended. We're going to discuss alternative solutions. 

Options:
1. Warn the customer at install and tell them to install the runtime
2. Add a --roll-forward flag during install that allows tool consumers to make the decision for themselves
3. Other?

We'll continue to discuss options in https://github.com/dotnet/sdk/issues/30336. We should make sure we remove the breaking change notice as well.