### PR TITLE
correct command model for nuget trust command and subcommands

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -271,7 +271,7 @@ namespace Microsoft.DotNet.Cli
                     option.EnsureHelpName();
                 }
 
-                if (command.Name.Equals(NuGetCommandParser.GetCommand().Name))
+                if (command.Equals(NuGetCommandParser.GetCommand()) || command.Parents.Any(parent => parent == NuGetCommandParser.GetCommand()))
                 {
                     NuGetCommand.Run(context.ParseResult);
                 }

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -166,11 +166,17 @@ namespace Microsoft.DotNet.Cli
                 new CliOption<string>("--source-url"),
             };
 
-            CliCommand CertificateCommand() => new CliCommand("certificate") {
-                new CliArgument<string>("NAME"),
-                new CliArgument<string>("FINGERPRINT"),
-                allowUntrustedRoot,
-                new CliOption<string>("--algorithm")
+            CliCommand CertificateCommand() {
+                CliOption<string> algorithm = new("--algorithm");
+                algorithm.DefaultValueFactory = () => "SHA256";
+                algorithm.AcceptOnlyFromAmong("SHA256", "SHA384", "SHA512");
+
+                return new CliCommand("certificate") {
+                    new CliArgument<string>("NAME"),
+                    new CliArgument<string>("FINGERPRINT"),
+                    allowUntrustedRoot,
+                    algorithm
+                };
             };
 
             CliCommand RemoveCommand() => new CliCommand("remove") {

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -168,7 +168,7 @@ namespace Microsoft.DotNet.Cli
 
             CliCommand CertificateCommand() {
                 CliOption<string> algorithm = new("--algorithm");
-                algorithm.DefaultValueFactory = () => "SHA256";
+                algorithm.DefaultValueFactory = (_argResult) => "SHA256";
                 algorithm.AcceptOnlyFromAmong("SHA256", "SHA384", "SHA512");
 
                 return new CliCommand("certificate") {

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -120,22 +120,70 @@ namespace Microsoft.DotNet.Cli
         {
             CliCommand trustCommand = new("trust");
 
-            CliArgument<string> commandArgument = new CliArgument<string>("command") { Arity = ArgumentArity.ZeroOrOne };
-            commandArgument.AcceptOnlyFromAmong(new string[] { "list", "author", "repository", "source", "certificate", "remove", "sync" });
+            CliOption<bool> allowUntrustedRoot = new("--allow-untrusted-root");
+            CliOption<string> owners = new("--owners");
 
-            trustCommand.Arguments.Add(commandArgument);
+            trustCommand.Subcommands.Add (new CliCommand("list"));
+            trustCommand.Subcommands.Add (AuthorCommand());
+            trustCommand.Subcommands.Add (RepositoryCommand());
+            trustCommand.Subcommands.Add (SourceCommand());
+            trustCommand.Subcommands.Add (CertificateCommand());
+            trustCommand.Subcommands.Add (RemoveCommand());
+            trustCommand.Subcommands.Add (SyncCommand());
 
-            trustCommand.Options.Add(new CliOption<string>("--algorithm"));
-            trustCommand.Options.Add(new CliOption<bool>("--allow-untrusted-root"));
-            trustCommand.Options.Add(new CliOption<string>("--owners"));
-            trustCommand.Options.Add(new CliOption<string>("--configfile"));
+            CliOption<string> configFile = new("--configfile");
+
+            // now set global options for all nuget commands: configfile, verbosity
+            // as well as the standard NugetCommand.Run handler
+
+            trustCommand.Options.Add(configFile);
             trustCommand.Options.Add(CommonOptions.VerbosityOption);
-
             trustCommand.SetAction(NuGetCommand.Run);
+
+            foreach (var command in trustCommand.Subcommands)
+            {
+                command.Options.Add(configFile);
+                command.Options.Add(CommonOptions.VerbosityOption);
+                command.SetAction(NuGetCommand.Run);
+            }
+
+            CliCommand AuthorCommand() => new CliCommand("author") {
+                new CliArgument<string>("NAME"),
+                new CliArgument<string>("PACKAGE"),
+                allowUntrustedRoot,
+            };
+
+            CliCommand RepositoryCommand() => new CliCommand("repository") {
+                new CliArgument<string>("NAME"),
+                new CliArgument<string>("PACKAGE"),
+                allowUntrustedRoot,
+                owners
+            };
+
+            CliCommand SourceCommand() => new CliCommand("source") {
+                new CliArgument<string>("NAME"),
+                owners,
+                new CliOption<string>("--source-url"),
+            };
+
+            CliCommand CertificateCommand() => new CliCommand("certificate") {
+                new CliArgument<string>("NAME"),
+                new CliArgument<string>("FINGERPRINT"),
+                allowUntrustedRoot,
+                new CliOption<string>("--algorithm")
+            };
+
+            CliCommand RemoveCommand() => new CliCommand("remove") {
+                new CliArgument<string>("NAME"),
+            };
+
+            CliCommand SyncCommand() => new CliCommand("sync") {
+                new CliArgument<string>("NAME"),
+            };
 
             return trustCommand;
         }
-        
+
         private static CliCommand GetSignCommand()
         {
             CliCommand signCommand = new("sign");

--- a/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -233,10 +233,7 @@ namespace Microsoft.DotNet.Tests.Commands
         public void GivenNuGetTrustCommandItDisplaysCompletions()
         {
             var expected = new[] {
-                "--algorithm",
-                "--allow-untrusted-root",
                 "--configfile",
-                "--owners",
                 "--verbosity",
                 "--help",
                 "-v",


### PR DESCRIPTION
Fixes #34610 

This models the various trust commands as of .NET 8.0.100 preview 7 in line with the actual implementations in NuGet.CommandLine.XPlat.dll.


Details of the various trust commands are below:

<details>
<summary>Output from help for each subcommand</summary>

```shell
> dotnet .\NuGet.CommandLine.XPlat.dll trust --help


Usage: dotnet nuget trust [options] [command]

Options:
  --configfile    The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help       Show help information
  -v|--verbosity  Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].

Commands:
  author       Adds a trusted signer with the given name, based on the author signature of the package.
  certificate  Adds a trusted signer with the given name, based on the repository signature or countersignature of a signed package.
  list         Lists all the trusted signers in the configuration.
  remove       Removes any trusted signers that match the given name.
  repository   Adds a trusted signer with the given name, based on the repository signature or countersignature of a signed package.
  source       Adds a trusted signer based on a given package source.
  sync         Deletes the current list of certificates and replaces them with an up-to-date list from the repository.

Use "trust [command] --help" for more information about a command.

>  dotnet .\NuGet.CommandLine.XPlat.dll trust author
error: Property 'name' should not be null or empty.


Usage: dotnet nuget trust author [arguments] [options]

Arguments:
  <NAME>     The name of the trusted signer to add. If name already exists in the configuration, the signature is appended.
  <PACKAGE>  The given package should be a local path to the signed .nupkg file.

Options:
  --allow-untrusted-root  Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
  --configfile            The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help               Show help information
  -v|--verbosity          Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].

> dotnet .\NuGet.CommandLine.XPlat.dll trust certificate
error: Property 'name' should not be null or empty.


Usage: dotnet nuget trust certificate [arguments] [options]

Arguments:
  <NAME>         The name of the trusted signer to add. If a trusted signer with the given name already exists, the certificate item is added to that signer. Otherwise a trusted author is created with a certificate item from the given certificate information.
  <FINGERPRINT>  The fingerprint of the certificate.

Options:
  --algorithm             Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to SHA256. Values supported are SHA256, SHA384 and SHA512.
  --allow-untrusted-root  Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
  --configfile            The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help               Show help information
  -v|--verbosity          Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].

> dotnet .\NuGet.CommandLine.XPlat.dll trust list --help


Usage: dotnet nuget trust list [options]

Options:
  --configfile    The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help       Show help information
  -v|--verbosity  Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].

> dotnet .\NuGet.CommandLine.XPlat.dll trust remove
error: Property 'name' should not be null or empty.


Usage: dotnet nuget trust remove [arguments] [options]

Arguments:
  <NAME>  The name of the existing trusted signer to remove.

Options:
  --configfile    The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help       Show help information
  -v|--verbosity  Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].

> dotnet .\NuGet.CommandLine.XPlat.dll trust repository
error: Property 'name' should not be null or empty.


Usage: dotnet nuget trust repository [arguments] [options]

Arguments:
  <NAME>     The name of the trusted signer to add. If name already exists in the configuration, the signature is appended.
  <PACKAGE>  The given package should be a local path to the signed .nupkg file.

Options:
  --allow-untrusted-root  Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. This is not recommended.
  --configfile            The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help               Show help information
  --owners                Semi-colon separated list of trusted owners to further restrict the trust of a repository.
  -v|--verbosity          Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].

> dotnet .\NuGet.CommandLine.XPlat.dll trust source
error: Property 'name' should not be null or empty.


Usage: dotnet nuget trust source [arguments] [options]

Arguments:
  <NAME>  "The name of the trusted signer to add. If only <NAME> is provided without --<source-url>, the package source from your NuGet configuration files with the same name is added to the trusted list. If <NAME> already exists in the configuration, the package source is appended to it."

Options:
  --configfile    The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help       Show help information
  --owners        Semi-colon separated list of trusted owners to further restrict the trust of a repository.
  --source-url    If a source-url is provided, it must be a v3 package source URL (like https://api.nuget.org/v3/index.json). Other package source types are not supported.
  -v|--verbosity  Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].

> dotnet .\NuGet.CommandLine.XPlat.dll trust sync
error: Property 'name' should not be null or empty.


Usage: dotnet nuget trust sync [arguments] [options]

Arguments:
  <NAME>  The name of the existing trusted signer to sync.

Options:
  --configfile    The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help       Show help information
  -v|--verbosity  Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
```
</details>