### PR TITLE
[release/8.0.1xx] Add WorkloadPublishProperties telemetry event

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         internal const string SdkTaskBaseCatchExceptionTelemetryEventName = "taskBaseCatchException";
         internal const string PublishPropertiesTelemetryEventName = "PublishProperties";
+        internal const string WorkloadPublishPropertiesTelemetryEventName = "WorkloadPublishProperties";
         internal const string ReadyToRunTelemetryEventName = "ReadyToRun";
 
         internal const string TargetFrameworkVersionTelemetryPropertyKey = "TargetFrameworkVersion";
@@ -141,6 +142,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 var passthroughEvents = new string[] {
                     SdkTaskBaseCatchExceptionTelemetryEventName, 
                     PublishPropertiesTelemetryEventName,
+                    WorkloadPublishPropertiesTelemetryEventName,
                     ReadyToRunTelemetryEventName };
 
                 if (passthroughEvents.Contains(args.EventName))


### PR DESCRIPTION
The Mono.ToolChain.Current manifest added a publish target for wasm and mobile workloads that send telemetry events for the type of configuration and options being used. This change allows that event to be fully tracked.