### PR TITLE
Remove tooltask validation for Entrypoint/EntrypointArgs

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -91,14 +91,6 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
         {
             throw new InvalidOperationException(Resource.FormatString(nameof(Strings.RequiredPropertyNotSetOrEmpty), nameof(WorkingDirectory)));
         }
-        if (Entrypoint.Length == 0)
-        {
-            throw new InvalidOperationException(Resource.FormatString(nameof(Strings.RequiredItemsNotSet), nameof(Entrypoint)));
-        }
-        if (Entrypoint.Any(e => string.IsNullOrWhiteSpace(e.ItemSpec)))
-        {
-            throw new InvalidOperationException(Resource.FormatString(nameof(Strings.RequiredItemsContainsEmptyItems), nameof(Entrypoint)));
-        }
 
         CommandLineBuilder builder = new();
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
@@ -49,11 +49,6 @@ public class CreateNewImageToolTaskTests
 
         task.WorkingDirectory = "MyWorkingDirectory";
 
-        e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
-        Assert.Equal("CONTAINER4002: Required 'Entrypoint' items were not set.", e.Message);
-
-        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
-
         string args = task.GenerateCommandLineCommandsInt();
         string workDir = GetPathToContainerize();
 
@@ -376,12 +371,10 @@ public class CreateNewImageToolTaskTests
     [InlineData("")]
     [InlineData("  ")]
     [Theory]
-    public void GenerateCommandLineCommands_EntryPointCannotHaveEmptyItems(string itemValue)
+    public void GenerateCommandLineCommands_EntryPointCanHaveEmptyItems(string itemValue)
     {
         CreateNewImage task = new();
-        List<string?> warnings = new();
         IBuildEngine buildEngine = A.Fake<IBuildEngine>();
-        A.CallTo(() => buildEngine.LogWarningEvent(A<BuildWarningEventArgs>.Ignored)).Invokes((BuildWarningEventArgs e) => warnings.Add(e.Message));
 
         task.BuildEngine = buildEngine;
 
@@ -393,8 +386,7 @@ public class CreateNewImageToolTaskTests
         task.WorkingDirectory = "MyWorkingDirectory";
         task.Entrypoint = new[] { new TaskItem(itemValue) };
 
-        Exception e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
-        Assert.Equal("CONTAINER4003: Required 'Entrypoint' items contain empty items.", e.Message);
+        task.GenerateCommandLineCommandsInt();
     }
 
     [Theory]
@@ -411,7 +403,6 @@ public class CreateNewImageToolTaskTests
         task.BaseImageName = "MyBaseImageName";
         task.Repository = "MyImageName";
         task.WorkingDirectory = "MyWorkingDirectory";
-        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
 
         task.AppCommandInstruction = value;
 


### PR DESCRIPTION
This fixes for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1843320.

We added proper passing of entrypoint/entrypointArgs/appCommand-related arguments to the CLI app when using the net472 targets - but we didn't remove the old validation that was no longer useful.

This means the targets no longer work for net472 _unless_ the user has set their own Entrypoint/EntrypointArgs, which I believe to be vanishingly rare. We have existing tests for this, but they weren't updated in the previous work.