### PR TITLE
[Containers] validate that the normalized repository name is a meaningful name

### DIFF
--- a/src/Assets/TestProjects/NetCoreCsharpAppReferenceCppCliLib/CSConsoleApp/CSConsoleApp.csproj
+++ b/src/Assets/TestProjects/NetCoreCsharpAppReferenceCppCliLib/CSConsoleApp/CSConsoleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <TargetFramework>$(CurrentTargetFramework)-windows</TargetFramework>
     <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>

--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -3,6 +3,7 @@
 
 #if NETFRAMEWORK
 using System;
+using System.Linq;
 #endif
 #if NET
 using System.Diagnostics.CodeAnalysis;
@@ -279,7 +280,13 @@ public static class ContainerHelpers
                 throw new ArgumentException(Resources.Resource.GetString(nameof(Strings.InvalidImageName)));
             }
             var loweredImageName = containerImageName.ToLowerInvariant();
-            normalizedImageName = imageNameCharacters.Replace(loweredImageName, "-");
+            var potentialNormalizedName = imageNameCharacters.Replace(loweredImageName, "-");
+            if (potentialNormalizedName.All(c => c == '-'))
+            {
+                // The name was normalized to all dashes, so there was nothing recoverable. We should throw.
+                throw new ArgumentException(Resources.Resource.GetString(nameof(Strings.InvalidImageName)));
+            }
+            normalizedImageName = potentialNormalizedName;
             return false;
         }
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -8,6 +8,7 @@ using System.Linq;
 #if NET
 using System.Diagnostics.CodeAnalysis;
 #endif
+using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.NET.Build.Containers.Resources;
 
@@ -31,13 +32,6 @@ public static class ContainerHelpers
     /// See <see href="https://github.com/distribution/distribution/blob/78b9c98c5c31c30d74f9acb7d96f98552f2cf78f/reference/normalize.go">normalize.go</see>.
     /// </summary>
     internal const string DefaultRegistry = "docker.io";
-
-    /// <summary>
-    /// Matches if the string is not lowercase or numeric, or ., _, or -.
-    /// </summary>
-    /// <remarks>Technically the period should be allowed as well, but due to inconsistent support between cloud providers we're removing it.</remarks>
-    private static Regex imageNameCharacters = new Regex(@"[^a-z0-9_\-/]");
-
 
     /// <summary>
     /// The enum contains possible error reasons during port parsing using <see cref="TryParsePort(string, out Port?, out ParsePortError?)"/> or <see cref="TryParsePort(string?, string?, out Port?, out ParsePortError?)"/>.
@@ -262,6 +256,8 @@ public static class ContainerHelpers
         return true;
     }
 
+
+
     /// <summary>
     /// Checks if a given container image name adheres to the image name spec. If not, and recoverable, then normalizes invalid characters.
     /// </summary>
@@ -274,36 +270,67 @@ public static class ContainerHelpers
         else
         {
             // check for leading alphanumeric character
-            if (!Char.IsLetterOrDigit(containerImageName, 0))
+            char firstChar = containerImageName[0];
+            if (!IsAlpha(firstChar) && !IsNumeric(firstChar))
             {
-                // The name did not start with an alphanumeric character, so we should normalize it.
+                // The name did not start with an alphanumeric character, so we can't normalize it.
                 var error = (nameof(Strings.InvalidImageName_NonAlphanumericStartCharacter), new []{ containerImageName });
                 return (null, null, error);
             }
 
-            // normalize the name
-            var loweredImageName = containerImageName.ToLowerInvariant();
-            var potentialNormalizedName = imageNameCharacters.Replace(loweredImageName, "-");
+
+            // normalize the name. a little more complex, but this does all of our checks in a single pass and doesn't require coming back
+            // after the normalization to check if our invariants hold
+            var normalizedAllChars = true;
+            var normalizationOccurred = false;
+            var builder = new StringBuilder(containerImageName);
+            for (int i = 0; i < containerImageName.Length; i++)
+            {
+                var current = containerImageName[i];
+                if (IsLowerAlpha(current) || IsNumeric(current) || IsAllowedPunctuation(current))
+                {
+                    // no need to set the builder's char here, since we preloaded
+                    normalizedAllChars = false;
+                }
+                else if (IsUpperAlpha(current))
+                {
+                    builder[i] = char.ToLowerInvariant(current);
+                    normalizationOccurred = true;
+                }
+                else
+                {
+                    builder[i] = '-';
+                    normalizationOccurred = true;
+                }
+            }
+            var normalizedImageName = builder.ToString();
 
             // check for normalization to useless name
-            if (potentialNormalizedName.All(c => c == '-'))
+            if (normalizedAllChars)
             {
                 // The name was normalized to all dashes, so there was nothing recoverable. We should throw.
-                var error = (nameof(Strings.InvalidImageName_EntireNameIsInvalidCharacters), new [] { containerImageName });
+                var error = (nameof(Strings.InvalidImageName_EntireNameIsInvalidCharacters), new string[] { containerImageName });
                 return (null, null, error);
             }
 
             // check for warning/notification that we did indeed perform normalization
-            if (potentialNormalizedName != containerImageName)
+            if (normalizationOccurred)
             {
-                var warning = (nameof(Strings.NormalizedContainerName), new[]{ containerImageName, potentialNormalizedName });
-                return (potentialNormalizedName, warning, null);
+                var warning = (nameof(Strings.NormalizedContainerName), new string[]{ containerImageName, normalizedImageName });
+                return (normalizedImageName, warning, null);
             }
+
             // user value was already normalized, so we don't need to do anything
             else
             {
-                return (potentialNormalizedName, null, null);
+                return (containerImageName, null, null);
             }
         }
