### PR TITLE
MSBuild terminal logger enamblement.

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Utils
     {
         private static readonly bool AlwaysExecuteMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_RUN_MSBUILD_OUTOFPROC");
         private static readonly bool UseMSBuildServer = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILD_SERVER", false);
-        private static readonly string TerminalLoggerDefault = Env.GetEnvironmentVariable("DOTNET_CLI_BUILD_TERMINAL_LOGGER");
+        private static readonly string TerminalLoggerDefault = Env.GetEnvironmentVariable("DOTNET_CLI_CONFIGURE_MSBUILD_TERMINAL_LOGGER");
 
         private const string MSBuildExeName = "MSBuild.dll";
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.Cli.Utils
     {
         private static readonly bool AlwaysExecuteMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_RUN_MSBUILD_OUTOFPROC");
         private static readonly bool UseMSBuildServer = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILD_SERVER", false);
+        private static readonly string TerminalLoggerDefault = Env.GetEnvironmentVariable("DOTNET_CLI_BUILD_TERMINAL_LOGGER");
 
         private const string MSBuildExeName = "MSBuild.dll";
 
@@ -52,6 +53,18 @@ namespace Microsoft.DotNet.Cli.Utils
             string defaultMSBuildPath = GetMSBuildExePath();
 
             _argsToForward = argsToForward;
+            string tlpDefault = TerminalLoggerDefault;
+            /* TODO: Consider to enable it for dotnet 9+ SDK
+            if (!string.IsNullOrWhiteSpace(tlpDefault))
+            {
+                tlpDefault = "auto";
+            }
+            */
+            if (!string.IsNullOrWhiteSpace(tlpDefault))
+            {
+                _argsToForward = _argsToForward.Concat(new[] { $"-tlp:default={tlpDefault}" });
+            }
+
             MSBuildPath = msbuildPath ?? defaultMSBuildPath;
 
             EnvironmentVariable("MSBUILDUSESERVER", UseMSBuildServer ? "1" : "0");
@@ -67,7 +80,7 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             _forwardingApp = new ForwardingAppImplementation(
                 MSBuildPath,
-                _msbuildRequiredParameters.Concat(_argsToForward.Select(Escape)),
+                GetAllArguments(),
                 environmentVariables: _msbuildRequiredEnvironmentVariables);
         }
 
@@ -95,13 +108,13 @@ namespace Microsoft.DotNet.Cli.Utils
 
             if (value == string.Empty || value == "\0")
             {
-                // Do not allow MSBUILDUSESERVER as null env vars are not properly transferred to build nodes
-                _msbuildRequiredEnvironmentVariables["MSBUILDUSESERVER"] = "0";
-
                 // Unlike ProcessStartInfo.EnvironmentVariables, Environment.SetEnvironmentVariable can't set a variable
                 // to an empty value, so we just fall back to calling MSBuild out-of-proc if we encounter this case.
                 // https://github.com/dotnet/runtime/issues/50554
                 InitializeForOutOfProcForwarding();
+
+                // Disable MSBUILDUSESERVER in any env vars are null as those are not properly transferred to build nodes
+                _msbuildRequiredEnvironmentVariables["MSBUILDUSESERVER"] = "0";
             }
         }
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 // https://github.com/dotnet/runtime/issues/50554
                 InitializeForOutOfProcForwarding();
 
-                // Disable MSBUILDUSESERVER in any env vars are null as those are not properly transferred to build nodes
+                // Disable MSBUILDUSESERVER if any env vars are null as those are not properly transferred to build nodes
                 _msbuildRequiredEnvironmentVariables["MSBUILDUSESERVER"] = "0";
             }
         }

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         internal const string TargetFrameworkTelemetryEventName = "targetframeworkeval";
         internal const string BuildTelemetryEventName = "build";
+        internal const string LoggingConfigurationTelemetryEventName = "loggingConfiguration";
 
         internal const string SdkTaskBaseCatchExceptionTelemetryEventName = "taskBaseCatchException";
         internal const string PublishPropertiesTelemetryEventName = "PublishProperties";
