### PR TITLE
Move `GenerateRuntimeConfigurationFiles=false` back to Blazor SDK from Wasm SDK

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -56,6 +56,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WasmFingerprintDotnetJs Condition="'$(_TargetingNET80OrLater)' == 'true'">false</WasmFingerprintDotnetJs>
     <WasmEnableWebcil Condition="'$(WasmEnableWebcil)' == '' and ('$(TargetFrameworkIdentifier)' != '.NETCoreApp' or '$(_TargetingNET80OrLater)' != 'true')">false</WasmEnableWebcil>
 
+    <!-- Turn off parts of the build that do not apply to Blazor projects -->
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
+
     <!-- Don't generate a NETSDK1151 error if a non self-contained Exe references a Blazor Exe -->
     <ShouldBeValidatedAsExecutableReference>false</ShouldBeValidatedAsExecutableReference>
 


### PR DESCRIPTION
- Migrated to Wasm SDK in initial split https://github.com/dotnet/sdk/pull/31154
- Currently it is part of Wasm SDK pack in runtime repository https://github.com/dotnet/runtime/blob/51af14c745e1074340a605faad3ba1bf8a969868/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets#L64
- But Wasm SDK uses (will use) runtime config to switch between hosts 