### PR TITLE
Add implementation and test for the DisableRuntimeMarshalling attribute.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -127,8 +127,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Runtime.Versioning.RequiresPreviewFeaturesAttribute" Condition="'$(EnablePreviewFeatures)' == 'true' and '$(GenerateRequiresPreviewFeaturesAttribute)' == 'true'">
       </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute" Condition="'$(DisableRuntimeMarshalling)' == 'true' and '$(GenerateDisableRuntimeMarshallingAttribute)' == 'true'">
-      </AssemblyAttribute>
     </ItemGroup>
 
     <ItemGroup Condition="'$(GenerateTargetPlatformAttribute)' == 'true'
@@ -153,6 +151,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute"
                          Condition="$([MSBuild]::VersionEquals($(SupportedOSPlatformVersion), '0.0'))" >
         <_Parameter1>$(TargetPlatformIdentifier)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(GenerateDisableRuntimeMarshallingAttribute)' == 'true'
+                         and '$(DisableRuntimeMarshalling)' == 'true'
+                         and '$(TargetPlatformIdentifier)' != ''
+                         and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                         and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '7.0'))">
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute">
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -156,7 +156,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup Condition="'$(GenerateDisableRuntimeMarshallingAttribute)' == 'true'
                          and '$(DisableRuntimeMarshalling)' == 'true'
-                         and '$(TargetPlatformIdentifier)' != ''
                          and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                          and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '7.0'))">
       <AssemblyAttribute Include="System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -41,6 +41,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateRequiresPreviewFeaturesAttribute Condition="'$(GenerateRequiresPreviewFeaturesAttribute)' == '' and '$(IsNetCoreAppTargetingLatestTFM)' == 'true'">true</GenerateRequiresPreviewFeaturesAttribute>
     <GenerateTargetPlatformAttribute Condition="'$(GenerateTargetPlatformAttribute)' == ''">true</GenerateTargetPlatformAttribute>
     <GenerateSupportedOSPlatformAttribute Condition="'$(GenerateSupportedOSPlatformAttribute)' == ''">true</GenerateSupportedOSPlatformAttribute>
+    <GenerateDisableRuntimeMarshallingAttribute Condition="'$(GenerateDisableRuntimeMarshallingAttribute)' == ''">true</GenerateDisableRuntimeMarshallingAttribute>
   </PropertyGroup>
 
   <!--
@@ -125,6 +126,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_Parameter2>%(AssemblyMetadata.Value)</_Parameter2>
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Runtime.Versioning.RequiresPreviewFeaturesAttribute" Condition="'$(EnablePreviewFeatures)' == 'true' and '$(GenerateRequiresPreviewFeaturesAttribute)' == 'true'">
+      </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute" Condition="'$(DisableRuntimeMarshalling)' == 'true' and '$(GenerateDisableRuntimeMarshallingAttribute)' == 'true'">
       </AssemblyAttribute>
     </ItemGroup>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -494,7 +494,7 @@ namespace Microsoft.NET.Build.Tests
                 testProject.AdditionalProperties["GenerateDisableRuntimeMarshallingAttribute"] = generateDisableRuntimeMarshallingAttribute.Value.ToString();
             }
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: disableRuntimeMarshalling.ToString() + "_" + generateDisableRuntimeMarshallingAttribute + "_" + targetFramework);
 
             var buildCommand = new BuildCommand(testAsset);
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -41,6 +41,7 @@ namespace Microsoft.NET.Build.Tests
                     "/p:Product=TestProduct",
                     "/p:AssemblyTitle=TestTitle",
                     "/p:Trademark=TestTrademark",
+                    "/p:DisableRuntimeMarshalling=true",
                     "/p:NeutralLanguage=fr",
                     attributeToOptOut == "All" ?
                         "/p:GenerateAssemblyInfo=false" :

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -19,6 +19,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("AssemblyDescriptionAttribute")]
         [InlineData("AssemblyTitleAttribute")]
         [InlineData("AssemblyTrademarkAttribute")]
+        [InlineData("DisableRuntimeMarshallingAttribute")]
         [InlineData("NeutralResourcesLanguageAttribute")]
         [InlineData("All")]
         public void It_respects_opt_outs(string attributeToOptOut)
@@ -60,6 +61,7 @@ namespace Microsoft.NET.Build.Tests
                 { "AssemblyProductAttribute", "TestProduct" },
                 { "AssemblyTitleAttribute", "TestTitle" },
                 { "AssemblyTrademarkAttribute", "TestTrademark" },
+                { "DisableRuntimeMarshallingAttribute", "" },                
                 { "NeutralResourcesLanguageAttribute", "fr" },
             };
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -465,10 +465,12 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData(true, true, ToolsetInfo.CurrentTargetFramework)]
-        [InlineData(true, false, ToolsetInfo.CurrentTargetFramework)]
-        [InlineData(false, false, ToolsetInfo.CurrentTargetFramework)]
-        public void TestDisableRuntimeMarshalling(bool disableRuntimeMarshalling, bool generateDisableRuntimeMarshallingAttribute, string targetFramework)
+        [InlineData(true, true, "net6.0", false)]
+        [InlineData(true, true, "net7.0", true)]
+        [InlineData(true, true, ToolsetInfo.CurrentTargetFramework, true)]
+        [InlineData(true, false, ToolsetInfo.CurrentTargetFramework, true)]
+        [InlineData(false, false, ToolsetInfo.CurrentTargetFramework, true)]
+        public void TestDisableRuntimeMarshalling(bool disableRuntimeMarshalling, bool generateDisableRuntimeMarshallingAttribute, string targetFramework, bool shouldHaveAttribute)
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld", identifier: $"{disableRuntimeMarshalling}${generateDisableRuntimeMarshallingAttribute}${targetFramework}")
@@ -503,6 +505,19 @@ namespace Microsoft.NET.Build.Tests
                 {
                     contains = true;
                     break;
+                }
+            }
+
+            if (disableRuntimeMarshalling && generateDisableRuntimeMarshallingAttribute)
+            {
+                if (shouldHaveAttribute)
+                {
+                    Assert.True(contains);
+                }
+                else
+                {
+                    // The assembly level attribute is generated only for .NET 7 and newer
+                    Assert.False(contains);
                 }
             }
 


### PR DESCRIPTION
Add DisableRuntimeMarshalling assembly attribute and test coverage. This enables an easy way to disable runtime marshalling for all projects in a solution via MSBuild and fits in with the general pattern of setting assembly attributes via the project file.