### PR TITLE
Correct command model for nuget trust command and subcommands

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -271,7 +271,7 @@ namespace Microsoft.DotNet.Cli
                     option.EnsureHelpName();
                 }
 
-                if (command.Name.Equals(NuGetCommandParser.GetCommand().Name))
+                if (command.Equals(NuGetCommandParser.GetCommand()) || command.Parents.Any(parent => parent == NuGetCommandParser.GetCommand()))
                 {
                     NuGetCommand.Run(context.ParseResult);
                 }

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -166,11 +166,17 @@ namespace Microsoft.DotNet.Cli
                 new CliOption<string>("--source-url"),
             };
 
-            CliCommand CertificateCommand() => new CliCommand("certificate") {
-                new CliArgument<string>("NAME"),
-                new CliArgument<string>("FINGERPRINT"),
-                allowUntrustedRoot,
-                new CliOption<string>("--algorithm")
+            CliCommand CertificateCommand() {
+                CliOption<string> algorithm = new("--algorithm");
+                algorithm.DefaultValueFactory = () => "SHA256";
+                algorithm.AcceptOnlyFromAmong("SHA256", "SHA384", "SHA512");
+
+                return new CliCommand("certificate") {
+                    new CliArgument<string>("NAME"),
+                    new CliArgument<string>("FINGERPRINT"),
+                    allowUntrustedRoot,
+                    algorithm
+                };
             };
 
             CliCommand RemoveCommand() => new CliCommand("remove") {

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -168,7 +168,7 @@ namespace Microsoft.DotNet.Cli
 
             CliCommand CertificateCommand() {
                 CliOption<string> algorithm = new("--algorithm");
-                algorithm.DefaultValueFactory = () => "SHA256";
+                algorithm.DefaultValueFactory = (_argResult) => "SHA256";
                 algorithm.AcceptOnlyFromAmong("SHA256", "SHA384", "SHA512");
 
                 return new CliCommand("certificate") {

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -120,22 +120,70 @@ namespace Microsoft.DotNet.Cli
         {
             CliCommand trustCommand = new("trust");
 
-            CliArgument<string> commandArgument = new CliArgument<string>("command") { Arity = ArgumentArity.ZeroOrOne };
-            commandArgument.AcceptOnlyFromAmong(new string[] { "list", "author", "repository", "source", "certificate", "remove", "sync" });
+            CliOption<bool> allowUntrustedRoot = new("--allow-untrusted-root");
+            CliOption<string> owners = new("--owners");
 
-            trustCommand.Arguments.Add(commandArgument);
+            trustCommand.Subcommands.Add (new CliCommand("list"));
+            trustCommand.Subcommands.Add (AuthorCommand());
+            trustCommand.Subcommands.Add (RepositoryCommand());
+            trustCommand.Subcommands.Add (SourceCommand());
+            trustCommand.Subcommands.Add (CertificateCommand());
+            trustCommand.Subcommands.Add (RemoveCommand());
+            trustCommand.Subcommands.Add (SyncCommand());
 
-            trustCommand.Options.Add(new CliOption<string>("--algorithm"));
-            trustCommand.Options.Add(new CliOption<bool>("--allow-untrusted-root"));
-            trustCommand.Options.Add(new CliOption<string>("--owners"));
-            trustCommand.Options.Add(new CliOption<string>("--configfile"));
+            CliOption<string> configFile = new("--configfile");
+
+            // now set global options for all nuget commands: configfile, verbosity
+            // as well as the standard NugetCommand.Run handler
+
+            trustCommand.Options.Add(configFile);
             trustCommand.Options.Add(CommonOptions.VerbosityOption);
-
             trustCommand.SetAction(NuGetCommand.Run);
+
+            foreach (var command in trustCommand.Subcommands)
+            {
+                command.Options.Add(configFile);
+                command.Options.Add(CommonOptions.VerbosityOption);
+                command.SetAction(NuGetCommand.Run);
+            }
+
+            CliCommand AuthorCommand() => new CliCommand("author") {
+                new CliArgument<string>("NAME"),
+                new CliArgument<string>("PACKAGE"),
+                allowUntrustedRoot,
+            };
+
+            CliCommand RepositoryCommand() => new CliCommand("repository") {
+                new CliArgument<string>("NAME"),
+                new CliArgument<string>("PACKAGE"),
+                allowUntrustedRoot,
+                owners
+            };
+
+            CliCommand SourceCommand() => new CliCommand("source") {
+                new CliArgument<string>("NAME"),
+                owners,
+                new CliOption<string>("--source-url"),
+            };
+
+            CliCommand CertificateCommand() => new CliCommand("certificate") {
+                new CliArgument<string>("NAME"),
+                new CliArgument<string>("FINGERPRINT"),
+                allowUntrustedRoot,
+                new CliOption<string>("--algorithm")
+            };
+
+            CliCommand RemoveCommand() => new CliCommand("remove") {
+                new CliArgument<string>("NAME"),
+            };
+
+            CliCommand SyncCommand() => new CliCommand("sync") {
+                new CliArgument<string>("NAME"),
+            };
 
             return trustCommand;
         }
-        
+
         private static CliCommand GetSignCommand()
         {
             CliCommand signCommand = new("sign");

--- a/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -233,10 +233,7 @@ namespace Microsoft.DotNet.Tests.Commands
         public void GivenNuGetTrustCommandItDisplaysCompletions()
         {
             var expected = new[] {
-                "--algorithm",
-                "--allow-untrusted-root",
                 "--configfile",
-                "--owners",
                 "--verbosity",
                 "--help",
                 "-v",


### PR DESCRIPTION
Flow down this change from rc1 to 8.0.100 stable so that we don't lose it.