### PR TITLE
Ensure GenAPI replaces init method body

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/BodyBlockCSharpSyntaxRewriter.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/BodyBlockCSharpSyntaxRewriter.cs
@@ -95,6 +95,7 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
             switch (node.Kind())
             {
                 case SyntaxKind.GetAccessorDeclaration:
+                case SyntaxKind.InitAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
                     {
                         var accessorListSyntax = (AccessorListSyntax?)node.Parent;
@@ -148,7 +149,7 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
             {
                 node = node.WithBody(GetThrowNullBody());
             }
-            else if (node.Kind() == SyntaxKind.SetAccessorDeclaration)
+            else if (node.Kind() is SyntaxKind.SetAccessorDeclaration or SyntaxKind.InitAccessorDeclaration)
             {
                 node = node.WithBody(GetEmptyBody());
             }

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -2489,7 +2489,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     public partial struct C<T>
                         where T : unmanaged
                     {
-                        public required (string? k, dynamic v, nint n) X { get { throw null; } init; }
+                        public required (string? k, dynamic v, nint n) X { get { throw null; } init { } }
                     }
 
                     public static partial class E


### PR DESCRIPTION
I noticed that we weren't emitting syntax that would compile for init properties.