### PR TITLE
Fix package verification for some valid packages on windows

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -285,6 +285,10 @@
       <Sha>10d0f7e94aa45889155c312f51cfc01bf326b853</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="6.0.4">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>e37fab9fc9f7bce120a7165491ed392a73f8ab51</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.23361.3">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
     <NewtonsoftJsonVersion>$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersion>
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
-    <SystemReflectionMetadataVersion>6.0.0</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <SystemSecurityCryptographyPkcsPackageVersion>6.0.4</SystemSecurityCryptographyPkcsPackageVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.23361.3</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,8 @@
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
     <NewtonsoftJsonVersion>$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersion>
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
-    <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>6.0.0</SystemReflectionMetadataVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>6.0.4</SystemSecurityCryptographyPkcsPackageVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.23361.3</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0</SystemSecurityCryptographyProtectedDataPackageVersion>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -43,5 +43,6 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsPackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/33928

## Description
Parsing failure: The Microsoft timestamping service does something unusual but within standards. There were a couple of bugs in System.Security.Cryptography.Pkcs where .NET failed to parse these attribute certificates, but those bugs were fixed, and the fixes were backported to the 6.0 runtime. However, some .NET 6.0 SDK feature bands didn't pick up the newer version of System.Security.Cryptography.Pkcs when executing msbuild or nuget.  

Currently in 3xx and 1xx, nuget builds against the 5.0.0 verison if this package and msbuild against 4.7.0 which means the 5.0.0 version gets loaded. In 6.0.4xx, msbuild moved forward to the 6.0.1 version if this package

## Customer Impact
On 6.0.3xx and 6.0.1xx, if you add certain packages to your project that are correctly signed, you'll get `error: NU3003: The package signature is invalid or cannot be verified on this platform.`  You'll also get this error if you run dotnet nuget verify against the package.

An example that shows this is Xunit version 2.5.0 and could impact any package signed with the .NET Foundation signing service after a recent change.

The change to the signing service merged on February 27, 2023 ([Make ACS the default timestamping service by dtivel · Pull Request #598 · dotnet/sign (github.com)](https://github.com/dotnet/sign/pull/598)).  The change which led to the parsing error was [simply defaulting to the Microsoft timestamping service](https://github.com/dotnet/sign/pull/598/files#diff-5b2caeaf35c92a62c3a106e3177262f94ac9eb82a701c5983fd296a0d75db8eaR37).  If a Sign CLI user used a different timestamping service, there probably wouldn't be parsing errors.

## Regression?
* [ ] Yes
* [x] No

## Risk
* [ ] High
* [ ] Medium
* [x] Low

## Verification

* [x] manual
* [ ] automated tests
