### PR TITLE
[Blazor] Remove hot reload deltas cache

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -3,12 +3,7 @@ export function receiveHotReload() {
 }
 
 export async function receiveHotReloadAsync() {
-  const cache = window.sessionStorage.getItem('blazor-webassembly-cache');
-  let headers;
-  if (cache) {
-    headers = { 'if-none-match' : cache.etag };
-  }
-  const response = await fetch('/_framework/blazor-hotreload', { headers });
+  const response = await fetch('/_framework/blazor-hotreload');
   if (response.status === 200) {
     const deltas = await response.json();
     if (deltas) {

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -124,7 +124,7 @@ setTimeout(async function () {
     styleElement.parentNode.insertBefore(newElement, styleElement.nextSibling);
   }
 
-  function applyBlazorDeltas(serverSecret, deltas, sendErrorToClient) {
+  async function applyBlazorDeltas(serverSecret, deltas, sendErrorToClient) {
     if (sharedSecret && (serverSecret != sharedSecret.encodedSharedSecret)) {
       // Validate the shared secret if it was specified. It might be unspecified in older versions of VS
       // that do not support this feature as yet.
@@ -143,16 +143,15 @@ setTimeout(async function () {
           console.warn(error);
           applyError = error;
         }
-      }); 
+      });
     }
 
-    fetch('/_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: JSON.stringify(deltas) })
-      .then(response => {
-        if (response.status == 200) {
-          const etag = response.headers['etag'];
-          window.sessionStorage.setItem('blazor-webassembly-cache', { etag, deltas });
-        }
-      });
+    try {
+      await fetch('/_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: JSON.stringify(deltas) });
+    } catch (error) {
+      console.warn(error);
+      applyError = error;
+    }
 
     if (applyError) {
       sendDeltaNotApplied(sendErrorToClient ? applyError : undefined);


### PR DESCRIPTION
# [Blazor] Remove hot reload deltas cache

Removes the cache containing hot reload deltas to apply after Blazor WebAssembly startup.

## Description

The hot reload deltas cache allows hot reload edits to get applied after Blazor WebAssembly startup without fetching them over localhost. However, the cache hasn't worked prior to this PR because:
* The Etag header was not being read correctly (always `undefined`)
* The `BlazorHotReload.js` script didn't read the cached deltas in the case of a cache hit. This would cause the Blazor application to not have the latest hot reload edits after the page was refreshed, if it weren't for the previous Etag bug.
* Only the most recent deltas were cached, but deltas for the entire session need to be cached in order to be applied correctly after a refresh. This bug also never manifested due to the aforementioned Etag bug.

Due to the complexity involved in addressing these bugs and the marginal performance gains of the cache (see the next section), I've opted to remove the hot reload deltas cache.

## Alternative

Fix the hot reload deltas cache. I implemented this in a [separate branch](https://github.com/dotnet/sdk/compare/mbuck/fix-deltas-cache) to determine whether the performance gains were worth the extra complexity. I found that, even after a long hot reload session with dozens of edits, the cache only saved between 2-3 _milliseconds_, whereas applying the deltas (not affected by the existence of the cache) took between 1 and 3 **seconds**.

If we do want to fix the cache instead of removing it, we can close this PR and open a new one on the `fix-deltas-cache` branch 🙂 

Fixes https://github.com/dotnet/aspnetcore/issues/48836