### PR TITLE
Add ProjectCapability for Native AOT properties.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1263,11 +1263,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for WPF and WinForms projects -->
   <PropertyGroup>
-    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
-                           and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                           and '$(_TargetFrameworkVersionWithoutV)' >= '8.0'">true</ShowNativeAOTProperties>
-    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
-                             and ('$(UseWPF)' == 'true' or '$(UseWindowsForms)' == 'true')">false</ShowNativeAOTProperties>
+    <ShowNativeAOTProperties Condition="('$(UseWPF)' == 'false' or '$(UseWPF)' == '')
+                             and ('$(UseWindowsForms)' == 'false' or '$(UseWindowsForms)' == '')
+                             and '$(ShowNativeAOTProperties)' == ''
+                             and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                             and '$(_TargetFrameworkVersionWithoutV)' >= '8.0'">true</ShowNativeAOTProperties>
   </PropertyGroup>
 
   <!-- Reference Manager capabilities -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1261,14 +1261,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="NativeAOTProperties" Condition="'$(ShowNativeAOTProperties)' == 'true'"/>
   </ItemGroup>
 
-  <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for class libraries, WPF, WinForms projects -->
+  <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for WPF and WinForms projects -->
   <PropertyGroup>
     <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
                            and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                            and '$(_TargetFrameworkVersionWithoutV)' >= '8.0'">true</ShowNativeAOTProperties>
-    <ShowNativeAOTProperties Condition="'$(UseWPF)' == 'true'
-                             or '$(UseWindowsForms)' == 'true'
-                             or '$(OutputType)' == 'Library'">false</ShowNativeAOTProperties>
+    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
+                             and ('$(UseWPF)' == 'true' or '$(UseWindowsForms)' == 'true')">false</ShowNativeAOTProperties>
   </PropertyGroup>
 
   <!-- Reference Manager capabilities -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1256,6 +1256,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="CrossPlatformExecutable" />
   </ItemGroup>
 
+  <!-- Native AOT compilation -->
+  <ItemGroup>
+    <ProjectCapability Include="NativeAOTProperties" Condition="'$(ShowNativeAOTProperties)' == 'true'"/>
+  </ItemGroup>
+
+  <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for class libraries, WPF, WinForms projects -->
+  <PropertyGroup>
+    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
+                           and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                           and '$(_TargetFrameworkVersionWithoutV)' >= '8.0'">true</ShowNativeAOTProperties>
+    <ShowNativeAOTProperties Condition="'$(UseWPF)' == 'true'
+                             or '$(UseWindowsForms)' == 'true'
+                             or '$(OutputType)' == 'Library'">false</ShowNativeAOTProperties>
+  </PropertyGroup>
+
   <!-- Reference Manager capabilities -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ProjectCapability Remove="ReferenceManagerAssemblies" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1263,8 +1263,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for WPF and WinForms projects -->
   <PropertyGroup>
-    <ShowNativeAOTProperties Condition="('$(UseWPF)' == 'false' or '$(UseWPF)' == '')
-                             and ('$(UseWindowsForms)' == 'false' or '$(UseWindowsForms)' == '')
+    <ShowNativeAOTProperties Condition="'$(UseWPF)' != 'true'
+                             and '$(UseWindowsForms)' != 'true'
                              and '$(ShowNativeAOTProperties)' == ''
                              and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                              and '$(_TargetFrameworkVersionWithoutV)' >= '8.0'">true</ShowNativeAOTProperties>

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -20,6 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == '' and '$(IsPackable)' == 'false'">true</WarnOnPackingNonPackableProject>
+    <ShowNativeAOTProperties>false</ShowNativeAOTProperties>
   </PropertyGroup>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props"


### PR DESCRIPTION
The `NativeAOTProperties` capability is being used in the project system side to control the visibility of the Native AOT properties introduced recently to .NET 8. The idea is that, in general, we want to set this capability to true so that we show these properties for projects targeting .NET 8 or higher. The exceptions at the moment would be class libraries, WPF and WinForms projects, which are filtered using the property condition. Other project types, like MAUI and Web projects, can disable this capability by setting the `ShowNativeAOTProperties` property to false in their props file.

Unit tests are on their way 🙂 