### PR TITLE
Fix in Microsoft.NET.Sdk.DefaultItems.targets for .DS_Store causing build failures on MacOSX

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -33,6 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.*proj</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.sln</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.vssscc</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/.DS_Store</DefaultItemExcludes>
 
     <!-- WARNING: This pattern is there to ignore folders such as .git and .vs, but it will also match items included with a
          relative path outside the project folder (for example "..\Shared\Shared.cs").  So be sure only to apply it to items


### PR DESCRIPTION
Context:

.DS_Store file is internal MacOSX file created by Finder and it is irrelevant for .NET builds, but can interfere with .NET builds.

Examples of build failures (dotnet/maui issues):

- https://github.com/dotnet/maui/issues/13452
  Resizetizer is not working if you get a .DS_Store file inside you Fonts files folder #13452
- https://github.com/dotnet/maui/issues/14279
  Microsoft.Maui.Resizetizer.targets breaks build on macOS #14279

Cause is globbing patterns which include `.DS_Store` on MacOSX:

https://github.com/dotnet/maui/blob/main/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj#L48 
https://github.com/dotnet/maui/blob/main/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj#L52

The workarounds in MAUI repo was:

1. to add `Exclude = "Resources\Images\.DS_Store" to MauiImage`
   ```
   <MauiImage Include="Resources\Images\*" Exclude = "Resources\Images\.DS_Store" />
   ```
2. to add property:
   ```
   <DefaultItemExcludes>$(DefaultItemExcludes);**\.DS_Store</DefaultItemExcludes>
   ```
   and use it for ItemGroups:
   ```
   <MauiImage Include="Resources\Images\*" Exclude="$(DefaultItemExcludes)" />
   ```