### PR TITLE
Fix runtime pack selection for `dotnet build` with PublishAot=true and PublishAotUsingRuntimePack=true

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -86,7 +86,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Allow opt-in to NativeAOT runtime pack for .NET 8.0 or higher -->
     <FrameworkReference Update="Microsoft.NETCore.App"
                         RuntimePackLabels="NativeAOT"
-                        Condition="'$(PublishAotUsingRuntimePack)' == 'true' And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '8.0')" />
+                        Condition="'$(_IsPublishing)' == 'true' and '$(PublishAotUsingRuntimePack)' == 'true' And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '8.0')" />
 
   </ItemGroup>
 


### PR DESCRIPTION
When using `dotnet build` instead of `dotnet publish` we are not really running NativeAOT compilation. We are just running a regular build with additional trimming analyzers and options. Thus we are not supposed to use the NativeAOT runtime pack.