### PR TITLE
Fix ApiCompat.Tool execution

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -24,10 +24,16 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 Description = "If true, generates a compatibility suppression file.",
                 Recursive = true
             };
-            CliOption<bool> preserveUnnecessarySuppressionsOption = new("--preserve-unnecessary-suppressions",
-                "If true, preserves unnecessary suppressions when re-generating the suppression file.");
-            CliOption<bool> permitUnnecessarySuppressionsOption = new("--permit-unnecessary-suppressions",
-                "If true, permits unnecessary suppressions in the suppression file.");
+            CliOption<bool> preserveUnnecessarySuppressionsOption = new("--preserve-unnecessary-suppressions")
+            {
+                Description = "If true, preserves unnecessary suppressions when re-generating the suppression file.",
+                Recursive = true
+            };
+            CliOption<bool> permitUnnecessarySuppressionsOption = new("--permit-unnecessary-suppressions")
+            {
+                Description = "If true, permits unnecessary suppressions in the suppression file.",
+                Recursive = true
+            };
             CliOption<string[]> suppressionFilesOption = new("--suppression-file")
             {
                 Description = "The path to one or more suppression files to read from.",


### PR DESCRIPTION
Regressed with https://github.com/dotnet/sdk/pull/32964

Fixes https://github.com/dotnet/sdk/issues/34405
```
Unhandled exception. System.ArgumentException: Names and aliases cannot contain whitespace: "If true, preserves unnecessary suppressions when re-generating the suppression file." (Parameter 'alias')
   at System.CommandLine.CliSymbol.ThrowIfEmptyOrWithWhitespaces(String value, String paramName, Boolean canContainWhitespaces)
   at System.CommandLine.AliasSet..ctor(String[] aliases)
   at System.CommandLine.CliOption..ctor(String name, String[] aliases)
   at System.CommandLine.CliOption`1..ctor(String name, String[] aliases, CliArgument`1 argument)
   at System.CommandLine.CliOption`1..ctor(String name, String[] aliases)
   at Microsoft.DotNet.ApiCompat.Tool.Program.Main(String[] args) in /_/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs:line 27
```