### PR TITLE
[release/8.0.1xx-rc1] Add WorkloadPublishProperties telemetry event

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         internal const string SdkTaskBaseCatchExceptionTelemetryEventName = "taskBaseCatchException";
         internal const string PublishPropertiesTelemetryEventName = "PublishProperties";
+        internal const string WorkloadPublishPropertiesTelemetryEventName = "WorkloadPublishProperties";
         internal const string ReadyToRunTelemetryEventName = "ReadyToRun";
 
         internal const string TargetFrameworkVersionTelemetryPropertyKey = "TargetFrameworkVersion";
@@ -124,6 +125,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 case SdkTaskBaseCatchExceptionTelemetryEventName:
                 case PublishPropertiesTelemetryEventName:
                 case ReadyToRunTelemetryEventName:
+                case WorkloadPublishPropertiesTelemetryEventName:
                     TrackEvent(telemetry, args.EventName, args.Properties, Array.Empty<string>(), Array.Empty<string>() );
                     break;
                 default:


### PR DESCRIPTION
The Mono.ToolChain.Current manifest added a publish target for wasm and mobile workloads that send telemetry events for the type of configuration and options being used. This change allows that event to be fully tracked.