### PR TITLE
Support option to not include platform

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -23,6 +23,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        Configuration-specific PropertyGroup), so in that case we won't append to it by default. -->
   <PropertyGroup Condition="'$(UsingNETSdkDefaults)' == 'true'">
     <AppendTargetFrameworkToOutputPath Condition="'$(AppendTargetFrameworkToOutputPath)' == ''">true</AppendTargetFrameworkToOutputPath>
+    <AppendPlatformToOutputPath Condition="'$(AppendPlatformToOutputPath)' == ''">true</AppendPlatformToOutputPath>
   </PropertyGroup>
 
   <!-- NOTE: If we want to default UseArtifactsOutput to true when targeting a given version of .NET or higher, this is where we would do it.
@@ -93,8 +94,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(UseArtifactsOutput)' != 'true'">
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
     <BaseOutputPath Condition="!HasTrailingSlash('$(BaseOutputPath)')">$(BaseOutputPath)\</BaseOutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
+    <OutputPath Condition="('$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU') or '$(AppendPlatformToOutputPath)' != 'true'">$(BaseOutputPath)$(Configuration)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU' and '$(AppendPlatformToOutputPath)' == 'true'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
     <OutputPath Condition="!HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
   </PropertyGroup>
 
@@ -103,8 +104,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(UseArtifactsIntermediateOutput)' != 'true'">
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition=" ($(IntermediateOutputPath) == '' and '$(PlatformName)' == 'AnyCPU') or '$(AppendPlatformToOutputPath)' != 'true' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' and '$(AppendPlatformToOutputPath)' == 'true' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -94,7 +94,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(UseArtifactsOutput)' != 'true'">
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
     <BaseOutputPath Condition="!HasTrailingSlash('$(BaseOutputPath)')">$(BaseOutputPath)\</BaseOutputPath>
-    <OutputPath Condition="('$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU') or '$(AppendPlatformToOutputPath)' != 'true'">$(BaseOutputPath)$(Configuration)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and ('$(PlatformName)' == 'AnyCPU' or '$(AppendPlatformToOutputPath)' != 'true')">$(BaseOutputPath)$(Configuration)\</OutputPath>
     <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU' and '$(AppendPlatformToOutputPath)' == 'true'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
     <OutputPath Condition="!HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
   </PropertyGroup>
@@ -104,7 +104,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(UseArtifactsIntermediateOutput)' != 'true'">
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition=" ($(IntermediateOutputPath) == '' and '$(PlatformName)' == 'AnyCPU') or '$(AppendPlatformToOutputPath)' != 'true' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and ('$(PlatformName)' == 'AnyCPU' or '$(AppendPlatformToOutputPath)' != 'true') ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' and '$(AppendPlatformToOutputPath)' == 'true' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -23,7 +23,9 @@ Copyright (c) .NET Foundation. All rights reserved.
        Configuration-specific PropertyGroup), so in that case we won't append to it by default. -->
   <PropertyGroup Condition="'$(UsingNETSdkDefaults)' == 'true'">
     <AppendTargetFrameworkToOutputPath Condition="'$(AppendTargetFrameworkToOutputPath)' == ''">true</AppendTargetFrameworkToOutputPath>
-    <AppendPlatformToOutputPath Condition="'$(AppendPlatformToOutputPath)' == ''">true</AppendPlatformToOutputPath>
+    <AppendPlatformToOutputPath Condition="'$(AppendPlatformToOutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">false</AppendPlatformToOutputPath>
+    <AppendPlatformToOutputPath Condition="'$(AppendPlatformToOutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">true</AppendPlatformToOutputPath>
+    <_PlatformToAppendToOutputPath Condition="'$(AppendPlatformToOutputPath)' == 'true'">$(PlatformName)\</_PlatformToAppendToOutputPath>
   </PropertyGroup>
 
   <!-- NOTE: If we want to default UseArtifactsOutput to true when targeting a given version of .NET or higher, this is where we would do it.
