### PR TITLE
[release/8.0.1xx] Add AdditionalRuntimeIdentifier if building from source

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -2,7 +2,11 @@
 
   <Target Name="PublishPortableRuntimeIdentifierGraph"
           BeforeTargets="Build">
-    
+
+      <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(TargetRid)' != '' AND '$(PortableRid)' != '' AND '$(TargetRid)' != '$(PortableRid)'">
+        <AdditionalRuntimeIdentifier Include="$(TargetRid)" Imports="$(PortableRid)" />
+      </ItemGroup>
+
       <UpdatePortableRuntimeIdentifierGraph
         InputFile="PortableRuntimeIdentifierGraph.json"
         OutputFile="$(OutputPath)/PortableRuntimeIdentifierGraph.json"


### PR DESCRIPTION
Port of https://github.com/dotnet/sdk/pull/34650

Specify RID to add to graph per mechanism in https://github.com/dotnet/sdk/pull/34279

Issue: https://github.com/dotnet/source-build/issues/3584