### PR TITLE
Revert "Allow MSBuild to use BinaryFormatter"

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -438,9 +438,6 @@
     <PropertyGroup>
       <ReplacementPattern>"version": ".*"</ReplacementPattern>
       <ReplacementString>"version": "$(MicrosoftNETCoreAppRuntimePackageVersion)"</ReplacementString>
-
-      <DisabledBinaryFormatterPattern>"System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false</DisabledBinaryFormatterPattern>
-      <EnableBinaryFormatterString>"System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": true</EnableBinaryFormatterString>
     </PropertyGroup>
     <ItemGroup>
       <!-- Exclude F# from retargeting: https://github.com/dotnet/toolset/issues/2866 -->
@@ -455,14 +452,6 @@
       DestinationFiles="@(ToolRuntimeConfigPath)"
       ReplacementPatterns="$(ReplacementPattern)"
       ReplacementStrings="$(ReplacementString)" />
-
-    <!-- Work around https://github.com/dotnet/msbuild/issues/6215 by opting back into net7 behavior -->
-    <ReplaceFileContents
-      InputFiles="@(ToolRuntimeConfigPath)"
-      DestinationFiles="@(ToolRuntimeConfigPath)"
-      ReplacementPatterns="$(DisabledBinaryFormatterPattern)"
-      ReplacementStrings="$(EnableBinaryFormatterString)"
-      Condition=" '%(ToolRuntimeConfigPath.FileName)' == 'MSBuild.runtimeconfig'" />
 
     <Move
       SourceFiles="@(MSBuild15Items)"


### PR DESCRIPTION
Reverts dotnet/sdk#33227

### Context
The BinaryFormatter was opted-in as a workaround for https://github.com/dotnet/msbuild/issues/8786 - that one is fixed and merged now. 
All other tracked outstanding MSBuild dependencies on BinaryFormatter should not be of concern for NET (just NetFramework).
