### PR TITLE
Fix the end of build install of workloads to always refresh the rollback file

### DIFF
--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -75,7 +75,7 @@
 
     <!-- Create a rollback file for installing workloads during the build  -->
     <WriteLinesToFile File="$(RedistLayoutPath)TestRollback.json"
-                      Condition="!Exists('$(RedistLayoutPath)TestRollback.json')"
+                      Overwrite="true"
                       Lines="{;@(WasmWorkloads->'&quot;%(Identity)&quot;: &quot;%(Version)&quot;', ', ');}"/>
 
     <OverrideAndCreateBundledNETCoreAppPackageVersion


### PR DESCRIPTION
It was failing if you had previously built with the same SDK but prior preview runtime as it wasn't updating the file. This conflicted with https://github.com/dotnet/sdk/pull/32882 in that I started getting exceptions from that build task because I had a preview 5 TestRollback.json but the task was looking for rc1 versions.