### PR TITLE
Add AdditionalRuntimeIdentifier if building from source

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -3,7 +3,7 @@
   <Target Name="PublishPortableRuntimeIdentifierGraph"
           BeforeTargets="Build">
 
-      <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(TargetRid)' != '' AND '$(TargetRid)' != '$(PortableRid)'">
+      <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(TargetRid)' != '' AND '$(PortableRid)' != '' AND '$(TargetRid)' != '$(PortableRid)'">
         <AdditionalRuntimeIdentifier Include="$(TargetRid)" Imports="$(PortableRid)" />
       </ItemGroup>
 

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -2,7 +2,11 @@
 
   <Target Name="PublishPortableRuntimeIdentifierGraph"
           BeforeTargets="Build">
-    
+
+      <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(TargetRid)' != '' AND '$(TargetRid)' != '$(PortableRid)'">
+        <AdditionalRuntimeIdentifier Include="$(TargetRid)" Imports="$(PortableRid)" />
+      </ItemGroup>
+
       <UpdatePortableRuntimeIdentifierGraph
         InputFile="PortableRuntimeIdentifierGraph.json"
         OutputFile="$(OutputPath)/PortableRuntimeIdentifierGraph.json"


### PR DESCRIPTION
Specify RID to add to graph per mechanism in https://github.com/dotnet/sdk/pull/34279

This needs https://github.com/dotnet/installer/pull/17197 to actually work (`TargetRid` is currently not set).

Fixes https://github.com/dotnet/source-build/issues/3584

cc @tmds @dotnet/source-build-internal 