### PR TITLE
Allow ArtifactsPath telemetry to flow

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -27,6 +27,9 @@ namespace Microsoft.DotNet.Tools.MSBuild
         internal const string SelfContainedTelemetryPropertyKey = "SelfContained";
         internal const string UseApphostTelemetryPropertyKey = "UseApphost";
         internal const string OutputTypeTelemetryPropertyKey = "OutputType";
+        internal const string UseArtifactsOutputTelemetryPropertyKey = "UseArtifactsOutput";
+        internal const string ArtifactsPathLocationTypeTelemetryPropertyKey = "ArtifactsPathLocationType";
+
 
         public MSBuildLogger()
         {
@@ -95,7 +98,9 @@ namespace Microsoft.DotNet.Tools.MSBuild
                     RuntimeIdentifierTelemetryPropertyKey,
                     SelfContainedTelemetryPropertyKey,
                     UseApphostTelemetryPropertyKey,
-                    OutputTypeTelemetryPropertyKey
+                    OutputTypeTelemetryPropertyKey,
+                    UseArtifactsOutputTelemetryPropertyKey,
+                    ArtifactsPathLocationTypeTelemetryPropertyKey
                 })
                 {
                     if (args.Properties.TryGetValue(key, out string value))
@@ -139,7 +144,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             else
             {
                 var passthroughEvents = new string[] {
-                    SdkTaskBaseCatchExceptionTelemetryEventName, 
+                    SdkTaskBaseCatchExceptionTelemetryEventName,
                     PublishPropertiesTelemetryEventName,
                     ReadyToRunTelemetryEventName };
 


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/32685 tried to do too much and got stuck in testing - this just explicitly adds and hashes the two ArtifactsPath-related properties we added back in preview 3, so that we can actually see them in telemetry.