### PR TITLE
[release/8.0.1xx-rc1] Fix runtime pack selection for `dotnet build` with PublishAot=true and PublishAotUsingRuntimePack=true

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -86,7 +86,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Allow opt-in to NativeAOT runtime pack for .NET 8.0 or higher -->
     <FrameworkReference Update="Microsoft.NETCore.App"
                         RuntimePackLabels="NativeAOT"
-                        Condition="'$(PublishAotUsingRuntimePack)' == 'true' And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '8.0')" />
+                        Condition="'$(_IsPublishing)' == 'true' and '$(PublishAotUsingRuntimePack)' == 'true' And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '8.0')" />
 
   </ItemGroup>
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/34640