### PR TITLE
Initial commit for dotnet sln configuration cmd

### DIFF
--- a/src/Assets/TestProjects/TestAppWithSlnAndReferenceToSingleCsproj/App.sln
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferenceToSingleCsproj/App.sln
@@ -1,0 +1,34 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26006.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App", "App\App.csproj", "{7072A694-548F-4CAE-A58F-12D257D5F486}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.ActiveCfg = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.Build.0 = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.ActiveCfg = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.Build.0 = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.ActiveCfg = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.Build.0 = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.ActiveCfg = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferenceToSingleCsproj/App/App.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferenceToSingleCsproj/App/App.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lib\Lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferenceToSingleCsproj/App/Program.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferenceToSingleCsproj/App/Program.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello from the main app");
+        Console.WriteLine(Lib.Library.GetMessage());
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/App.sln
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/App.sln
@@ -1,0 +1,75 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32929.385
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App", "App\App.csproj", "{7072A694-548F-4CAE-A58F-12D257D5F486}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib", "Lib\Lib.csproj", "{D4ED07FD-E893-4D38-8E19-33C3027D687A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "First", "Multiple\First.csproj", "{F1383793-E608-49EA-A9BE-B7C26E94850B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Second", "Multiple\Second.csproj", "{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.ActiveCfg = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.ActiveCfg = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.ActiveCfg = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.Build.0 = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.ActiveCfg = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.Build.0 = Release|x86
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x64.Build.0 = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x86.Build.0 = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x64.Build.0 = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x86.Build.0 = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x64.Build.0 = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {69061246-1432-4C95-A7C9-B17C637C8639}
+	EndGlobalSection
+EndGlobal

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/App/App.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/App/App.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lib\Lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/App/Program.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/App/Program.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello from the main app");
+        Console.WriteLine(Lib.Library.GetMessage());
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Empty/README
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Empty/README
@@ -1,0 +1,2 @@
+This directory is intentionally empty.
+

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Lib/Lib.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Lib/Lib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Lib/Library.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Lib/Library.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Lib
+{
+    public class Library
+    {
+        public static string GetMessage()
+        {
+            return "Message from Lib";
+        }
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Multiple/First.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Multiple/First.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Multiple/Second.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndReferencesToMultipleCsproj/Multiple/Second.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -37,7 +37,7 @@ using Microsoft.DotNet.Tools.Common;
 
 namespace Microsoft.DotNet.Cli.Sln.Internal
 {
-    public class SlnFile
+    public partial class SlnFile
     {
         private SlnProjectCollection _projects = new SlnProjectCollection();
         private SlnSectionCollection _sections = new SlnSectionCollection();
@@ -178,6 +178,7 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
                             var sec = new SlnSection();
                             sec.Read(reader, line, ref curLineNum);
                             _sections.Add(sec);
+                            LoadConfigurations(sec);
                         }
                         else // Ignore text that's out of place
                         {
@@ -239,7 +240,7 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
         }
     }
 
-    public class SlnProject
+    public partial class SlnProject
     {
         private SlnSectionCollection _sections = new SlnSectionCollection();
 
@@ -390,7 +391,7 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
     {
         private SlnPropertySetCollection _nestedPropertySets;
         private SlnPropertySet _properties;
-        private List<string> _sectionLines;
+        internal List<string> _sectionLines;
         private int _baseIndex;
 
         public string Id { get; set; }
@@ -507,7 +508,7 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
                 String.Format(LocalizableStrings.InvalidSectionTypeError, s));
         }
 
-        private string FromSectionType(bool isProjectSection, SlnSectionType type)
+        internal string FromSectionType(bool isProjectSection, SlnSectionType type)
         {
             if (type == SlnSectionType.PreProcess)
             {
@@ -633,7 +634,7 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
     /// <summary>
     /// A collection of properties
     /// </summary>
-    public class SlnPropertySet : IDictionary<string, string>
+    public partial class SlnPropertySet : IDictionary<string, string>
     {
         private OrderedDictionary _values = new OrderedDictionary();
         private bool _isMetadata;

--- a/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFileConfig.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFileConfig.cs
@@ -1,0 +1,290 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// TBD - license to be updated
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using static System.Collections.Specialized.BitVector32;
+using Microsoft.DotNet.Cli.Utils;
+using System.Security.Permissions;
+using Microsoft.DotNet.Cli.Sln.Internal.FileManipulation;
+using NuGet.Versioning;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Cli.Sln.Internal
+{
+    public class ProjConfigPlatform
+    {
+        internal string _slnConfig;
+        private string _slnPlatform;
+        internal string _build;
+        private string _deploy;
+        private string _projConfig;
+        private string _projPlatform;
+
+        public ProjConfigPlatform(string slnConfig, string slnPlatform,
+            string build, string deploy, string projConfig, string projPlatform, string line)
+        {
+            _slnConfig = slnConfig;
+            _slnPlatform = slnPlatform;
+            _build = build;
+            _deploy = deploy;
+            _projConfig = projConfig;
+            _projPlatform = projPlatform;
+        }
+
+        public ProjConfigPlatform(ProjConfigPlatform pcp, string newSlnConfig, string createNewProjectConfig, string build=null)
+        {
+            _slnConfig = newSlnConfig;
+            _slnPlatform = pcp._slnPlatform;
+            if (string.IsNullOrEmpty(build)) _build = pcp._build; else _build = build;
+            _deploy = pcp._deploy;
+            if (createNewProjectConfig.Equals("y"))
+                _projConfig = newSlnConfig;
+            else
+                _projConfig = pcp._projConfig;
+            _projPlatform = pcp._projPlatform;
+        }
+
+        public string PropertyKey()
+        {
+            return _slnConfig + "|" + _slnPlatform + "." + _build;
+        }
+
+        public string PropertyValue()
+        {
+            return _projConfig + "|" + _projPlatform;
+        }
+    }
+
+    public class SlnConfigPlatform
+    {
+        internal string _config;
+        internal string _platform;
+        public SlnConfigPlatform(string config, string platform)
+        {
+            _config = config;
+            _platform = platform;
+        }
+
+        public SlnConfigPlatform(SlnConfigPlatform scp, string newconfig)
+        {
+            _config = newconfig;
+            _platform = scp._platform;
+        }
+
+        public string PropertyKey()
+        {
+            return _config + "|" + _platform;
+        }
+    }
+
+    public partial class SlnFile
+    {
+        //private string ActiveSlnConfig = "";
+        //private string ActiveSlnPlatform = "";
+        private const string SlnConfigPlatformsSectionId = "SolutionConfigurationPlatforms";
+        private const string ProjConfigPlatformsSectionId = "ProjectConfigurationPlatforms";
+
+        private List<string> _slnConfigs = new List<string>();
+        private List<string> _slnPlatforms = new List<string>();
+        private List<SlnConfigPlatform> _slnConfigPlatforms = new List<SlnConfigPlatform>();
+        internal void LoadConfigurations(SlnSection sec)
+        {
+            string Id = sec.Id;
+            
+            if (Id.Equals(SlnConfigPlatformsSectionId))
+            {
+                LoadConfigurations(sec._sectionLines);
+            }
+            else if (Id.Equals(ProjConfigPlatformsSectionId))
+            {
+                foreach (SlnProject project in _projects)
+                {
+                    List<string> projSectionLines = sec._sectionLines.FindAll(
+                        delegate (string line)
+                        {
+                            return line.StartsWith(project.Id);
+                        });
+
+                    project.LoadConfigurations(projSectionLines);
+                }
+            }
+        }
+        public bool LoadConfigurations(List<string> sectionLines)
+        {
+            foreach (string line in sectionLines)
+            {
+                int i = line.IndexOf('|');
+                int j = line.IndexOf('=');
+                if (i != -1 && j != -1)
+                {
+                    string config = line.Substring(0, i).Trim();
+                    string platform = line.Substring(i + 1, j - i - 1).Trim();
+                    SlnConfigPlatform entry = new SlnConfigPlatform(config, platform);
+                    _slnConfigPlatforms.Add(entry);
+
+                    if (!_slnConfigs.Contains(config))
+                        _slnConfigs.Add(config);
+
+                    if (!_slnPlatforms.Contains(platform))
+                        _slnPlatforms.Add(platform);
+                }
+            }
+            return true;
+        }
+
+        public void WriteConfigutations(string file = null)
+        {
+            Write(file);
+        }
+
+        public void AddNewSlnConfig(SlnConfigPlatform scp, string newConfigName)
+        {
+            if (!_slnConfigs.Contains(newConfigName))
+                _slnConfigs.Add(newConfigName);
+
+            SlnConfigPlatform newscp = new SlnConfigPlatform(scp, newConfigName);
+            _slnConfigPlatforms.Add(newscp);
+
+            string key = newscp.PropertyKey();
+            _sections.GetSection(SlnConfigPlatformsSectionId).Properties.AddProperty(key, key);
+        }
+
+        public bool AddNewSlnConfig(string newconfigname, string copyfromoldconfig = null, string createnewprojectconfig = null)
+         {
+            if(_slnConfigs.Contains(newconfigname))
+            {
+                throw new GracefulException("ConfigureAddConfigAlreadyExists");
+            }
+
+            if (!string.IsNullOrEmpty(copyfromoldconfig) && !_slnConfigs.Contains(copyfromoldconfig))
+            {
+                throw new GracefulException("ConfigureAddCopyFromDoesNotExists");
+            }
+
+            List<SlnConfigPlatform> slnconfigplatforms = _slnConfigPlatforms.FindAll(scp => scp._config.Equals(copyfromoldconfig));
+            if (slnconfigplatforms.Count <= 0) 
+            {
+                return false;
+            }
+
+            foreach (SlnConfigPlatform scp in slnconfigplatforms)
+                AddNewSlnConfig(scp, newconfigname);
+
+            foreach (SlnProject project in _projects)
+            {
+                List<ProjConfigPlatform> projconfigplatforms =
+                    project._projConfigPlatforms.FindAll(pcp => pcp._slnConfig.Equals(copyfromoldconfig));
+
+                if (projconfigplatforms.Count <= 0)
+                    continue;
+
+                foreach (ProjConfigPlatform pcp in projconfigplatforms)
+                {
+                    project._propSet = _sections.GetSection(ProjConfigPlatformsSectionId).NestedPropertySets.GetPropertySet(project.Id);
+                    project.AddNewSlnConfig(pcp, newconfigname, copyfromoldconfig, createnewprojectconfig);
+                }
+            }
+             return true;
+         }
+
+        public bool AddNewSlnPlatform(string newconfigname, string copyfromoldconfig = "", bool createnewprojectconfig = true)
+        {
+            return true;
+        }
+
+        public bool AddNewProjConfig(string project, string newconfigname, string copyfromoldconfig = "", bool createnewslnconfig = true)
+        {
+            return true;
+        }
+
+        public bool AddNewProjPlatform(string project, string newconfigname, string copyfromoldconfig = "", bool createnewslnconfig = true)
+        {
+            return true;
+        }
+
+    }
+
+    public partial class SlnProject
+    {
+        internal SlnPropertySet _propSet;
+        private List<string> _projConfigs = new List<string>();
+        private List<string> _projPlatforms = new List<string>();
+        internal List<ProjConfigPlatform> _projConfigPlatforms = new List<ProjConfigPlatform>();
+        private const string ProjConfigPlatformsSectionId = "ProjectConfigurationPlatforms";
+        public void AddNewSlnConfig(ProjConfigPlatform pcp, string newConfigName, string copyFromOldConfig, string createNewProjectConfig)
+        {
+            if (!_projConfigs.Contains(newConfigName))
+                _projConfigs.Add(newConfigName);
+
+            if (string.IsNullOrEmpty(copyFromOldConfig))
+            {
+                //Add 2 entries, one for Activeconfig & Build.0
+                ProjConfigPlatform newpcp = new ProjConfigPlatform(pcp, newConfigName, createNewProjectConfig, "ActiveCfg");
+                _projConfigPlatforms.Add(newpcp);
+                _propSet.AddProperty(newpcp.PropertyKey(), newpcp.PropertyValue());
+
+                newpcp = new ProjConfigPlatform(pcp, newConfigName, createNewProjectConfig, "Build.0");
+                _projConfigPlatforms.Add(newpcp);
+                _propSet.AddProperty(newpcp.PropertyKey(), newpcp.PropertyValue());
+            }
+            else
+            {
+                ProjConfigPlatform newpcp = new ProjConfigPlatform(pcp, newConfigName, createNewProjectConfig);
+                _projConfigPlatforms.Add(newpcp);
+                _propSet.AddProperty(newpcp.PropertyKey(), newpcp.PropertyValue());
+            }
+        }
+
+        internal bool LoadConfigurations(List<string> sectionLines)
+        {
+            foreach (string line in sectionLines)
+            {
+                int p = line.IndexOf('.');
+                if (p != -1)
+                {
+                    int i = line.IndexOf('|', p);
+                    int j = line.IndexOf('.', i);
+                    int l = line.IndexOf('=', j);
+                    int m = line.IndexOf('|', l);
+                    int n = line.Length;
+                    if (i != -1 && j != -1 && l != -1)
+                    {
+                        string slnConfig = line.Substring(p + 1, i - p - 1).Trim();
+                        string slnPlatform = line.Substring(i + 1, j - i - 1).Trim();
+                        string build = line.Substring(j + 1, l - j - 1).Trim();
+                        string deploy = "";
+                        string projConfig = line.Substring(l + 1, m - l - 1).Trim();
+                        string projPlatform = line.Substring(m + 1, n - m - 1).Trim();
+
+                        ProjConfigPlatform entry = new ProjConfigPlatform(slnConfig, slnPlatform, build, deploy, projConfig, projPlatform, line);
+                        _projConfigPlatforms.Add(entry);
+
+                        if (!_projConfigs.Contains(projConfig))
+                            _projConfigs.Add(projConfig);
+
+                        if (!_projPlatforms.Contains(projPlatform))
+                            _projPlatforms.Add(projPlatform);
+                    }
+                }
+            }
+            return false;
+        }
+
+    }
+
+    public partial class SlnPropertySet
+    {
+        internal void AddProperty(string key, string value)
+        {
+            _values.Add(key, value);
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
@@ -177,4 +177,49 @@
   <data name="SolutionFolderHeader" xml:space="preserve">
     <value>Solution Folder(s)</value>
   </data>
+  <data name="ConfigurationAddCommand" xml:space="preserve">
+    <value>Add new config or platform to a solution file.</value>
+  </data>
+  <data name="ConfigurationAddConfigAlreadyExists" xml:space="preserve">
+    <value>Solution config {0} already exists.</value>
+  </data>
+  <data name="ConfigurationAddCopyFromConfigDoesNotExists" xml:space="preserve">
+    <value>Solution config {0} to copy from, does not exists.</value>
+  </data>
+  <data name="ConfigurationAddCopyFromPlatformDoesNotExists" xml:space="preserve">
+    <value>Solution platform {0} to copy from, does not exists.</value>
+  </data>
+  <data name="ConfigurationAddNewConfigOptionUpdateProjMissing" xml:space="preserve">
+    <value>Update project options is not specified.</value>
+  </data>
+  <data name="ConfigurationAddNewConfigPlatformNameMissing" xml:space="preserve">
+    <value>Specify at least one config or platform to add.</value>
+  </data>
+  <data name="ConfigurationAddOptionCopySettingsFrom" xml:space="preserve">
+    <value>Existing config or platform to copy project settings from.</value>
+  </data>
+  <data name="ConfigurationAddOptionNewConfigName" xml:space="preserve">
+    <value>New config to add to the solution.</value>
+  </data>
+  <data name="ConfigurationAddOptionNewPlatformName" xml:space="preserve">
+    <value>New platform to add to the solution.</value>
+  </data>
+  <data name="ConfigurationAddOptionUpdateProjects" xml:space="preserve">
+    <value>Indicates whether to update project config or platform settings.</value>
+  </data>
+  <data name="ConfigurationAddPlatformAlreadyExists" xml:space="preserve">
+    <value>Solution platform {0} already exists.</value>
+  </data>
+  <data name="ConfigurationAddSlnMissing" xml:space="preserve">
+    <value>Solution file does not exists.</value>
+  </data>
+  <data name="ConfigurationArgumentSlnDescription" xml:space="preserve">
+    <value>The solution file to operate on. If not specified, the command will search the current directory for one.</value>
+  </data>
+  <data name="ConfigurationCommand" xml:space="preserve">
+    <value>Configuration Manager commands for .NET CLI.</value>
+  </data>
+  <data name="FileHeaderMissingError" xml:space="preserve">
+    <value>Expected file header not found</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
@@ -29,9 +29,11 @@ namespace Microsoft.DotNet.Cli
             DocumentedCommand command = new("sln", DocsLink, LocalizableStrings.AppFullName);
 
             command.Arguments.Add(SlnArgument);
+            //command.Subcommands.Add(SlnConfigurationParser.GetCommand());
             command.Subcommands.Add(SlnAddParser.GetCommand());
             command.Subcommands.Add(SlnListParser.GetCommand());
             command.Subcommands.Add(SlnRemoveParser.GetCommand());
+            command.Subcommands.Add(SlnConfigurationParser.GetCommand());
 
             command.SetAction((parseResult) => parseResult.HandleMissingCommand());
 

--- a/src/Cli/dotnet/commands/dotnet-sln/configuration/ConfigurationCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/configuration/ConfigurationCommandParser.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.CommandFactory;
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Resources;
+using LocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
+
+namespace Microsoft.DotNet.Cli
+{
+    internal static class SlnConfigurationParser
+    {
+        private static readonly CliCommand Command = ConstructCommand();
+
+        public static CliCommand GetCommand()
+        {
+            return Command;
+        }
+
+        private static CliCommand ConstructCommand()
+        {
+            CliCommand command = new("configuration", LocalizableStrings.ConfigurationCommand);
+
+            command.Subcommands.Add(ConfigurationAddParser.GetCommand());
+
+            /*
+            command.Subcommands.Add(ConfigureRenameParser.GetCommand());
+            command.Subcommands.Add(ConfigureRemoveParser.GetCommand());
+            command.Subcommands.Add(ConfigureUpdateParser.GetCommand());
+            */
+
+            command.SetAction((parseResult) => parseResult.HandleMissingCommand());
+
+            return command;
+        }
+    }
+}
+

--- a/src/Cli/dotnet/commands/dotnet-sln/configuration/add/AddConfigToSolutionCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/configuration/add/AddConfigToSolutionCommand.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.Cli.Sln.Internal;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Common;
+using LocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
+
+namespace Microsoft.DotNet.Cli
+{
+    internal class AddConfigToSolutionCommand : CommandBase
+    {
+        private readonly string _fileOrDirectory;
+        private readonly string _configName;
+        private readonly string _platformName;
+        private readonly string _copyFrom;
+        private readonly string _updateProj;
+
+        public AddConfigToSolutionCommand(
+            ParseResult parseResult) : base(parseResult)
+        {
+            //_fileOrDirectory = parseResult.GetValue(ConfigurationCommandParser.ConfigureArgument);
+            _fileOrDirectory = parseResult.GetValue(SlnCommandParser.SlnArgument);
+            _configName = parseResult.GetValue(ConfigurationAddParser.ConfigName);
+            _platformName = parseResult.GetValue(ConfigurationAddParser.PlatformName);
+            _copyFrom = parseResult.GetValue(ConfigurationAddParser.CopyFromConfig);
+            _updateProj = parseResult.GetValue(ConfigurationAddParser.UpdateProject);
+        }
+
+        public override int Execute()
+        {
+            SlnFile slnFile;
+            slnFile = SlnFileFactory.CreateFromFileOrDirectory(_fileOrDirectory);
+
+            if (string.IsNullOrEmpty(_configName) && string.IsNullOrEmpty(_platformName))
+            {
+                throw new GracefulException(LocalizableStrings.ConfigurationAddNewConfigPlatformNameMissing);
+            }
+
+            if (string.IsNullOrEmpty(_updateProj) && string.IsNullOrEmpty(_updateProj))
+            {
+                throw new GracefulException(LocalizableStrings.ConfigurationAddNewConfigOptionUpdateProjMissing);
+            }
+ 
+            try
+            {
+                if (slnFile.AddNewSlnConfig(_configName, _copyFrom, _updateProj))
+                {
+                    slnFile.WriteConfigutations();
+                }
+            }
+            catch (GracefulException e)
+            {
+                switch (e.Message)
+                {
+                    case "ConfigureAddConfigAlreadyExists":
+                        throw new GracefulException(
+                            string.Format(LocalizableStrings.ConfigurationAddConfigAlreadyExists, _configName));
+
+                    case "ConfigureAddCopyFromDoesNotExists":
+                        throw new GracefulException(
+                            string.Format(LocalizableStrings.ConfigurationAddCopyFromConfigDoesNotExists, _copyFrom));
+                }
+            }
+
+            return 0;
+        }
+    }
+}
+

--- a/src/Cli/dotnet/commands/dotnet-sln/configuration/add/ConfigurationAddParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/configuration/add/ConfigurationAddParser.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.DotNet.Cli;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+//using Microsoft.DotNet.Tools.Sln.Add;
+using LocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
+
+namespace Microsoft.DotNet.Cli
+{
+    public static class ConfigurationAddParser
+    {
+        public static readonly CliOption<string> ConfigName = new CliOption<string>("-c", "--config")
+        {
+            Description = LocalizableStrings.ConfigurationAddOptionNewConfigName
+        };
+
+        public static readonly CliOption<string> PlatformName = new CliOption<string>("-p", "--platform")
+        {
+            Description = LocalizableStrings.ConfigurationAddOptionNewPlatformName
+        };
+
+        public static readonly CliOption<string> UpdateProject = new CliOption<string>("-up", "--updateproj")
+        {
+            Description = LocalizableStrings.ConfigurationAddOptionUpdateProjects
+        };
+
+        public static readonly CliOption<string> CopyFromConfig = new CliOption<string>("-cf", "--copyfrom")
+        {
+            Description = LocalizableStrings.ConfigurationAddOptionCopySettingsFrom
+        };
+
+        private static readonly CliCommand Command = ConstructCommand();
+
+        public static CliCommand GetCommand()
+        {
+            return Command;
+        }
+
+        private static CliCommand ConstructCommand()
+        {
+            CliCommand command = new("add", LocalizableStrings.ConfigurationAddCommand);
+
+            command.Options.Add(ConfigName);
+            command.Options.Add(PlatformName);
+            command.Options.Add(CopyFromConfig);
+            command.Options.Add(UpdateProject);
+
+            command.SetAction((parseResult) => new AddConfigToSolutionCommand(parseResult).Execute());
+
+            return command;
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
@@ -27,6 +27,81 @@
         <target state="translated">Přidá do souboru řešení jeden nebo více projektů.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Umístěte projekt do kořene řešení, není potřeba vytvářet složku řešení.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
@@ -27,6 +27,81 @@
         <target state="translated">Fügt einer Projektmappendatei ein oder mehrere Projekte hinzu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Platzieren Sie das Projekt im Stamm der Projektmappe, statt einen Projektmappenordner zu erstellen.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
@@ -27,6 +27,81 @@
         <target state="translated">Agrega uno o varios proyectos a un archivo de solución.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Coloque el proyecto en la raíz de la solución, en lugar de crear una carpeta de soluciones.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
@@ -27,6 +27,81 @@
         <target state="translated">Ajoutez un ou plusieurs projets à un fichier solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Place le projet à la racine de la solution, au lieu de créer un dossier solution.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
@@ -27,6 +27,81 @@
         <target state="translated">Consente di aggiungere uno o più progetti a un file di soluzione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Inserisce il progetto nella radice della soluzione invece di creare una cartella soluzione.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
@@ -27,6 +27,81 @@
         <target state="translated">1 つ以上のプロジェクトをソリューション ファイルに追加します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">ソリューション フォルダーを作成するのではなく、プロジェクトをソリューションのルートに配置します。</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
@@ -27,6 +27,81 @@
         <target state="translated">솔루션 파일에 하나 이상의 프로젝트를 추가합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">솔루션 폴더를 만드는 대신, 솔루션의 루트에 프로젝트를 배치하세요.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
@@ -27,6 +27,81 @@
         <target state="translated">Dodaj co najmniej jeden projekt do pliku rozwiązania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Umieść projekt w katalogu głównym rozwiązania zamiast tworzyć folder rozwiązania.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
@@ -27,6 +27,81 @@
         <target state="translated">Adicionar um ou mais projetos em um arquivo de solução.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Coloque o projeto na raiz da solução, em vez de criar uma pasta da solução.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
@@ -27,6 +27,81 @@
         <target state="translated">Добавление проектов в файл решения.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Поместите проект в корень решения вместо создания папки решения.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
@@ -27,6 +27,81 @@
         <target state="translated">Bir çözüm dosyasına bir veya daha fazla proje ekler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Bir çözüm klasörü oluşturmak yerine projeyi çözümün köküne yerleştirin.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
@@ -27,6 +27,81 @@
         <target state="translated">将一个或多个项目添加到解决方案文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">将项目放在解决方案的根目录下，而不是创建解决方案文件夹。</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
@@ -27,6 +27,81 @@
         <target state="translated">為解決方案檔新增一或多個專案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationAddCommand">
+        <source>Add new config or platform to a solution file.</source>
+        <target state="new">Add new config or platform to a solution file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddConfigAlreadyExists">
+        <source>Solution config {0} already exists.</source>
+        <target state="new">Solution config {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromConfigDoesNotExists">
+        <source>Solution config {0} to copy from, does not exists.</source>
+        <target state="new">Solution config {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddCopyFromPlatformDoesNotExists">
+        <source>Solution platform {0} to copy from, does not exists.</source>
+        <target state="new">Solution platform {0} to copy from, does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigOptionUpdateProjMissing">
+        <source>Update project options is not specified.</source>
+        <target state="new">Update project options is not specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddNewConfigPlatformNameMissing">
+        <source>Specify at least one config or platform to add.</source>
+        <target state="new">Specify at least one config or platform to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionCopySettingsFrom">
+        <source>Existing config or platform to copy project settings from.</source>
+        <target state="new">Existing config or platform to copy project settings from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewConfigName">
+        <source>New config to add to the solution.</source>
+        <target state="new">New config to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionNewPlatformName">
+        <source>New platform to add to the solution.</source>
+        <target state="new">New platform to add to the solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddOptionUpdateProjects">
+        <source>Indicates whether to update project config or platform settings.</source>
+        <target state="new">Indicates whether to update project config or platform settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddPlatformAlreadyExists">
+        <source>Solution platform {0} already exists.</source>
+        <target state="new">Solution platform {0} already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationAddSlnMissing">
+        <source>Solution file does not exists.</source>
+        <target state="new">Solution file does not exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationArgumentSlnDescription">
+        <source>The solution file to operate on. If not specified, the command will search the current directory for one.</source>
+        <target state="new">The solution file to operate on. If not specified, the command will search the current directory for one.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigurationCommand">
+        <source>Configuration Manager commands for .NET CLI.</source>
+        <target state="new">Configuration Manager commands for .NET CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileHeaderMissingError">
+        <source>Expected file header not found</source>
+        <target state="new">Expected file header not found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">請將專案放置在解決方案的根目錄中，而非放置於建立解決方案的資料夾中。</target>

--- a/src/Tests/dotnet-sln.Tests/GivenDotnetSlnConfigurationAdd.cs
+++ b/src/Tests/dotnet-sln.Tests/GivenDotnetSlnConfigurationAdd.cs
@@ -1,0 +1,546 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Sln.Internal;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools;
+using Microsoft.DotNet.Tools.Common;
+using LocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
+
+namespace Microsoft.DotNet.Cli.Sln.Add.Tests
+{
+    public class GivenDotnetSlnConfigurationAdd : SdkTest
+    {
+        private Func<string, string> HelpText = (defaultVal) => $@"Description:
+  Add new config or platform to a solution file.
+
+Usage:
+  dotnet sln <SLN_FILE> configuration add [options]
+
+Arguments:
+  <SLN_FILE>  The solution file to operate on. If not specified, the command will search the current directory for one. [default: {PathUtility.EnsureTrailingSlash(defaultVal)}]
+
+Options:
+  -c, --config <c>        New config to add to the solution.
+  -p, --platform <p>      New platform to add to the solution.
+  -cf, --copyfrom <cf>    Existing config or platform to copy project settings from.
+  -up, --updateproj <up>  Indicates whether to update project config or platform settings.
+  -?, -h, --help          Show command line help.";
+
+        public GivenDotnetSlnConfigurationAdd(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private const string ExpectedSlnWhenNewConfigIsAddedSingleProjCopyfromUpdateProjSlnIsUpdated_n = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26006.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""App"", ""App\App.csproj"", ""{7072A694-548F-4CAE-A58F-12D257D5F486}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		newconfig|Any CPU = newconfig|Any CPU
+		newconfig|x64 = newconfig|x64
+		newconfig|x86 = newconfig|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.ActiveCfg = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.Build.0 = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.ActiveCfg = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.Build.0 = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.ActiveCfg = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.Build.0 = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.ActiveCfg = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.Build.0 = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|Any CPU.ActiveCfg = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|Any CPU.Build.0 = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x64.ActiveCfg = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x64.Build.0 = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x86.ActiveCfg = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x86.Build.0 = Debug|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal
+";
+
+        private const string ExpectedSlnWhenNewConfigIsAddedSingleProjCopyfromUpdateProjSlnIsUpdated_y = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26006.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""App"", ""App\App.csproj"", ""{7072A694-548F-4CAE-A58F-12D257D5F486}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		newconfig|Any CPU = newconfig|Any CPU
+		newconfig|x64 = newconfig|x64
+		newconfig|x86 = newconfig|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.ActiveCfg = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.Build.0 = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.ActiveCfg = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.Build.0 = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.ActiveCfg = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.Build.0 = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.ActiveCfg = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.Build.0 = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|Any CPU.ActiveCfg = newconfig|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|Any CPU.Build.0 = newconfig|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x64.ActiveCfg = newconfig|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x64.Build.0 = newconfig|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x86.ActiveCfg = newconfig|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x86.Build.0 = newconfig|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal
+";
+
+        private const string ExpectedSlnWhenNewConfigIsAddedMultipleProjCopyfromUpdateProjSlnIsUpdated_n = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32929.385
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""App"", ""App\App.csproj"", ""{7072A694-548F-4CAE-A58F-12D257D5F486}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Lib"", ""Lib\Lib.csproj"", ""{D4ED07FD-E893-4D38-8E19-33C3027D687A}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""First"", ""Multiple\First.csproj"", ""{F1383793-E608-49EA-A9BE-B7C26E94850B}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Second"", ""Multiple\Second.csproj"", ""{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		newconfig|Any CPU = newconfig|Any CPU
+		newconfig|x64 = newconfig|x64
+		newconfig|x86 = newconfig|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.ActiveCfg = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.ActiveCfg = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.ActiveCfg = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.Build.0 = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.ActiveCfg = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.Build.0 = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|Any CPU.ActiveCfg = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x64.ActiveCfg = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x86.ActiveCfg = Debug|x86
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x64.Build.0 = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x86.Build.0 = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|Any CPU.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|x64.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|x64.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|x86.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|x86.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x64.Build.0 = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x86.Build.0 = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|Any CPU.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|x64.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|x64.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|x86.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|x86.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x64.Build.0 = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x86.Build.0 = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|Any CPU.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|x64.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|x64.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|x86.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|x86.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {69061246-1432-4C95-A7C9-B17C637C8639}
+	EndGlobalSection
+EndGlobal
+";
+
+        private const string ExpectedSlnWhenNewConfigIsAddedMultipleProjCopyfromUpdateProjSlnIsUpdated_y = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32929.385
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""App"", ""App\App.csproj"", ""{7072A694-548F-4CAE-A58F-12D257D5F486}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Lib"", ""Lib\Lib.csproj"", ""{D4ED07FD-E893-4D38-8E19-33C3027D687A}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""First"", ""Multiple\First.csproj"", ""{F1383793-E608-49EA-A9BE-B7C26E94850B}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Second"", ""Multiple\Second.csproj"", ""{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		newconfig|Any CPU = newconfig|Any CPU
+		newconfig|x64 = newconfig|x64
+		newconfig|x86 = newconfig|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.ActiveCfg = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.ActiveCfg = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.ActiveCfg = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.Build.0 = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.ActiveCfg = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.Build.0 = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|Any CPU.ActiveCfg = newconfig|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x64.ActiveCfg = newconfig|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.newconfig|x86.ActiveCfg = newconfig|x86
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x64.Build.0 = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.Release|x86.Build.0 = Release|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|Any CPU.ActiveCfg = newconfig|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|Any CPU.Build.0 = newconfig|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|x64.ActiveCfg = newconfig|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|x64.Build.0 = newconfig|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|x86.ActiveCfg = newconfig|Any CPU
+		{D4ED07FD-E893-4D38-8E19-33C3027D687A}.newconfig|x86.Build.0 = newconfig|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x64.Build.0 = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.Release|x86.Build.0 = Release|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|Any CPU.ActiveCfg = newconfig|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|Any CPU.Build.0 = newconfig|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|x64.ActiveCfg = newconfig|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|x64.Build.0 = newconfig|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|x86.ActiveCfg = newconfig|Any CPU
+		{F1383793-E608-49EA-A9BE-B7C26E94850B}.newconfig|x86.Build.0 = newconfig|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x64.Build.0 = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.Release|x86.Build.0 = Release|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|Any CPU.ActiveCfg = newconfig|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|Any CPU.Build.0 = newconfig|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|x64.ActiveCfg = newconfig|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|x64.Build.0 = newconfig|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|x86.ActiveCfg = newconfig|Any CPU
+		{5F64398F-08F6-4FDA-87DE-6F138AF81DC8}.newconfig|x86.Build.0 = newconfig|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {69061246-1432-4C95-A7C9-B17C637C8639}
+	EndGlobalSection
+EndGlobal
+";
+
+        private const string ExpectedSlnWhenNewConfigIsAddedSlnFileWithNoProjectReferencesSlnIsUpdated = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26006.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		newconfig|Any CPU = newconfig|Any CPU
+		newconfig|x64 = newconfig|x64
+		newconfig|x86 = newconfig|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal
+";
+
+        [Theory]
+        [InlineData("--help")]
+        [InlineData("-h")]
+        [InlineData("-?")]
+        [InlineData("/?")]
+        public void WhenHelpOptionIsPassedItPrintsUsage(string helpArg)
+        {
+            var cmd = new DotnetCommand(Log)
+                .Execute($"sln", "configuration", "add", helpArg);
+            cmd.Should().Pass();
+            cmd.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized(HelpText(Directory.GetCurrentDirectory()));
+        }
+
+        [Theory]
+        [InlineData("")]
+        public void WhenNoCommandIsPassedItPrintsError(string commandName)
+        {
+            var cmd = new DotnetCommand(Log)
+                .Execute($"sln configuration {commandName}".Trim().Split());
+            cmd.Should().Fail();
+            cmd.StdErr.Should().Be(CommonLocalizableStrings.RequiredCommandNotPassed);
+        }
+
+        [Theory]
+        [InlineData("unknownCommandName")]
+        public void WhenUnknownCommandIsPassedItPrintsError(string commandName)
+        {
+            var cmd = new DotnetCommand(Log)
+                .Execute($"sln configuration {commandName}".Trim().Split());
+            cmd.Should().Fail();
+            cmd.StdErr.Should().Be("Unrecognized command or argument 'unknownCommandName'.");
+        }
+
+        [Fact]
+        public void WhenNoConfigIsPassedItPrintsErrorAndUsage()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndReferenceToSingleCsproj", identifier: "GivenDotnetSlnConfigurationAdd")
+                .WithSource()
+                .Path;
+
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(@"sln", "App.sln", "configuration", "add");
+            cmd.Should().Fail();
+            cmd.StdErr.Should().Be(LocalizableStrings.ConfigurationAddNewConfigPlatformNameMissing);
+            cmd.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized("");
+        }
+
+        [Fact]
+        public void WhenNoUnpdateProjIsPassedItPrintsErrorAndUsage()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndReferenceToSingleCsproj", identifier: "GivenDotnetSlnConfigurationAdd")
+                .WithSource()
+                .Path;
+
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(@"sln", "App.sln", "configuration", "add", "-c", "newconfig");
+            cmd.Should().Fail();
+            cmd.StdErr.Should().Be(LocalizableStrings.ConfigurationAddNewConfigOptionUpdateProjMissing);
+            cmd.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized("");
+        }
+
+        [Fact]
+        public void WhenNewConfigIsAddedSingleProjCopyfromUpdateProjSlnIsUpdated_n()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndReferenceToSingleCsproj")
+                .WithSource()
+                .Path;
+
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"sln", "App.sln", "configuration", "add", "-c", "newconfig", "-cf", "Debug", "-up", "n");
+            cmd.Should().Pass();
+
+            var slnPath = Path.Combine(projectDirectory, "App.sln");
+            File.ReadAllText(slnPath)
+                .Should().BeVisuallyEquivalentTo(ExpectedSlnWhenNewConfigIsAddedSingleProjCopyfromUpdateProjSlnIsUpdated_n);
+        }
+
+        [Fact]
+        public void WhenNewConfigIsAddedSingleProjCopyfromUpdateProjSlnIsUpdated_y()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndReferenceToSingleCsproj")
+                .WithSource()
+                .Path;
+
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"sln", "App.sln", "configuration", "add", "-c", "newconfig", "-cf", "Debug", "-up", "y");
+            cmd.Should().Pass();
+
+            var slnPath = Path.Combine(projectDirectory, "App.sln");
+            File.ReadAllText(slnPath)
+                .Should().BeVisuallyEquivalentTo(ExpectedSlnWhenNewConfigIsAddedSingleProjCopyfromUpdateProjSlnIsUpdated_y);
+
+        }
+
+        [Fact]
+        public void WhenNewConfigIsAddedMultipleProjCopyfromUpdateProjSlnIsUpdated_n()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndReferencesToMultipleCsproj")
+                .WithSource()
+                .Path;
+
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"sln", "App.sln", "configuration", "add", "-c", "newconfig", "-cf", "Debug", "-up", "n");
+            cmd.Should().Pass();
+
+            var slnPath = Path.Combine(projectDirectory, "App.sln");
+            File.ReadAllText(slnPath)
+                .Should().BeVisuallyEquivalentTo(ExpectedSlnWhenNewConfigIsAddedMultipleProjCopyfromUpdateProjSlnIsUpdated_n);
+        }
+
+        [Fact]
+        public void WhenNewConfigIsAddedMultipleProjCopyfromUpdateProjSlnIsUpdated_y()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndReferencesToMultipleCsproj")
+                .WithSource()
+                .Path;
+
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"sln", "App.sln", "configuration", "add", "-c", "newconfig", "-cf", "Debug", "-up", "y");
+            cmd.Should().Pass();
+
+            var slnPath = Path.Combine(projectDirectory, "App.sln");
+            File.ReadAllText(slnPath)
+                .Should().BeVisuallyEquivalentTo(ExpectedSlnWhenNewConfigIsAddedMultipleProjCopyfromUpdateProjSlnIsUpdated_y);
+
+        }
+
+        [Fact]
+        public void WhenNewConfigIsAddedSlnFileWithNoProjectReferencesSlnIsUpdated()
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("SlnFileWithNoProjectReferencesAndCSharpProject")
+                .WithSource()
+                .Path;
+
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"sln", "App.sln", "configuration", "add", "-c", "newconfig", "-cf", "Debug", "-up", "y");
+            cmd.Should().Pass();
+
+            var slnPath = Path.Combine(projectDirectory, "App.sln");
+            File.ReadAllText(slnPath)
+                .Should().BeVisuallyEquivalentTo(ExpectedSlnWhenNewConfigIsAddedSlnFileWithNoProjectReferencesSlnIsUpdated);
+        }
+
+        private string GetExpectedSlnContents(
+            string slnPath,
+            string slnTemplate,
+            string expectedLibProjectGuid = null)
+        {
+            var slnFile = SlnFile.Read(slnPath);
+
+            if (string.IsNullOrEmpty(expectedLibProjectGuid))
+            {
+                var matchingProjects = slnFile.Projects
+                    .Where((p) => p.FilePath.EndsWith("Lib.csproj"))
+                    .ToList();
+
+                matchingProjects.Count.Should().Be(1);
+                var slnProject = matchingProjects[0];
+                expectedLibProjectGuid = slnProject.Id;
+            }
+            var slnContents = slnTemplate.Replace("__LIB_PROJECT_GUID__", expectedLibProjectGuid);
+
+            var matchingSrcFolder = slnFile.Projects
+                    .Where((p) => p.FilePath == "src")
+                    .ToList();
+            if (matchingSrcFolder.Count == 1)
+            {
+                slnContents = slnContents.Replace("__SRC_FOLDER_GUID__", matchingSrcFolder[0].Id);
+            }
+
+            var matchingSolutionFolder = slnFile.Projects
+                    .Where((p) => p.FilePath == "TestFolder")
+                    .ToList();
+            if (matchingSolutionFolder.Count == 1)
+            {
+                slnContents = slnContents.Replace("__SOLUTION_FOLDER_GUID__", matchingSolutionFolder[0].Id);
+            }
+
+            return slnContents;
+        }
+    }
+}


### PR DESCRIPTION
As reported in https://github.com/dotnet/sdk/issues/10359 support for custom configurations is missing currently in dotnet cli.
A new dotnet sln configuration command will enable to add, remove, rename, update the config or platform to a solution file.
This PR is for 'add' command, limited to adding config to a solution file.
dotnet sln [<SOLUTION_FILE>] configuration add -c|--config [-cf|--copyfrom ] [-up|--updateproj <y/n>]

PRs for, 1) 'add' command to add platform 2) 'remove', 'rename', 'update' commands, to follow after this PR is approved.

Original changes were submitted in https://github.com/dotnet/sdk/pull/29139. @marcpopMSFT As suggested, the changes have been reworked to move the configuration command to be part of dotnet sln.
