### PR TITLE
fix AppHostShellShimMaker to make it work well with Crossplatform ResourceUpdater

### DIFF
--- a/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
+++ b/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.ShellShim
                 HostWriter.CreateAppHost(appHostSourceFilePath: appHostSourcePath,
                                          appHostDestinationFilePath: appHostDestinationFilePath,
                                          appBinaryFilePath: appBinaryFilePath,
-                                         windowsGraphicalUserInterface: (windowsGraphicalUserInterfaceBit == WindowsGUISubsystem),
+                                         windowsGraphicalUserInterface: (windowsGraphicalUserInterfaceBit == WindowsGUISubsystem) && OperatingSystem.IsWindows(),
                                          assemblyToCopyResourcesFrom: entryPointFullPath);
             }
             else


### PR DESCRIPTION
This should fix one test failure in #34522 `Microsoft.DotNet.ShellShim.Tests.AppHostShellShimMakerTests.GivenNonWindowsMachineWhenCallWithWpfDllItCanCreateShimWithoutThrow`

This is ready for review. @dotnet/domestic-cat