### PR TITLE
Fix redist.csproj build failure on SLN rebuild in VS

### DIFF
--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -50,8 +50,8 @@
     <ProjectReference Include="..\tool_msbuild\tool_msbuild.csproj" />
     <ProjectReference Include="..\tool_nuget\tool_nuget.csproj" />
     <ProjectReference Include="..\..\Cli\dotnet\dotnet.csproj" />
-    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
-    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Extensions.Tasks\Microsoft.NET.Build.Extensions.Tasks.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Extensions.Tasks\Microsoft.NET.Build.Extensions.Tasks.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Resolvers\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj" />
     <ProjectReference Include="$(RepoRoot)src\BuiltInTools\dotnet-watch\dotnet-watch.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
   </ItemGroup>

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -9,6 +9,9 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <!-- do not import analyzer assemblies from the sdk as they will be double loaded -->
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <!-- Disable the fast up-to-date check as it relies on the redist.dll, which we delete as part of the build process in GereateLayout.targets. -->
+    <!-- Property info: https://github.com/dotnet/project-system/blob/main/docs/up-to-date-check.md#disabling-the-up-to-date-check -->
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <Import Project="targets\BuildToolsetTasks.targets" />

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -228,10 +228,6 @@
     <Delete Files="$(OutputPath)/$(TargetName).deps.json;
                    $(OutputPath)/$(TargetName).runtimeconfig.json" />
 
-    <ItemGroup>
-      <BundledToolProjects Remove="redist" />
-    </ItemGroup>
-
     <Delete Files="$(OutputPath)/%(BundledToolProjects.Identity).dll;
                    $(OutputPath)/%(BundledToolProjects.Identity).pdb" />
 

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -226,8 +226,13 @@
           DestinationFiles="$(OutputPath)/%(BundledTools.Identity).runtimeconfig.json" />
 
     <Delete Files="$(OutputPath)/$(TargetName).deps.json;
-                   $(OutputPath)/$(TargetName).runtimeconfig.json;
-                   $(OutputPath)/%(BundledToolProjects.Identity).dll;
+                   $(OutputPath)/$(TargetName).runtimeconfig.json" />
+
+    <ItemGroup>
+      <BundledToolProjects Remove="redist" />
+    </ItemGroup>
+
+    <Delete Files="$(OutputPath)/%(BundledToolProjects.Identity).dll;
                    $(OutputPath)/%(BundledToolProjects.Identity).pdb" />
 
     <ChangeEntryPointLibraryName


### PR DESCRIPTION
## Summary
Currently, the SDK repo will build properly (all projects succeed) when using `build.cmd`. However, if you open the `sdk.sln` and hit *Rebuild Solution*, the build will have 1 project that fails. That project is `redist.csproj`.

## Resolution

I spent some time digging and I don't pretend to know how the entire build of this project works. However, after a bunch of digging in the binlogs, it only fails for these 2 ProjectReferences:

![image](https://github.com/dotnet/sdk/assets/17788297/b8a3cc42-7c82-41ed-921d-b6615d03b1f2)

These 2 projects, `Microsoft.NET.Build.Extensions.Tasks` and `Microsoft.NET.Build.Tasks`, build completely fine independently. It is only in the `redist.csproj` project that causes an issue. Now, I don't know why this is only an issue for VS and not for `build.cmd`, but I looked at how they are referenced:

https://github.com/dotnet/sdk/blob/0622981c6d82bda0dab39e38218ef4b5fa760612/src/Layout/redist/redist.csproj#L53-L54

The `SkipGetTargetFrameworkProperties` stood out to me. [Looking at the documentation](https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-items?view=vs-2022#projectreference), this forces it to not set the `TargetFramework` value.

Now, the error image above says about not finding the `GetTargetPath` target. That comes from the `Microsoft.Common.CurrentVersion.targets file.

https://github.com/dotnet/msbuild/blob/76a6ec27c2fbeee0145c20eec91e17a5490b6c86/src/Tasks/Microsoft.Common.CurrentVersion.targets#L2153-L2169

When rebuilding the build system for the .NET Project System repo, I ran into a similar issue like this when doing SDK-style VSIX projects. I remembered it was because when a `TargetFramework` is not resolved, it doesn't know how to load the subsequent `.target` files since they are framework-specific in folder structure. For example, we use this one in ***amd64***:

> C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\\***amd64***\Microsoft.Common.CurrentVersion.targets

Similarly, there are ones for `CSharp` language if you don't specify the language. In the .NET Project System situation, I forced both the framework and language so certain things could resolve properly. (Note: It doesn't work this way in that repo anymore, but it used to prior to [this PR](https://github.com/dotnet/project-system/pull/8964) from April).

To fix this, I simply removed the `SkipGetTargetFrameworkProperties` for the ProjectReference. I'm not sure why it was set in the first place...? Someone with more knowledge than me might be able to provide some insight.

After this change, the build succeeded. However, there was a warning from the incremental build system:

![image](https://github.com/dotnet/sdk/assets/17788297/37e5e6bc-13dc-4a69-b590-d88cb0a1fef8)

This is showing that warning because it uses build outputs to compare for the "state of the world" before/after build (using things such as timestamps on the files). Took a bunch more digging in the binlogs to figure out why the file wasn't there. I even recorded a video with the folder open side-by-side with the VS log to figure out when `redist.dll` exists (because it does) but then gets deleted.

~After locating when/why that happens, I tried to determine the reason it gets deleted (to see if I'd affect the build by not deleting it). I didn't see anything obvious (such as it getting packaged inappropriately), so I simply avoided deleting the file. The `BundledToolProjects` items are only used in the `GenerateCliRuntimeConfigurationFiles` target in `GenerateLayout.targets`, so I simply modify the item list prior to the Delete being called.~ I split the non-list items into a separate Delete call since those calls get duplicated per item from the item lists. You can see the duplication highlighted here in `#FF00FF`:

![image](https://github.com/dotnet/sdk/assets/17788297/0a5c65c6-3b79-4d08-a556-57d690f3fa5a)

So, a very minor optimization, but I figured I would point it out. ~With the `redist.dll` remaining after building `redist.csproj`, now there is no longer an incremental build warning. So, we get everything looking green in the end. 🥳~

![image](https://github.com/dotnet/sdk/assets/17788297/9f6063b9-745b-447b-a668-6ab3c9622fbc)

*Edit*: Instead to keeping `redist.dll` in the output folder, I've disabled the fast up-to-date check for the `redist.csproj`. This check drives the warning about the project being out-of-date. Thus, we no longer get this warning and the `redist.dll` can be successfully deleted without issue.