@@ -94,8 +96,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(UseArtifactsOutput)' != 'true'">
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
     <BaseOutputPath Condition="!HasTrailingSlash('$(BaseOutputPath)')">$(BaseOutputPath)\</BaseOutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and ('$(PlatformName)' == 'AnyCPU' or '$(AppendPlatformToOutputPath)' != 'true')">$(BaseOutputPath)$(Configuration)\</OutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU' and '$(AppendPlatformToOutputPath)' == 'true'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == ''">$(BaseOutputPath)$(_PlatformToAppendToOutputPath)$(Configuration)\</OutputPath>
     <OutputPath Condition="!HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
   </PropertyGroup>
 
@@ -104,8 +105,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(UseArtifactsIntermediateOutput)' != 'true'">
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and ('$(PlatformName)' == 'AnyCPU' or '$(AppendPlatformToOutputPath)' != 'true') ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' and '$(AppendPlatformToOutputPath)' == 'true' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' ">$(BaseIntermediateOutputPath)$(_PlatformToAppendToOutputPath)$(Configuration)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -201,7 +201,7 @@ namespace Microsoft.NET.Build.Tests
                 }
 
                 var outputDirectory = buildCommand.GetOutputDirectory("net46", runtimeIdentifier: shouldAppend ? rid : "", platform: shouldIncludePlatform ? "AnyCPU" : "");
