### PR TITLE
Implement automated cleanup of stage 0

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -154,6 +154,9 @@ function CleanOutStage0ToolsetsAndRuntimes {
       Remove-Item (Join-Path $coreRuntimePath "$majorVersion.*") -Recurse
       Remove-Item (Join-Path $wdRuntimePath "$majorVersion.*") -Recurse
       Remove-Item (Join-Path $sdkPath "$majorVersion.*") -Recurse
+      Remove-Item (Join-Path $dotnetRoot "packs") -Recurse
+      Remove-Item (Join-Path $dotnetRoot "sdk-manifests") -Recurse
+      Remove-Item (Join-Path $dotnetRoot "templates") -Recurse
       throw "Installed a new SDK, deleting existing shared frameworks and sdk folders. Please rerun build"
     }
   }
@@ -166,5 +169,3 @@ function CleanOutStage0ToolsetsAndRuntimes {
 InitializeCustomSDKToolset
 
 CleanOutStage0ToolsetsAndRuntimes
-
-throw "exit early"

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -133,4 +133,38 @@ function InstallDotNetSharedFramework([string]$version) {
   }
 }
 
+# Let's clear out the stage-zero folders that map to the current runtime to keep stage 2 clean
+function CleanOutStage0ToolsetsAndRuntimes {
+  $GlobalJson = Get-Content -Raw -Path (Join-Path $RepoRoot 'global.json') | ConvertFrom-Json
+  $dotnetSdkVersion = $GlobalJson.tools.dotnet
+  $dotnetRoot = $env:DOTNET_INSTALL_DIR
+  $versionPath = Join-Path $dotnetRoot '.version'
+  $aspnetRuntimePath = [IO.Path]::Combine( $dotnetRoot, 'shared' ,'Microsoft.AspNetCore.App')
+  $coreRuntimePath = [IO.Path]::Combine( $dotnetRoot, 'shared' ,'Microsoft.NETCore.App')
+  $wdRuntimePath = [IO.Path]::Combine( $dotnetRoot, 'shared', 'Microsoft.WindowsDesktop.App')
+  $sdkPath = Join-Path $dotnetRoot 'sdk'
+  $majorVersion = $dotnetSdkVersion.Substring(0,1)
+
+  if (Test-Path($versionPath)) {
+    $lastInstalledSDK = Get-Content -Raw -Path ($versionPath)
+    if ($lastInstalledSDK -ne $dotnetSdkVersion)
+    {
+      $dotnetSdkVersion | Out-File -FilePath $versionPath -NoNewline
+      Remove-Item (Join-Path $aspnetRuntimePath "$majorVersion.*") -Recurse
+      Remove-Item (Join-Path $coreRuntimePath "$majorVersion.*") -Recurse
+      Remove-Item (Join-Path $wdRuntimePath "$majorVersion.*") -Recurse
+      Remove-Item (Join-Path $sdkPath "$majorVersion.*") -Recurse
+      throw "Installed a new SDK, deleting existing shared frameworks and sdk folders. Please rerun build"
+    }
+  }
+  else
+  {
+    $dotnetSdkVersion | Out-File -FilePath $versionPath -NoNewline
+  }
+}
+
 InitializeCustomSDKToolset
+
+CleanOutStage0ToolsetsAndRuntimes
+
+throw "exit early"

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -68,4 +68,52 @@ export NUGET_PACKAGES=$NUGET_PACKAGES
   echo "$scriptContents" > ${scriptPath}
 }
 
+# ReadVersionFromJson [json key]
+function ReadGlobalVersion {
+  local key=$1
+
+  if command -v jq &> /dev/null; then
+    _ReadGlobalVersion="$(jq -r ".[] | select(has(\"$key\")) | .\"$key\"" "$global_json_file")"
+  elif [[ "$(cat "$global_json_file")" =~ \"$key\"[[:space:]\:]*\"([^\"]+) ]]; then
+    _ReadGlobalVersion=${BASH_REMATCH[1]}
+  fi
+
+  if [[ -z "$_ReadGlobalVersion" ]]; then
+    Write-PipelineTelemetryError -category 'Build' "Error: Cannot find \"$key\" in $global_json_file"
+    ExitWithExitCode 1
+  fi
+}
+
+function CleanOutStage0ToolsetsAndRuntimes {
+  ReadGlobalVersion "dotnet"
+  local dotnetSdkVersion=$_ReadGlobalVersion
+  local dotnetRoot=$DOTNET_INSTALL_DIR
+  local versionPath="$dotnetRoot/.version"
+  local majorVersion="${dotnetSdkVersion:0:1}"
+  local aspnetRuntimePath="$dotnetRoot/shared/Microsoft.AspNetCore.App/$majorVersion.*"
+  local coreRuntimePath="$dotnetRoot/shared/Microsoft.NETCore.App/$majorVersion.*"
+  local wdRuntimePath="$dotnetRoot/shared/Microsoft.WindowsDesktop.App/$majorVersion.*"
+  local sdkPath="$dotnetRoot/sdk/$majorVersion.*"
+
+  if [ -f "$versionPath" ]; then
+    local lastInstalledSDK=$(cat $versionPath)
+    if [[ "$lastInstalledSDK" != "$dotnetSdkVersion" ]]; then
+      echo $dotnetSdkVersion > $versionPath
+      rm -rf $aspnetRuntimePath
+      rm -rf $coreRuntimePath
+      rm -rf $wdRuntimePath
+      rm -rf $sdkPath
+      rm -rf "$dotnetRoot/packs"
+      rm -rf "$dotnetRoot/sdk-manifests"
+      rm -rf "$dotnetRoot/templates"
+      Write-PipelineTelemetryError -category 'Build' "Found old version of SDK, cleaning out folder. Please run build.sh again"
+      ExitWithExitCode 1
+    fi
+  else
+    echo $dotnetSdkVersion > $versionPath
+  fi
+}
+
 InitializeCustomSDKToolset
+
+CleanOutStage0ToolsetsAndRuntimes


### PR DESCRIPTION
In discussions, we've seen folks have a lot of issues with the .dotnet folder grow larger and larger and cause issues (like with multiple template folders). Since we use stage0 both to build the SDK but also to create the stage2 SDK, it can cause issues with our tooling as well in the Overlay target.

In this PR, we write out a .version file in the .dotnet directory with the sdk version in global.json (which we just installed). 

In future builds, if this version is different than what's in the global.json, we delete a bunch of folders from the .dotnet repo and then ask the developer to rerun. I don't believe we can rerun as we would risk a circular dependency.

Do folks want this to be in place?