+
+        static bool IsUpperAlpha(char c) => c >= 'A' && c <= 'Z';
+        static bool IsLowerAlpha(char c) => c >= 'a' && c <= 'z';
+        static bool IsAlpha(char c) => IsLowerAlpha(c) || IsUpperAlpha(c);
+        static bool IsNumeric(char c) => c >= '0' && c <= '9';
+        static bool IsAllowedPunctuation(char c) => (c == '_') || (c == '-') || (c == '/');
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -277,8 +277,8 @@ public static class ContainerHelpers
             if (!Char.IsLetterOrDigit(containerImageName, 0))
             {
                 // The name did not start with an alphanumeric character, so we should normalize it.
-                var error = (nameof(Strings.InvalidImageName_NonAlphanumericStartCharacter), containerImageName)
-                return (null, null, error)
+                var error = (nameof(Strings.InvalidImageName_NonAlphanumericStartCharacter), new []{ containerImageName });
+                return (null, null, error);
             }
 
             // normalize the name
@@ -289,20 +289,20 @@ public static class ContainerHelpers
             if (potentialNormalizedName.All(c => c == '-'))
             {
                 // The name was normalized to all dashes, so there was nothing recoverable. We should throw.
-                var error = (nameof(Strings.InvalidImageName_EntireNameIsInvalidCharacters), containerImageName)
-                return (null, null, error)
+                var error = (nameof(Strings.InvalidImageName_EntireNameIsInvalidCharacters), new [] { containerImageName });
+                return (null, null, error);
             }
 
             // check for warning/notification that we did indeed perform normalization
             if (potentialNormalizedName != containerImageName)
             {
-                var warning = (nameof(Strings.NormalizedContainerName), new[]{ containerImageName, normalizedImageName })
+                var warning = (nameof(Strings.NormalizedContainerName), new[]{ containerImageName, potentialNormalizedName });
                 return (potentialNormalizedName, warning, null);
             }
             // user value was already normalized, so we don't need to do anything
             else
             {
-                return (potentialNormalizedName, null, null)
+                return (potentialNormalizedName, null, null);
             }
         }
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
@@ -40,6 +40,7 @@ internal static class KnownStrings
         public static readonly string CONTAINER2009 = nameof(CONTAINER2009);
         public static readonly string CONTAINER2010 = nameof(CONTAINER2010);
         public static readonly string CONTAINER2012 = nameof(CONTAINER2012);
+        public static readonly string CONTAINER2014 = nameof(CONTAINER2014);
 
         public static readonly string CONTAINER4001 = nameof(CONTAINER4001);
         public static readonly string CONTAINER4002 = nameof(CONTAINER4002);

--- a/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
@@ -34,13 +34,13 @@ internal static class KnownStrings
         public static readonly string CONTAINER1011 = nameof(CONTAINER1011);
         public static readonly string CONTAINER1012 = nameof(CONTAINER1012);
         public static readonly string CONTAINER1013 = nameof(CONTAINER1013);
