### PR TITLE
[release/8.0.1xx-preview7] Disable ConfigurationBinder source generator in Blazor WASM

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -20,6 +20,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Similarly these feature switches must be configured before they are initialized in imported SDKs -->
     <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == ''">true</JsonSerializerIsReflectionEnabledByDefault>
+
+    <!-- EnableConfigurationBindingGenerator is enabled by default for trimmed apps, but Blazor WASM disables it by default -->
+    <EnableConfigurationBindingGenerator Condition="'$(EnableConfigurationBindingGenerator)' == ''">false</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />


### PR DESCRIPTION
## Customer Impact

Customers are getting warnings from the auth Blazor WASM project templates by default. `dotnet build`ing

```
dotnet new blazorwasm --auth Individual
```

produces:

```
Program.cs(16,5): warning SYSLIB1104: Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.
```

## Testing

Manually tested the change builds Blazor WASM apps with auth successfully with no warnings.

## Risk

Low - this changes the behavior back to 8.0-preview6 and earlier for Blazor WASM apps.

## Summary

This source generator is enabled by default with PublishTrimmed=true, which is the default for Blazor WASM apps. However, we don't want Blazor WASM apps to use the source generator. There are warnings in the project templates caused by https://github.com/dotnet/runtime/issues/89273.

Contributes to #34135

I'm not sure how to add automated tests for this. Ideas welcome. We have tests in the aspnetcore repo. See https://github.com/dotnet/aspnetcore/pull/49470 which is broken because of this.