### PR TITLE
Fix official build break

### DIFF
--- a/src/Common/CompileOptions.cs
+++ b/src/Common/CompileOptions.cs
@@ -3,7 +3,7 @@
 
 
 #if MICROSOFT_ENABLE_TELEMETRY
-      [assembly: AssemblyMetadata("TelemetryOptOutDefault", Microsoft.DotNet.Cli.CompileOptions.TelemetryOptOutDefaultString)]
+      [assembly: System.Reflection.AssemblyMetadata("TelemetryOptOutDefault", Microsoft.DotNet.Cli.CompileOptions.TelemetryOptOutDefaultString)]
 #endif
 
 namespace Microsoft.DotNet.Cli


### PR DESCRIPTION
Fully qualify type name to allow build to pass.

Looks to be caused by https://github.com/dotnet/sdk/commit/b295f29b9df07cbd6ff638c27613e55ff8ff5b91#diff-a95ce20c6351149841ecb40e61766742fc62968336e294bf46d2a6e381d76c17L4.