### PR TITLE
Enable interceptors feature when ConfigurationBindingGenerator is enabled

### DIFF
--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -59,8 +59,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableConfigurationBindingGenerator Condition="'$(EnableConfigurationBindingGenerator)' == ''">true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 
-  <!-- Enable the interceptors compiler feature by default for projects that use the RequestDelegateGenerator. -->
-  <PropertyGroup Condition="'$(EnableRequestDelegateGenerator)' == 'true'">
+  <!-- Enable the interceptors compiler feature by default for projects that use the RequestDelegateGenerator or the ConfigurationBindingGenerator. -->
+  <PropertyGroup Condition="'$(EnableRequestDelegateGenerator)' == 'true' Or $(EnableConfigurationBindingGenerator)' == 'true'">
     <Features>$(Features);InterceptorsPreview</Features>
   </PropertyGroup>
 


### PR DESCRIPTION
Assuming we don't change our minds about this approach, I'm setting up this PR to merge along side the ConfigBindingGenerator implementation. https://github.com/dotnet/runtime/pull/90340/.

cc @ericstj 