### PR TITLE
Exempt version from workload set

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -367,6 +367,9 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                         }
                         if (workloadSet != null)
                         {
+                            // Baseline workload manifest file starts with a version that can
+                            // (erroneously) be parsed as a workload manifest ID.
+                            workloadSet.ManifestVersions.Remove(new ManifestId("Version"));
                             workloadSet.Version = Path.GetFileName(workloadSetDirectory);
                             availableWorkloadSets[workloadSet.Version] = workloadSet;
                         }


### PR DESCRIPTION
"Version" is included in the baseline manifest in the json, but it is not a workload ID. The SDK is parsing it as such.