-                var publishDirectory = publishCommand.GetOutputDirectory("net46", runtimeIdentifier: rid);
+                var publishDirectory = publishCommand.GetOutputDirectory("net46", runtimeIdentifier: rid, platformIdentifier: shouldIncludePlatform ? "AnyCPU" : "");
 
                 foreach (var directory in new[] { outputDirectory, publishDirectory })
                 {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -139,14 +139,14 @@ namespace Microsoft.NET.Build.Tests
 
         [WindowsOnlyTheory]
         // implicit rid with option to append rid to output path off -> do not append
-        [InlineData("implicitOff", "", false, false)]
+        [InlineData("implicitOff", "", false, false, "true", true)]
         // implicit rid with option to append rid to output path on -> do not append (never append implicit rid irrespective of option)
-        [InlineData("implicitOn", "", true, false)]
+        [InlineData("implicitOn", "", true, false, "", false)]
         // explicit  rid with option to append rid to output path off -> do not append
-        [InlineData("explicitOff", $"{ToolsetInfo.LatestWinRuntimeIdentifier}-x86", false, false)]
+        [InlineData("explicitOff", $"{ToolsetInfo.LatestWinRuntimeIdentifier}-x86", false, false, "false", false)]
         // explicit rid with option to append rid to output path on -> append
-        [InlineData("explicitOn", $"{ToolsetInfo.LatestWinRuntimeIdentifier}-x64", true, true)]
-        public void It_appends_rid_to_outdir_correctly(string identifier, string rid, bool useAppendOption, bool shouldAppend)
+        [InlineData("explicitOn", $"{ToolsetInfo.LatestWinRuntimeIdentifier}-x64", true, true, "", false)]
+        public void It_appends_rid_to_outdir_correctly(string identifier, string rid, bool useAppendOption, bool shouldAppend, string appendPlatformValue, bool shouldIncludePlatform)
         {
             foreach (bool multiTarget in new[] { false, true })
             {
@@ -159,6 +159,7 @@ namespace Microsoft.NET.Build.Tests
                         var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
                         propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", rid));
                         propertyGroup.Add(new XElement(ns + "AppendRuntimeIdentifierToOutputPath", useAppendOption.ToString()));
+                        propertyGroup.Add(new XElement(ns + "AppendPlatformToOutputPath", appendPlatformValue));
 
                         if (multiTarget)
                         {
@@ -199,7 +200,7 @@ namespace Microsoft.NET.Build.Tests
                         throw new ArgumentOutOfRangeException(nameof(rid));
                 }
 
-                var outputDirectory = buildCommand.GetOutputDirectory("net46", runtimeIdentifier: shouldAppend ? rid : "");
+                var outputDirectory = buildCommand.GetOutputDirectory("net46", runtimeIdentifier: shouldAppend ? rid : "", platform: shouldIncludePlatform ? "AnyCPU" : "");
                 var publishDirectory = publishCommand.GetOutputDirectory("net46", runtimeIdentifier: rid);
 
                 foreach (var directory in new[] { outputDirectory, publishDirectory })

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/ComposeStoreCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/ComposeStoreCommand.cs
@@ -19,9 +19,9 @@ namespace Microsoft.NET.TestFramework.Commands
         {
         }
 
-        public override DirectoryInfo GetOutputDirectory(string targetFramework = "netcoreapp1.0", string configuration = "Debug", string runtimeIdentifier = "")
+        public override DirectoryInfo GetOutputDirectory(string targetFramework = "netcoreapp1.0", string configuration = "Debug", string runtimeIdentifier = "", string platformIdentifier = "")
         {
-            string output = Path.Combine(ProjectRootPath, "bin", BuildRelativeOutputPath(targetFramework, configuration, runtimeIdentifier));
+            string output = Path.Combine(ProjectRootPath, "bin", BuildRelativeOutputPath(targetFramework, configuration, runtimeIdentifier, platformIdentifier));
             return new DirectoryInfo(output);
         }
 
@@ -30,14 +30,14 @@ namespace Microsoft.NET.TestFramework.Commands
             return Path.Combine(GetOutputDirectory().FullName, $"{appName}.dll");
         }
 
-        private string BuildRelativeOutputPath(string targetFramework, string configuration, string runtimeIdentifier)
+        private string BuildRelativeOutputPath(string targetFramework, string configuration, string runtimeIdentifier, string platformIdentifier)
         {
             if (runtimeIdentifier.Length == 0)
             {
                 runtimeIdentifier = RuntimeInformation.RuntimeIdentifier;
             }
             string arch = runtimeIdentifier.Substring(runtimeIdentifier.LastIndexOf("-") + 1);
-            return Path.Combine(configuration, arch, targetFramework, PublishSubfolderName);
+            return Path.Combine(platformIdentifier, configuration, arch, targetFramework, PublishSubfolderName);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
@@ -72,7 +72,7 @@ namespace Microsoft.NET.TestFramework.Commands
         {
             if (TestAsset != null)
             {
-                return new DirectoryInfo(OutputPathCalculator.FromProject(ProjectFile, TestAsset).GetOutputDirectory(targetFramework, configuration, runtimeIdentifier));
+                return new DirectoryInfo(OutputPathCalculator.FromProject(ProjectFile, TestAsset).GetOutputDirectory(targetFramework, configuration, runtimeIdentifier, platform));
             }
 
             platform ??= string.Empty;

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
@@ -68,18 +68,19 @@ namespace Microsoft.NET.TestFramework.Commands
             return buildProjectFiles[0];
         }
 
-        public virtual DirectoryInfo GetOutputDirectory(string targetFramework = null, string configuration = "Debug", string runtimeIdentifier = null)
+        public virtual DirectoryInfo GetOutputDirectory(string targetFramework = null, string configuration = "Debug", string runtimeIdentifier = null, string platform = null)
         {
             if (TestAsset != null)
             {
                 return new DirectoryInfo(OutputPathCalculator.FromProject(ProjectFile, TestAsset).GetOutputDirectory(targetFramework, configuration, runtimeIdentifier));
             }
 
-            targetFramework = targetFramework ?? string.Empty;
-            configuration = configuration ?? string.Empty;
-            runtimeIdentifier = runtimeIdentifier ?? string.Empty;
+            platform ??= string.Empty;
+            targetFramework ??= string.Empty;
+            configuration ??= string.Empty;
+            runtimeIdentifier ??= string.Empty;
 
-            string output = Path.Combine(ProjectRootPath, "bin", configuration, targetFramework, runtimeIdentifier);
+            string output = Path.Combine(ProjectRootPath, "bin", platform, configuration, targetFramework, runtimeIdentifier);
             return new DirectoryInfo(output);
         }
 

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.TestFramework.Commands
 
         }
 
-        public override DirectoryInfo GetOutputDirectory(string targetFramework = null, string configuration = "Debug", string runtimeIdentifier = "")
+        public override DirectoryInfo GetOutputDirectory(string targetFramework = null, string configuration = "Debug", string runtimeIdentifier = "", string platformIdentifier = "")
         {
             if (TestAsset != null)
             {
@@ -34,7 +34,7 @@ namespace Microsoft.NET.TestFramework.Commands
                 targetFramework = "netcoreapp1.1";
             }
 
-            DirectoryInfo baseDirectory = base.GetOutputDirectory(targetFramework, configuration, runtimeIdentifier); 
+            DirectoryInfo baseDirectory = base.GetOutputDirectory(targetFramework, configuration, runtimeIdentifier, platformIdentifier); 
             return new DirectoryInfo(Path.Combine(baseDirectory.FullName, PublishSubfolderName));
         }
 

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.TestFramework.Commands
         {
             if (TestAsset != null)
             {
-                return new DirectoryInfo(OutputPathCalculator.FromProject(ProjectFile, TestAsset).GetPublishDirectory(targetFramework, configuration, runtimeIdentifier));
+                return new DirectoryInfo(OutputPathCalculator.FromProject(ProjectFile, TestAsset).GetPublishDirectory(targetFramework, configuration, runtimeIdentifier, platformIdentifier));
             }
 
             if (string.IsNullOrEmpty(targetFramework))

--- a/src/Tests/Microsoft.NET.TestFramework/OutputPathCalculator.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/OutputPathCalculator.cs
@@ -159,7 +159,7 @@ namespace Microsoft.NET.TestFramework
             return !string.IsNullOrEmpty(TargetFrameworks);
         }
 
-        public string GetOutputDirectory(string targetFramework = null, string configuration = "Debug", string runtimeIdentifier = "")
+        public string GetOutputDirectory(string targetFramework = null, string configuration = "Debug", string runtimeIdentifier = "", string platform = "")
         {
             if (UseArtifactsOutput)
             {
@@ -188,24 +188,25 @@ namespace Microsoft.NET.TestFramework
             }
             else
             {
-                targetFramework = targetFramework ?? TargetFramework ?? string.Empty;
-                configuration = configuration ?? string.Empty;
-                runtimeIdentifier = runtimeIdentifier ?? RuntimeIdentifier ?? string.Empty;
+                targetFramework ??= TargetFramework ?? string.Empty;
+                configuration ??= string.Empty;
+                runtimeIdentifier ??= RuntimeIdentifier ?? string.Empty;
+                platform ??= string.Empty;
 
                 if (IsSdkProject)
                 {
-                    string output = System.IO.Path.Combine(Path.GetDirectoryName(ProjectPath), "bin", configuration, targetFramework, runtimeIdentifier);
+                    string output = System.IO.Path.Combine(Path.GetDirectoryName(ProjectPath), "bin", platform, configuration, targetFramework, runtimeIdentifier);
                     return output;
                 }
                 else
                 {
-                    string output = System.IO.Path.Combine(Path.GetDirectoryName(ProjectPath), "bin", configuration);
+                    string output = System.IO.Path.Combine(Path.GetDirectoryName(ProjectPath), "bin", platform, configuration);
                     return output;
                 }
             }
         }
 
-        public string GetPublishDirectory(string targetFramework = null, string configuration = "Debug", string runtimeIdentifier = "")
+        public string GetPublishDirectory(string targetFramework = null, string configuration = "Debug", string runtimeIdentifier = "", string platform = "")
         {
             if (UseArtifactsOutput)
             {
@@ -234,11 +235,12 @@ namespace Microsoft.NET.TestFramework
             }
             else
             {
-                targetFramework = targetFramework ?? TargetFramework ?? string.Empty;
-                configuration = configuration ?? string.Empty;
-                runtimeIdentifier = runtimeIdentifier ?? RuntimeIdentifier ?? string.Empty;
+                targetFramework ??= TargetFramework ?? string.Empty;
+                configuration ??= string.Empty;
+                runtimeIdentifier ??= RuntimeIdentifier ?? string.Empty;
+                platform ??= string.Empty;
 
-                string output = System.IO.Path.Combine(Path.GetDirectoryName(ProjectPath), "bin", configuration, targetFramework, runtimeIdentifier, "publish");
+                string output = System.IO.Path.Combine(Path.GetDirectoryName(ProjectPath), "bin", platform, configuration, targetFramework, runtimeIdentifier, "publish");
                 return output;
             }
         }


### PR DESCRIPTION
In your output path

See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1860846

A user would like to be able to opt out of appending the platform to the output path. This permits that.

Note that this is not as simple as adding a condition on the version that appends a platform because the version that does not append a platform needs to run if the former version does not. This ensures that is true. An alternate formulation would be unconditionally setting IntermediateOutputPath or OutputPath, then modifying it as necessary.