### PR TITLE
Test for aot library with eventpipe

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -753,16 +753,16 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Theory]
-        [InlineData(ToolsetInfo.CurrentTargetFramework, "Static")]
-        [InlineData(ToolsetInfo.CurrentTargetFramework, "Shared")]
-        public void NativeAotLib_errors_out_when_eventpipe_is_enabled(string targetFramework, string libType)
+        [InlineData("Static")]
+        [InlineData("Shared")]
+        public void NativeAotLib_errors_out_when_eventpipe_is_enabled(string libType)
         {
             // Revisit once the issue is fixed
             // https://github.com/dotnet/runtime/issues/89346
             var projectName = "AotStaticLibraryPublishWithEventPipe";
-            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+            var rid = EnvironmentInfo.GetCompatibleRid(ToolsetInfo.CurrentTargetFramework);
 
-            var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
+            var testProject = CreateTestProjectWithAotLibrary(ToolsetInfo.CurrentTargetFramework, projectName);
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["RuntimeIdentifier"] = rid;
             testProject.AdditionalProperties["NativeLib"] = libType;

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -752,54 +752,52 @@ namespace Microsoft.NET.Publish.Tests
             IsNativeImage(publishedDll).Should().BeTrue();
         }
 
-        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [Theory]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void NativeAotStaticLib_errors_out_when_eventpipe_is_enabled(string targetFramework)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                var projectName = "AotStaticLibraryPublishWithEventPipe";
-                var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+            // Revisit once the issue is fixed
+            // https://github.com/dotnet/runtime/issues/89346
+            var projectName = "AotStaticLibraryPublishWithEventPipe";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
-                var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
-                testProject.AdditionalProperties["PublishAot"] = "true";
-                testProject.AdditionalProperties["RuntimeIdentifier"] = rid;
-                testProject.AdditionalProperties["NativeLib"] = "Static";
-                testProject.AdditionalProperties["SelfContained"] = "true";
-                testProject.AdditionalProperties["EventSourceSupport"] = "true";
-                var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
+            testProject.AdditionalProperties["PublishAot"] = "true";
+            testProject.AdditionalProperties["RuntimeIdentifier"] = rid;
+            testProject.AdditionalProperties["NativeLib"] = "Static";
+            testProject.AdditionalProperties["SelfContained"] = "true";
+            testProject.AdditionalProperties["EventSourceSupport"] = "true";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-                publishCommand
-                    .Execute()
-                    .Should().Fail()
-                    .And.HaveStdOutContaining("EventSource is not supported");
-            }
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdOutContaining("EventSource is not supported");
         }
 
-        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [Theory]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void NativeAotSharedLib_errors_out_when_eventpipe_is_enabled(string targetFramework)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                var projectName = "AotStaticLibraryPublishWithEventPipe";
-                var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+            // Revisit once the issue is fixed
+            // https://github.com/dotnet/runtime/issues/89346
+            var projectName = "AotStaticLibraryPublishWithEventPipe";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
-                var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
-                testProject.AdditionalProperties["PublishAot"] = "true";
-                testProject.AdditionalProperties["RuntimeIdentifier"] = rid;
-                testProject.AdditionalProperties["NativeLib"] = "Shared";
-                testProject.AdditionalProperties["SelfContained"] = "true";
-                testProject.AdditionalProperties["EventSourceSupport"] = "true";
-                var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
+            testProject.AdditionalProperties["PublishAot"] = "true";
+            testProject.AdditionalProperties["RuntimeIdentifier"] = rid;
+            testProject.AdditionalProperties["NativeLib"] = "Shared";
+            testProject.AdditionalProperties["SelfContained"] = "true";
+            testProject.AdditionalProperties["EventSourceSupport"] = "true";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-                publishCommand
-                    .Execute()
-                    .Should().Fail()
-                    .And.HaveStdOutContaining("EventSource is not supported");
-            }
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdOutContaining("EventSource is not supported");
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -753,8 +753,9 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Theory]
-        [InlineData(ToolsetInfo.CurrentTargetFramework)]
-        public void NativeAotStaticLib_errors_out_when_eventpipe_is_enabled(string targetFramework)
+        [InlineData(ToolsetInfo.CurrentTargetFramework, "Static")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, "Shared")]
+        public void NativeAotLib_errors_out_when_eventpipe_is_enabled(string targetFramework, string libType)
         {
             // Revisit once the issue is fixed
             // https://github.com/dotnet/runtime/issues/89346
@@ -764,31 +765,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["RuntimeIdentifier"] = rid;
-            testProject.AdditionalProperties["NativeLib"] = "Static";
-            testProject.AdditionalProperties["SelfContained"] = "true";
-            testProject.AdditionalProperties["EventSourceSupport"] = "true";
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand
-                .Execute()
-                .Should().Fail()
-                .And.HaveStdOutContaining("EventSource is not supported");
-        }
-
-        [Theory]
-        [InlineData(ToolsetInfo.CurrentTargetFramework)]
-        public void NativeAotSharedLib_errors_out_when_eventpipe_is_enabled(string targetFramework)
-        {
-            // Revisit once the issue is fixed
-            // https://github.com/dotnet/runtime/issues/89346
-            var projectName = "AotStaticLibraryPublishWithEventPipe";
-            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
-
-            var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
-            testProject.AdditionalProperties["PublishAot"] = "true";
-            testProject.AdditionalProperties["RuntimeIdentifier"] = rid;
-            testProject.AdditionalProperties["NativeLib"] = "Shared";
+            testProject.AdditionalProperties["NativeLib"] = libType;
             testProject.AdditionalProperties["SelfContained"] = "true";
             testProject.AdditionalProperties["EventSourceSupport"] = "true";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -754,6 +754,56 @@ namespace Microsoft.NET.Publish.Tests
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void NativeAotStaticLib_errors_out_when_eventpipe_is_enabled(string targetFramework)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var projectName = "AotStaticLibraryPublishWithEventPipe";
+                var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+                var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
+                testProject.AdditionalProperties["PublishAot"] = "true";
+                testProject.AdditionalProperties["RuntimeIdentifier"] = rid;
+                testProject.AdditionalProperties["NativeLib"] = "Static";
+                testProject.AdditionalProperties["SelfContained"] = "true";
+                testProject.AdditionalProperties["EventSourceSupport"] = "true";
+                var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                publishCommand
+                    .Execute()
+                    .Should().Fail()
+                    .And.HaveStdOutContaining("EventSource is not supported");
+            }
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void NativeAotSharedLib_errors_out_when_eventpipe_is_enabled(string targetFramework)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var projectName = "AotStaticLibraryPublishWithEventPipe";
+                var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+                var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
+                testProject.AdditionalProperties["PublishAot"] = "true";
+                testProject.AdditionalProperties["RuntimeIdentifier"] = rid;
+                testProject.AdditionalProperties["NativeLib"] = "Shared";
+                testProject.AdditionalProperties["SelfContained"] = "true";
+                testProject.AdditionalProperties["EventSourceSupport"] = "true";
+                var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                publishCommand
+                    .Execute()
+                    .Should().Fail()
+                    .And.HaveStdOutContaining("EventSource is not supported");
+            }
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void NativeAotSharedLib_only_runs_when_switch_is_enabled(string targetFramework)
         {
             var projectName = "AotSharedLibraryPublish";


### PR DESCRIPTION
We don't yet support `EventPipe `in native AOT libraries and this test validates that.

Fixes #34839