-
+        
+        public static readonly string CONTAINER2005 = nameof(CONTAINER2005);
         public static readonly string CONTAINER2007 = nameof(CONTAINER2007);
         public static readonly string CONTAINER2008 = nameof(CONTAINER2008);
         public static readonly string CONTAINER2009 = nameof(CONTAINER2009);
         public static readonly string CONTAINER2010 = nameof(CONTAINER2010);
         public static readonly string CONTAINER2012 = nameof(CONTAINER2012);
-        public static readonly string CONTAINER2014 = nameof(CONTAINER2014);
 
         public static readonly string CONTAINER4001 = nameof(CONTAINER4001);
         public static readonly string CONTAINER4002 = nameof(CONTAINER4002);

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -223,15 +223,6 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER2014: Invalid {0}: {1}..
-        /// </summary>
-        internal static string InvalidContainerImageName {
-            get {
-                return ResourceManager.GetString("InvalidContainerImageName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to CONTAINER2015: {0}: &apos;{1}&apos; was not a valid Environment Variable. Ignoring..
         /// </summary>
         internal static string InvalidEnvVar {
@@ -241,11 +232,20 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER2005: The first character of the image name must be a lowercase letter or a digit..
+        ///   Looks up a localized string similar to CONTAINER2005: The inferred image name &apos;{0}&apos; contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character..
         /// </summary>
-        internal static string InvalidImageName {
+        internal static string InvalidImageName_EntireNameIsInvalidCharacters {
             get {
-                return ResourceManager.GetString("InvalidImageName", resourceCulture);
+                return ResourceManager.GetString("InvalidImageName_EntireNameIsInvalidCharacters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2005: The first character of the image name &apos;{0}&apos; must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _..
+        /// </summary>
+        internal static string InvalidImageName_NonAlphanumericStartCharacter {
+            get {
+                return ResourceManager.GetString("InvalidImageName_NonAlphanumericStartCharacter", resourceCulture);
             }
         }
         

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,79 +26,79 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -179,15 +179,10 @@
   </data>
   <data name="HostObjectNotDetected" xml:space="preserve">
     <value>No host object detected.</value>
-    <comment/>
   </data>
   <data name="ImageLoadFailed" xml:space="preserve">
     <value>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</value>
     <comment>{StrBegin="CONTAINER1009: "}</comment>
-  </data>
-  <data name="InvalidContainerImageName" xml:space="preserve">
-    <value>CONTAINER2014: Invalid {0}: {1}.</value>
-    <comment>{StrBegin="CONTAINER2014: "}</comment>
   </data>
   <data name="InvalidEnvVar" xml:space="preserve">
     <value>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</value>
@@ -255,7 +250,6 @@
   </data>
   <data name="NormalizedContainerName" xml:space="preserve">
     <value>'{0}' was not a valid container image name, it was normalized to '{1}'</value>
-    <comment/>
   </data>
   <data name="PublishDirectoryDoesntExist" xml:space="preserve">
     <value>CONTAINER2011: {0} '{1}' does not exist</value>
@@ -303,6 +297,6 @@
   </data>
   <data name="InvalidImageName_EntireNameIsInvalidCharacters" xml:space="preserve">
     <value>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</value>
-    <comment>{StrBegin="Container2005: "}</comment>
+    <comment>{StrBegin="CONTAINER2005: "}</comment>
   </data>
 </root>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -193,7 +193,7 @@
     <comment>{StrBegin="CONTAINER2015: "}</comment>
   </data>
   <data name="InvalidImageName" xml:space="preserve">
-    <value>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</value>
+    <value>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</value>
     <comment>{StrBegin="CONTAINER2005: "}</comment>
   </data>
   <data name="InvalidSdkVersion" xml:space="preserve">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -179,6 +179,7 @@
   </data>
   <data name="HostObjectNotDetected" xml:space="preserve">
     <value>No host object detected.</value>
+    <comment/>
   </data>
   <data name="ImageLoadFailed" xml:space="preserve">
     <value>CONTAINER1009: Failed to load image to local Docker daemon. stdout: {0}</value>
@@ -192,8 +193,8 @@
     <value>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</value>
     <comment>{StrBegin="CONTAINER2015: "}</comment>
   </data>
-  <data name="InvalidImageName" xml:space="preserve">
-    <value>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</value>
+  <data name="InvalidImageName_NonAlphanumericStartCharacter" xml:space="preserve">
+    <value>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</value>
     <comment>{StrBegin="CONTAINER2005: "}</comment>
   </data>
   <data name="InvalidSdkVersion" xml:space="preserve">
@@ -254,6 +255,7 @@
   </data>
   <data name="NormalizedContainerName" xml:space="preserve">
     <value>'{0}' was not a valid container image name, it was normalized to '{1}'</value>
+    <comment/>
   </data>
   <data name="PublishDirectoryDoesntExist" xml:space="preserve">
     <value>CONTAINER2011: {0} '{1}' does not exist</value>
@@ -298,5 +300,9 @@
   <data name="_Test" xml:space="preserve">
     <value>CONTAINER0000: Value for unit test {0}</value>
     <comment>Used only for unit tests</comment>
+  </data>
+  <data name="InvalidImageName_EntireNameIsInvalidCharacters" xml:space="preserve">
+    <value>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</value>
+    <comment>{StrBegin="Container2005: "}</comment>
   </data>
 </root>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' není platná proměnná prostředí. Ignorování.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: První znak názvu obrázku musí být malé písmeno nebo číslice.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: Nepovedlo se načíst image do místního procesu démon Dockeru. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: Neplatná {0}: {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: '{1}' není platná proměnná prostředí. Ignorování.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: První znak názvu obrázku musí být malé písmeno nebo číslice.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: První znak názvu obrázku musí být malé písmeno nebo číslice.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: „{1}“ war keine gültige Umgebungsvariable. Sie wird ignoriert.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: Das erste Zeichen des Imagenamens muss ein Kleinbuchstabe oder eine Ziffer sein.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: Fehler beim Laden des Images in den lokalen Docker-Daemon. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: Ungültiger {0}: {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: „{1}“ war keine gültige Umgebungsvariable. Sie wird ignoriert.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: Das erste Zeichen des Imagenamens muss ein Kleinbuchstabe oder eine Ziffer sein.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: Das erste Zeichen des Imagenamens muss ein Kleinbuchstabe oder eine Ziffer sein.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: "{1}" no era una variable de entorno válida. Ignorando.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: El primer carácter del nombre de la imagen debe ser una letra minúscula o un dígito.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: No se pudo cargar la imagen en el demonio de Docker local. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: {0} no válido: {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: "{1}" no era una variable de entorno válida. Ignorando.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: El primer carácter del nombre de la imagen debe ser una letra minúscula o un dígito.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: El primer carácter del nombre de la imagen debe ser una letra minúscula o un dígito.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: le premier caractère du nom de l’image doit être une lettre minuscule ou un chiffre.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: le premier caractère du nom de l’image doit être une lettre minuscule ou un chiffre.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: échec du chargement de l’image dans le démon Docker local. stdout : {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: {0} non valide : {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0} : '{1}' n’était pas une variable d’environnement valide. Ignorant.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0} : '{1}' n’était pas une variable d’environnement valide. Ignorant.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: le premier caractère du nom de l’image doit être une lettre minuscule ou un chiffre.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: non è stato possibile caricare l'immagine nel daemon Docker locale. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: {0}non valido: {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: '{1}' non è una variabile di ambiente valida. Il valore verrà ignorato.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: il primo carattere del nome dell'immagine deve essere una lettera minuscola o una cifra.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: il primo carattere del nome dell'immagine deve essere una lettera minuscola o una cifra.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' non è una variabile di ambiente valida. Il valore verrà ignorato.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: il primo carattere del nome dell'immagine deve essere una lettera minuscola o una cifra.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' は有効な環境変数ではありませんでした。無視しています。</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: イメージ名の最初の文字は、小文字または数字である必要があります。</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: イメージ名の最初の文字は、小文字または数字である必要があります。</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: イメージ名の最初の文字は、小文字または数字である必要があります。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: ローカル Docker デーモンにイメージを読み込めませんでした。stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: 無効な {0}: {1}。</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: '{1}' は有効な環境変数ではありませんでした。無視しています。</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: 이미지 이름의 첫 글자는 소문자 또는 숫자여야 합니다.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: 이미지 이름의 첫 글자는 소문자 또는 숫자여야 합니다.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: 로컬 Docker 디먼에 이미지를 로드하지 못했습니다. 표준 출력: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: 잘못된 {0}: {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: '{1}'은(는) 유효한 환경 변수가 아닙니다. 무시 중.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}'은(는) 유효한 환경 변수가 아닙니다. 무시 중.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: 이미지 이름의 첫 글자는 소문자 또는 숫자여야 합니다.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: „{1}” nie jest prawidłową zmienną środowiskową. Ignorowanie.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: pierwszy znak nazwy obrazu musi być małą literą lub cyfrą.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: pierwszy znak nazwy obrazu musi być małą literą lub cyfrą.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: pierwszy znak nazwy obrazu musi być małą literą lub cyfrą.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: nie można załadować obrazu do lokalnego demona platformy Docker. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: Nieprawidłowy element {0}: {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: „{1}” nie jest prawidłową zmienną środowiskową. Ignorowanie.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' não era uma variável de ambiente válida. Ignorando.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: O primeiro caractere do nome da imagem deve ser uma letra minúscula ou um dígito.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: falha ao carregar a imagem no daemon do Docker local. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: Inválido {0}: {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: '{1}' não era uma variável de ambiente válida. Ignorando.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: O primeiro caractere do nome da imagem deve ser uma letra minúscula ou um dígito.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: O primeiro caractere do nome da imagem deve ser uma letra minúscula ou um dígito.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: "{1}" не является допустимой переменной среды. Пропуск.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: первый символ имени изображения должен быть строчной буквой или цифрой.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: первый символ имени изображения должен быть строчной буквой или цифрой.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: первый символ имени изображения должен быть строчной буквой или цифрой.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: не удалось загрузить образ в локальную управляющую программу Docker. StdOut:{0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: недопустимый {0}: {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: "{1}" не является допустимой переменной среды. Пропуск.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: Görüntü yerel Docker daemon'a yüklenemedi. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: Geçersiz {0}: {1}.</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: '{1}' geçerli bir Ortam Değişkeni değildi. Görmezden geliniyor.</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: Görüntü adının ilk karakteri küçük harf veya rakam olmalıdır.</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: Görüntü adının ilk karakteri küçük harf veya rakam olmalıdır.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' geçerli bir Ortam Değişkeni değildi. Görmezden geliniyor.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: Görüntü adının ilk karakteri küçük harf veya rakam olmalıdır.</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: "{1}" 不是有效的环境变量。忽略。</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: 图像名称的第一个字符必须是小写字母或数字。</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: 未能将映像加载到本地 Docker 守护程序。stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: 无效 {0}: {1}。</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: "{1}" 不是有效的环境变量。忽略。</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: 图像名称的第一个字符必须是小写字母或数字。</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: 图像名称的第一个字符必须是小写字母或数字。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -98,8 +98,8 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit.</source>
-        <target state="translated">CONTAINER2005: 映像名稱的第一個字元必須是小寫字母或數字。</target>
+        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: 映像名稱的第一個字元必須是小寫字母或數字。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -87,11 +87,6 @@
         <target state="translated">CONTAINER1009: 無法將映像載入至本機 Docker 精靈。stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidContainerImageName">
-        <source>CONTAINER2014: Invalid {0}: {1}.</source>
-        <target state="translated">CONTAINER2014: 無效的 {0}: {1}。</target>
-        <note>{StrBegin="CONTAINER2014: "}</note>
-      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="translated">CONTAINER2015: {0}: '{1}' 不是有效的環境變數。正在忽略。</target>
@@ -100,7 +95,7 @@
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
         <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
         <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
-        <note>{StrBegin="Container2005: "}</note>
+        <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
         <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -97,9 +97,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' 不是有效的環境變數。正在忽略。</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidImageName">
-        <source>CONTAINER2005: The first character of the image name must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="needs-review-translation">CONTAINER2005: 映像名稱的第一個字元必須是小寫字母或數字。</target>
+      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="new">CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</target>
+        <note>{StrBegin="Container2005: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="new">CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
@@ -141,22 +141,19 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
             return !Log.HasLoggedErrors;
         }
 
-        try
+        var (normalizedImageName, normalizationWarning, normalizationError) = ContainerHelpers.NormalizeImageName(ContainerImageName);
+        if (normalizedImageName is not null)
         {
-            if (!ContainerHelpers.NormalizeImageName(ContainerImageName, out var normalizedImageName))
-            {
-                Log.LogMessageFromResources(nameof(Strings.NormalizedContainerName), nameof(ContainerImageName), normalizedImageName);
-                NewContainerImageName = normalizedImageName!; // known to be not null due to output of NormalizeImageName
-            }
-            else
-            {
-                // name was valid already
-                NewContainerImageName = ContainerImageName;
-            }
+            NewContainerImageName = normalizedImageName;
         }
-        catch (ArgumentException)
+        if (normalizationWarning is (string warningMessageKey, object[] warningParams))
         {
-            Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidContainerImageName), nameof(ContainerImageName), ContainerImageName);
+            Log.LogMessageFromResources(warningMessageKey, warningParams);
+        }
+
+        if (normalizationError is (string errorMessageKey, object[] errorParams))
+        {
+            Log.LogErrorWithCodeFromResources(errorMessageKey, errorParams);
             return !Log.HasLoggedErrors;
         }
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -11,6 +11,7 @@ using Microsoft.NET.TestFramework.Commands;
 using Microsoft.DotNet.Cli.Utils;
 using System.IO;
 using System.Xml.Linq;
+using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
@@ -26,13 +27,13 @@ public class EndToEndTests
 
     public static string NewImageName([CallerMemberName] string callerMemberName = "")
     {
-        bool normalized = ContainerHelpers.NormalizeImageName(callerMemberName, out string? normalizedName);
-        if (!normalized)
+        var (normalizedName, warning, error) = ContainerHelpers.NormalizeImageName(callerMemberName);
+        if (error is (var format, var args))
         {
-            return normalizedName!;
+            throw new ArgumentException(String.Format(Strings.ResourceManager.GetString(format)!, args));
         }
 
-        return callerMemberName;
+        return normalizedName!; // non-null if error is null
     }
 
     [DockerDaemonAvailableFact]

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -223,7 +223,7 @@ public class EndToEndTests
             $"/p:ContainerBaseImage={DockerRegistryManager.FullyQualifiedBaseImageDefault}",
             $"/p:ContainerRegistry={DockerRegistryManager.LocalRegistry}",
             $"/p:ContainerImageName={imageName}",
-            $"/p:Version={imageTag}")
+            $"/p:ContainerImageTag={imageTag}")
             .WithEnvironmentVariable("NUGET_PACKAGES", privateNuGetAssets.FullName)
             .WithWorkingDirectory(newProjectDir.FullName)
             .Execute()
@@ -352,7 +352,7 @@ public class EndToEndTests
             $"/p:ContainerBaseImage={DockerRegistryManager.FullyQualifiedBaseImageDefault}",
             $"/p:ContainerRegistry={DockerRegistryManager.LocalRegistry}",
             $"/p:ContainerImageName={imageName}",
-            $"/p:Version={imageTag}")
+            $"/p:ContainerImageTag={imageTag}")
             .WithEnvironmentVariable("NUGET_PACKAGES", privateNuGetAssets.FullName)
             .WithWorkingDirectory(newProjectDir.FullName)
             .Execute()

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/LayoutSanityTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/LayoutSanityTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Containers.IntegrationTests
             string dotnetDirectory = Path.GetDirectoryName(dotnetPath) ?? throw new InvalidOperationException("dotnet is in unexpected location.");
             string expectedWedSdkPropsPath = Path.Combine(dotnetDirectory, "sdk", TestContext.Current.ToolsetUnderTest.SdkVersion, "Sdks", "Microsoft.NET.Sdk.Web", "Sdk", "Sdk.props");
 
-            Assert.True(File.Exists(expectedWedSdkPropsPath));
+            Assert.True(File.Exists(expectedWedSdkPropsPath), "Expected to see the Web SDK props in the redist directory");
 
             string projectFileContent = File.ReadAllText(expectedWedSdkPropsPath);
             XDocument projectXml = XDocument.Parse(projectFileContent);

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -10,9 +10,10 @@ using static Microsoft.NET.Build.Containers.KnownStrings.Properties;
 
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
+[Collection("Docker tests")]
 public class ParseContainerPropertiesTests
 {
-    [Fact]
+    [DockerDaemonAvailableFact]
     public void Baseline()
     {
         var (project, _, d) = ProjectInitializer.InitProject(new () {
@@ -34,7 +35,7 @@ public class ParseContainerPropertiesTests
         instance.GetItems("ProjectCapability").Select(i => i.EvaluatedInclude).ToArray().Should().BeEquivalentTo(new[] { "NetSdkOCIImageBuild" });
     }
 
-    [Fact]
+    [DockerDaemonAvailableFact]
     public void SpacesGetReplacedWithDashes()
     {
          var (project, _, d) = ProjectInitializer.InitProject(new () {
@@ -50,7 +51,7 @@ public class ParseContainerPropertiesTests
         Assert.Equal("7.0", instance.GetPropertyValue(ContainerBaseTag));
     }
 
-    [Fact]
+    [DockerDaemonAvailableFact]
     public void RegexCatchesInvalidContainerNames()
     {
          var (project, logs, d) = ProjectInitializer.InitProject(new () {
@@ -62,10 +63,10 @@ public class ParseContainerPropertiesTests
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
         Assert.True(instance.Build(new[]{ComputeContainerConfig}, new [] { logs }, null, out var outputs));
-        Assert.Contains(logs.Messages, m => m.Message?.Contains("'ContainerImageName' was not a valid container image name, it was normalized to 'dotnet-testimage'") == true);
+        Assert.Contains(logs.Messages, m => m.Message?.Contains("'dotnet testimage' was not a valid container image name, it was normalized to 'dotnet-testimage'") == true);
     }
 
-    [Fact]
+    [DockerDaemonAvailableFact]
     public void RegexCatchesInvalidContainerTags()
     {
         var (project, logs, d) = ProjectInitializer.InitProject(new () {
@@ -82,7 +83,7 @@ public class ParseContainerPropertiesTests
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2007);
     }
 
-    [Fact]
+    [DockerDaemonAvailableFact]
     public void CanOnlySupplyOneOfTagAndTags()
     {
         var (project, logs, d) = ProjectInitializer.InitProject(new () {
@@ -100,7 +101,7 @@ public class ParseContainerPropertiesTests
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2008);
     }
 
-    [Fact]
+    [DockerDaemonAvailableFact]
     public void FailsOnCompletelyInvalidRepositoryNames()
     {
         var (project, logs, d) = ProjectInitializer.InitProject(new () {
@@ -114,6 +115,6 @@ public class ParseContainerPropertiesTests
         Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
-        Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2014);
+        Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -117,4 +117,21 @@ public class ParseContainerPropertiesTests
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);
     }
+
+    [DockerDaemonAvailableFact]
+    public void FailsWhenFirstCharIsAUnicodeLetterButNonLatin()
+    {
+        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+            [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
+            [ContainerRegistry] = "localhost:5010",
+            [ContainerImageName] = "㓳but-otherwise-valid",
+            [ContainerImageTag] = "5.0"
+        });
+        using var _ = d;
+        var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
+        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+
+        Assert.True(logs.Errors.Count > 0);
+        Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);
+    }
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -107,7 +107,7 @@ public class ParseContainerPropertiesTests
         var (project, logs, d) = ProjectInitializer.InitProject(new () {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
-            [ContainerRepository] = "㓳㓴㓵㓶㓷㓹㓺㓻",
+            [ContainerImageName] = "㓳㓴㓵㓶㓷㓹㓺㓻",
             [ContainerImageTag] = "5.0"
         });
         using var _ = d;

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -100,4 +100,21 @@ public class ParseContainerPropertiesTests
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2008);
     }
+
+    [Fact]
+    public void FailsOnCompletelyInvalidRepositoryNames()
+    {
+        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+            [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
+            [ContainerRegistry] = "localhost:5010",
+            [ContainerRepository] = "㓳㓴㓵㓶㓷㓹㓺㓻",
+            [ContainerImageTag] = "5.0"
+        });
+        using var _ = d;
+        var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
+        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+
+        Assert.True(logs.Errors.Count > 0);
+        Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2014);
+    }
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -10,10 +10,9 @@ using static Microsoft.NET.Build.Containers.KnownStrings.Properties;
 
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
-[Collection("Docker tests")]
 public class ParseContainerPropertiesTests
 {
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void Baseline()
     {
         var (project, _, d) = ProjectInitializer.InitProject(new () {
@@ -35,7 +34,7 @@ public class ParseContainerPropertiesTests
         instance.GetItems("ProjectCapability").Select(i => i.EvaluatedInclude).ToArray().Should().BeEquivalentTo(new[] { "NetSdkOCIImageBuild" });
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void SpacesGetReplacedWithDashes()
     {
          var (project, _, d) = ProjectInitializer.InitProject(new () {
@@ -51,7 +50,7 @@ public class ParseContainerPropertiesTests
         Assert.Equal("7.0", instance.GetPropertyValue(ContainerBaseTag));
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void RegexCatchesInvalidContainerNames()
     {
          var (project, logs, d) = ProjectInitializer.InitProject(new () {
@@ -66,7 +65,7 @@ public class ParseContainerPropertiesTests
         Assert.Contains(logs.Messages, m => m.Message?.Contains("'ContainerImageName' was not a valid container image name, it was normalized to 'dotnet-testimage'") == true);
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void RegexCatchesInvalidContainerTags()
     {
         var (project, logs, d) = ProjectInitializer.InitProject(new () {
@@ -83,7 +82,7 @@ public class ParseContainerPropertiesTests
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2007);
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void CanOnlySupplyOneOfTagAndTags()
     {
         var (project, logs, d) = ProjectInitializer.InitProject(new () {

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -39,13 +39,13 @@ public class TargetsTests
     [Theory]
     public void CanNormalizeInputContainerNames(string projectName, string expectedContainerImageName, bool shouldPass)
     {
-        var (project, _, d) = ProjectInitializer.InitProject(new()
+        var (project, logger, d) = ProjectInitializer.InitProject(new()
         {
             [AssemblyName] = projectName
         }, projectName: $"{nameof(CanNormalizeInputContainerNames)}_{projectName}_{expectedContainerImageName}_{shouldPass}");
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        instance.Build(new[] { ComputeContainerConfig }, null, null, out var outputs).Should().Be(shouldPass, "Build should have succeeded");
+        instance.Build(new[] { ComputeContainerConfig }, new[]{ logger }, null, out var outputs).Should().Be(shouldPass, String.Join(Environment.NewLine, logger.AllMessages));
         Assert.Equal(expectedContainerImageName, instance.GetPropertyValue(ContainerImageName));
     }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProject.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NET.Build.Tests
             var exe = Path.Combine( //find the platform directory
                 new DirectoryInfo(Path.Combine(testAsset.TestRoot, "CSConsoleApp", "bin")).GetDirectories().Single().FullName,
                 "Debug",
-                ToolsetInfo.CurrentTargetFramework,
+                $"{ToolsetInfo.CurrentTargetFramework}-windows",
                 "CSConsoleApp.exe");
 
             var runCommand = new RunExeCommand(Log, exe);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishACppCliProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishACppCliProject.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NET.Build.Tests
             var exe = Path.Combine( //find the platform directory
                 new DirectoryInfo(Path.Combine(testAsset.TestRoot, "CSConsoleApp", "bin")).GetDirectories().Single().FullName,
                 "Debug",
-                "netcoreapp3.1",
+                $"{ToolsetInfo.CurrentTargetFramework}-windows",
                 "publish",
                 "CSConsoleApp.exe");
 


### PR DESCRIPTION
## Description

When inferring a container name based on the project name the tooling attempts to normalize the project name and remove any invalid characters from the normalized name. This is to ensure that the generated images are usable by all container registries. However, we didn't cover the case where the entire input string was invalid characters - in this case we should fail fast and notify the user that they need to provide an explicit value for the ContainerRepository.

This fixes AzDO work item [1858645](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1858645).

## Customer Impact

GB18030 customers (and other customers whose entire image name post-normalization was comprised of normalized characters) would error during image push with a useless and confusing error.

## Regression
**No** - this validation has been in place since our initial releases

## Risk
**Low** - we have a lot of testing around name validation, and it just got both stricter and more clear when erroring

## Testing

Manual and automated - we explicitly cover two cases we didn't before:
* all invalid container repository name characters
* first name character is a non-latin alphanumeric character


This should flow to 7.0.4xx and main to cover the other in-support SDK versions that shipped the containers feature.