### PR TITLE
Change prerelease label to servicing

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
   <!-- Repo Version Information -->
   <PropertyGroup>
     <VersionPrefix>7.0.401</VersionPrefix>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
     <!-- Enable to remove prerelease label. -->


### PR DESCRIPTION
This should have been part of the branding update