### PR TITLE
reenable CI for the 1xx branch

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - main
+    - release/8.0.1xx
     - internal/release/*
     - exp/*
 


### PR DESCRIPTION
RC2 is still public and we need CI builds from there to flow