### PR TITLE
Fix CanSortByDownloadCountAndThenByName test by using CurrentCulture comparison to match product

### DIFF
--- a/src/Tests/dotnet-new.Tests/DotnetNewSearchTests.cs
+++ b/src/Tests/dotnet-new.Tests/DotnetNewSearchTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Utils;
@@ -461,7 +461,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             // rows can be shrunk: ML.NET Console App for Training and ML.NET Console App for Train...
             // in this case ML.NET Console App for Training < ML.NET Console App for Train...
             // therefore use custom comparer
-            var nameComparer = new ShrinkAwareOrdinalStringComparer();
+            var nameComparer = new ShrinkAwareCurrentCultureStringComparer();
             var downloadCountComparer = new DownloadCountComparer();
 
             var orderedRows = tableOutput
@@ -935,7 +935,7 @@ For more information, run:
             }
         }
 
-        private class ShrinkAwareOrdinalStringComparer : IComparer<string>
+        private class ShrinkAwareCurrentCultureStringComparer : IComparer<string>
         {
             public int Compare(string? left, string? right)
             {
@@ -958,18 +958,18 @@ For more information, run:
                 bool rightIsShrunk = right.EndsWith("...");
                 if (!(leftIsShrunk ^ rightIsShrunk))
                 {
-                    return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+                    return string.Compare(left, right, StringComparison.CurrentCultureIgnoreCase);
                 }
 
-                if (rightIsShrunk && left.StartsWith(right.Substring(0, right.Length - 3), StringComparison.OrdinalIgnoreCase))
+                if (rightIsShrunk && left.StartsWith(right.Substring(0, right.Length - 3), StringComparison.CurrentCultureIgnoreCase))
                 {
                     return -1;
                 }
-                if (leftIsShrunk && right.StartsWith(left.Substring(0, left.Length - 3), StringComparison.OrdinalIgnoreCase))
+                if (leftIsShrunk && right.StartsWith(left.Substring(0, left.Length - 3), StringComparison.CurrentCultureIgnoreCase))
                 {
                     return 1;
                 }
-                return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+                return string.Compare(left, right, StringComparison.CurrentCultureIgnoreCase);
             }
         }
 


### PR DESCRIPTION
In recent test runs, `CanSortByDownloadCountAndThenByName` is failing with:
```
Assert.Equal() Failure\n          ↓ (pos 0)\nExpected: AtCoderFs templ...\nActual:   [MDP.Net] 主控...\n          ↑ (pos 0)
```
https://dev.azure.com/dnceng-public/public/_build/results?buildId=382195&view=ms.vss-test-web.build-test-results-tab&runId=8153796&resultId=100059&paneView=debug

The tests were determining the expected order by comparing with `OrdinalIgnoreCase`, but the product uses `CurrentCultureIgnoreCase`:
https://github.com/dotnet/sdk/blob/cfa6ec2353784e22171bc4539181a1a935e066e9/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs#L190
This makes the tests use `CurrentCultureIgnoreCase` to match the product.