### PR TITLE
Removing stale msbuild feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -33,7 +33,6 @@
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <!-- Used for Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
-    <add key="darc-pub-DotNet-msbuild-Trusted-8ffc3fe" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-8ffc3fe3/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->


### PR DESCRIPTION
### Context

The feed seems to be stale, and based on stats not actually used: https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/724b07b9-93de-4ad8-a0d0-29346fed06b5/nuget/v3/query2?q=Microsoft.Build&prerelease=true

MSBuild main gets pushed to [dotnet-tools](https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json) feed.

So trying to remove - to see if it get's used anywhere (and if yes - then why it is used)


FYI @marcpopMSFT 
