### PR TITLE
[main] Disable ConfigurationBinder source generator in Blazor WASM

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -20,6 +20,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Similarly these feature switches must be configured before they are initialized in imported SDKs -->
     <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == ''">true</JsonSerializerIsReflectionEnabledByDefault>
+
+    <!-- EnableConfigurationBindingGenerator is enabled by default for trimmed apps, but Blazor WASM disables it by default -->
+    <EnableConfigurationBindingGenerator Condition="'$(EnableConfigurationBindingGenerator)' == ''">false</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />


### PR DESCRIPTION
This change ports https://github.com/dotnet/sdk/pull/34142 (release/8.0.1xx-preview7) to main.

This source generator is enabled by default with PublishTrimmed=true, which is the default for Blazor WASM apps. However, we don't want Blazor WASM apps to use the source generator. There are warnings in the project templates caused by https://github.com/dotnet/runtime/issues/89273.

Fix #34135

I'm not sure how to add automated tests for this. Ideas welcome. We have tests in the aspnetcore repo. See https://github.com/dotnet/aspnetcore/pull/49470 which is broken because of this.