### PR TITLE
Allow PublishSingleFile and PublishAot specified simultaneously

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -952,7 +952,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="GenerateSingleFileBundle"
-          Condition="'$(PublishSingleFile)' == 'true'"
+          Condition="'$(PublishSingleFile)' == 'true' and '$(PublishAot)' != 'true'"
           DependsOnTargets="_ComputeFilesToBundle;PrepareForBundle;_GenerateSingleFileBundleInputCache"
           Inputs="@(FilesToBundle);$(_GenerateSingleFileBundlePropertyInputsCache)"
           Outputs="$(PublishedSingleFilePath)">


### PR DESCRIPTION
We made native AOT targets error out if these are specified at the same time due to bad failure mode. But running through this, it appears to be mostly harmless except for this task.

So proposing taking this and rolling back https://github.com/dotnet/runtime/pull/73995. But no hard feelings if people feel otherwise.

We might want to eventually set `PublishSingleFile` when `PublishAot` is set, same way we do for `PublishTrimmed`. Some of the SDK behaviors look relevant. Others don't. I don't have a good sense on this one.

Cc @dotnet/ilc-contrib 