@@ -85,69 +86,84 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         internal static void FormatAndSend(ITelemetry telemetry, TelemetryEventArgs args)
         {
-            if (args.EventName == TargetFrameworkTelemetryEventName)
+            switch (args.EventName)
             {
-                var newEventName = $"msbuild/{TargetFrameworkTelemetryEventName}";
-                Dictionary<string, string> maskedProperties = new Dictionary<string, string>();
-
-                foreach (var key in new[] {
-                    TargetFrameworkVersionTelemetryPropertyKey,
-                    RuntimeIdentifierTelemetryPropertyKey,
-                    SelfContainedTelemetryPropertyKey,
-                    UseApphostTelemetryPropertyKey,
-                    OutputTypeTelemetryPropertyKey
-                })
-                {
-                    if (args.Properties.TryGetValue(key, out string value))
+                case TargetFrameworkTelemetryEventName:
                     {
-                        maskedProperties.Add(key, Sha256Hasher.HashWithNormalizedCasing(value));
-                    }
-                }
+                        var newEventName = $"msbuild/{TargetFrameworkTelemetryEventName}";
+                        Dictionary<string, string> maskedProperties = new Dictionary<string, string>();
 
-                telemetry.TrackEvent(newEventName, maskedProperties, measurements: null);
-            }
-            else if (args.EventName == BuildTelemetryEventName)
-            {
-                var newEventName = $"msbuild/{BuildTelemetryEventName}";
-                Dictionary<string, string> properties = new Dictionary<string, string>(args.Properties);
-                Dictionary<string, double> measurements = new Dictionary<string, double>();
-
-                string[] toBeHashed = new[] { "ProjectPath", "BuildTarget" };
-                foreach (var propertyToBeHashed in toBeHashed)
-                {
-                    if (properties.TryGetValue(propertyToBeHashed, out string value))
-                    {
-                        properties[propertyToBeHashed] = Sha256Hasher.HashWithNormalizedCasing(value);
-                    }
-                }
-
-                string[] toBeMeasured = new[] { "BuildDurationInMilliseconds", "InnerBuildDurationInMilliseconds" };
-                foreach (var propertyToBeMeasured in toBeMeasured)
-                {
-                    if (properties.TryGetValue(propertyToBeMeasured, out string value))
-                    {
-                        properties.Remove(propertyToBeMeasured);
-                        if (double.TryParse(value, CultureInfo.InvariantCulture, out double realValue))
+                        foreach (var key in new[] {
+                            TargetFrameworkVersionTelemetryPropertyKey,
+                            RuntimeIdentifierTelemetryPropertyKey,
+                            SelfContainedTelemetryPropertyKey,
+                            UseApphostTelemetryPropertyKey,
+                            OutputTypeTelemetryPropertyKey
+                        })
                         {
-                            measurements[propertyToBeMeasured] = realValue;
+                            if (args.Properties.TryGetValue(key, out string value))
+                            {
+                                maskedProperties.Add(key, Sha256Hasher.HashWithNormalizedCasing(value));
+                            }
                         }
+
+                        telemetry.TrackEvent(newEventName, maskedProperties, measurements: null);
+                        break;
+                    }
+                case BuildTelemetryEventName:
+                    TrackEvent(telemetry, $"msbuild/{BuildTelemetryEventName}", args.Properties,
+                        toBeHashed: new[] { "ProjectPath", "BuildTarget" },
+                        toBeMeasured: new[] { "BuildDurationInMilliseconds", "InnerBuildDurationInMilliseconds" });
+                    break;
+                case LoggingConfigurationTelemetryEventName:
+                    TrackEvent(telemetry, $"msbuild/{LoggingConfigurationTelemetryEventName}", args.Properties,
+                        toBeHashed: Array.Empty<string>(),
+                        toBeMeasured: new[] { "FileLoggersCount" });
+                    break;
+                // Pass through events that don't need special handling
+                case SdkTaskBaseCatchExceptionTelemetryEventName:
+                case PublishPropertiesTelemetryEventName:
+                case ReadyToRunTelemetryEventName:
+                    TrackEvent(telemetry, args.EventName, args.Properties, Array.Empty<string>(), Array.Empty<string>() );
+                    break;
+                default:
+                    // Ignore unknown events
+                    break;
+            }
+        }
+
+        private static void TrackEvent(ITelemetry telemetry, string eventName, IDictionary<string, string> eventProperties, string[] toBeHashed, string[] toBeMeasured)
+        {
+            Dictionary<string, string> properties = null;
+            Dictionary<string, double> measurements = null;
+
+            foreach (var propertyToBeHashed in toBeHashed)
+            {
+                if (eventProperties.TryGetValue(propertyToBeHashed, out string value))
+                {
+                    // Lets lazy allocate in case there is tons of telemetry 
+                    properties ??= new Dictionary<string, string>(eventProperties);
+                    properties[propertyToBeHashed] = Sha256Hasher.HashWithNormalizedCasing(value);
+                }
+            }
+
+            foreach (var propertyToBeMeasured in toBeMeasured)
+            {
+                if (eventProperties.TryGetValue(propertyToBeMeasured, out string value))
+                {
+                    // Lets lazy allocate in case there is tons of telemetry 
+                    properties ??= new Dictionary<string, string>(eventProperties);
+                    properties.Remove(propertyToBeMeasured);
+                    if (double.TryParse(value, CultureInfo.InvariantCulture, out double realValue))
+                    {
+                        // Lets lazy allocate in case there is tons of telemetry
+                        measurements ??= new Dictionary<string, double>();
+                        measurements[propertyToBeMeasured] = realValue;
                     }
                 }
-
-                telemetry.TrackEvent(newEventName, properties, measurements);
             }
-            else
-            {
-                var passthroughEvents = new string[] {
-                    SdkTaskBaseCatchExceptionTelemetryEventName, 
-                    PublishPropertiesTelemetryEventName,
-                    ReadyToRunTelemetryEventName };
 
-                if (passthroughEvents.Contains(args.EventName))
-                {
-                    telemetry.TrackEvent(args.EventName, args.Properties, measurements: null);
-                }
-            }
+            telemetry.TrackEvent(eventName, properties ?? eventProperties, measurements);
         }
 
         private void OnTelemetryLogged(object sender, TelemetryEventArgs args)


### PR DESCRIPTION
Fixes: part of https://github.com/dotnet/msbuild/issues/9063

Changes done:
-  prepare for easy enablement in dotnet 9
- support new msbuild logging configuration telemetry
- minor refactoring