### PR TITLE
Prefer docker tool when both podman and docker are present

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -20,7 +20,7 @@ internal sealed class DockerCli : ILocalRegistry
     private const string Commands = $"{DockerCommand}/{PodmanCommand}";
 
     private readonly ILogger _logger;
-    private string? _commandPath;
+    private string? _command;
     private string? _fullCommandPath;
 
     public DockerCli(string? command, ILoggerFactory loggerFactory)
@@ -32,7 +32,7 @@ internal sealed class DockerCli : ILocalRegistry
             throw new ArgumentException($"{command} is an unknown command.");
         }
 
-        this._commandPath = command;
+        this._command = command;
         this._logger = loggerFactory.CreateLogger<DockerCli>();
     }
 
@@ -110,7 +110,7 @@ internal sealed class DockerCli : ILocalRegistry
 
     public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken)
     {
-        bool commandPathWasUnknown = this._commandPath is null; // avoid running the version command twice.
+        bool commandPathWasUnknown = this._command is null; // avoid running the version command twice.
         string? command = await GetCommandAsync(cancellationToken);
         if (command is null)
         {
@@ -277,9 +277,9 @@ internal sealed class DockerCli : ILocalRegistry
 
     private async ValueTask<string?> GetCommandAsync(CancellationToken cancellationToken)
     {
-        if (_commandPath != null)
+        if (_command != null)
         {
-            return _commandPath;
+            return _command;
         }
 
         // Try to find the docker or podman cli.
@@ -297,18 +297,18 @@ internal sealed class DockerCli : ILocalRegistry
         // be explicit with this check so that we don't do the link target check unless it might actually be a solution.
         if (dockerCommand.Result && podmanCommand.Result && IsPodmanAlias())
         {
-            _commandPath = PodmanCommand;
+            _command = PodmanCommand;
         }
         else if (dockerCommand.Result)
         {
-            _commandPath = DockerCommand;
+            _command = DockerCommand;
         }
         else if (podmanCommand.Result)
         {
-            _commandPath = PodmanCommand;
+            _command = PodmanCommand;
         }
 
-        return _commandPath;
+        return _command;
     }
 
     private static bool IsPodmanAlias()
@@ -356,6 +356,6 @@ internal sealed class DockerCli : ILocalRegistry
 
     public override string ToString()
     {
-        return string.Format(Strings.DockerCli_PushInfo, _commandPath);
+        return string.Format(Strings.DockerCli_PushInfo, _command);
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -63,7 +63,7 @@ internal sealed class DockerCli : ILocalRegistry
         string? command = await GetCommandAsync(cancellationToken);
         if (command is null)
         {
-            throw new NotImplementedException(Resource.FormatString(Strings.DockerProcessCreationFailed, Commands));
+            throw new NotImplementedException(Resource.FormatString(Strings.ContainerRuntimeProcessCreationFailed, Commands));
         }
 
         _fullCommandPath = FindFullPathFromPath(command);
@@ -87,7 +87,7 @@ internal sealed class DockerCli : ILocalRegistry
 
         if (loadProcess is null)
         {
-            throw new NotImplementedException(Resource.FormatString(Strings.DockerProcessCreationFailed, commandPath));
+            throw new NotImplementedException(Resource.FormatString(Strings.ContainerRuntimeProcessCreationFailed, commandPath));
         }
 
         // Create new stream tarball
@@ -284,7 +284,8 @@ internal sealed class DockerCli : ILocalRegistry
 
         // Try to find the docker or podman cli.
         // On systems with podman it's not uncommon for docker to be an alias to podman.
-        // We try to find podman first so we can identify those systems to be using podman.
+        // We have to attempt to locate both binaries and inspect the output of the 'docker' binary if present to determine
+        // if it is actually podman.
         var podmanCommand = TryRunVersionCommandAsync(PodmanCommand, cancellationToken);
         var dockerCommand = TryRunVersionCommandAsync(DockerCommand, cancellationToken);
 

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -297,14 +297,15 @@ internal sealed class DockerCli : ILocalRegistry
 
     private static bool IsPodmanAlias()
     {
-        var dockerPath = FindFullPathFromPath("docker");
-        if (dockerPath is null)
+        var dockerPath = FindFullPathFromPath(DockerCommand);
+        var podmanPath = FindFullPathFromPath(PodmanCommand);
+        if (dockerPath is null || podmanPath is null)
         {
             return false;
         }
 
         var fi = new FileInfo(dockerPath);
-        return fi.LinkTarget == null;
+        return fi.LinkTarget == podmanPath;
     }
 
     private async Task<bool> TryRunVersionCommandAsync(string command, CancellationToken cancellationToken)

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -283,7 +283,12 @@ internal sealed class DockerCli : ILocalRegistry
             dockerCommand
         ).ConfigureAwait(false);
 
-        if (dockerCommand.Result && !IsPodmanAlias())
+        // be explicit with this check so that we don't do the link target check unless it might actually be a solution.
+        if (dockerCommand.Result && podmanCommand.Result && IsPodmanAlias())
+        {
+            _commandPath = PodmanCommand;
+        }
+        else if (dockerCommand.Result)
         {
             _commandPath = DockerCommand;
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -283,7 +283,7 @@ internal sealed class DockerCli : ILocalRegistry
             dockerCommand
         ).ConfigureAwait(false);
 
-        if (dockerCommand.Result)
+        if (dockerCommand.Result && !IsPodmanAlias())
         {
             _commandPath = DockerCommand;
         }
@@ -293,6 +293,18 @@ internal sealed class DockerCli : ILocalRegistry
         }
 
         return _commandPath;
+    }
+
+    private static bool IsPodmanAlias()
+    {
+        var dockerPath = FindFullPathFromPath("docker");
+        if (dockerPath is null)
+        {
+            return false;
+        }
+
+        var fi = new FileInfo(dockerPath);
+        return fi.LinkTarget == null;
     }
 
     private async Task<bool> TryRunVersionCommandAsync(string command, CancellationToken cancellationToken)

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -8,10 +8,11 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.NET.Build.Containers.Resources {
+namespace Microsoft.NET.Build.Containers.Resources
+{
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,94 +23,114 @@ namespace Microsoft.NET.Build.Containers.Resources {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Strings {
-        
+    internal class Strings
+    {
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Strings() {
+        internal Strings()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.NET.Build.Containers.Resources.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER0000: Value for unit test {0}.
         /// </summary>
-        internal static string _Test {
-            get {
+        internal static string _Test
+        {
+            get
+            {
                 return ResourceManager.GetString("_Test", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry..
         /// </summary>
-        internal static string AmazonRegistryFailed {
-            get {
+        internal static string AmazonRegistryFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("AmazonRegistryFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed..
         /// </summary>
-        internal static string AmbiguousTags {
-            get {
+        internal static string AmbiguousTags
+        {
+            get
+            {
                 return ResourceManager.GetString("AmbiguousTags", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2009: Could not parse {0}: {1}.
         /// </summary>
-        internal static string BaseImageNameParsingFailed {
-            get {
+        internal static string BaseImageNameParsingFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("BaseImageNameParsingFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2013: {0} had spaces in it, replacing with dashes..
         /// </summary>
-        internal static string BaseImageNameWithSpaces {
-            get {
+        internal static string BaseImageNameWithSpaces
+        {
+            get
+            {
                 return ResourceManager.GetString("BaseImageNameWithSpaces", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/<image>'..
         /// </summary>
-        internal static string BaseImageNameRegistryFallback {
-            get {
+        internal static string BaseImageNameRegistryFallback
+        {
+            get
+            {
                 return ResourceManager.GetString("BaseImageNameRegistryFallback", resourceCulture);
             }
         }
@@ -117,539 +138,665 @@ namespace Microsoft.NET.Build.Containers.Resources {
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1011: Couldn&apos;t find matching base image for {0} that matches RuntimeIdentifier {1}..
         /// </summary>
-        internal static string BaseImageNotFound {
-            get {
+        internal static string BaseImageNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("BaseImageNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1001: Failed to upload blob using {0}; received status code &apos;{1}&apos;..
         /// </summary>
-        internal static string BlobUploadFailed {
-            get {
+        internal static string BlobUploadFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("BlobUploadFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pushed container &apos;{0}&apos; to Docker daemon..
         /// </summary>
-        internal static string ContainerBuilder_ImageUploadedToLocalDaemon {
-            get {
+        internal static string ContainerBuilder_ImageUploadedToLocalDaemon
+        {
+            get
+            {
                 return ResourceManager.GetString("ContainerBuilder_ImageUploadedToLocalDaemon", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pushed container &apos;{0}&apos; to registry &apos;{1}&apos;..
         /// </summary>
-        internal static string ContainerBuilder_ImageUploadedToRegistry {
-            get {
+        internal static string ContainerBuilder_ImageUploadedToRegistry
+        {
+            get
+            {
                 return ResourceManager.GetString("ContainerBuilder_ImageUploadedToRegistry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Building image &apos;{0}&apos; with tags &apos;{1}&apos; on top of base image &apos;{2}&apos;..
         /// </summary>
-        internal static string ContainerBuilder_StartBuildingImage {
-            get {
+        internal static string ContainerBuilder_StartBuildingImage
+        {
+            get
+            {
                 return ResourceManager.GetString("ContainerBuilder_StartBuildingImage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1007: Could not deserialize token from JSON..
         /// </summary>
-        internal static string CouldntDeserializeJsonToken {
-            get {
+        internal static string CouldntDeserializeJsonToken
+        {
+            get
+            {
                 return ResourceManager.GetString("CouldntDeserializeJsonToken", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2012: Could not recognize registry &apos;{0}&apos;..
         /// </summary>
-        internal static string CouldntRecognizeRegistry {
-            get {
+        internal static string CouldntRecognizeRegistry
+        {
+            get
+            {
                 return ResourceManager.GetString("CouldntRecognizeRegistry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}.
         /// </summary>
-        internal static string DockerInfoFailed {
-            get {
+        internal static string DockerInfoFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("DockerInfoFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER3002: Failed to get docker info: {0}.
         /// </summary>
-        internal static string DockerInfoFailed_Ex {
-            get {
+        internal static string DockerInfoFailed_Ex
+        {
+            get
+            {
                 return ResourceManager.GetString("DockerInfoFailed_Ex", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER3001: Failed creating docker process..
         /// </summary>
-        internal static string DockerProcessCreationFailed {
-            get {
-                return ResourceManager.GetString("DockerProcessCreationFailed", resourceCulture);
+        internal static string ContainerRuntimeProcessCreationFailed
+        {
+            get
+            {
+                return ResourceManager.GetString("ContainerRuntimeProcessCreationFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4006: Property &apos;{0}&apos; is empty or contains whitespace and will be ignored..
         /// </summary>
-        internal static string EmptyOrWhitespacePropertyIgnored {
-            get {
+        internal static string EmptyOrWhitespacePropertyIgnored
+        {
+            get
+            {
                 return ResourceManager.GetString("EmptyOrWhitespacePropertyIgnored", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4004: Items &apos;{0}&apos; contain empty item(s) which will be ignored..
         /// </summary>
-        internal static string EmptyValuesIgnored {
-            get {
+        internal static string EmptyValuesIgnored
+        {
+            get
+            {
                 return ResourceManager.GetString("EmptyValuesIgnored", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1008: Failed retrieving credentials for &quot;{0}&quot;: {1}.
         /// </summary>
-        internal static string FailedRetrievingCredentials {
-            get {
+        internal static string FailedRetrievingCredentials
+        {
+            get
+            {
                 return ResourceManager.GetString("FailedRetrievingCredentials", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No host object detected..
         /// </summary>
-        internal static string HostObjectNotDetected {
-            get {
+        internal static string HostObjectNotDetected
+        {
+            get
+            {
                 return ResourceManager.GetString("HostObjectNotDetected", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1009: Failed to load image to local registry. stdout: {0}.
         /// </summary>
-        internal static string ImageLoadFailed {
-            get {
+        internal static string ImageLoadFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("ImageLoadFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1010: Pulling images from local registry is not supported..
         /// </summary>
-        internal static string ImagePullNotSupported {
-            get {
+        internal static string ImagePullNotSupported
+        {
+            get
+            {
                 return ResourceManager.GetString("ImagePullNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2015: {0}: &apos;{1}&apos; was not a valid Environment Variable. Ignoring..
         /// </summary>
-        internal static string InvalidEnvVar {
-            get {
+        internal static string InvalidEnvVar
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidEnvVar", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2005: The inferred image name &apos;{0}&apos; contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character..
         /// </summary>
-        internal static string InvalidImageName_EntireNameIsInvalidCharacters {
-            get {
+        internal static string InvalidImageName_EntireNameIsInvalidCharacters
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidImageName_EntireNameIsInvalidCharacters", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2005: The first character of the image name &apos;{0}&apos; must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _..
         /// </summary>
-        internal static string InvalidImageName_NonAlphanumericStartCharacter {
-            get {
+        internal static string InvalidImageName_NonAlphanumericStartCharacter
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidImageName_NonAlphanumericStartCharacter", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2017: A ContainerPort item was provided with an invalid port number &apos;{0}&apos;. ContainerPort items must have an Include value that is an integer, and a Type value that is either &apos;tcp&apos; or &apos;udp&apos;..
         /// </summary>
-        internal static string InvalidPort_Number {
-            get {
+        internal static string InvalidPort_Number
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidPort_Number", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2017: A ContainerPort item was provided with an invalid port number &apos;{0}&apos; and an invalid port type &apos;{1}&apos;. ContainerPort items must have an Include value that is an integer, and a Type value that is either &apos;tcp&apos; or &apos;udp&apos;..
         /// </summary>
-        internal static string InvalidPort_NumberAndType {
-            get {
+        internal static string InvalidPort_NumberAndType
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidPort_NumberAndType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2017: A ContainerPort item was provided with an invalid port type &apos;{0}&apos;. ContainerPort items must have an Include value that is an integer, and a Type value that is either &apos;tcp&apos; or &apos;udp&apos;..
         /// </summary>
-        internal static string InvalidPort_Type {
-            get {
+        internal static string InvalidPort_Type
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidPort_Type", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2018: Invalid SDK prerelease version &apos;{0}&apos; - only &apos;rc&apos; and &apos;preview&apos; are supported..
         /// </summary>
-        internal static string InvalidSdkPrereleaseVersion {
-            get {
+        internal static string InvalidSdkPrereleaseVersion
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidSdkPrereleaseVersion", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2019: Invalid SDK semantic version &apos;{0}&apos;..
         /// </summary>
-        internal static string InvalidSdkVersion {
-            get {
+        internal static string InvalidSdkVersion
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidSdkVersion", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period..
         /// </summary>
-        internal static string InvalidTag {
-            get {
+        internal static string InvalidTag
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidTag", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period..
         /// </summary>
-        internal static string InvalidTags {
-            get {
+        internal static string InvalidTags
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidTags", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1003: Token response had neither token nor access_token..
         /// </summary>
-        internal static string InvalidTokenResponse {
-            get {
+        internal static string InvalidTokenResponse
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidTokenResponse", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4005: Item &apos;{0}&apos; contains items without metadata &apos;Value&apos;, and they will be ignored..
         /// </summary>
-        internal static string ItemsWithoutMetadata {
-            get {
+        internal static string ItemsWithoutMetadata
+        {
+            get
+            {
                 return ResourceManager.GetString("ItemsWithoutMetadata", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.
         /// </summary>
-        internal static string LocalRegistryNotAvailable {
-            get {
+        internal static string LocalRegistryNotAvailable
+        {
+            get
+            {
                 return ResourceManager.GetString("LocalRegistryNotAvailable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error while reading daemon config: {0}.
         /// </summary>
-        internal static string LocalDocker_FailedToGetConfig {
-            get {
+        internal static string LocalDocker_FailedToGetConfig
+        {
+            get
+            {
                 return ResourceManager.GetString("LocalDocker_FailedToGetConfig", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The daemon server reported errors: {0}.
         /// </summary>
-        internal static string LocalDocker_LocalDaemonErrors {
-            get {
+        internal static string LocalDocker_LocalDaemonErrors
+        {
+            get
+            {
                 return ResourceManager.GetString("LocalDocker_LocalDaemonErrors", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2004: Unable to download layer with descriptor &apos;{0}&apos; from registry &apos;{1}&apos; because it does not exist..
         /// </summary>
-        internal static string MissingLinkToRegistry {
-            get {
+        internal static string MissingLinkToRegistry
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingLinkToRegistry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2016: ContainerPort item &apos;{0}&apos; does not specify the port number. Please ensure the item&apos;s Include is a port number, for example &apos;&lt;ContainerPort Include=&quot;80&quot; /&gt;&apos;.
         /// </summary>
-        internal static string MissingPortNumber {
-            get {
+        internal static string MissingPortNumber
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingPortNumber", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1004: No RequestUri specified..
         /// </summary>
-        internal static string NoRequestUriSpecified {
-            get {
+        internal static string NoRequestUriSpecified
+        {
+            get
+            {
                 return ResourceManager.GetString("NoRequestUriSpecified", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; was not a valid container image name, it was normalized to &apos;{1}&apos;.
         /// </summary>
-        internal static string NormalizedContainerName {
-            get {
+        internal static string NormalizedContainerName
+        {
+            get
+            {
                 return ResourceManager.GetString("NormalizedContainerName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2011: {0} &apos;{1}&apos; does not exist.
         /// </summary>
-        internal static string PublishDirectoryDoesntExist {
-            get {
+        internal static string PublishDirectoryDoesntExist
+        {
+            get
+            {
                 return ResourceManager.GetString("PublishDirectoryDoesntExist", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploaded config to registry..
         /// </summary>
-        internal static string Registry_ConfigUploaded {
-            get {
+        internal static string Registry_ConfigUploaded
+        {
+            get
+            {
                 return ResourceManager.GetString("Registry_ConfigUploaded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploading config to registry at blob &apos;{0}&apos;,.
         /// </summary>
-        internal static string Registry_ConfigUploadStarted {
-            get {
+        internal static string Registry_ConfigUploadStarted
+        {
+            get
+            {
                 return ResourceManager.GetString("Registry_ConfigUploadStarted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Layer &apos;{0}&apos; already exists..
         /// </summary>
-        internal static string Registry_LayerExists {
-            get {
+        internal static string Registry_LayerExists
+        {
+            get
+            {
                 return ResourceManager.GetString("Registry_LayerExists", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Finished uploading layer &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_LayerUploaded {
-            get {
+        internal static string Registry_LayerUploaded
+        {
+            get
+            {
                 return ResourceManager.GetString("Registry_LayerUploaded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploading layer &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_LayerUploadStarted {
-            get {
+        internal static string Registry_LayerUploadStarted
+        {
+            get
+            {
                 return ResourceManager.GetString("Registry_LayerUploadStarted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploaded manifest to &apos;{0}&apos;..
         /// </summary>
-        internal static string Registry_ManifestUploaded {
-            get {
+        internal static string Registry_ManifestUploaded
+        {
+            get
+            {
                 return ResourceManager.GetString("Registry_ManifestUploaded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploading manifest to registry &apos;{0}&apos; as blob &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_ManifestUploadStarted {
-            get {
+        internal static string Registry_ManifestUploadStarted
+        {
+            get
+            {
                 return ResourceManager.GetString("Registry_ManifestUploadStarted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploaded tag &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_TagUploaded {
-            get {
+        internal static string Registry_TagUploaded
+        {
+            get
+            {
                 return ResourceManager.GetString("Registry_TagUploaded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploading tag &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_TagUploadStarted {
-            get {
+        internal static string Registry_TagUploadStarted
+        {
+            get
+            {
                 return ResourceManager.GetString("Registry_TagUploadStarted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1013: Failed to push to the output registry: {0}.
         /// </summary>
-        internal static string RegistryOutputPushFailed {
-            get {
+        internal static string RegistryOutputPushFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("RegistryOutputPushFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1005: Registry push failed..
         /// </summary>
-        internal static string RegistryPushFailed {
-            get {
+        internal static string RegistryPushFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("RegistryPushFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4003: Required &apos;{0}&apos; items contain empty items..
         /// </summary>
-        internal static string RequiredItemsContainsEmptyItems {
-            get {
+        internal static string RequiredItemsContainsEmptyItems
+        {
+            get
+            {
                 return ResourceManager.GetString("RequiredItemsContainsEmptyItems", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4002: Required &apos;{0}&apos; items were not set..
         /// </summary>
-        internal static string RequiredItemsNotSet {
-            get {
+        internal static string RequiredItemsNotSet
+        {
+            get
+            {
                 return ResourceManager.GetString("RequiredItemsNotSet", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4001: Required property &apos;{0}&apos; was not set or empty..
         /// </summary>
-        internal static string RequiredPropertyNotSetOrEmpty {
-            get {
+        internal static string RequiredPropertyNotSetOrEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("RequiredPropertyNotSetOrEmpty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1006: Too many retries, stopping..
         /// </summary>
-        internal static string TooManyRetries {
-            get {
+        internal static string TooManyRetries
+        {
+            get
+            {
                 return ResourceManager.GetString("TooManyRetries", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2002: Unknown local registry type &apos;{0}&apos;. Valid local container registry types are {1}..
         /// </summary>
-        internal static string UnknownLocalRegistryType {
-            get {
+        internal static string UnknownLocalRegistryType
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownLocalRegistryType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message..
         /// </summary>
-        internal static string UnknownMediaType {
-            get {
+        internal static string UnknownMediaType
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownMediaType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2001: Unrecognized mediaType &apos;{0}&apos;..
         /// </summary>
-        internal static string UnrecognizedMediaType {
-            get {
+        internal static string UnrecognizedMediaType
+        {
+            get
+            {
                 return ResourceManager.GetString("UnrecognizedMediaType", resourceCulture);
             }
         }
 
-        internal static string UnknownAppCommandInstruction {
-            get {
+        internal static string UnknownAppCommandInstruction
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownAppCommandInstruction", resourceCulture);
             }
         }
 
-        internal static string BaseEntrypointOverwritten {
-            get {
+        internal static string BaseEntrypointOverwritten
+        {
+            get
+            {
                 return ResourceManager.GetString("BaseEntrypointOverwritten", resourceCulture);
             }
         }
 
-        internal static string EntrypointAndAppCommandArgsSetNoAppCommandInstruction {
-            get {
+        internal static string EntrypointAndAppCommandArgsSetNoAppCommandInstruction
+        {
+            get
+            {
                 return ResourceManager.GetString("EntrypointAndAppCommandArgsSetNoAppCommandInstruction", resourceCulture);
             }
         }
 
-        internal static string EntrypointArgsSetNoEntrypoint {
-            get {
+        internal static string EntrypointArgsSetNoEntrypoint
+        {
+            get
+            {
                 return ResourceManager.GetString("EntrypointArgsSetNoEntrypoint", resourceCulture);
             }
         }
 
-        internal static string AppCommandArgsSetNoAppCommand {
-            get {
+        internal static string AppCommandArgsSetNoAppCommand
+        {
+            get
+            {
                 return ResourceManager.GetString("AppCommandArgsSetNoAppCommand", resourceCulture);
             }
         }
 
-        internal static string AppCommandSetNotUsed {
-            get {
+        internal static string AppCommandSetNotUsed
+        {
+            get
+            {
                 return ResourceManager.GetString("AppCommandSetNotUsed", resourceCulture);
             }
         }
 
-        internal static string EntrypointSetNoAppCommandInstruction {
-            get {
+        internal static string EntrypointSetNoAppCommandInstruction
+        {
+            get
+            {
                 return ResourceManager.GetString("EntrypointSetNoAppCommandInstruction", resourceCulture);
             }
         }
 
-        internal static string EntrypointConflictAppCommand {
-            get {
+        internal static string EntrypointConflictAppCommand
+        {
+            get
+            {
                 return ResourceManager.GetString("EntrypointConflictAppCommand", resourceCulture);
             }
         }
 
-        internal static string EntrypointArgsSetPreferAppCommandArgs {
-            get {
+        internal static string EntrypointArgsSetPreferAppCommandArgs
+        {
+            get
+            {
                 return ResourceManager.GetString("EntrypointArgsSetPreferAppCommandArgs", resourceCulture);
             }
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -161,7 +161,7 @@
     <value>CONTAINER3002: Failed to get docker info: {0}</value>
     <comment>{StrBegin="CONTAINER3002: "}</comment>
   </data>
-  <data name="DockerProcessCreationFailed" xml:space="preserve">
+  <data name="ContainerRuntimeProcessCreationFailed" xml:space="preserve">
     <value>CONTAINER3001: Failed creating {0} process.</value>
     <comment>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</comment>
   </data>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -1,30 +1,50 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="cs"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Požadavek na Amazon Elastic Container Registry předčasně selhal. To je často způsobeno tím, že cílové úložiště v registru neexistuje.</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: Požadavek na Amazon Elastic Container Registry
+          předčasně selhal. To je často způsobeno tím, že cílové úložiště v registru neexistuje.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
         <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed.</source>
-        <target state="translated">CONTAINER2008: Byly poskytnuty {0} i {1}, ale je povolen pouze jeden nebo druhý.</target>
+        <target state="translated">CONTAINER2008: Byly poskytnuty {0} i {1}, ale je povolen pouze
+          jeden nebo druhý.</target>
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs se poskytují bez zadání ContainerAppCommand.</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: ContainerAppCommandArgs se poskytují bez zadání
+          ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand a ContainerAppCommandArgs musí být prázdné, pokud je ContainerAppCommandInstruction „{0}“.</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommand a ContainerAppCommandArgs musí
+          být prázdné, pokud je ContainerAppCommandInstruction „{0}“.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: Základní image má vstupní bod, který se přepíše, aby se aplikace spustila. Pokud je to žádoucí, nastavte ContainerAppCommandInstruction na „Entrypoint“. Pokud chcete zachovat vstupní bod základní image, nastavte ContainerAppCommandInstruction na „DefaultArgs“.</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: Základní image má vstupní bod, který se přepíše,
+          aby se aplikace spustila. Pokud je to žádoucí, nastavte ContainerAppCommandInstruction na
+          „Entrypoint“. Pokud chcete zachovat vstupní bod základní image, nastavte
+          ContainerAppCommandInstruction na „DefaultArgs“.</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,23 +53,29 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} neurčuje registr a bude načten z Docker Hub. Před název zadejte registr imagí, například: „{1}/&lt;image&gt;“.</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} neurčuje registr a bude načten z Docker Hub.
+          Před název zadejte registr imagí, například: „{1}/&lt;image&gt;“.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
-        <target state="translated">CONTAINER2013: {0} obsahoval mezery, které se nahradily pomlčkami.</target>
+        <target state="translated">CONTAINER2013: {0} obsahoval mezery, které se nahradily
+          pomlčkami.</target>
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: Pro {0} nelze najít odpovídající základní image, která odpovídá identifikátoru RuntimeIdentifier {1}.</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: Pro {0} nelze najít odpovídající základní image,
+          která odpovídá identifikátoru RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: Nepovedlo se nahrát objekt blob pomocí {0}; přijatý stavový kód {1}</target>
+        <target state="translated">CONTAINER1001: Nepovedlo se nahrát objekt blob pomocí {0};
+          přijatý stavový kód {1}</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
@@ -79,7 +105,8 @@
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>
-        <target state="translated">CONTAINER3002: Nepovedlo se získat informace o dockeru ({0})\n{1}\n{2}</target>
+        <target state="translated">CONTAINER3002: Nepovedlo se získat informace o dockeru
+          ({0})\n{1}\n{2}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed_Ex">
@@ -87,49 +114,69 @@
         <target state="translated">CONTAINER3002: Nepovedlo se získat informace o Dockeru: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: Vytvoření procesu {0} se nezdařilo.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
-        <target state="translated">CONTAINER4006: Vlastnost '{0}' je prázdná nebo obsahuje prázdné znaky a bude ignorována.</target>
+        <target state="translated">CONTAINER4006: Vlastnost '{0}' je prázdná nebo obsahuje prázdné
+          znaky a bude ignorována.</target>
         <note>{StrBegin="CONTAINER4006: "}</note>
       </trans-unit>
       <trans-unit id="EmptyValuesIgnored">
         <source>CONTAINER4004: Items '{0}' contain empty item(s) which will be ignored.</source>
-        <target state="translated">CONTAINER4004: Položky '{0}' obsahují prázdné položky, které budou ignorovány.</target>
+        <target state="translated">CONTAINER4004: Položky '{0}' obsahují prázdné položky, které
+          budou ignorovány.</target>
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Jsou k dispozici ContainerEntrypoint a ContainerAppCommandArgs. Pokud chcete nakonfigurovat způsob spuštění aplikace, musí být nastavená vlastnost ContainerAppInstruction. Platné pokyny jsou {0}.</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: Jsou k dispozici ContainerEntrypoint a
+          ContainerAppCommandArgs. Pokud chcete nakonfigurovat způsob spuštění aplikace, musí být
+          nastavená vlastnost ContainerAppInstruction. Platné pokyny jsou {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Je k dispozici ContainerEntrypoint. Pokud chcete nakonfigurovat způsob spuštění aplikace, musí být nastavená vlastnost ContainerAppInstruction. Platné pokyny jsou {0}.</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: Je k dispozici ContainerEntrypoint. Pokud chcete
+          nakonfigurovat způsob spuštění aplikace, musí být nastavená vlastnost
+          ContainerAppInstruction. Platné pokyny jsou {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs se poskytují bez zadání ContainerEntrypoint.</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: ContainerEntrypointArgs se poskytují bez zadání
+          ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: Je k dispozici containerEntrypointArgsSet. Proveďte změnu, aby se pro argumenty, které musí být vždycky nastavené, používaly ContainerAppCommandArgs, nebo ContainerDefaultArgs pro argumenty, které se dají přepsat při vytvoření kontejneru.</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: Je k dispozici containerEntrypointArgsSet.
+          Proveďte změnu, aby se pro argumenty, které musí být vždycky nastavené, používaly
+          ContainerAppCommandArgs, nebo ContainerDefaultArgs pro argumenty, které se dají přepsat
+          při vytvoření kontejneru.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint nejde kombinovat s ContainerAppCommandInstruction „{0}“.</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint nejde kombinovat s
+          ContainerAppCommandInstruction „{0}“.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
         <source>CONTAINER1008: Failed retrieving credentials for "{0}": {1}</source>
-        <target state="translated">CONTAINER1008: Načtení přihlašovacích údajů pro „{0}“ se nezdařilo: {1}</target>
+        <target state="translated">CONTAINER1008: Načtení přihlašovacích údajů pro „{0}“ se
+          nezdařilo: {1}</target>
         <note>{StrBegin="CONTAINER1008: "}</note>
       </trans-unit>
       <trans-unit id="HostObjectNotDetected">
@@ -139,7 +186,8 @@
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: Nepodařilo se načíst bitovou kopii z místního registru. stdout: {0}</target>
+        <target state="translated">CONTAINER1009: Nepodařilo se načíst bitovou kopii z místního
+          registru. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
@@ -149,37 +197,59 @@
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
-        <target state="translated">CONTAINER2015: {0}: '{1}' není platná proměnná prostředí. Ignorování.</target>
+        <target state="translated">CONTAINER2015: {0}: '{1}' není platná proměnná prostředí.
+          Ignorování.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Odvozený název image „{0}“ obsahuje zcela neplatné znaky. Platné znaky pro název obrázku jsou alfanumerické znaky, -, /, nebo _, a název obrázku musí začínat alfanumerickým znakem.</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: Odvozený název image „{0}“ obsahuje zcela neplatné
+          znaky. Platné znaky pro název obrázku jsou alfanumerické znaky, -, /, nebo _, a název
+          obrázku musí začínat alfanumerickým znakem.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: První znak názvu obrázku „{0}“ musí být malé písmeno nebo číslice a všechny znaky v názvu musí být alfanumerické znaky, -, /, nebo _.</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: První znak názvu obrázku „{0}“ musí být malé
+          písmeno nebo číslice a všechny znaky v názvu musí být alfanumerické znaky, -, /, nebo _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným číslem portu '{0}'. Položky ContainerPort musí mít hodnotu Include, která je celé číslo, a hodnotu Typu, která je buď tcp, nebo udp.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným
+          číslem portu '{0}'. Položky ContainerPort musí mít hodnotu Include, která je celé číslo, a
+          hodnotu Typu, která je buď tcp, nebo udp.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným číslem portu '{0}' a neplatným typem portu '{1}'. Položky ContainerPort musí mít hodnotu Include, která je celé číslo, a hodnotu Typu, která je buď tcp, nebo udp.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným
+          číslem portu '{0}' a neplatným typem portu '{1}'. Položky ContainerPort musí mít hodnotu
+          Include, která je celé číslo, a hodnotu Typu, která je buď tcp, nebo udp.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným typem portu '{0}'. Položky ContainerPort musí mít hodnotu Include, která je celé číslo, a hodnotu Typu, která je buď tcp, nebo udp.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným
+          typem portu '{0}'. Položky ContainerPort musí mít hodnotu Include, která je celé číslo, a
+          hodnotu Typu, která je buď tcp, nebo udp.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: Neplatná verze předběžné verze sady SDK '{0}' – podporují se jen 'rc' a 'preview'.</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
+        <target state="translated">CONTAINER2018: Neplatná verze předběžné verze sady SDK '{0}' –
+          podporují se jen 'rc' a 'preview'.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -188,13 +258,18 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: Byla zadána neplatná {0} : {1}. Značky obrázků musí být alfanumerické, podtržítka, spojovníky nebo tečky.</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: Byla zadána neplatná {0} : {1}. Značky obrázků
+          musí být alfanumerické, podtržítka, spojovníky nebo tečky.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: Byla zadána neplatná {0} : {1}. {0} musí být seznam platných značek obrázků oddělených středníky. Značky obrázků musí být alfanumerické, podtržítka, spojovníky nebo tečky.</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: Byla zadána neplatná {0} : {1}. {0} musí být
+          seznam platných značek obrázků oddělených středníky. Značky obrázků musí být
+          alfanumerické, podtržítka, spojovníky nebo tečky.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
@@ -203,13 +278,17 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
-        <target state="translated">CONTAINER4005: Položka '{0}' obsahuje položky bez metadat 'Value' a budou ignorovány.</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
+        <target state="translated">CONTAINER4005: Položka '{0}' obsahuje položky bez metadat 'Value'
+          a budou ignorovány.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
-        <target state="translated">CONTAINER1012: Místní registr není k dispozici, ale bylo požadováno vložení do místního registru.</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
+        <target state="translated">CONTAINER1012: Místní registr není k dispozici, ale bylo
+          požadováno vložení do místního registru.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -223,13 +302,19 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: Nelze stáhnout vrstvu s popisovačem '{0}' z registru '{1}', protože neexistuje.</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: Nelze stáhnout vrstvu s popisovačem '{0}' z
+          registru '{1}', protože neexistuje.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: Položka ContainerPort '{0}' neurčuje číslo portu. Ujistěte se prosím, že položka Include je číslo portu, například &lt;ContainerPort Include="80" /&gt;.</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: Položka ContainerPort '{0}' neurčuje číslo portu.
+          Ujistěte se prosím, že položka Include je číslo portu, například &lt;ContainerPort
+          Include="80" /&gt;.</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -239,7 +324,8 @@
       </trans-unit>
       <trans-unit id="NormalizedContainerName">
         <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
-        <target state="translated">'{0}' nebyl platný název image kontejneru, byl normalizován na '{1}'</target>
+        <target state="translated">'{0}' nebyl platný název image kontejneru, byl normalizován na
+          '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
@@ -314,7 +400,8 @@
       </trans-unit>
       <trans-unit id="RequiredPropertyNotSetOrEmpty">
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
-        <target state="translated">CONTAINER4001: Požadovaná vlastnost '{0}' nebyla nastavena nebo je prázdná.</target>
+        <target state="translated">CONTAINER4001: Požadovaná vlastnost '{0}' nebyla nastavena nebo
+          je prázdná.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TooManyRetries">
@@ -324,17 +411,24 @@
       </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: Neznámé AppCommandInstruction „{0}“. Platné pokyny jsou {1}.</target>
+        <target state="translated">CONTAINER2021: Neznámé AppCommandInstruction „{0}“. Platné pokyny
+          jsou {1}.</target>
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: Neznámý typ místního registru „{0}“. Platné typy registru místního kontejneru jsou {1}.</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: Neznámý typ místního registru „{0}“. Platné typy
+          registru místního kontejneru jsou {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: Manifest pro {0}:{1} z registru {2} byl neznámý typ: {3}. Nahlaste prosím problém na https://github.com/dotnet/sdk-container-builds/issues s touto zprávou.</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: Manifest pro {0}:{1} z registru {2} byl neznámý
+          typ: {3}. Nahlaste prosím problém na https://github.com/dotnet/sdk-container-builds/issues
+          s touto zprávou.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="cs"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Požadavek na Amazon Elastic Container Registry
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: Požadavek na Amazon Elastic Container Registry
           předčasně selhal. To je často způsobeno tím, že cílové úložiště v registru neexistuje.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
@@ -24,16 +15,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs se poskytují bez zadání
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: ContainerAppCommandArgs se poskytují bez zadání
           ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand a ContainerAppCommandArgs musí
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommand a ContainerAppCommandArgs musí
           být prázdné, pokud je ContainerAppCommandInstruction „{0}“.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -43,10 +32,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: Základní image má vstupní bod, který se přepíše,
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: Základní image má vstupní bod, který se přepíše,
           aby se aplikace spustila. Pokud je to žádoucí, nastavte ContainerAppCommandInstruction na
           „Entrypoint“. Pokud chcete zachovat vstupní bod základní image, nastavte
           ContainerAppCommandInstruction na „DefaultArgs“.</target>
@@ -58,9 +45,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} neurčuje registr a bude načten z Docker Hub.
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} neurčuje registr a bude načten z Docker Hub.
           Před název zadejte registr imagí, například: „{1}/&lt;image&gt;“.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
@@ -71,9 +57,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: Pro {0} nelze najít odpovídající základní image,
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: Pro {0} nelze najít odpovídající základní image,
           která odpovídá identifikátoru RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -126,9 +111,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: Vytvoření procesu {0} se nezdařilo.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: Vytvoření procesu {0} se nezdařilo.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -143,43 +127,36 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Jsou k dispozici ContainerEntrypoint a
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: Jsou k dispozici ContainerEntrypoint a
           ContainerAppCommandArgs. Pokud chcete nakonfigurovat způsob spuštění aplikace, musí být
           nastavená vlastnost ContainerAppInstruction. Platné pokyny jsou {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Je k dispozici ContainerEntrypoint. Pokud chcete
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: Je k dispozici ContainerEntrypoint. Pokud chcete
           nakonfigurovat způsob spuštění aplikace, musí být nastavená vlastnost
           ContainerAppInstruction. Platné pokyny jsou {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs se poskytují bez zadání
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: ContainerEntrypointArgs se poskytují bez zadání
           ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: Je k dispozici containerEntrypointArgsSet.
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: Je k dispozici containerEntrypointArgsSet.
           Proveďte změnu, aby se pro argumenty, které musí být vždycky nastavené, používaly
           ContainerAppCommandArgs, nebo ContainerDefaultArgs pro argumenty, které se dají přepsat
           při vytvoření kontejneru.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint nejde kombinovat s
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint nejde kombinovat s
           ContainerAppCommandInstruction „{0}“.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -212,53 +189,42 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Odvozený název image „{0}“ obsahuje zcela neplatné
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: Odvozený název image „{0}“ obsahuje zcela neplatné
           znaky. Platné znaky pro název obrázku jsou alfanumerické znaky, -, /, nebo _, a název
           obrázku musí začínat alfanumerickým znakem.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: První znak názvu obrázku „{0}“ musí být malé
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: První znak názvu obrázku „{0}“ musí být malé
           písmeno nebo číslice a všechny znaky v názvu musí být alfanumerické znaky, -, /, nebo _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným
           číslem portu '{0}'. Položky ContainerPort musí mít hodnotu Include, která je celé číslo, a
           hodnotu Typu, která je buď tcp, nebo udp.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným
           číslem portu '{0}' a neplatným typem portu '{1}'. Položky ContainerPort musí mít hodnotu
           Include, která je celé číslo, a hodnotu Typu, která je buď tcp, nebo udp.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Položka ContainerPort byla poskytnuta s neplatným
           typem portu '{0}'. Položky ContainerPort musí mít hodnotu Include, která je celé číslo, a
           hodnotu Typu, která je buď tcp, nebo udp.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: Neplatná verze předběžné verze sady SDK '{0}' –
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: Neplatná verze předběžné verze sady SDK '{0}' –
           podporují se jen 'rc' a 'preview'.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -268,16 +234,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: Byla zadána neplatná {0} : {1}. Značky obrázků
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: Byla zadána neplatná {0} : {1}. Značky obrázků
           musí být alfanumerické, podtržítka, spojovníky nebo tečky.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: Byla zadána neplatná {0} : {1}. {0} musí být
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: Byla zadána neplatná {0} : {1}. {0} musí být
           seznam platných značek obrázků oddělených středníky. Značky obrázků musí být
           alfanumerické, podtržítka, spojovníky nebo tečky.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
@@ -288,16 +252,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: Položka '{0}' obsahuje položky bez metadat 'Value'
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: Položka '{0}' obsahuje položky bez metadat 'Value'
           a budou ignorovány.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: Místní registr není k dispozici, ale bylo
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: Místní registr není k dispozici, ale bylo
           požadováno vložení do místního registru.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -312,17 +274,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: Nelze stáhnout vrstvu s popisovačem '{0}' z
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: Nelze stáhnout vrstvu s popisovačem '{0}' z
           registru '{1}', protože neexistuje.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: Položka ContainerPort '{0}' neurčuje číslo portu.
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: Položka ContainerPort '{0}' neurčuje číslo portu.
           Ujistěte se prosím, že položka Include je číslo portu, například &lt;ContainerPort
           Include="80" /&gt;.</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
@@ -426,17 +385,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: Neznámý typ místního registru „{0}“. Platné typy
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: Neznámý typ místního registru „{0}“. Platné typy
           registru místního kontejneru jsou {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: Manifest pro {0}:{1} z registru {2} byl neznámý
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: Manifest pro {0}:{1} z registru {2} byl neznámý
           typ: {3}. Nahlaste prosím problém na https://github.com/dotnet/sdk-container-builds/issues
           s touto zprávou.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="de"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Vorzeitiger Fehler bei der Anforderung an Amazon
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: Vorzeitiger Fehler bei der Anforderung an Amazon
           Elastic Container Registry. Dieser Fehler wird häufig verursacht, wenn das Ziel-Repository
           nicht in der Registrierung vorhanden ist.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
@@ -25,16 +16,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs werden ohne Angabe eines
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: ContainerAppCommandArgs werden ohne Angabe eines
           ContainerAppCommand bereitgestellt.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand und ContainerAppCommandArgs
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommand und ContainerAppCommandArgs
           müssen leer sein, wenn "ContainerAppCommandInstruction" den Wert "{0}" aufweist.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -44,10 +33,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: Das Basisimage verfügt über einen Einstiegspunkt,
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: Das Basisimage verfügt über einen Einstiegspunkt,
           der überschrieben wird, um die Anwendung zu starten. Legen Sie
           "ContainerAppCommandInstruction" auf "Entrypoint" fest, wenn dies gewünscht ist. Um den
           Einstiegspunkt des Basisimages beizubehalten, legen Sie "ContainerAppCommandInstruction"
@@ -60,9 +47,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} gibt keine Registrierung an und wird aus
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} gibt keine Registrierung an und wird aus
           Docker Hub abgerufen. Stellen Sie dem Namen die Imageregistrierung voran, z. B.:
           "{1}/&lt;image&gt;".</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
@@ -74,9 +60,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: Es wurde kein übereinstimmendes Basisimage für {0}
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: Es wurde kein übereinstimmendes Basisimage für {0}
           gefunden, das mit RuntimeIdentifier {1} übereinstimmt.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -131,9 +116,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: Fehler beim Erstellen des {0}-Prozesses.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: Fehler beim Erstellen des {0}-Prozesses.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -148,44 +132,37 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Ein ContainerEntrypoint und
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: Ein ContainerEntrypoint und
           ContainerAppCommandArgs werden bereitgestellt. ContainerAppInstruction muss festgelegt
           werden, um zu konfigurieren, wie die Anwendung gestartet wird. Gültige Anweisungen sind
           {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Ein ContainerEntrypoint wird bereitgestellt.
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: Ein ContainerEntrypoint wird bereitgestellt.
           ContainerAppInstruction muss festgelegt werden, um zu konfigurieren, wie die Anwendung
           gestartet wird. Gültige Anweisungen sind {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs werden ohne Angabe eines
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: ContainerEntrypointArgs werden ohne Angabe eines
           ContainerEntrypoint bereitgestellt.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet werden bereitgestellt.
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: ContainerEntrypointArgsSet werden bereitgestellt.
           Ändern Sie diese Einstellung, um ContainerAppCommandArgs für Argumente zu verwenden, die
           immer festgelegt werden müssen, oder ContainerDefaultArgs für Argumente, die beim
           Erstellen des Containers überschrieben werden können.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint kann nicht mit
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint kann nicht mit
           ContainerAppCommandInstruction "{0}" kombiniert werden.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -219,58 +196,47 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Der abgeleitete Imagename '{0}' enthält
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: Der abgeleitete Imagename '{0}' enthält
           vollständig ungültige Zeichen. Die gültigen Zeichen für einen Bildnamen sind
           alphanumerische Zeichen, -, /, oder _, und der Bildname muss mit einem alphanumerischen
           Zeichen beginnen.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: Das erste Zeichen des Bildnamens "{0}" muss ein
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: Das erste Zeichen des Bildnamens "{0}" muss ein
           Kleinbuchstabe oder eine Ziffer sein, und alle Zeichen im Namen müssen ein
           alphanumerisches Zeichen, -, /oder _ sein.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Ein ContainerPort-Element wurde mit einer
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Ein ContainerPort-Element wurde mit einer
           ungültigen Portnummer „{0}“ angegeben. ContainerPort-Elemente müssen einen Include-Wert
           aufweisen, der eine ganze Zahl ist, und einen Type-Wert, der entweder „tcp“ oder „udp“
           ist.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Ein ContainerPort-Element wurde mit einer
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Ein ContainerPort-Element wurde mit einer
           ungültigen Portnummer „{0}“ und einem ungültigen Port-Typ „{1}“ angegeben.
           ContainerPort-Elemente müssen einen Include-Wert aufweisen, der eine ganze Zahl ist, und
           einen Type-Wert, der entweder „tcp“ oder „udp“ ist.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Ein ContainerPort-Element wurde mit einem
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Ein ContainerPort-Element wurde mit einem
           ungültigen Port-Typ „{0}“ angegeben. ContainerPort-Elemente müssen einen Include-Wert
           aufweisen, der eine ganze Zahl ist, und einen Type-Wert, der entweder „tcp“ oder „udp“
           ist.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: Ungültige SDK-Vorabversion „{0}“. Es werden nur
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: Ungültige SDK-Vorabversion „{0}“. Es werden nur
           „rc“ und „preview“ unterstützt.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -280,16 +246,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: Ungültige {0} angegeben: {1}. Imagetags müssen
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: Ungültige {0} angegeben: {1}. Imagetags müssen
           alphanumerisch, Unterstrich, Bindestrich oder Punkt sein.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: Ungültige {0} angegeben: {1}. {0} muss eine durch
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: Ungültige {0} angegeben: {1}. {0} muss eine durch
           Semikolons getrennte Liste gültiger Imagetags sein. Imagetags müssen alphanumerisch,
           Unterstrich, Bindestrich oder Punkt sein.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
@@ -301,16 +265,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: Das Element „{0}“ enthält Elemente ohne Metadatum
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: Das Element „{0}“ enthält Elemente ohne Metadatum
           „Value“. Diese werden ignoriert.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: Die lokale Registrierung ist nicht verfügbar, es
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: Die lokale Registrierung ist nicht verfügbar, es
           wurde jedoch eine Pushübertragung in eine lokale Registrierung angefordert.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -325,17 +287,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: Die Ebene mit dem Deskriptor „{0}“ kann nicht aus
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: Die Ebene mit dem Deskriptor „{0}“ kann nicht aus
           der Registrierung „{1}“ heruntergeladen werden, da sie nicht vorhanden ist.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: Das ContainerPort-Element „{0}“ gibt keine
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: Das ContainerPort-Element „{0}“ gibt keine
           Portnummer an. Stellen Sie sicher, dass der Include des Elements eine Portnummer ist, z.
           B. „&lt;ContainerPort Include="80" /&gt;“</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
@@ -445,17 +404,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: Unbekannter lokaler Registrierungstyp "{0}".
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: Unbekannter lokaler Registrierungstyp "{0}".
           Gültige lokale Containerregistrierungstypen sind {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: Das Manifest für {0}:{1} aus der Registrierung {2}
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: Das Manifest für {0}:{1} aus der Registrierung {2}
           war ein unbekannter Typ: {3}. Bitte melden Sie das Problem unter
           https://github.com/dotnet/sdk-container-builds/issues mit dieser Meldung.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -1,30 +1,52 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="de"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Vorzeitiger Fehler bei der Anforderung an Amazon Elastic Container Registry. Dieser Fehler wird häufig verursacht, wenn das Ziel-Repository nicht in der Registrierung vorhanden ist.</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: Vorzeitiger Fehler bei der Anforderung an Amazon
+          Elastic Container Registry. Dieser Fehler wird häufig verursacht, wenn das Ziel-Repository
+          nicht in der Registrierung vorhanden ist.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
         <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed.</source>
-        <target state="translated">CONTAINER2008: Es wurden sowohl {0} als auch {1} angegeben, es ist jedoch nur die eine oder die andere Angabe zulässig.</target>
+        <target state="translated">CONTAINER2008: Es wurden sowohl {0} als auch {1} angegeben, es
+          ist jedoch nur die eine oder die andere Angabe zulässig.</target>
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs werden ohne Angabe eines ContainerAppCommand bereitgestellt.</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: ContainerAppCommandArgs werden ohne Angabe eines
+          ContainerAppCommand bereitgestellt.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand und ContainerAppCommandArgs müssen leer sein, wenn "ContainerAppCommandInstruction" den Wert "{0}" aufweist.</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommand und ContainerAppCommandArgs
+          müssen leer sein, wenn "ContainerAppCommandInstruction" den Wert "{0}" aufweist.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: Das Basisimage verfügt über einen Einstiegspunkt, der überschrieben wird, um die Anwendung zu starten. Legen Sie "ContainerAppCommandInstruction" auf "Entrypoint" fest, wenn dies gewünscht ist. Um den Einstiegspunkt des Basisimages beizubehalten, legen Sie "ContainerAppCommandInstruction" auf "DefaultArgs" fest.</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: Das Basisimage verfügt über einen Einstiegspunkt,
+          der überschrieben wird, um die Anwendung zu starten. Legen Sie
+          "ContainerAppCommandInstruction" auf "Entrypoint" fest, wenn dies gewünscht ist. Um den
+          Einstiegspunkt des Basisimages beizubehalten, legen Sie "ContainerAppCommandInstruction"
+          auf "DefaultArgs" fest.</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,28 +55,36 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} gibt keine Registrierung an und wird aus Docker Hub abgerufen. Stellen Sie dem Namen die Imageregistrierung voran, z. B.: "{1}/&lt;image&gt;".</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} gibt keine Registrierung an und wird aus
+          Docker Hub abgerufen. Stellen Sie dem Namen die Imageregistrierung voran, z. B.:
+          "{1}/&lt;image&gt;".</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
-        <target state="translated">CONTAINER2013: {0} enthielt Leerzeichen. Diese werden durch Bindestriche ersetzt.</target>
+        <target state="translated">CONTAINER2013: {0} enthielt Leerzeichen. Diese werden durch
+          Bindestriche ersetzt.</target>
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: Es wurde kein übereinstimmendes Basisimage für {0} gefunden, das mit RuntimeIdentifier {1} übereinstimmt.</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: Es wurde kein übereinstimmendes Basisimage für {0}
+          gefunden, das mit RuntimeIdentifier {1} übereinstimmt.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: Fehler beim Hochladen des Blobs mit {0}; der Statuscode „{1}“ wurde empfangen.</target>
+        <target state="translated">CONTAINER1001: Fehler beim Hochladen des Blobs mit {0}; der
+          Statuscode „{1}“ wurde empfangen.</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
         <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Der Container „{0}“ wurde per Push an den Docker-Daemon übertragen.</target>
+        <target state="translated">Der Container „{0}“ wurde per Push an den Docker-Daemon
+          übertragen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
@@ -64,12 +94,14 @@
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">
         <source>Building image '{0}' with tags '{1}' on top of base image '{2}'.</source>
-        <target state="translated">Das Image „{0}“ mit den Tags „{1}“ wird auf dem Basisimage „{2}“ erstellt.</target>
+        <target state="translated">Das Image „{0}“ mit den Tags „{1}“ wird auf dem Basisimage „{2}“
+          erstellt.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
-        <target state="translated">CONTAINER1007: Das Token konnte nicht aus JSON deserialisiert werden.</target>
+        <target state="translated">CONTAINER1007: Das Token konnte nicht aus JSON deserialisiert
+          werden.</target>
         <note>{StrBegin="CONTAINER1007: "}</note>
       </trans-unit>
       <trans-unit id="CouldntRecognizeRegistry">
@@ -79,7 +111,8 @@
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>
-        <target state="translated">CONTAINER3002: Fehler beim Abrufen von Docker-Informationen({0})\n{1}\n{2}</target>
+        <target state="translated">CONTAINER3002: Fehler beim Abrufen von
+          Docker-Informationen({0})\n{1}\n{2}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed_Ex">
@@ -87,49 +120,70 @@
         <target state="translated">CONTAINER3002: Fehler beim Abrufen von Docker-Informationen: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: Fehler beim Erstellen des {0}-Prozesses.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
-        <target state="translated">CONTAINER4006: Die Eigenschaft „{0}“ ist leer oder enthält Leerzeichen und wird ignoriert.</target>
+        <target state="translated">CONTAINER4006: Die Eigenschaft „{0}“ ist leer oder enthält
+          Leerzeichen und wird ignoriert.</target>
         <note>{StrBegin="CONTAINER4006: "}</note>
       </trans-unit>
       <trans-unit id="EmptyValuesIgnored">
         <source>CONTAINER4004: Items '{0}' contain empty item(s) which will be ignored.</source>
-        <target state="translated">CONTAINER4004: Elemente „{0}“ enthalten leere Elemente, die ignoriert werden.</target>
+        <target state="translated">CONTAINER4004: Elemente „{0}“ enthalten leere Elemente, die
+          ignoriert werden.</target>
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Ein ContainerEntrypoint und ContainerAppCommandArgs werden bereitgestellt. ContainerAppInstruction muss festgelegt werden, um zu konfigurieren, wie die Anwendung gestartet wird. Gültige Anweisungen sind {0}.</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: Ein ContainerEntrypoint und
+          ContainerAppCommandArgs werden bereitgestellt. ContainerAppInstruction muss festgelegt
+          werden, um zu konfigurieren, wie die Anwendung gestartet wird. Gültige Anweisungen sind
+          {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Ein ContainerEntrypoint wird bereitgestellt. ContainerAppInstruction muss festgelegt werden, um zu konfigurieren, wie die Anwendung gestartet wird. Gültige Anweisungen sind {0}.</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: Ein ContainerEntrypoint wird bereitgestellt.
+          ContainerAppInstruction muss festgelegt werden, um zu konfigurieren, wie die Anwendung
+          gestartet wird. Gültige Anweisungen sind {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs werden ohne Angabe eines ContainerEntrypoint bereitgestellt.</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: ContainerEntrypointArgs werden ohne Angabe eines
+          ContainerEntrypoint bereitgestellt.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet werden bereitgestellt. Ändern Sie diese Einstellung, um ContainerAppCommandArgs für Argumente zu verwenden, die immer festgelegt werden müssen, oder ContainerDefaultArgs für Argumente, die beim Erstellen des Containers überschrieben werden können.</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet werden bereitgestellt.
+          Ändern Sie diese Einstellung, um ContainerAppCommandArgs für Argumente zu verwenden, die
+          immer festgelegt werden müssen, oder ContainerDefaultArgs für Argumente, die beim
+          Erstellen des Containers überschrieben werden können.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint kann nicht mit ContainerAppCommandInstruction "{0}" kombiniert werden.</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint kann nicht mit
+          ContainerAppCommandInstruction "{0}" kombiniert werden.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
         <source>CONTAINER1008: Failed retrieving credentials for "{0}": {1}</source>
-        <target state="translated">CONTAINER1008: Fehler beim Abrufen der Anmeldeinformationen für „{0}“: {1}</target>
+        <target state="translated">CONTAINER1008: Fehler beim Abrufen der Anmeldeinformationen für
+          „{0}“: {1}</target>
         <note>{StrBegin="CONTAINER1008: "}</note>
       </trans-unit>
       <trans-unit id="HostObjectNotDetected">
@@ -139,47 +193,76 @@
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: Fehler beim Laden des Images aus der lokalen Registrierung. stdout: {0}</target>
+        <target state="translated">CONTAINER1009: Fehler beim Laden des Images aus der lokalen
+          Registrierung. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
-        <target state="translated">CONTAINER1010: Das Pullen von Images aus der lokalen Registrierung wird nicht unterstützt.</target>
+        <target state="translated">CONTAINER1010: Das Pullen von Images aus der lokalen
+          Registrierung wird nicht unterstützt.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
-        <target state="translated">CONTAINER2015: {0}: „{1}“ war keine gültige Umgebungsvariable. Sie wird ignoriert.</target>
+        <target state="translated">CONTAINER2015: {0}: „{1}“ war keine gültige Umgebungsvariable.
+          Sie wird ignoriert.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Der abgeleitete Imagename '{0}' enthält vollständig ungültige Zeichen. Die gültigen Zeichen für einen Bildnamen sind alphanumerische Zeichen, -, /, oder _, und der Bildname muss mit einem alphanumerischen Zeichen beginnen.</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: Der abgeleitete Imagename '{0}' enthält
+          vollständig ungültige Zeichen. Die gültigen Zeichen für einen Bildnamen sind
+          alphanumerische Zeichen, -, /, oder _, und der Bildname muss mit einem alphanumerischen
+          Zeichen beginnen.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: Das erste Zeichen des Bildnamens "{0}" muss ein Kleinbuchstabe oder eine Ziffer sein, und alle Zeichen im Namen müssen ein alphanumerisches Zeichen, -, /oder _ sein.</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: Das erste Zeichen des Bildnamens "{0}" muss ein
+          Kleinbuchstabe oder eine Ziffer sein, und alle Zeichen im Namen müssen ein
+          alphanumerisches Zeichen, -, /oder _ sein.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Ein ContainerPort-Element wurde mit einer ungültigen Portnummer „{0}“ angegeben. ContainerPort-Elemente müssen einen Include-Wert aufweisen, der eine ganze Zahl ist, und einen Type-Wert, der entweder „tcp“ oder „udp“ ist.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Ein ContainerPort-Element wurde mit einer
+          ungültigen Portnummer „{0}“ angegeben. ContainerPort-Elemente müssen einen Include-Wert
+          aufweisen, der eine ganze Zahl ist, und einen Type-Wert, der entweder „tcp“ oder „udp“
+          ist.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Ein ContainerPort-Element wurde mit einer ungültigen Portnummer „{0}“ und einem ungültigen Port-Typ „{1}“ angegeben. ContainerPort-Elemente müssen einen Include-Wert aufweisen, der eine ganze Zahl ist, und einen Type-Wert, der entweder „tcp“ oder „udp“ ist.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Ein ContainerPort-Element wurde mit einer
+          ungültigen Portnummer „{0}“ und einem ungültigen Port-Typ „{1}“ angegeben.
+          ContainerPort-Elemente müssen einen Include-Wert aufweisen, der eine ganze Zahl ist, und
+          einen Type-Wert, der entweder „tcp“ oder „udp“ ist.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Ein ContainerPort-Element wurde mit einem ungültigen Port-Typ „{0}“ angegeben. ContainerPort-Elemente müssen einen Include-Wert aufweisen, der eine ganze Zahl ist, und einen Type-Wert, der entweder „tcp“ oder „udp“ ist.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Ein ContainerPort-Element wurde mit einem
+          ungültigen Port-Typ „{0}“ angegeben. ContainerPort-Elemente müssen einen Include-Wert
+          aufweisen, der eine ganze Zahl ist, und einen Type-Wert, der entweder „tcp“ oder „udp“
+          ist.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: Ungültige SDK-Vorabversion „{0}“. Es werden nur „rc“ und „preview“ unterstützt.</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
+        <target state="translated">CONTAINER2018: Ungültige SDK-Vorabversion „{0}“. Es werden nur
+          „rc“ und „preview“ unterstützt.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -188,28 +271,38 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: Ungültige {0} angegeben: {1}. Imagetags müssen alphanumerisch, Unterstrich, Bindestrich oder Punkt sein.</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: Ungültige {0} angegeben: {1}. Imagetags müssen
+          alphanumerisch, Unterstrich, Bindestrich oder Punkt sein.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: Ungültige {0} angegeben: {1}. {0} muss eine durch Semikolons getrennte Liste gültiger Imagetags sein. Imagetags müssen alphanumerisch, Unterstrich, Bindestrich oder Punkt sein.</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: Ungültige {0} angegeben: {1}. {0} muss eine durch
+          Semikolons getrennte Liste gültiger Imagetags sein. Imagetags müssen alphanumerisch,
+          Unterstrich, Bindestrich oder Punkt sein.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
         <source>CONTAINER1003: Token response had neither token nor access_token.</source>
-        <target state="translated">CONTAINER1003: Die Tokenantwort enthielt weder ein Token noch access_token.</target>
+        <target state="translated">CONTAINER1003: Die Tokenantwort enthielt weder ein Token noch
+          access_token.</target>
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
-        <target state="translated">CONTAINER4005: Das Element „{0}“ enthält Elemente ohne Metadatum „Value“. Diese werden ignoriert.</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
+        <target state="translated">CONTAINER4005: Das Element „{0}“ enthält Elemente ohne Metadatum
+          „Value“. Diese werden ignoriert.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
-        <target state="translated">CONTAINER1012: Die lokale Registrierung ist nicht verfügbar, es wurde jedoch eine Pushübertragung in eine lokale Registrierung angefordert.</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
+        <target state="translated">CONTAINER1012: Die lokale Registrierung ist nicht verfügbar, es
+          wurde jedoch eine Pushübertragung in eine lokale Registrierung angefordert.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -223,13 +316,19 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: Die Ebene mit dem Deskriptor „{0}“ kann nicht aus der Registrierung „{1}“ heruntergeladen werden, da sie nicht vorhanden ist.</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: Die Ebene mit dem Deskriptor „{0}“ kann nicht aus
+          der Registrierung „{1}“ heruntergeladen werden, da sie nicht vorhanden ist.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: Das ContainerPort-Element „{0}“ gibt keine Portnummer an. Stellen Sie sicher, dass der Include des Elements eine Portnummer ist, z. B. „&lt;ContainerPort Include="80" /&gt;“</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: Das ContainerPort-Element „{0}“ gibt keine
+          Portnummer an. Stellen Sie sicher, dass der Include des Elements eine Portnummer ist, z.
+          B. „&lt;ContainerPort Include="80" /&gt;“</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -239,7 +338,8 @@
       </trans-unit>
       <trans-unit id="NormalizedContainerName">
         <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
-        <target state="translated">„{0}“ war kein gültiger Containerimagename, er wurde zu „{1}“ normalisiert.</target>
+        <target state="translated">„{0}“ war kein gültiger Containerimagename, er wurde zu „{1}“
+          normalisiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
@@ -249,7 +349,8 @@
       </trans-unit>
       <trans-unit id="RegistryOutputPushFailed">
         <source>CONTAINER1013: Failed to push to the output registry: {0}</source>
-        <target state="translated">CONTAINER1013: Fehler beim Pushen in die Ausgaberegistrierung: {0}</target>
+        <target state="translated">CONTAINER1013: Fehler beim Pushen in die Ausgaberegistrierung:
+          {0}</target>
         <note>{StrBegin="CONTAINER1013: "}</note>
       </trans-unit>
       <trans-unit id="RegistryPushFailed">
@@ -259,7 +360,8 @@
       </trans-unit>
       <trans-unit id="Registry_ConfigUploadStarted">
         <source>Uploading config to registry at blob '{0}',</source>
-        <target state="translated">Die Konfiguration wird in die Registrierung unter Blob „{0}“ hochgeladen,</target>
+        <target state="translated">Die Konfiguration wird in die Registrierung unter Blob „{0}“
+          hochgeladen,</target>
         <note />
       </trans-unit>
       <trans-unit id="Registry_ConfigUploaded">
@@ -284,7 +386,8 @@
       </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
-        <target state="translated">Das Manifest wird in die Registrierung „{0}“ als Blob „{1}“ hochgeladen.</target>
+        <target state="translated">Das Manifest wird in die Registrierung „{0}“ als Blob „{1}“
+          hochgeladen.</target>
         <note>{0} is the registry name</note>
       </trans-unit>
       <trans-unit id="Registry_ManifestUploaded">
@@ -304,37 +407,48 @@
       </trans-unit>
       <trans-unit id="RequiredItemsContainsEmptyItems">
         <source>CONTAINER4003: Required '{0}' items contain empty items.</source>
-        <target state="translated">CONTAINER4003: Erforderliche „{0}“-Elemente enthalten leere Elemente.</target>
+        <target state="translated">CONTAINER4003: Erforderliche „{0}“-Elemente enthalten leere
+          Elemente.</target>
         <note>{StrBegin="CONTAINER4003: "}</note>
       </trans-unit>
       <trans-unit id="RequiredItemsNotSet">
         <source>CONTAINER4002: Required '{0}' items were not set.</source>
-        <target state="translated">CONTAINER4002: Erforderliche „{0}“-Elemente wurden nicht festgelegt.</target>
+        <target state="translated">CONTAINER4002: Erforderliche „{0}“-Elemente wurden nicht
+          festgelegt.</target>
         <note>{StrBegin="CONTAINER4002: "}</note>
       </trans-unit>
       <trans-unit id="RequiredPropertyNotSetOrEmpty">
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
-        <target state="translated">CONTAINER4001: Die erforderliche Eigenschaft „{0}“ wurde nicht festgelegt oder ist leer.</target>
+        <target state="translated">CONTAINER4001: Die erforderliche Eigenschaft „{0}“ wurde nicht
+          festgelegt oder ist leer.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>
-        <target state="translated">CONTAINER1006: Zu viele Wiederholungsversuche, Vorgang wird beendet.</target>
+        <target state="translated">CONTAINER1006: Zu viele Wiederholungsversuche, Vorgang wird
+          beendet.</target>
         <note>{StrBegin="CONTAINER1006: "}</note>
       </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: Unbekannte AppCommandInstruction "{0}". Gültige Anweisungen sind {1}.</target>
+        <target state="translated">CONTAINER2021: Unbekannte AppCommandInstruction "{0}". Gültige
+          Anweisungen sind {1}.</target>
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: Unbekannter lokaler Registrierungstyp "{0}". Gültige lokale Containerregistrierungstypen sind {1}.</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: Unbekannter lokaler Registrierungstyp "{0}".
+          Gültige lokale Containerregistrierungstypen sind {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: Das Manifest für {0}:{1} aus der Registrierung {2} war ein unbekannter Typ: {3}. Bitte melden Sie das Problem unter https://github.com/dotnet/sdk-container-builds/issues mit dieser Meldung.</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: Das Manifest für {0}:{1} aus der Registrierung {2}
+          war ein unbekannter Typ: {3}. Bitte melden Sie das Problem unter
+          https://github.com/dotnet/sdk-container-builds/issues mit dieser Meldung.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -1,352 +1,547 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
-    <body>
-      <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Error prematuro en la solicitud al registro de contenedor elástico de Amazon. Esto suele ocurrir cuando el repositorio de destino no existe en el registro.</target>
-        <note>{StrBegin="CONTAINER1002: "}</note>
-      </trans-unit>
-      <trans-unit id="AmbiguousTags">
-        <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed.</source>
-        <target state="translated">CONTAINER2008: Se proporcionaron {0} y {1}, pero solo se permite uno de los dos.</target>
-        <note>{StrBegin="CONTAINER2008: "}</note>
-      </trans-unit>
-      <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs se proporcionan sin especificar containerAppCommand.</target>
-        <note>{StrBegin="CONTAINER2025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand y ContainerAppCommandArgs deben estar vacíos cuando ContainerAppCommandInstruction es '{0}'.</target>
-        <note>{StrBegin="CONTAINER2026: "}</note>
-      </trans-unit>
-      <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: la imagen base tiene un punto de entrada que se sobrescribirá para iniciar la aplicación. Establezca ContainerAppCommandInstruction en "Entrypoint" si lo desea. Para conservar el punto de entrada de la imagen base, establezca ContainerAppCommandInstruction en "DefaultArgs".</target>
-        <note>{StrBegin="CONTAINER2022: "}</note>
-      </trans-unit>
-      <trans-unit id="BaseImageNameParsingFailed">
-        <source>CONTAINER2009: Could not parse {0}: {1}</source>
-        <target state="translated">CONTAINER2009: No se pudo analizar {0}: {1}</target>
-        <note>{StrBegin="CONTAINER2009: "}</note>
-      </trans-unit>
-      <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} no especifica un registro y se extraerá de Docker Hub. Anteponer el nombre al registro de imágenes, por ejemplo: "{1}/&lt;image&gt;".</target>
-        <note>{StrBegin="CONTAINER2020: "}</note>
-      </trans-unit>
-      <trans-unit id="BaseImageNameWithSpaces">
-        <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
-        <target state="translated">CONTAINER2013: {0} tenía espacios, reemplazando por guiones.</target>
-        <note>{StrBegin="CONTAINER2013: "}</note>
-      </trans-unit>
-      <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: No se pudo encontrar una imagen base coincidente para {0} que coincida con el RuntimeIdentifier {1}.</target>
-        <note>{StrBegin="CONTAINER1011: "}</note>
-      </trans-unit>
-      <trans-unit id="BlobUploadFailed">
-        <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: no se pudo cargar el blob mediante {0}; se ha recibido el código de estado "{1}".</target>
-        <note>{StrBegin="CONTAINER1001: "}</note>
-      </trans-unit>
-      <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Se insertó el contenedor "{0}" en el demonio de Docker.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">Se insertó el contenedor "{0}" en el registro "{1}".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ContainerBuilder_StartBuildingImage">
-        <source>Building image '{0}' with tags '{1}' on top of base image '{2}'.</source>
-        <target state="translated">Compilando imagen "{0}" con etiquetas "{1}" encima de la imagen base "{2}".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldntDeserializeJsonToken">
-        <source>CONTAINER1007: Could not deserialize token from JSON.</source>
-        <target state="translated">CONTAINER1007: No se pudo deserializar el token de JSON.</target>
-        <note>{StrBegin="CONTAINER1007: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldntRecognizeRegistry">
-        <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
-        <target state="translated">CONTAINER2012: No se pudo reconocer el registro "{0}".</target>
-        <note>{StrBegin="CONTAINER2012: "}</note>
-      </trans-unit>
-      <trans-unit id="DockerInfoFailed">
-        <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>
-        <target state="translated">CONTAINER3002: No se pudo obtener la información de docker ({0})\n{1}\n{2}</target>
-        <note>{StrBegin="CONTAINER3002: "}</note>
-      </trans-unit>
-      <trans-unit id="DockerInfoFailed_Ex">
-        <source>CONTAINER3002: Failed to get docker info: {0}</source>
-        <target state="translated">CONTAINER3002: No se pudo obtener la información de docker: {0}</target>
-        <note>{StrBegin="CONTAINER3002: "}</note>
-      </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
-        <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: No se pudo crear {0} el proceso.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
-      </trans-unit>
-      <trans-unit id="EmptyOrWhitespacePropertyIgnored">
-        <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
-        <target state="translated">CONTAINER4006: La propiedad "{0}" está vacía o contiene espacios en blanco y se omitirá.</target>
-        <note>{StrBegin="CONTAINER4006: "}</note>
-      </trans-unit>
-      <trans-unit id="EmptyValuesIgnored">
-        <source>CONTAINER4004: Items '{0}' contain empty item(s) which will be ignored.</source>
-        <target state="translated">CONTAINER4004: los elementos "{0}" contienen elementos vacíos que se omitirán.</target>
-        <note>{StrBegin="CONTAINER4004: "}</note>
-      </trans-unit>
-      <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: se proporcionan ContainerEntrypoint y ContainerAppCommandArgs. ContainerAppInstruction debe establecerse para configurar cómo se inicia la aplicación. Las instrucciones válidas son {0}.</target>
-        <note>{StrBegin="CONTAINER2023: "}</note>
-      </trans-unit>
-      <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: se proporciona containerEntrypoint. ContainerAppInstruction debe establecerse para configurar cómo se inicia la aplicación. Las instrucciones válidas son {0}.</target>
-        <note>{StrBegin="CONTAINER2027: "}</note>
-      </trans-unit>
-      <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs se proporcionan sin especificar containerEntrypoint.</target>
-        <note>{StrBegin="CONTAINER2024: "}</note>
-      </trans-unit>
-      <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: se proporciona ContainerEntrypointArgsSet. Cambie para usar ContainerAppCommandArgs para los argumentos que siempre se deben establecer o ContainerDefaultArgs para los argumentos que se pueden invalidar cuando se crea el contenedor.</target>
-        <note>{StrBegin="CONTAINER2029: "}</note>
-      </trans-unit>
-      <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint no se puede combinar con ContainerAppCommandInstruction '{0}'.</target>
-        <note>{StrBegin="CONTAINER2028: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedRetrievingCredentials">
-        <source>CONTAINER1008: Failed retrieving credentials for "{0}": {1}</source>
-        <target state="translated">CONTAINER1008: No se pudieron recuperar las credenciales de "{0}": {1}</target>
-        <note>{StrBegin="CONTAINER1008: "}</note>
-      </trans-unit>
-      <trans-unit id="HostObjectNotDetected">
-        <source>No host object detected.</source>
-        <target state="translated">No se detectó ningún objeto host.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ImageLoadFailed">
-        <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: no se pudo cargar la imagen desde el registro local. Stdout: {0}</target>
-        <note>{StrBegin="CONTAINER1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ImagePullNotSupported">
-        <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
-        <target state="translated">CONTAINER1010: No se admite la extracción de imágenes del registro local.</target>
-        <note>{StrBegin="CONTAINER1010: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidEnvVar">
-        <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
-        <target state="translated">CONTAINER2015: {0}: "{1}" no era una variable de entorno válida. Ignorando.</target>
-        <note>{StrBegin="CONTAINER2015: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: el nombre de imagen inferido '{0}' contiene caracteres totalmente no válidos. Los caracteres válidos para un nombre de imagen son los caracteres alfanuméricos, -, /, o _; el nombre de imagen tiene que comenzar con uno.</target>
-        <note>{StrBegin="CONTAINER2005: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: el primer carácter del nombre de imagen '{0}' tiene que ser una letra minúscula o un dígito y todos los caracteres del nombre deben ser alfanuméricos, -, /, o _.</target>
-        <note>{StrBegin="CONTAINER2005: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Se proporcionó un elemento ContainerPort con un número de puerto "{0}". Los elementos ContainerPort deben tener un valor Include que sea un entero y un valor Type que sea "tcp" o "udp".</target>
-        <note>{StrBegin="CONTAINER2017: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Se proporcionó un elemento ContainerPort con un número de puerto no válido "{0}" y un tipo de puerto no válido "{1}". Los elementos ContainerPort deben tener un valor Include que sea un entero y un valor Type que sea "tcp" o "udp".</target>
-        <note>{StrBegin="CONTAINER2017: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Se proporcionó un elemento ContainerPort con un tipo de puerto "{0}". Los elementos ContainerPort deben tener un valor Include que sea un entero y un valor Type que sea "tcp" o "udp".</target>
-        <note>{StrBegin="CONTAINER2017: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: Versión preliminar del SDK "{0}" no válida : solo se admiten "rc" y "preview".</target>
-        <note>{StrBegin="CONTAINER2018: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidSdkVersion">
-        <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
-        <target state="translated">CONTAINER2019: Versión "{0}" de semántica del SDK no válida.</target>
-        <note>{StrBegin="CONTAINER2019: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: Se proporcionó un {0} no válido: {1}. Las etiquetas de imagen deben ser alfanuméricas, con guion bajo, guiones o puntos.</target>
-        <note>{StrBegin="CONTAINER2007: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: se proporcionó un {0} no válido: {1}. {0} debe ser una lista delimitada por punto y coma de etiquetas de imagen válidas. Las etiquetas de imagen deben ser alfanuméricas, con guion bajo, guiones o puntos.</target>
-        <note>{StrBegin="CONTAINER2010: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidTokenResponse">
-        <source>CONTAINER1003: Token response had neither token nor access_token.</source>
-        <target state="translated">CONTAINER1003: La respuesta del token no tenía ningún token ni access_token.</target>
-        <note>{StrBegin="CONTAINER1003: "}</note>
-      </trans-unit>
-      <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
-        <target state="translated">CONTAINER4005: El elemento "{0}" contiene elementos sin metadatos "Value" y se omitirán.</target>
-        <note>{StrBegin="CONTAINER4005: "}</note>
-      </trans-unit>
-      <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
-        <target state="translated">CONTAINER1012: el registro local no está disponible, pero se solicitó la inserción en un registro local.</target>
-        <note>{StrBegin="CONTAINER1012: "}</note>
-      </trans-unit>
-      <trans-unit id="LocalDocker_FailedToGetConfig">
-        <source>Error while reading daemon config: {0}</source>
-        <target state="translated">Error al leer la configuración del demonio: {0}</target>
-        <note>{0} is the exception message that ends with period</note>
-      </trans-unit>
-      <trans-unit id="LocalDocker_LocalDaemonErrors">
-        <source>The daemon server reported errors: {0}</source>
-        <target state="translated">El servidor demonio notificó los errores: {0}</target>
-        <note>{0} are the list of messages, each message starts with new line</note>
-      </trans-unit>
-      <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: No se puede descargar la capa con el descriptor "{0}" del registro "{1}" porque no existe.</target>
-        <note>{StrBegin="CONTAINER2004: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: El elemento ContainerPort "{0}" no especifica el número de puerto. Asegúrate de que la inclusión del elemento es un número de puerto, por ejemplo, "&lt;ContainerPort Include="80" /&gt;"</target>
-        <note>{StrBegin="CONTAINER2016: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRequestUriSpecified">
-        <source>CONTAINER1004: No RequestUri specified.</source>
-        <target state="translated">CONTAINER1004: No se especificó RequestUri.</target>
-        <note>{StrBegin="CONTAINER1004: "}</note>
-      </trans-unit>
-      <trans-unit id="NormalizedContainerName">
-        <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
-        <target state="translated">"{0}" no era un nombre de imagen de contenedor válido, se normalizó a "{1}"</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishDirectoryDoesntExist">
-        <source>CONTAINER2011: {0} '{1}' does not exist</source>
-        <target state="translated">CONTAINER2011: {0} "{1}" no existe</target>
-        <note>{StrBegin="CONTAINER2011: "}</note>
-      </trans-unit>
-      <trans-unit id="RegistryOutputPushFailed">
-        <source>CONTAINER1013: Failed to push to the output registry: {0}</source>
-        <target state="translated">CONTAINER1013: No se pudieron enviar cambios al el Registro de salida: {0}</target>
-        <note>{StrBegin="CONTAINER1013: "}</note>
-      </trans-unit>
-      <trans-unit id="RegistryPushFailed">
-        <source>CONTAINER1005: Registry push failed; received status code '{0}'.</source>
-        <target state="new">CONTAINER1005: Registry push failed; received status code '{0}'.</target>
-        <note>{StrBegin="CONTAINER1005: "}</note>
-      </trans-unit>
-      <trans-unit id="Registry_ConfigUploadStarted">
-        <source>Uploading config to registry at blob '{0}',</source>
-        <target state="translated">Cargando la configuración en el Registro en el blob "{0}",</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Registry_ConfigUploaded">
-        <source>Uploaded config to registry.</source>
-        <target state="translated">Se cargó la configuración en el Registro.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Registry_LayerExists">
-        <source>Layer '{0}' already exists.</source>
-        <target state="translated">La capa "{0}" ya existe.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Registry_LayerUploadStarted">
-        <source>Uploading layer '{0}' to '{1}'.</source>
-        <target state="translated">Cargando la capa "{0}" en "{1}".</target>
-        <note>{0} is the layer digest, {1} is the registry name</note>
-      </trans-unit>
-      <trans-unit id="Registry_LayerUploaded">
-        <source>Finished uploading layer '{0}' to '{1}'.</source>
-        <target state="translated">Finalizó la carga de la capa "{0}" en "{1}".</target>
-        <note>{0} is the layer digest, {1} is the registry name</note>
-      </trans-unit>
-      <trans-unit id="Registry_ManifestUploadStarted">
-        <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
-        <target state="translated">Cargando manifiesto en el Registro "{0}" como blob "{1}".</target>
-        <note>{0} is the registry name</note>
-      </trans-unit>
-      <trans-unit id="Registry_ManifestUploaded">
-        <source>Uploaded manifest to '{0}'.</source>
-        <target state="translated">Se cargó el manifiesto en "{0}".</target>
-        <note>{0} is the registry name</note>
-      </trans-unit>
-      <trans-unit id="Registry_TagUploadStarted">
-        <source>Uploading tag '{0}' to '{1}'.</source>
-        <target state="translated">Cargando la etiqueta "{0}" en "{1}".</target>
-        <note>{1} is the registry name</note>
-      </trans-unit>
-      <trans-unit id="Registry_TagUploaded">
-        <source>Uploaded tag '{0}' to '{1}'.</source>
-        <target state="translated">Etiqueta cargada "{0}" en "{1}".</target>
-        <note>{1} is the registry name</note>
-      </trans-unit>
-      <trans-unit id="RequiredItemsContainsEmptyItems">
-        <source>CONTAINER4003: Required '{0}' items contain empty items.</source>
-        <target state="translated">CONTAINER4003: Los elementos de "{0}" necesarios contienen elementos vacíos.</target>
-        <note>{StrBegin="CONTAINER4003: "}</note>
-      </trans-unit>
-      <trans-unit id="RequiredItemsNotSet">
-        <source>CONTAINER4002: Required '{0}' items were not set.</source>
-        <target state="translated">CONTAINER4002: No se establecieron los elementos de "{0}" necesarios.</target>
-        <note>{StrBegin="CONTAINER4002: "}</note>
-      </trans-unit>
-      <trans-unit id="RequiredPropertyNotSetOrEmpty">
-        <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
-        <target state="translated">CONTAINER4001: La propiedad necesaria "{0}" no se estableció o estaba vacía.</target>
-        <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TooManyRetries">
-        <source>CONTAINER1006: Too many retries, stopping.</source>
-        <target state="translated">CONTAINER1006: Demasiados reintentos, deteniendo.</target>
-        <note>{StrBegin="CONTAINER1006: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownAppCommandInstruction">
-        <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: AppCommandInstruction ''{0}desconocido. Las instrucciones válidas son {1}.</target>
-        <note>{StrBegin="CONTAINER2021: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: tipo de registro local desconocido '{0}'. Los tipos de registro de contenedor locales válidos son {1}.</target>
-        <note>{StrBegin="CONTAINER2002: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: El manifiesto de {0}:{1} del registro {2} era de un tipo desconocido: {3}. Presente un problema en https://github.com/dotnet/sdk-container-builds/issues con este mensaje.</target>
-        <note>{StrBegin="CONTAINER2003: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedMediaType">
-        <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
-        <target state="translated">CONTAINER2001: mediaType "{0}" no reconocido.</target>
-        <note>{StrBegin="CONTAINER2001: "}</note>
-      </trans-unit>
-      <trans-unit id="_Test">
-        <source>CONTAINER0000: Value for unit test {0}</source>
-        <target state="translated">CONTAINER0000: Valor de la prueba unitaria {0}</target>
-        <note>Used only for unit tests</note>
-      </trans-unit>
-    </body>
-  </file>
+<xliff
+        xmlns="urn:oasis:names:tc:xliff:document:1.2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        version="1.2"
+        xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+    <file
+            datatype="xml"
+            source-language="en"
+            target-language="es"
+            original="../Strings.resx">
+        <body>
+            <trans-unit id="AmazonRegistryFailed">
+                <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed
+                    prematurely. This
+                    is often caused when the target repository does not exist in the registry.</source>
+                <target state="translated">CONTAINER1002: Error prematuro en la solicitud al
+                    registro de
+                    contenedor elástico de Amazon. Esto suele ocurrir cuando el repositorio de
+                    destino no
+                    existe en el registro.</target>
+                <note>{StrBegin="CONTAINER1002: "}</note>
+            </trans-unit>
+            <trans-unit id="AmbiguousTags">
+                <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is
+                    allowed.</source>
+                <target state="translated">CONTAINER2008: Se proporcionaron {0} y {1}, pero solo se
+                    permite
+                    uno de los dos.</target>
+                <note>{StrBegin="CONTAINER2008: "}</note>
+            </trans-unit>
+            <trans-unit id="AppCommandArgsSetNoAppCommand">
+                <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+                    ContainerAppCommand.</source>
+                <target state="translated">CONTAINER2025: ContainerAppCommandArgs se proporcionan
+                    sin
+                    especificar containerAppCommand.</target>
+                <note>{StrBegin="CONTAINER2025: "}</note>
+            </trans-unit>
+            <trans-unit id="AppCommandSetNotUsed">
+                <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty
+                    when
+                    ContainerAppCommandInstruction is '{0}'.</source>
+                <target state="translated">CONTAINER2026: ContainerAppCommand y
+                    ContainerAppCommandArgs
+                    deben estar vacíos cuando ContainerAppCommandInstruction es '{0}'.</target>
+                <note>{StrBegin="CONTAINER2026: "}</note>
+            </trans-unit>
+            <trans-unit id="BaseEntrypointOverwritten">
+                <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to
+                    start
+                    the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is
+                    desired. To
+                    preserve the base image entrypoint, set ContainerAppCommandInstruction to
+                    'DefaultArgs'.</source>
+                <target state="translated">CONTAINER2022: la imagen base tiene un punto de entrada
+                    que se
+                    sobrescribirá para iniciar la aplicación. Establezca
+                    ContainerAppCommandInstruction en
+                    "Entrypoint" si lo desea. Para conservar el punto de entrada de la imagen base,
+                    establezca
+                    ContainerAppCommandInstruction en "DefaultArgs".</target>
+                <note>{StrBegin="CONTAINER2022: "}</note>
+            </trans-unit>
+            <trans-unit id="BaseImageNameParsingFailed">
+                <source>CONTAINER2009: Could not parse {0}: {1}</source>
+                <target state="translated">CONTAINER2009: No se pudo analizar {0}: {1}</target>
+                <note>{StrBegin="CONTAINER2009: "}</note>
+            </trans-unit>
+            <trans-unit id="BaseImageNameRegistryFallback">
+                <source>CONTAINER2020: {0} does not specify a registry and will be pulled from
+                    Docker Hub.
+                    Please prefix the name with the image registry, for example:
+                    '{1}/&lt;image&gt;'.</source>
+                <target state="translated">CONTAINER2020: {0} no especifica un registro y se
+                    extraerá de
+                    Docker Hub. Anteponer el nombre al registro de imágenes, por ejemplo:
+                    "{1}/&lt;image&gt;".</target>
+                <note>{StrBegin="CONTAINER2020: "}</note>
+            </trans-unit>
+            <trans-unit id="BaseImageNameWithSpaces">
+                <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
+                <target state="translated">CONTAINER2013: {0} tenía espacios, reemplazando por
+                    guiones.</target>
+                <note>{StrBegin="CONTAINER2013: "}</note>
+            </trans-unit>
+            <trans-unit id="BaseImageNotFound">
+                <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+                    RuntimeIdentifier {1}.</source>
+                <target state="translated">CONTAINER1011: No se pudo encontrar una imagen base
+                    coincidente
+                    para {0} que coincida con el RuntimeIdentifier {1}.</target>
+                <note>{StrBegin="CONTAINER1011: "}</note>
+            </trans-unit>
+            <trans-unit id="BlobUploadFailed">
+                <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
+                <target state="translated">CONTAINER1001: no se pudo cargar el blob mediante {0}; se
+                    ha
+                    recibido el código de estado "{1}".</target>
+                <note>{StrBegin="CONTAINER1001: "}</note>
+            </trans-unit>
+            <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
+                <source>Pushed container '{0}' to Docker daemon.</source>
+                <target state="translated">Se insertó el contenedor "{0}" en el demonio de Docker.</target>
+                <note />
+            </trans-unit>
+            <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
+                <source>Pushed container '{0}' to registry '{1}'.</source>
+                <target state="translated">Se insertó el contenedor "{0}" en el registro "{1}".</target>
+                <note />
+            </trans-unit>
+            <trans-unit id="ContainerBuilder_StartBuildingImage">
+                <source>Building image '{0}' with tags '{1}' on top of base image '{2}'.</source>
+                <target state="translated">Compilando imagen "{0}" con etiquetas "{1}" encima de la
+                    imagen
+                    base "{2}".</target>
+                <note />
+            </trans-unit>
+            <trans-unit id="CouldntDeserializeJsonToken">
+                <source>CONTAINER1007: Could not deserialize token from JSON.</source>
+                <target state="translated">CONTAINER1007: No se pudo deserializar el token de JSON.</target>
+                <note>{StrBegin="CONTAINER1007: "}</note>
+            </trans-unit>
+            <trans-unit id="CouldntRecognizeRegistry">
+                <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
+                <target state="translated">CONTAINER2012: No se pudo reconocer el registro "{0}".</target>
+                <note>{StrBegin="CONTAINER2012: "}</note>
+            </trans-unit>
+            <trans-unit id="DockerInfoFailed">
+                <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>
+                <target state="translated">CONTAINER3002: No se pudo obtener la información de
+                    docker
+                    ({0})\n{1}\n{2}</target>
+                <note>{StrBegin="CONTAINER3002: "}</note>
+            </trans-unit>
+            <trans-unit id="DockerInfoFailed_Ex">
+                <source>CONTAINER3002: Failed to get docker info: {0}</source>
+                <target state="translated">CONTAINER3002: No se pudo obtener la información de
+                    docker: {0}</target>
+                <note>{StrBegin="CONTAINER3002: "}</note>
+            </trans-unit>
+            <trans-unit id="ContainerRuntimeProcessCreationFailed">
+                <source>CONTAINER3001: Failed creating {0} process.</source>
+                <target state="translated">CONTAINER3001: No se pudo crear {0} el proceso.</target>
+                <note>CONTAINER3001: {0} is the name of the command we failed to run, usually
+                    'docker' or
+                    'podman'.</note>
+            </trans-unit>
+            <trans-unit id="EmptyOrWhitespacePropertyIgnored">
+                <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be
+                    ignored.</source>
+                <target state="translated">CONTAINER4006: La propiedad "{0}" está vacía o contiene
+                    espacios
+                    en blanco y se omitirá.</target>
+                <note>{StrBegin="CONTAINER4006: "}</note>
+            </trans-unit>
+            <trans-unit id="EmptyValuesIgnored">
+                <source>CONTAINER4004: Items '{0}' contain empty item(s) which will be ignored.</source>
+                <target state="translated">CONTAINER4004: los elementos "{0}" contienen elementos
+                    vacíos que
+                    se omitirán.</target>
+                <note>{StrBegin="CONTAINER4004: "}</note>
+            </trans-unit>
+            <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
+                <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are
+                    provided.
+                    ContainerAppInstruction must be set to configure how the application is started.
+                    Valid
+                    instructions are {0}.</source>
+                <target state="translated">CONTAINER2023: se proporcionan ContainerEntrypoint y
+                    ContainerAppCommandArgs. ContainerAppInstruction debe establecerse para
+                    configurar cómo se
+                    inicia la aplicación. Las instrucciones válidas son {0}.</target>
+                <note>{StrBegin="CONTAINER2023: "}</note>
+            </trans-unit>
+            <trans-unit id="EntrypointSetNoAppCommandInstruction">
+                <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction
+                    must be
+                    set to configure how the application is started. Valid instructions are {0}.</source>
+                <target state="translated">CONTAINER2027: se proporciona containerEntrypoint.
+                    ContainerAppInstruction debe establecerse para configurar cómo se inicia la
+                    aplicación.
+                    Las instrucciones válidas son {0}.</target>
+                <note>{StrBegin="CONTAINER2027: "}</note>
+            </trans-unit>
+            <trans-unit id="EntrypointArgsSetNoEntrypoint">
+                <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+                    ContainerEntrypoint.</source>
+                <target state="translated">CONTAINER2024: ContainerEntrypointArgs se proporcionan
+                    sin
+                    especificar containerEntrypoint.</target>
+                <note>{StrBegin="CONTAINER2024: "}</note>
+            </trans-unit>
+            <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
+                <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+                    ContainerAppCommandArgs for arguments that must always be set, or
+                    ContainerDefaultArgs for
+                    arguments that can be overridden when the container is created.</source>
+                <target state="translated">CONTAINER2029: se proporciona ContainerEntrypointArgsSet.
+                    Cambie
+                    para usar ContainerAppCommandArgs para los argumentos que siempre se deben
+                    establecer o
+                    ContainerDefaultArgs para los argumentos que se pueden invalidar cuando se crea
+                    el
+                    contenedor.</target>
+                <note>{StrBegin="CONTAINER2029: "}</note>
+            </trans-unit>
+            <trans-unit id="EntrypointConflictAppCommand">
+                <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+                    ContainerAppCommandInstruction '{0}'.</source>
+                <target state="translated">CONTAINER2028: ContainerEntrypoint no se puede combinar
+                    con
+                    ContainerAppCommandInstruction '{0}'.</target>
+                <note>{StrBegin="CONTAINER2028: "}</note>
+            </trans-unit>
+            <trans-unit id="FailedRetrievingCredentials">
+                <source>CONTAINER1008: Failed retrieving credentials for "{0}": {1}</source>
+                <target state="translated">CONTAINER1008: No se pudieron recuperar las credenciales
+                    de
+                    "{0}": {1}</target>
+                <note>{StrBegin="CONTAINER1008: "}</note>
+            </trans-unit>
+            <trans-unit id="HostObjectNotDetected">
+                <source>No host object detected.</source>
+                <target state="translated">No se detectó ningún objeto host.</target>
+                <note />
+            </trans-unit>
+            <trans-unit id="ImageLoadFailed">
+                <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
+                <target state="translated">CONTAINER1009: no se pudo cargar la imagen desde el
+                    registro
+                    local. Stdout: {0}</target>
+                <note>{StrBegin="CONTAINER1009: "}</note>
+            </trans-unit>
+            <trans-unit id="ImagePullNotSupported">
+                <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
+                <target state="translated">CONTAINER1010: No se admite la extracción de imágenes del
+                    registro local.</target>
+                <note>{StrBegin="CONTAINER1010: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidEnvVar">
+                <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
+                <target state="translated">CONTAINER2015: {0}: "{1}" no era una variable de entorno
+                    válida.
+                    Ignorando.</target>
+                <note>{StrBegin="CONTAINER2015: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
+                <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid
+                    characters.
+                    The valid characters for an image name are alphanumeric characters, -, /, or _,
+                    and the
+                    image name must start with an alphanumeric character.</source>
+                <target state="translated">CONTAINER2005: el nombre de imagen inferido '{0}'
+                    contiene
+                    caracteres totalmente no válidos. Los caracteres válidos para un nombre de
+                    imagen son los
+                    caracteres alfanuméricos, -, /, o _; el nombre de imagen tiene que comenzar con
+                    uno.</target>
+                <note>{StrBegin="CONTAINER2005: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
+                <source>CONTAINER2005: The first character of the image name '{0}' must be a
+                    lowercase
+                    letter or a digit and all characters in the name must be an alphanumeric
+                    character, -, /,
+                    or _.</source>
+                <target state="translated">CONTAINER2005: el primer carácter del nombre de imagen
+                    '{0}'
+                    tiene que ser una letra minúscula o un dígito y todos los caracteres del nombre
+                    deben ser
+                    alfanuméricos, -, /, o _.</target>
+                <note>{StrBegin="CONTAINER2005: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidPort_Number">
+                <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number
+                    '{0}'.
+                    ContainerPort items must have an Include value that is an integer, and a Type
+                    value that
+                    is either 'tcp' or 'udp'.</source>
+                <target state="translated">CONTAINER2017: Se proporcionó un elemento ContainerPort
+                    con un
+                    número de puerto "{0}". Los elementos ContainerPort deben tener un valor Include
+                    que sea
+                    un entero y un valor Type que sea "tcp" o "udp".</target>
+                <note>{StrBegin="CONTAINER2017: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidPort_NumberAndType">
+                <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number
+                    '{0}'
+                    and an invalid port type '{1}'. ContainerPort items must have an Include value
+                    that is an
+                    integer, and a Type value that is either 'tcp' or 'udp'.</source>
+                <target state="translated">CONTAINER2017: Se proporcionó un elemento ContainerPort
+                    con un
+                    número de puerto no válido "{0}" y un tipo de puerto no válido "{1}". Los
+                    elementos
+                    ContainerPort deben tener un valor Include que sea un entero y un valor Type que
+                    sea "tcp"
+                    o "udp".</target>
+                <note>{StrBegin="CONTAINER2017: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidPort_Type">
+                <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type
+                    '{0}'.
+                    ContainerPort items must have an Include value that is an integer, and a Type
+                    value that
+                    is either 'tcp' or 'udp'.</source>
+                <target state="translated">CONTAINER2017: Se proporcionó un elemento ContainerPort
+                    con un
+                    tipo de puerto "{0}". Los elementos ContainerPort deben tener un valor Include
+                    que sea un
+                    entero y un valor Type que sea "tcp" o "udp".</target>
+                <note>{StrBegin="CONTAINER2017: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidSdkPrereleaseVersion">
+                <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and
+                    'preview' are
+                    supported.</source>
+                <target state="translated">CONTAINER2018: Versión preliminar del SDK "{0}" no válida
+                    : solo
+                    se admiten "rc" y "preview".</target>
+                <note>{StrBegin="CONTAINER2018: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidSdkVersion">
+                <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
+                <target state="translated">CONTAINER2019: Versión "{0}" de semántica del SDK no
+                    válida.</target>
+                <note>{StrBegin="CONTAINER2019: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidTag">
+                <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+                    underscore, hyphen, or period.</source>
+                <target state="translated">CONTAINER2007: Se proporcionó un {0} no válido: {1}. Las
+                    etiquetas de imagen deben ser alfanuméricas, con guion bajo, guiones o puntos.</target>
+                <note>{StrBegin="CONTAINER2007: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidTags">
+                <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited
+                    list of
+                    valid image tags. Image tags must be alphanumeric, underscore, hyphen, or
+                    period.</source>
+                <target state="translated">CONTAINER2010: se proporcionó un {0} no válido: {1}. {0}
+                    debe ser
+                    una lista delimitada por punto y coma de etiquetas de imagen válidas. Las
+                    etiquetas de
+                    imagen deben ser alfanuméricas, con guion bajo, guiones o puntos.</target>
+                <note>{StrBegin="CONTAINER2010: "}</note>
+            </trans-unit>
+            <trans-unit id="InvalidTokenResponse">
+                <source>CONTAINER1003: Token response had neither token nor access_token.</source>
+                <target state="translated">CONTAINER1003: La respuesta del token no tenía ningún
+                    token ni
+                    access_token.</target>
+                <note>{StrBegin="CONTAINER1003: "}</note>
+            </trans-unit>
+            <trans-unit id="ItemsWithoutMetadata">
+                <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they
+                    will be
+                    ignored.</source>
+                <target state="translated">CONTAINER4005: El elemento "{0}" contiene elementos sin
+                    metadatos
+                    "Value" y se omitirán.</target>
+                <note>{StrBegin="CONTAINER4005: "}</note>
+            </trans-unit>
+            <trans-unit id="LocalRegistryNotAvailable">
+                <source>CONTAINER1012: The local registry is not available, but pushing to a local
+                    registry
+                    was requested.</source>
+                <target state="translated">CONTAINER1012: el registro local no está disponible, pero
+                    se
+                    solicitó la inserción en un registro local.</target>
+                <note>{StrBegin="CONTAINER1012: "}</note>
+            </trans-unit>
+            <trans-unit id="LocalDocker_FailedToGetConfig">
+                <source>Error while reading daemon config: {0}</source>
+                <target state="translated">Error al leer la configuración del demonio: {0}</target>
+                <note>{0} is the exception message that ends with period</note>
+            </trans-unit>
+            <trans-unit id="LocalDocker_LocalDaemonErrors">
+                <source>The daemon server reported errors: {0}</source>
+                <target state="translated">El servidor demonio notificó los errores: {0}</target>
+                <note>{0} are the list of messages, each message starts with new line</note>
+            </trans-unit>
+            <trans-unit id="MissingLinkToRegistry">
+                <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry
+                    '{1}'
+                    because it does not exist.</source>
+                <target state="translated">CONTAINER2004: No se puede descargar la capa con el
+                    descriptor
+                    "{0}" del registro "{1}" porque no existe.</target>
+                <note>{StrBegin="CONTAINER2004: "}</note>
+            </trans-unit>
+            <trans-unit id="MissingPortNumber">
+                <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number.
+                    Please
+                    ensure the item's Include is a port number, for example '&lt;ContainerPort
+                    Include="80"
+                    /&gt;'</source>
+                <target state="translated">CONTAINER2016: El elemento ContainerPort "{0}" no
+                    especifica el
+                    número de puerto. Asegúrate de que la inclusión del elemento es un número de
+                    puerto, por
+                    ejemplo, "&lt;ContainerPort Include="80" /&gt;"</target>
+                <note>{StrBegin="CONTAINER2016: "}</note>
+            </trans-unit>
+            <trans-unit id="NoRequestUriSpecified">
+                <source>CONTAINER1004: No RequestUri specified.</source>
+                <target state="translated">CONTAINER1004: No se especificó RequestUri.</target>
+                <note>{StrBegin="CONTAINER1004: "}</note>
+            </trans-unit>
+            <trans-unit id="NormalizedContainerName">
+                <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
+                <target state="translated">"{0}" no era un nombre de imagen de contenedor válido, se
+                    normalizó a "{1}"</target>
+                <note />
+            </trans-unit>
+            <trans-unit id="PublishDirectoryDoesntExist">
+                <source>CONTAINER2011: {0} '{1}' does not exist</source>
+                <target state="translated">CONTAINER2011: {0} "{1}" no existe</target>
+                <note>{StrBegin="CONTAINER2011: "}</note>
+            </trans-unit>
+            <trans-unit id="RegistryOutputPushFailed">
+                <source>CONTAINER1013: Failed to push to the output registry: {0}</source>
+                <target state="translated">CONTAINER1013: No se pudieron enviar cambios al el
+                    Registro de
+                    salida: {0}</target>
+                <note>{StrBegin="CONTAINER1013: "}</note>
+            </trans-unit>
+            <trans-unit id="RegistryPushFailed">
+                <source>CONTAINER1005: Registry push failed; received status code '{0}'.</source>
+                <target state="new">CONTAINER1005: Registry push failed; received status code '{0}'.</target>
+                <note>{StrBegin="CONTAINER1005: "}</note>
+            </trans-unit>
+            <trans-unit id="Registry_ConfigUploadStarted">
+                <source>Uploading config to registry at blob '{0}',</source>
+                <target state="translated">Cargando la configuración en el Registro en el blob
+                    "{0}",</target>
+                <note />
+            </trans-unit>
+            <trans-unit id="Registry_ConfigUploaded">
+                <source>Uploaded config to registry.</source>
+                <target state="translated">Se cargó la configuración en el Registro.</target>
+                <note />
+            </trans-unit>
+            <trans-unit id="Registry_LayerExists">
+                <source>Layer '{0}' already exists.</source>
+                <target state="translated">La capa "{0}" ya existe.</target>
+                <note />
+            </trans-unit>
+            <trans-unit id="Registry_LayerUploadStarted">
+                <source>Uploading layer '{0}' to '{1}'.</source>
+                <target state="translated">Cargando la capa "{0}" en "{1}".</target>
+                <note>{0} is the layer digest, {1} is the registry name</note>
+            </trans-unit>
+            <trans-unit id="Registry_LayerUploaded">
+                <source>Finished uploading layer '{0}' to '{1}'.</source>
+                <target state="translated">Finalizó la carga de la capa "{0}" en "{1}".</target>
+                <note>{0} is the layer digest, {1} is the registry name</note>
+            </trans-unit>
+            <trans-unit id="Registry_ManifestUploadStarted">
+                <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
+                <target state="translated">Cargando manifiesto en el Registro "{0}" como blob "{1}".</target>
+                <note>{0} is the registry name</note>
+            </trans-unit>
+            <trans-unit id="Registry_ManifestUploaded">
+                <source>Uploaded manifest to '{0}'.</source>
+                <target state="translated">Se cargó el manifiesto en "{0}".</target>
+                <note>{0} is the registry name</note>
+            </trans-unit>
+            <trans-unit id="Registry_TagUploadStarted">
+                <source>Uploading tag '{0}' to '{1}'.</source>
+                <target state="translated">Cargando la etiqueta "{0}" en "{1}".</target>
+                <note>{1} is the registry name</note>
+            </trans-unit>
+            <trans-unit id="Registry_TagUploaded">
+                <source>Uploaded tag '{0}' to '{1}'.</source>
+                <target state="translated">Etiqueta cargada "{0}" en "{1}".</target>
+                <note>{1} is the registry name</note>
+            </trans-unit>
+            <trans-unit id="RequiredItemsContainsEmptyItems">
+                <source>CONTAINER4003: Required '{0}' items contain empty items.</source>
+                <target state="translated">CONTAINER4003: Los elementos de "{0}" necesarios
+                    contienen
+                    elementos vacíos.</target>
+                <note>{StrBegin="CONTAINER4003: "}</note>
+            </trans-unit>
+            <trans-unit id="RequiredItemsNotSet">
+                <source>CONTAINER4002: Required '{0}' items were not set.</source>
+                <target state="translated">CONTAINER4002: No se establecieron los elementos de "{0}"
+                    necesarios.</target>
+                <note>{StrBegin="CONTAINER4002: "}</note>
+            </trans-unit>
+            <trans-unit id="RequiredPropertyNotSetOrEmpty">
+                <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
+                <target state="translated">CONTAINER4001: La propiedad necesaria "{0}" no se
+                    estableció o
+                    estaba vacía.</target>
+                <note>{StrBegin="CONTAINER4001: "}</note>
+            </trans-unit>
+            <trans-unit id="TooManyRetries">
+                <source>CONTAINER1006: Too many retries, stopping.</source>
+                <target state="translated">CONTAINER1006: Demasiados reintentos, deteniendo.</target>
+                <note>{StrBegin="CONTAINER1006: "}</note>
+            </trans-unit>
+            <trans-unit id="UnknownAppCommandInstruction">
+                <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are
+                    {1}.</source>
+                <target state="translated">CONTAINER2021: AppCommandInstruction ''{0}desconocido.
+                    Las
+                    instrucciones válidas son {1}.</target>
+                <note>{StrBegin="CONTAINER2021: "}</note>
+            </trans-unit>
+            <trans-unit id="UnknownLocalRegistryType">
+                <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container
+                    registry
+                    types are {1}.</source>
+                <target state="translated">CONTAINER2002: tipo de registro local desconocido '{0}'.
+                    Los
+                    tipos de registro de contenedor locales válidos son {1}.</target>
+                <note>{StrBegin="CONTAINER2002: "}</note>
+            </trans-unit>
+            <trans-unit id="UnknownMediaType">
+                <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown
+                    type: {3}.
+                    Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues
+                    with this
+                    message.</source>
+                <target state="translated">CONTAINER2003: El manifiesto de {0}:{1} del registro {2}
+                    era de
+                    un tipo desconocido: {3}. Presente un problema en
+                    https://github.com/dotnet/sdk-container-builds/issues con este mensaje.</target>
+                <note>{StrBegin="CONTAINER2003: "}</note>
+            </trans-unit>
+            <trans-unit id="UnrecognizedMediaType">
+                <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
+                <target state="translated">CONTAINER2001: mediaType "{0}" no reconocido.</target>
+                <note>{StrBegin="CONTAINER2001: "}</note>
+            </trans-unit>
+            <trans-unit id="_Test">
+                <source>CONTAINER0000: Value for unit test {0}</source>
+                <target state="translated">CONTAINER0000: Valor de la prueba unitaria {0}</target>
+                <note>Used only for unit tests</note>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
@@ -71,6 +72,11 @@
         <target state="translated">Compilando imagen "{0}" con etiquetas "{1}" encima de la imagen base "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
+        <source>CONTAINER3001: Failed creating {0} process.</source>
+        <target state="new">CONTAINER3001: Failed creating {0} process.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: No se pudo deserializar el token de JSON.</target>
@@ -95,11 +101,6 @@
         <source>CONTAINER3002: Failed to get docker info: {0}</source>
         <target state="translated">CONTAINER3002: No se pudo obtener la información de docker: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
-      </trans-unit>
-      <trans-unit id="ContainerRegistryProcessCreationFailed">
-        <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: No se pudo crear {0} el proceso.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="fr"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: la demande à Amazon Elastic Container Registry a
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: la demande à Amazon Elastic Container Registry a
           échoué prématurément. Cela est souvent dû au fait que le dépôt cible n’existe pas dans le
           Registre.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
@@ -25,16 +16,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: les ContainerAppCommandArgs sont fournis sans
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: les ContainerAppCommandArgs sont fournis sans
           spécifier de ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand et ContainerAppCommandArgs
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommand et ContainerAppCommandArgs
           doivent être vides lorsque ContainerAppCommandInstruction est '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -44,10 +33,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: L'image de base a un point d'entrée qui sera
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: L'image de base a un point d'entrée qui sera
           écrasé pour démarrer l'application. Définissez ContainerAppCommandInstruction sur
           'Entrypoint' si vous le souhaitez. Pour conserver le point d'entrée de l'image de base,
           définissez ContainerAppCommandInstruction sur "DefaultArgs".</target>
@@ -59,9 +46,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} ne spécifie pas de registre et sera extrait de
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} ne spécifie pas de registre et sera extrait de
           Docker Hub. Veuillez préfixer le nom avec le registre d'images, par exemple :
           '{1}/&lt;image&gt;'.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
@@ -73,9 +59,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: impossible de trouver une image de base
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: impossible de trouver une image de base
           correspondante pour {0} qui correspond à RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -130,9 +115,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: Échec du processus de création {0}.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: Échec du processus de création {0}.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -147,43 +131,36 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Un ContainerEntrypoint et ContainerAppCommandArgs
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: Un ContainerEntrypoint et ContainerAppCommandArgs
           sont fournis. ContainerAppInstruction doit être défini pour configurer le mode de
           démarrage de l'application. Les instructions valides sont {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Un ContainerEntrypoint est fourni.
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: Un ContainerEntrypoint est fourni.
           ContainerAppInstruction doit être défini pour configurer le mode de démarrage de
           l'application. Les instructions valides sont {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: les ContainerEntrypointArgs sont fournis sans
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: les ContainerEntrypointArgs sont fournis sans
           spécifier de ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet est fourni. Changez
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: ContainerEntrypointArgsSet est fourni. Changez
           pour utiliser ContainerAppCommandArgs pour les arguments qui doivent toujours être
           définis, ou ContainerDefaultArgs pour les arguments qui peuvent être remplacés lors de la
           création du conteneur.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint ne peut pas être combiné avec
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint ne peut pas être combiné avec
           ContainerAppCommandInstruction '{0}'.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -217,56 +194,45 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: le nom d'image déduit '{0}' contient des
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: le nom d'image déduit '{0}' contient des
           caractères entièrement non valides. Les caractères valides pour un nom d'image sont les
           caractères alphanumériques, -, / ou _, et le nom de l'image doit commencer par un
           caractère alphanumérique.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: le premier caractère du nom de l'image '{0}' doit
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: le premier caractère du nom de l'image '{0}' doit
           être une lettre minuscule ou un chiffre et tous les caractères du nom doivent être un
           caractère alphanumérique, -, / ou _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un élément ContainerPort a été fourni avec un
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: un élément ContainerPort a été fourni avec un
           numéro de port non valide «{0}». Les éléments ContainerPort doivent avoir une valeur
           Include qui est un entier et une valeur Type qui est 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un élément ContainerPort a été fourni avec un
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: un élément ContainerPort a été fourni avec un
           numéro de port non valide '{0}' et un type de port non valide '{1}'. Les éléments
           ContainerPort doivent avoir une valeur Include qui est un entier et une valeur Type qui
           est 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un élément ContainerPort a été fourni avec un type
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: un élément ContainerPort a été fourni avec un type
           de port non valide «{0}». Les éléments ContainerPort doivent avoir une valeur Include qui
           est un entier et une valeur Type qui est 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: version préliminaire du SDK non valide '{0}' -
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: version préliminaire du SDK non valide '{0}' -
           seuls 'rc' et 'preview' sont pris en charge.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -276,16 +242,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: {0} non valide fournie : {1}. Les balises d’image
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: {0} non valide fournie : {1}. Les balises d’image
           doivent être alphanumériques, traits de soulignement, traits d’union ou point.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: {0} non valide fournie : {1}. {0} doit être une
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: {0} non valide fournie : {1}. {0} doit être une
           liste de balises d’image valides délimitées par des points-virgules. Les balises d’image
           doivent être alphanumériques, traits de soulignement, traits d’union ou point.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
@@ -297,16 +261,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: l’élément '{0}' contient des éléments sans
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: l’élément '{0}' contient des éléments sans
           métadonnées 'Value'. Ils seront ignorés.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: Le registre local n'est pas disponible, mais la
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: Le registre local n'est pas disponible, mais la
           transmission vers un registre local a été demandée.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -321,17 +283,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: impossible de télécharger la couche avec le
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: impossible de télécharger la couche avec le
           descripteur '{0}' à partir du Registre '{1}', car elle n’existe pas.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: l’élément ContainerPort '{0}' ne spécifie pas le
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: l’élément ContainerPort '{0}' ne spécifie pas le
           numéro de port. Vérifiez que l’élément Include est un numéro de port, par exemple
           '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
@@ -440,17 +399,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: type de registre local inconnu '{0}'. Les types de
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: type de registre local inconnu '{0}'. Les types de
           registre de conteneurs locaux valides sont {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: le manifeste pour {0}:{1} du Registre {2} était
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: le manifeste pour {0}:{1} du Registre {2} était
           d’un type inconnu : {3}. Veuillez lever un problème au
           https://github.com/dotnet/sdk-container-builds/issues avec ce message.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -1,30 +1,51 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="fr"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: la demande à Amazon Elastic Container Registry a échoué prématurément. Cela est souvent dû au fait que le dépôt cible n’existe pas dans le Registre.</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: la demande à Amazon Elastic Container Registry a
+          échoué prématurément. Cela est souvent dû au fait que le dépôt cible n’existe pas dans le
+          Registre.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
         <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed.</source>
-        <target state="translated">CONTAINER2008: {0} et {1} ont été fournis, mais seul l’un ou l’autre est autorisé.</target>
+        <target state="translated">CONTAINER2008: {0} et {1} ont été fournis, mais seul l’un ou
+          l’autre est autorisé.</target>
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: les ContainerAppCommandArgs sont fournis sans spécifier de ContainerAppCommand.</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: les ContainerAppCommandArgs sont fournis sans
+          spécifier de ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand et ContainerAppCommandArgs doivent être vides lorsque ContainerAppCommandInstruction est '{0}'.</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommand et ContainerAppCommandArgs
+          doivent être vides lorsque ContainerAppCommandInstruction est '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: L'image de base a un point d'entrée qui sera écrasé pour démarrer l'application. Définissez ContainerAppCommandInstruction sur 'Entrypoint' si vous le souhaitez. Pour conserver le point d'entrée de l'image de base, définissez ContainerAppCommandInstruction sur "DefaultArgs".</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: L'image de base a un point d'entrée qui sera
+          écrasé pour démarrer l'application. Définissez ContainerAppCommandInstruction sur
+          'Entrypoint' si vous le souhaitez. Pour conserver le point d'entrée de l'image de base,
+          définissez ContainerAppCommandInstruction sur "DefaultArgs".</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,23 +54,30 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} ne spécifie pas de registre et sera extrait de Docker Hub. Veuillez préfixer le nom avec le registre d'images, par exemple : '{1}/&lt;image&gt;'.</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} ne spécifie pas de registre et sera extrait de
+          Docker Hub. Veuillez préfixer le nom avec le registre d'images, par exemple :
+          '{1}/&lt;image&gt;'.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
-        <target state="translated">CONTAINER2013: {0} contenait des espaces, remplacés par des tirets.</target>
+        <target state="translated">CONTAINER2013: {0} contenait des espaces, remplacés par des
+          tirets.</target>
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: impossible de trouver une image de base correspondante pour {0} qui correspond à RuntimeIdentifier {1}.</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: impossible de trouver une image de base
+          correspondante pour {0} qui correspond à RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: échec du chargement de l’objet blob à l’aide de {0}; le code d’état «{1}» a été reçu.</target>
+        <target state="translated">CONTAINER1001: échec du chargement de l’objet blob à l’aide de
+          {0}; le code d’état «{1}» a été reçu.</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
@@ -64,12 +92,14 @@
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">
         <source>Building image '{0}' with tags '{1}' on top of base image '{2}'.</source>
-        <target state="translated">Génération de l’image «{0}» avec des balises «{1}» au-dessus de l’image de base «{2}».</target>
+        <target state="translated">Génération de l’image «{0}» avec des balises «{1}» au-dessus de
+          l’image de base «{2}».</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
-        <target state="translated">CONTAINER1007: impossible de désérialiser le jeton à partir de JSON.</target>
+        <target state="translated">CONTAINER1007: impossible de désérialiser le jeton à partir de
+          JSON.</target>
         <note>{StrBegin="CONTAINER1007: "}</note>
       </trans-unit>
       <trans-unit id="CouldntRecognizeRegistry">
@@ -79,7 +109,8 @@
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>
-        <target state="translated">CONTAINER3002: échec de l’obtention des informations docker ({0})\n{1}\n{2}</target>
+        <target state="translated">CONTAINER3002: échec de l’obtention des informations docker
+          ({0})\n{1}\n{2}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed_Ex">
@@ -87,49 +118,69 @@
         <target state="translated">CONTAINER3002: échec de l’obtention des informations docker : {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: Échec du processus de création {0}.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
-        <target state="translated">CONTAINER4006: la propriété '{0}' est vide ou contient un espace blanc et sera ignorée.</target>
+        <target state="translated">CONTAINER4006: la propriété '{0}' est vide ou contient un espace
+          blanc et sera ignorée.</target>
         <note>{StrBegin="CONTAINER4006: "}</note>
       </trans-unit>
       <trans-unit id="EmptyValuesIgnored">
         <source>CONTAINER4004: Items '{0}' contain empty item(s) which will be ignored.</source>
-        <target state="translated">CONTAINER4004: les éléments '{0}' contiennent un ou plusieurs éléments vides qui seront ignorés.</target>
+        <target state="translated">CONTAINER4004: les éléments '{0}' contiennent un ou plusieurs
+          éléments vides qui seront ignorés.</target>
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Un ContainerEntrypoint et ContainerAppCommandArgs sont fournis. ContainerAppInstruction doit être défini pour configurer le mode de démarrage de l'application. Les instructions valides sont {0}.</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: Un ContainerEntrypoint et ContainerAppCommandArgs
+          sont fournis. ContainerAppInstruction doit être défini pour configurer le mode de
+          démarrage de l'application. Les instructions valides sont {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Un ContainerEntrypoint est fourni. ContainerAppInstruction doit être défini pour configurer le mode de démarrage de l'application. Les instructions valides sont {0}.</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: Un ContainerEntrypoint est fourni.
+          ContainerAppInstruction doit être défini pour configurer le mode de démarrage de
+          l'application. Les instructions valides sont {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: les ContainerEntrypointArgs sont fournis sans spécifier de ContainerEntrypoint.</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: les ContainerEntrypointArgs sont fournis sans
+          spécifier de ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet est fourni. Changez pour utiliser ContainerAppCommandArgs pour les arguments qui doivent toujours être définis, ou ContainerDefaultArgs pour les arguments qui peuvent être remplacés lors de la création du conteneur.</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet est fourni. Changez
+          pour utiliser ContainerAppCommandArgs pour les arguments qui doivent toujours être
+          définis, ou ContainerDefaultArgs pour les arguments qui peuvent être remplacés lors de la
+          création du conteneur.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint ne peut pas être combiné avec ContainerAppCommandInstruction '{0}'.</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint ne peut pas être combiné avec
+          ContainerAppCommandInstruction '{0}'.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
         <source>CONTAINER1008: Failed retrieving credentials for "{0}": {1}</source>
-        <target state="translated">CONTAINER1008: échec de la récupération des informations d’identification pour «{0}» : {1}</target>
+        <target state="translated">CONTAINER1008: échec de la récupération des informations
+          d’identification pour «{0}» : {1}</target>
         <note>{StrBegin="CONTAINER1008: "}</note>
       </trans-unit>
       <trans-unit id="HostObjectNotDetected">
@@ -139,47 +190,74 @@
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: Échec du chargement de l'image à partir du registre local. sortie standard : {0}</target>
+        <target state="translated">CONTAINER1009: Échec du chargement de l'image à partir du
+          registre local. sortie standard : {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
-        <target state="translated">CONTAINER1010: L'extraction d'images à partir du registre local n'est pas prise en charge.</target>
+        <target state="translated">CONTAINER1010: L'extraction d'images à partir du registre local
+          n'est pas prise en charge.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
-        <target state="translated">CONTAINER2015: {0} : '{1}' n’était pas une variable d’environnement valide. Ignorant.</target>
+        <target state="translated">CONTAINER2015: {0} : '{1}' n’était pas une variable
+          d’environnement valide. Ignorant.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: le nom d'image déduit '{0}' contient des caractères entièrement non valides. Les caractères valides pour un nom d'image sont les caractères alphanumériques, -, / ou _, et le nom de l'image doit commencer par un caractère alphanumérique.</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: le nom d'image déduit '{0}' contient des
+          caractères entièrement non valides. Les caractères valides pour un nom d'image sont les
+          caractères alphanumériques, -, / ou _, et le nom de l'image doit commencer par un
+          caractère alphanumérique.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: le premier caractère du nom de l'image '{0}' doit être une lettre minuscule ou un chiffre et tous les caractères du nom doivent être un caractère alphanumérique, -, / ou _.</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: le premier caractère du nom de l'image '{0}' doit
+          être une lettre minuscule ou un chiffre et tous les caractères du nom doivent être un
+          caractère alphanumérique, -, / ou _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un élément ContainerPort a été fourni avec un numéro de port non valide «{0}». Les éléments ContainerPort doivent avoir une valeur Include qui est un entier et une valeur Type qui est 'tcp' ou 'udp'.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: un élément ContainerPort a été fourni avec un
+          numéro de port non valide «{0}». Les éléments ContainerPort doivent avoir une valeur
+          Include qui est un entier et une valeur Type qui est 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un élément ContainerPort a été fourni avec un numéro de port non valide '{0}' et un type de port non valide '{1}'. Les éléments ContainerPort doivent avoir une valeur Include qui est un entier et une valeur Type qui est 'tcp' ou 'udp'.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: un élément ContainerPort a été fourni avec un
+          numéro de port non valide '{0}' et un type de port non valide '{1}'. Les éléments
+          ContainerPort doivent avoir une valeur Include qui est un entier et une valeur Type qui
+          est 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un élément ContainerPort a été fourni avec un type de port non valide «{0}». Les éléments ContainerPort doivent avoir une valeur Include qui est un entier et une valeur Type qui est 'tcp' ou 'udp'.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: un élément ContainerPort a été fourni avec un type
+          de port non valide «{0}». Les éléments ContainerPort doivent avoir une valeur Include qui
+          est un entier et une valeur Type qui est 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: version préliminaire du SDK non valide '{0}' - seuls 'rc' et 'preview' sont pris en charge.</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
+        <target state="translated">CONTAINER2018: version préliminaire du SDK non valide '{0}' -
+          seuls 'rc' et 'preview' sont pris en charge.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -188,28 +266,38 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: {0} non valide fournie : {1}. Les balises d’image doivent être alphanumériques, traits de soulignement, traits d’union ou point.</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: {0} non valide fournie : {1}. Les balises d’image
+          doivent être alphanumériques, traits de soulignement, traits d’union ou point.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: {0} non valide fournie : {1}. {0} doit être une liste de balises d’image valides délimitées par des points-virgules. Les balises d’image doivent être alphanumériques, traits de soulignement, traits d’union ou point.</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: {0} non valide fournie : {1}. {0} doit être une
+          liste de balises d’image valides délimitées par des points-virgules. Les balises d’image
+          doivent être alphanumériques, traits de soulignement, traits d’union ou point.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
         <source>CONTAINER1003: Token response had neither token nor access_token.</source>
-        <target state="translated">CONTAINER1003: la réponse de jeton n’avait ni jeton ni access_token.</target>
+        <target state="translated">CONTAINER1003: la réponse de jeton n’avait ni jeton ni
+          access_token.</target>
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
-        <target state="translated">CONTAINER4005: l’élément '{0}' contient des éléments sans métadonnées 'Value'. Ils seront ignorés.</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
+        <target state="translated">CONTAINER4005: l’élément '{0}' contient des éléments sans
+          métadonnées 'Value'. Ils seront ignorés.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
-        <target state="translated">CONTAINER1012: Le registre local n'est pas disponible, mais la transmission vers un registre local a été demandée.</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
+        <target state="translated">CONTAINER1012: Le registre local n'est pas disponible, mais la
+          transmission vers un registre local a été demandée.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -223,13 +311,19 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: impossible de télécharger la couche avec le descripteur '{0}' à partir du Registre '{1}', car elle n’existe pas.</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: impossible de télécharger la couche avec le
+          descripteur '{0}' à partir du Registre '{1}', car elle n’existe pas.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: l’élément ContainerPort '{0}' ne spécifie pas le numéro de port. Vérifiez que l’élément Include est un numéro de port, par exemple '&lt;ContainerPort Include="80" /&gt;'</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: l’élément ContainerPort '{0}' ne spécifie pas le
+          numéro de port. Vérifiez que l’élément Include est un numéro de port, par exemple
+          '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -239,7 +333,8 @@
       </trans-unit>
       <trans-unit id="NormalizedContainerName">
         <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
-        <target state="translated">'{0}' n’était pas un nom d’image conteneur valide, il a été normalisé pour '{1}'</target>
+        <target state="translated">'{0}' n’était pas un nom d’image conteneur valide, il a été
+          normalisé pour '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
@@ -249,7 +344,8 @@
       </trans-unit>
       <trans-unit id="RegistryOutputPushFailed">
         <source>CONTAINER1013: Failed to push to the output registry: {0}</source>
-        <target state="translated">CONTAINER1013: échec de l’envoi (push) vers le Registre de sortie : {0}</target>
+        <target state="translated">CONTAINER1013: échec de l’envoi (push) vers le Registre de sortie
+          : {0}</target>
         <note>{StrBegin="CONTAINER1013: "}</note>
       </trans-unit>
       <trans-unit id="RegistryPushFailed">
@@ -259,7 +355,8 @@
       </trans-unit>
       <trans-unit id="Registry_ConfigUploadStarted">
         <source>Uploading config to registry at blob '{0}',</source>
-        <target state="translated">Chargement de la configuration dans le Registre sur l’objet blob «{0}»,</target>
+        <target state="translated">Chargement de la configuration dans le Registre sur l’objet blob
+          «{0}»,</target>
         <note />
       </trans-unit>
       <trans-unit id="Registry_ConfigUploaded">
@@ -284,7 +381,8 @@
       </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
-        <target state="translated">Chargement du manifeste dans le Registre '{0}' en tant qu’objet blob '{1}'.</target>
+        <target state="translated">Chargement du manifeste dans le Registre '{0}' en tant qu’objet
+          blob '{1}'.</target>
         <note>{0} is the registry name</note>
       </trans-unit>
       <trans-unit id="Registry_ManifestUploaded">
@@ -304,17 +402,20 @@
       </trans-unit>
       <trans-unit id="RequiredItemsContainsEmptyItems">
         <source>CONTAINER4003: Required '{0}' items contain empty items.</source>
-        <target state="translated">CONTAINER4003: les éléments de '{0}' obligatoires contiennent des éléments vides.</target>
+        <target state="translated">CONTAINER4003: les éléments de '{0}' obligatoires contiennent des
+          éléments vides.</target>
         <note>{StrBegin="CONTAINER4003: "}</note>
       </trans-unit>
       <trans-unit id="RequiredItemsNotSet">
         <source>CONTAINER4002: Required '{0}' items were not set.</source>
-        <target state="translated">CONTAINER4002: les éléments de '{0}' requis n’ont pas été définis.</target>
+        <target state="translated">CONTAINER4002: les éléments de '{0}' requis n’ont pas été
+          définis.</target>
         <note>{StrBegin="CONTAINER4002: "}</note>
       </trans-unit>
       <trans-unit id="RequiredPropertyNotSetOrEmpty">
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
-        <target state="translated">CONTAINER4001: la propriété requise '{0}' n’a pas été définie ou vide.</target>
+        <target state="translated">CONTAINER4001: la propriété requise '{0}' n’a pas été définie ou
+          vide.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TooManyRetries">
@@ -324,17 +425,24 @@
       </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: instruction de commande d'application inconnue '{0}'. Les instructions valides sont {1}.</target>
+        <target state="translated">CONTAINER2021: instruction de commande d'application
+          inconnue '{0}'. Les instructions valides sont {1}.</target>
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: type de registre local inconnu '{0}'. Les types de registre de conteneurs locaux valides sont {1}.</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: type de registre local inconnu '{0}'. Les types de
+          registre de conteneurs locaux valides sont {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: le manifeste pour {0}:{1} du Registre {2} était d’un type inconnu : {3}. Veuillez lever un problème au https://github.com/dotnet/sdk-container-builds/issues avec ce message.</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: le manifeste pour {0}:{1} du Registre {2} était
+          d’un type inconnu : {3}. Veuillez lever un problème au
+          https://github.com/dotnet/sdk-container-builds/issues avec ce message.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="it"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: la richiesta ad Amazon Elastic Container Registry
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: la richiesta ad Amazon Elastic Container Registry
           non è riuscita in modo anomalo. Questo problema si verifica spesso quando il repository di
           destinazione non esiste nel registro.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
@@ -25,16 +16,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: sono stati forniti ContainerAppCommandArgs senza
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: sono stati forniti ContainerAppCommandArgs senza
           specificare un elemento ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs
           devono essere vuoti quando ContainerAppCommandInstruction è '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -44,10 +33,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: l'immagine di base contiene un punto di ingresso
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: l'immagine di base contiene un punto di ingresso
           che verrà sovrascritto per avviare l'applicazione. Impostare
           ContainerAppCommandInstruction su 'Entrypoint', se necessario. Per mantenere il punto di
           ingresso dell'immagine di base, impostare ContainerAppCommandInstruction su 'DefaultArgs'.</target>
@@ -59,9 +46,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} non specifica un Registro di sistema e verrà
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} non specifica un Registro di sistema e verrà
           estratto da Docker Hub. Aggiungere al nome il prefisso del registro immagini, ad esempio
           '{1}/&lt;image&gt;'.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
@@ -73,9 +59,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: non è stato possibile trovare l'immagine di base
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: non è stato possibile trovare l'immagine di base
           corrispondente per {0} che corrisponde a RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -132,9 +117,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: creazione del processo {0} non riuscita.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: creazione del processo {0} non riuscita.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -149,43 +133,36 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: sono stati forniti ContainerEntrypoint e
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: sono stati forniti ContainerEntrypoint e
           ContainerAppCommandArgs. ContainerAppInstruction deve essere impostato per configurare la
           modalità di avvio dell'applicazione. Istruzioni valide sono {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: è stato fornito ContainerEntrypoint.
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: è stato fornito ContainerEntrypoint.
           ContainerAppInstruction deve essere impostato per configurare la modalità di avvio
           dell'applicazione. Istruzioni valide sono {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: sono stati forniti ContainerEntrypointArgs senza
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: sono stati forniti ContainerEntrypointArgs senza
           specificare un elemento ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: è stato fornito ContainerEntrypointArgsSet.
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: è stato fornito ContainerEntrypointArgsSet.
           Modificare per usare ContainerAppCommandArgs per gli argomenti che devono essere sempre
           impostati o ContainerDefaultArgs per gli argomenti di cui è possibile eseguire l'override
           quando viene creato il contenitore.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: non è possibile combinare ContainerEntrypoint con
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: non è possibile combinare ContainerEntrypoint con
           '{0}' ContainerAppCommandInstruction.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -219,56 +196,45 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: il nome dell'immagine dedotto '{0}' contiene
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: il nome dell'immagine dedotto '{0}' contiene
           caratteri completamente non validi. I caratteri validi per un nome di immagine sono
           caratteri alfanumerici, -, / o _, e il nome dell'immagine deve iniziare con un carattere
           alfanumerico.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: il primo carattere del nome dell'immagine '{0}'
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: il primo carattere del nome dell'immagine '{0}'
           deve essere una lettera minuscola o una cifra e tutti i caratteri nel nome devono essere
           un carattere alfanumerico, -, /o _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un elemento ContainerPort è stato fornito con un
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: un elemento ContainerPort è stato fornito con un
           numero di porta '{0}' non valido. Gli elementi ContainerPort devono avere un valore
           Include che è un numero intero e un valore Type impostato su 'tcp' o 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un elemento ContainerPort è stato fornito con un
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: un elemento ContainerPort è stato fornito con un
           numero di porta '{0}' non valido e un tipo di porta '{1}' non valido. Gli elementi
           ContainerPort devono avere un valore Include che è un numero intero e un valore Type
           impostato su 'tcp' o 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un elemento ContainerPort è stato fornito con un
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: un elemento ContainerPort è stato fornito con un
           tipo di porta '{0}' non valido. Gli elementi ContainerPort devono avere un valore Include
           che è un numero intero e un valore Type impostato su 'tcp' o 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: valore '{0}' non valido per la versione non
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: valore '{0}' non valido per la versione non
           definitiva dell'SDK - Sono supportate solo le versioni 'rc' e 'preview'.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -278,16 +244,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: il valore {0} specificato non è valido: {1}. I tag
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: il valore {0} specificato non è valido: {1}. I tag
           immagine devono essere alfanumerici, di sottolineatura, trattino o punto.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: il valore {0} specificato non è valido: {1}. {0}
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: il valore {0} specificato non è valido: {1}. {0}
           deve essere un elenco delimitato da punto e virgola di tag di immagine validi. I tag
           immagine devono essere alfanumerici, di sottolineatura, trattino o punto.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
@@ -299,16 +263,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: l'elemento '{0}' contiene elementi senza 'Value'
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: l'elemento '{0}' contiene elementi senza 'Value'
           di metadati e tali elementi verranno ignorati.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: il registro locale non è disponibile, ma è stato
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: il registro locale non è disponibile, ma è stato
           richiesto il push a un registro locale.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -323,17 +285,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: non è possibile scaricare il livello con
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: non è possibile scaricare il livello con
           descrittore '{0}' dal registro '{1}' perché non esiste.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: l'elemento ContainerPort '{0}' non specifica il
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: l'elemento ContainerPort '{0}' non specifica il
           numero di porta. Assicurarsi che il valore Include dell'elemento sia un numero di porta,
           ad esempio '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
@@ -442,17 +401,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: tipo di registro locale '{0}' sconosciuto. I tipi
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: tipo di registro locale '{0}' sconosciuto. I tipi
           di registri contenitore locali validi sono {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: il manifesto per {0}:{1} dal registro {2} era un
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: il manifesto per {0}:{1} dal registro {2} era un
           tipo sconosciuto: {3}. Segnalare un problema in
           https://github.com/dotnet/sdk-container-builds/issues con questo messaggio.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -1,30 +1,51 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="it"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: la richiesta ad Amazon Elastic Container Registry non è riuscita in modo anomalo. Questo problema si verifica spesso quando il repository di destinazione non esiste nel registro.</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: la richiesta ad Amazon Elastic Container Registry
+          non è riuscita in modo anomalo. Questo problema si verifica spesso quando il repository di
+          destinazione non esiste nel registro.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
         <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed.</source>
-        <target state="translated">CONTAINER2008: sono stati forniti sia {0} che {1}, ma è consentito specificare solo uno di questi valori.</target>
+        <target state="translated">CONTAINER2008: sono stati forniti sia {0} che {1}, ma è
+          consentito specificare solo uno di questi valori.</target>
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: sono stati forniti ContainerAppCommandArgs senza specificare un elemento ContainerAppCommand.</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: sono stati forniti ContainerAppCommandArgs senza
+          specificare un elemento ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs devono essere vuoti quando ContainerAppCommandInstruction è '{0}'.</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs
+          devono essere vuoti quando ContainerAppCommandInstruction è '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: l'immagine di base contiene un punto di ingresso che verrà sovrascritto per avviare l'applicazione. Impostare ContainerAppCommandInstruction su 'Entrypoint', se necessario. Per mantenere il punto di ingresso dell'immagine di base, impostare ContainerAppCommandInstruction su 'DefaultArgs'.</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: l'immagine di base contiene un punto di ingresso
+          che verrà sovrascritto per avviare l'applicazione. Impostare
+          ContainerAppCommandInstruction su 'Entrypoint', se necessario. Per mantenere il punto di
+          ingresso dell'immagine di base, impostare ContainerAppCommandInstruction su 'DefaultArgs'.</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,23 +54,30 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} non specifica un Registro di sistema e verrà estratto da Docker Hub. Aggiungere al nome il prefisso del registro immagini, ad esempio '{1}/&lt;image&gt;'.</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} non specifica un Registro di sistema e verrà
+          estratto da Docker Hub. Aggiungere al nome il prefisso del registro immagini, ad esempio
+          '{1}/&lt;image&gt;'.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
-        <target state="translated">CONTAINER2013: {0} conteneva spazi, che verranno sostituiti con trattini.</target>
+        <target state="translated">CONTAINER2013: {0} conteneva spazi, che verranno sostituiti con
+          trattini.</target>
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: non è stato possibile trovare l'immagine di base corrispondente per {0} che corrisponde a RuntimeIdentifier {1}.</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: non è stato possibile trovare l'immagine di base
+          corrispondente per {0} che corrisponde a RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: non è stato possibile caricare il BLOB usando {0}; codice di stato ricevuto '{1}'.</target>
+        <target state="translated">CONTAINER1001: non è stato possibile caricare il BLOB usando {0};
+          codice di stato ricevuto '{1}'.</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
@@ -59,77 +87,103 @@
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
         <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">È stato eseguito il push del contenitore '{0}' nel registro '{1}'.</target>
+        <target state="translated">È stato eseguito il push del contenitore '{0}' nel registro
+          '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">
         <source>Building image '{0}' with tags '{1}' on top of base image '{2}'.</source>
-        <target state="translated">Compilazione dell'immagine '{0}' con i tag '{1}' sopra l'immagine di base '{2}'.</target>
+        <target state="translated">Compilazione dell'immagine '{0}' con i tag '{1}' sopra l'immagine
+          di base '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
-        <target state="translated">CONTAINER1007: non è stato possibile deserializzare il token da JSON.</target>
+        <target state="translated">CONTAINER1007: non è stato possibile deserializzare il token da
+          JSON.</target>
         <note>{StrBegin="CONTAINER1007: "}</note>
       </trans-unit>
       <trans-unit id="CouldntRecognizeRegistry">
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
-        <target state="translated">CONTAINER2012: non è stato possibile riconoscere il registro '{0}'.</target>
+        <target state="translated">CONTAINER2012: non è stato possibile riconoscere il registro
+          '{0}'.</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>
-        <target state="translated">CONTAINER3002: non è stato possibile ottenere le informazioni su Docker ({0})\n{1}\n{2}</target>
+        <target state="translated">CONTAINER3002: non è stato possibile ottenere le informazioni su
+          Docker ({0})\n{1}\n{2}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed_Ex">
         <source>CONTAINER3002: Failed to get docker info: {0}</source>
-        <target state="translated">CONTAINER3002: non è stato possibile ottenere le informazioni su Docker: {0}</target>
+        <target state="translated">CONTAINER3002: non è stato possibile ottenere le informazioni su
+          Docker: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: creazione del processo {0} non riuscita.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
-        <target state="translated">CONTAINER4006: la proprietà '{0}' è vuota o contiene spazi vuoti e verrà ignorata.</target>
+        <target state="translated">CONTAINER4006: la proprietà '{0}' è vuota o contiene spazi vuoti
+          e verrà ignorata.</target>
         <note>{StrBegin="CONTAINER4006: "}</note>
       </trans-unit>
       <trans-unit id="EmptyValuesIgnored">
         <source>CONTAINER4004: Items '{0}' contain empty item(s) which will be ignored.</source>
-        <target state="translated">CONTAINER4004: gli elementi '{0}' contengono elementi vuoti che verranno ignorati.</target>
+        <target state="translated">CONTAINER4004: gli elementi '{0}' contengono elementi vuoti che
+          verranno ignorati.</target>
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: sono stati forniti ContainerEntrypoint e ContainerAppCommandArgs. ContainerAppInstruction deve essere impostato per configurare la modalità di avvio dell'applicazione. Istruzioni valide sono {0}.</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: sono stati forniti ContainerEntrypoint e
+          ContainerAppCommandArgs. ContainerAppInstruction deve essere impostato per configurare la
+          modalità di avvio dell'applicazione. Istruzioni valide sono {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: è stato fornito ContainerEntrypoint. ContainerAppInstruction deve essere impostato per configurare la modalità di avvio dell'applicazione. Istruzioni valide sono {0}.</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: è stato fornito ContainerEntrypoint.
+          ContainerAppInstruction deve essere impostato per configurare la modalità di avvio
+          dell'applicazione. Istruzioni valide sono {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: sono stati forniti ContainerEntrypointArgs senza specificare un elemento ContainerEntrypoint.</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: sono stati forniti ContainerEntrypointArgs senza
+          specificare un elemento ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: è stato fornito ContainerEntrypointArgsSet. Modificare per usare ContainerAppCommandArgs per gli argomenti che devono essere sempre impostati o ContainerDefaultArgs per gli argomenti di cui è possibile eseguire l'override quando viene creato il contenitore.</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: è stato fornito ContainerEntrypointArgsSet.
+          Modificare per usare ContainerAppCommandArgs per gli argomenti che devono essere sempre
+          impostati o ContainerDefaultArgs per gli argomenti di cui è possibile eseguire l'override
+          quando viene creato il contenitore.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: non è possibile combinare ContainerEntrypoint con '{0}' ContainerAppCommandInstruction.</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: non è possibile combinare ContainerEntrypoint con
+          '{0}' ContainerAppCommandInstruction.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
         <source>CONTAINER1008: Failed retrieving credentials for "{0}": {1}</source>
-        <target state="translated">CONTAINER1008: non è stato possibile recuperare le credenziali per "{0}": {1}</target>
+        <target state="translated">CONTAINER1008: non è stato possibile recuperare le credenziali
+          per "{0}": {1}</target>
         <note>{StrBegin="CONTAINER1008: "}</note>
       </trans-unit>
       <trans-unit id="HostObjectNotDetected">
@@ -139,47 +193,74 @@
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: non è stato possibile caricare l'immagine dal registro locale. stdout: {0}</target>
+        <target state="translated">CONTAINER1009: non è stato possibile caricare l'immagine dal
+          registro locale. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
-        <target state="translated">CONTAINER1010: il pull di immagini dal registro locale non è supportato.</target>
+        <target state="translated">CONTAINER1010: il pull di immagini dal registro locale non è
+          supportato.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
-        <target state="translated">CONTAINER2015: {0}: '{1}' non è una variabile di ambiente valida. Il valore verrà ignorato.</target>
+        <target state="translated">CONTAINER2015: {0}: '{1}' non è una variabile di ambiente valida.
+          Il valore verrà ignorato.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: il nome dell'immagine dedotto '{0}' contiene caratteri completamente non validi. I caratteri validi per un nome di immagine sono caratteri alfanumerici, -, / o _, e il nome dell'immagine deve iniziare con un carattere alfanumerico.</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: il nome dell'immagine dedotto '{0}' contiene
+          caratteri completamente non validi. I caratteri validi per un nome di immagine sono
+          caratteri alfanumerici, -, / o _, e il nome dell'immagine deve iniziare con un carattere
+          alfanumerico.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: il primo carattere del nome dell'immagine '{0}' deve essere una lettera minuscola o una cifra e tutti i caratteri nel nome devono essere un carattere alfanumerico, -, /o _.</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: il primo carattere del nome dell'immagine '{0}'
+          deve essere una lettera minuscola o una cifra e tutti i caratteri nel nome devono essere
+          un carattere alfanumerico, -, /o _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un elemento ContainerPort è stato fornito con un numero di porta '{0}' non valido. Gli elementi ContainerPort devono avere un valore Include che è un numero intero e un valore Type impostato su 'tcp' o 'udp'.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: un elemento ContainerPort è stato fornito con un
+          numero di porta '{0}' non valido. Gli elementi ContainerPort devono avere un valore
+          Include che è un numero intero e un valore Type impostato su 'tcp' o 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un elemento ContainerPort è stato fornito con un numero di porta '{0}' non valido e un tipo di porta '{1}' non valido. Gli elementi ContainerPort devono avere un valore Include che è un numero intero e un valore Type impostato su 'tcp' o 'udp'.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: un elemento ContainerPort è stato fornito con un
+          numero di porta '{0}' non valido e un tipo di porta '{1}' non valido. Gli elementi
+          ContainerPort devono avere un valore Include che è un numero intero e un valore Type
+          impostato su 'tcp' o 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: un elemento ContainerPort è stato fornito con un tipo di porta '{0}' non valido. Gli elementi ContainerPort devono avere un valore Include che è un numero intero e un valore Type impostato su 'tcp' o 'udp'.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: un elemento ContainerPort è stato fornito con un
+          tipo di porta '{0}' non valido. Gli elementi ContainerPort devono avere un valore Include
+          che è un numero intero e un valore Type impostato su 'tcp' o 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: valore '{0}' non valido per la versione non definitiva dell'SDK - Sono supportate solo le versioni 'rc' e 'preview'.</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
+        <target state="translated">CONTAINER2018: valore '{0}' non valido per la versione non
+          definitiva dell'SDK - Sono supportate solo le versioni 'rc' e 'preview'.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -188,28 +269,38 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: il valore {0} specificato non è valido: {1}. I tag immagine devono essere alfanumerici, di sottolineatura, trattino o punto.</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: il valore {0} specificato non è valido: {1}. I tag
+          immagine devono essere alfanumerici, di sottolineatura, trattino o punto.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: il valore {0} specificato non è valido: {1}. {0} deve essere un elenco delimitato da punto e virgola di tag di immagine validi. I tag immagine devono essere alfanumerici, di sottolineatura, trattino o punto.</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: il valore {0} specificato non è valido: {1}. {0}
+          deve essere un elenco delimitato da punto e virgola di tag di immagine validi. I tag
+          immagine devono essere alfanumerici, di sottolineatura, trattino o punto.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
         <source>CONTAINER1003: Token response had neither token nor access_token.</source>
-        <target state="translated">CONTAINER1003: la risposta del token non contiene né token né access_token.</target>
+        <target state="translated">CONTAINER1003: la risposta del token non contiene né token né
+          access_token.</target>
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
-        <target state="translated">CONTAINER4005: l'elemento '{0}' contiene elementi senza 'Value' di metadati e tali elementi verranno ignorati.</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
+        <target state="translated">CONTAINER4005: l'elemento '{0}' contiene elementi senza 'Value'
+          di metadati e tali elementi verranno ignorati.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
-        <target state="translated">CONTAINER1012: il registro locale non è disponibile, ma è stato richiesto il push a un registro locale.</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
+        <target state="translated">CONTAINER1012: il registro locale non è disponibile, ma è stato
+          richiesto il push a un registro locale.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -223,13 +314,19 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: non è possibile scaricare il livello con descrittore '{0}' dal registro '{1}' perché non esiste.</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: non è possibile scaricare il livello con
+          descrittore '{0}' dal registro '{1}' perché non esiste.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: l'elemento ContainerPort '{0}' non specifica il numero di porta. Assicurarsi che il valore Include dell'elemento sia un numero di porta, ad esempio '&lt;ContainerPort Include="80" /&gt;'</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: l'elemento ContainerPort '{0}' non specifica il
+          numero di porta. Assicurarsi che il valore Include dell'elemento sia un numero di porta,
+          ad esempio '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -239,7 +336,8 @@
       </trans-unit>
       <trans-unit id="NormalizedContainerName">
         <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
-        <target state="translated">'{0}' non è un nome di immagine contenitore valido, è stato normalizzato in '{1}'</target>
+        <target state="translated">'{0}' non è un nome di immagine contenitore valido, è stato
+          normalizzato in '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
@@ -249,7 +347,8 @@
       </trans-unit>
       <trans-unit id="RegistryOutputPushFailed">
         <source>CONTAINER1013: Failed to push to the output registry: {0}</source>
-        <target state="translated">CONTAINER1013: non è stato possibile eseguire il push nel registro di output: {0}</target>
+        <target state="translated">CONTAINER1013: non è stato possibile eseguire il push nel
+          registro di output: {0}</target>
         <note>{StrBegin="CONTAINER1013: "}</note>
       </trans-unit>
       <trans-unit id="RegistryPushFailed">
@@ -259,7 +358,8 @@
       </trans-unit>
       <trans-unit id="Registry_ConfigUploadStarted">
         <source>Uploading config to registry at blob '{0}',</source>
-        <target state="translated">Caricamento della configurazione nel Registro di sistema nel BLOB '{0}',</target>
+        <target state="translated">Caricamento della configurazione nel Registro di sistema nel BLOB
+          '{0}',</target>
         <note />
       </trans-unit>
       <trans-unit id="Registry_ConfigUploaded">
@@ -284,7 +384,8 @@
       </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
-        <target state="translated">Caricamento del manifesto nel Registro di sistema '{0}' come BLOB '{1}'.</target>
+        <target state="translated">Caricamento del manifesto nel Registro di sistema '{0}' come BLOB
+          '{1}'.</target>
         <note>{0} is the registry name</note>
       </trans-unit>
       <trans-unit id="Registry_ManifestUploaded">
@@ -304,17 +405,20 @@
       </trans-unit>
       <trans-unit id="RequiredItemsContainsEmptyItems">
         <source>CONTAINER4003: Required '{0}' items contain empty items.</source>
-        <target state="translated">CONTAINER4003: gli elementi '{0}' obbligatori contengono elementi vuoti.</target>
+        <target state="translated">CONTAINER4003: gli elementi '{0}' obbligatori contengono elementi
+          vuoti.</target>
         <note>{StrBegin="CONTAINER4003: "}</note>
       </trans-unit>
       <trans-unit id="RequiredItemsNotSet">
         <source>CONTAINER4002: Required '{0}' items were not set.</source>
-        <target state="translated">CONTAINER4002: gli elementi '{0}' obbligatori non sono stati impostati.</target>
+        <target state="translated">CONTAINER4002: gli elementi '{0}' obbligatori non sono stati
+          impostati.</target>
         <note>{StrBegin="CONTAINER4002: "}</note>
       </trans-unit>
       <trans-unit id="RequiredPropertyNotSetOrEmpty">
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
-        <target state="translated">CONTAINER4001: la proprietà obbligatoria '{0}' non è stata impostata o è vuota.</target>
+        <target state="translated">CONTAINER4001: la proprietà obbligatoria '{0}' non è stata
+          impostata o è vuota.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TooManyRetries">
@@ -324,17 +428,24 @@
       </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: appCommandInstruction '{0}'sconosciuta. Istruzioni valide sono {1}.</target>
+        <target state="translated">CONTAINER2021: appCommandInstruction '{0}'sconosciuta. Istruzioni
+          valide sono {1}.</target>
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: tipo di registro locale '{0}' sconosciuto. I tipi di registri contenitore locali validi sono {1}.</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: tipo di registro locale '{0}' sconosciuto. I tipi
+          di registri contenitore locali validi sono {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: il manifesto per {0}:{1} dal registro {2} era un tipo sconosciuto: {3}. Segnalare un problema in https://github.com/dotnet/sdk-container-builds/issues con questo messaggio.</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: il manifesto per {0}:{1} dal registro {2} era un
+          tipo sconosciuto: {3}. Segnalare un problema in
+          https://github.com/dotnet/sdk-container-builds/issues con questo messaggio.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -1,10 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="ja"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Amazon Elastic Container Registry への要求が処理の途中で失敗しました。これは多くの場合、ターゲット リポジトリがレジストリに存在しない場合に発生します。</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: Amazon Elastic Container Registry
+          への要求が処理の途中で失敗しました。これは多くの場合、ターゲット リポジトリがレジストリに存在しない場合に発生します。</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
@@ -13,18 +23,26 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs が指定されていますが、ContainerAppCommand が指定されていません。</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: ContainerAppCommandArgs
+          が指定されていますが、ContainerAppCommand が指定されていません。</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommandInstruction が '{0}' の場合、ContainerAppCommand と ContainerAppCommandArgs を空にする必要があります。</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommandInstruction が '{0}'
+          の場合、ContainerAppCommand と ContainerAppCommandArgs を空にする必要があります。</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: 基本イメージに、アプリケーションの開始時に上書きされるエントリ ポイントがあります。このまま上書きする場合は、ContainerAppCommandInstruction を 'Entrypoint' に設定します。基本イメージのエントリ ポイントを保持するには、ContainerAppCommandInstruction を 'DefaultArgs' に設定します。</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: 基本イメージに、アプリケーションの開始時に上書きされるエントリ
+          ポイントがあります。このまま上書きする場合は、ContainerAppCommandInstruction を 'Entrypoint' に設定します。基本イメージのエントリ
+          ポイントを保持するには、ContainerAppCommandInstruction を 'DefaultArgs' に設定します。</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,8 +51,10 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} でレジストリが指定されていないため、Docker Hub からプルされます。名前の前にイメージ レジストリを付けてください。例: '{1}/&lt;image&gt;'。</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} でレジストリが指定されていないため、Docker Hub
+          からプルされます。名前の前にイメージ レジストリを付けてください。例: '{1}/&lt;image&gt;'。</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
@@ -43,13 +63,16 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: RuntimeIdentifier {1} に一致する {0} に一致する基本イメージが見つかりませんでした。</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: RuntimeIdentifier {1} に一致する {0}
+          に一致する基本イメージが見つかりませんでした。</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: {0} を使用して BLOB をアップロードできませんでした; 状態コード '{1}' を受信しました。</target>
+        <target state="translated">CONTAINER1001: {0} を使用して BLOB をアップロードできませんでした; 状態コード '{1}'
+          を受信しました。</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
@@ -87,10 +110,11 @@
         <target state="translated">CONTAINER3002: Docker 情報を取得できませんでした: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: {0} プロセスを作成できませんでした。</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -103,28 +127,41 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: ContainerEntrypoint と ContainerAppCommandArgs が指定されています。アプリケーションの開始方法を構成するには、ContainerAppInstruction を設定する必要があります。有効な手順は {0} です。</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: ContainerEntrypoint と ContainerAppCommandArgs
+          が指定されています。アプリケーションの開始方法を構成するには、ContainerAppInstruction を設定する必要があります。有効な手順は {0} です。</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: ContainerEntrypoint が指定されています。アプリケーションの開始方法を構成するには、ContainerAppInstruction を設定する必要があります。有効な手順は {0} です。</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: ContainerEntrypoint
+          が指定されています。アプリケーションの開始方法を構成するには、ContainerAppInstruction を設定する必要があります。有効な手順は {0} です。</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs が指定されていますが、ContainerEntrypoint が指定されていません。</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: ContainerEntrypointArgs
+          が指定されていますが、ContainerEntrypoint が指定されていません。</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet が使用されています。常に設定されている必要がある引数の場合 ContainerAppCommandArgs を使用するか、コンテナーの作成時にオーバーライドできる引数の場合 ContainerDefaultArgs を使用するように変更してください。</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet
+          が使用されています。常に設定されている必要がある引数の場合 ContainerAppCommandArgs を使用するか、コンテナーの作成時にオーバーライドできる引数の場合
+          ContainerDefaultArgs を使用するように変更してください。</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint を ContainerAppCommandInstruction '{0}' と組み合わせることはできません。</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint を
+          ContainerAppCommandInstruction '{0}' と組み合わせることはできません。</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
@@ -153,33 +190,51 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: 推定されたイメージ名 '{0}' に、完全に無効な文字が含まれています。イメージ名に有効な文字は英数字、-、/、または _で、イメージ名の先頭には英数字を使用する必要があります。</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: 推定されたイメージ名 '{0}'
+          に、完全に無効な文字が含まれています。イメージ名に有効な文字は英数字、-、/、または _で、イメージ名の先頭には英数字を使用する必要があります。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: イメージ名 '{0}' は小文字は数字で、名前に含まれるすべての文字は英数字、-、または _ である必要があります。</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: イメージ名 '{0}' は小文字は数字で、名前に含まれるすべての文字は英数字、-、または _
+          である必要があります。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 無効なポート場合 '{0}' を使用して ContainerPort 項目が指定されました。ContainerPort 項目には、整数である Include 値と、'tcp' または 'udp' のいずれかである Type 値が必要です。</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 無効なポート場合 '{0}' を使用して ContainerPort
+          項目が指定されました。ContainerPort 項目には、整数である Include 値と、'tcp' または 'udp' のいずれかである Type 値が必要です。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 無効なポート番号 '{0}' と無効なポートの種類 '{1}' を使用して ContainerPort 項目が指定されました。ContainerPort 項目には、整数である Include 値と、'tcp' または 'udp' のいずれかである Type 値が必要です。</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 無効なポート番号 '{0}' と無効なポートの種類 '{1}' を使用して
+          ContainerPort 項目が指定されました。ContainerPort 項目には、整数である Include 値と、'tcp' または 'udp' のいずれかである Type
+          値が必要です。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 無効なポートの種類 '{0}' を使用して ContainerPort 項目が指定されました。ContainerPort 項目には、整数である Include 値と、'tcp' または 'udp' のいずれかである Type 値が必要です。</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 無効なポートの種類 '{0}' を使用して ContainerPort
+          項目が指定されました。ContainerPort 項目には、整数である Include 値と、'tcp' または 'udp' のいずれかである Type 値が必要です。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: SDK プレリリース バージョン '{0}' が無効です。'rc' と 'preview' のみがサポートされています。</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
+        <target state="translated">CONTAINER2018: SDK プレリリース バージョン '{0}' が無効です。'rc' と 'preview'
+          のみがサポートされています。</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -188,13 +243,17 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: 無効な {0} が指定されました: {1}。イメージ タグは、英数字、アンダースコア、ハイフン、またはピリオドである必要があります。</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: 無効な {0} が指定されました: {1}。イメージ
+          タグは、英数字、アンダースコア、ハイフン、またはピリオドである必要があります。</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: 無効な {0} が指定されました: {1}。{0} は、セミコロンで区切られた有効なイメージ タグのリストである必要があります。イメージ タグは、英数字、アンダースコア、ハイフン、またはピリオドである必要があります。</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: 無効な {0} が指定されました: {1}。{0} は、セミコロンで区切られた有効なイメージ
+          タグのリストである必要があります。イメージ タグは、英数字、アンダースコア、ハイフン、またはピリオドである必要があります。</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
@@ -203,12 +262,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
         <target state="translated">CONTAINER4005: 項目 '{0}' にメタデータ 'Value' のない項目が含まれており、これらは無視されます。</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
         <target state="translated">CONTAINER1012: ローカル レジストリが使用できませんが、ローカル レジストリへのプッシュが要求されました。</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -223,13 +284,18 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: レジストリ '{1}' 内の記述子 '{0}' を持つレイヤーは存在しないため、ダウンロードできません。</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: レジストリ '{1}' 内の記述子 '{0}'
+          を持つレイヤーは存在しないため、ダウンロードできません。</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort 項目 '{0}' でポート番号が指定されていません。項目の Include がポート番号 (e '&lt;ContainerPort Include="80" /&gt;' など) であることを確認してください</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: ContainerPort 項目 '{0}' でポート番号が指定されていません。項目の
+          Include がポート番号 (e '&lt;ContainerPort Include="80" /&gt;' など) であることを確認してください</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -328,13 +394,18 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: 不明なローカル レジストリの種類 '{0}'。有効なローカル コンテナー レジストリの種類は {1} です。</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: 不明なローカル レジストリの種類 '{0}'。有効なローカル コンテナー レジストリの種類は {1}
+          です。</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: レジストリ {0} からの {1}:{2} のマニフェストは不明な種類でした: {3}。このメッセージを使用して https://github.com/dotnet/sdk-container-builds/issues で問題を発生させてください。</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: レジストリ {0} からの {1}:{2} のマニフェストは不明な種類でした:
+          {3}。このメッセージを使用して https://github.com/dotnet/sdk-container-builds/issues で問題を発生させてください。</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="ja"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Amazon Elastic Container Registry
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: Amazon Elastic Container Registry
           への要求が処理の途中で失敗しました。これは多くの場合、ターゲット リポジトリがレジストリに存在しない場合に発生します。</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
@@ -23,16 +14,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: ContainerAppCommandArgs
           が指定されていますが、ContainerAppCommand が指定されていません。</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommandInstruction が '{0}'
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommandInstruction が '{0}'
           の場合、ContainerAppCommand と ContainerAppCommandArgs を空にする必要があります。</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -42,10 +31,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: 基本イメージに、アプリケーションの開始時に上書きされるエントリ
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: 基本イメージに、アプリケーションの開始時に上書きされるエントリ
           ポイントがあります。このまま上書きする場合は、ContainerAppCommandInstruction を 'Entrypoint' に設定します。基本イメージのエントリ
           ポイントを保持するには、ContainerAppCommandInstruction を 'DefaultArgs' に設定します。</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
@@ -56,9 +43,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} でレジストリが指定されていないため、Docker Hub
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} でレジストリが指定されていないため、Docker Hub
           からプルされます。名前の前にイメージ レジストリを付けてください。例: '{1}/&lt;image&gt;'。</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
@@ -68,9 +54,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: RuntimeIdentifier {1} に一致する {0}
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: RuntimeIdentifier {1} に一致する {0}
           に一致する基本イメージが見つかりませんでした。</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -122,9 +107,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: {0} プロセスを作成できませんでした。</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: {0} プロセスを作成できませんでした。</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -137,40 +121,33 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: ContainerEntrypoint と ContainerAppCommandArgs
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: ContainerEntrypoint と ContainerAppCommandArgs
           が指定されています。アプリケーションの開始方法を構成するには、ContainerAppInstruction を設定する必要があります。有効な手順は {0} です。</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: ContainerEntrypoint
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: ContainerEntrypoint
           が指定されています。アプリケーションの開始方法を構成するには、ContainerAppInstruction を設定する必要があります。有効な手順は {0} です。</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: ContainerEntrypointArgs
           が指定されていますが、ContainerEntrypoint が指定されていません。</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: ContainerEntrypointArgsSet
           が使用されています。常に設定されている必要がある引数の場合 ContainerAppCommandArgs を使用するか、コンテナーの作成時にオーバーライドできる引数の場合
           ContainerDefaultArgs を使用するように変更してください。</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint を
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint を
           ContainerAppCommandInstruction '{0}' と組み合わせることはできません。</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -200,50 +177,39 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: 推定されたイメージ名 '{0}'
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: 推定されたイメージ名 '{0}'
           に、完全に無効な文字が含まれています。イメージ名に有効な文字は英数字、-、/、または _で、イメージ名の先頭には英数字を使用する必要があります。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: イメージ名 '{0}' は小文字は数字で、名前に含まれるすべての文字は英数字、-、または _
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: イメージ名 '{0}' は小文字は数字で、名前に含まれるすべての文字は英数字、-、または _
           である必要があります。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 無効なポート場合 '{0}' を使用して ContainerPort
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 無効なポート場合 '{0}' を使用して ContainerPort
           項目が指定されました。ContainerPort 項目には、整数である Include 値と、'tcp' または 'udp' のいずれかである Type 値が必要です。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 無効なポート番号 '{0}' と無効なポートの種類 '{1}' を使用して
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 無効なポート番号 '{0}' と無効なポートの種類 '{1}' を使用して
           ContainerPort 項目が指定されました。ContainerPort 項目には、整数である Include 値と、'tcp' または 'udp' のいずれかである Type
           値が必要です。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 無効なポートの種類 '{0}' を使用して ContainerPort
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 無効なポートの種類 '{0}' を使用して ContainerPort
           項目が指定されました。ContainerPort 項目には、整数である Include 値と、'tcp' または 'udp' のいずれかである Type 値が必要です。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: SDK プレリリース バージョン '{0}' が無効です。'rc' と 'preview'
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: SDK プレリリース バージョン '{0}' が無効です。'rc' と 'preview'
           のみがサポートされています。</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -253,16 +219,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: 無効な {0} が指定されました: {1}。イメージ
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: 無効な {0} が指定されました: {1}。イメージ
           タグは、英数字、アンダースコア、ハイフン、またはピリオドである必要があります。</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: 無効な {0} が指定されました: {1}。{0} は、セミコロンで区切られた有効なイメージ
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: 無効な {0} が指定されました: {1}。{0} は、セミコロンで区切られた有効なイメージ
           タグのリストである必要があります。イメージ タグは、英数字、アンダースコア、ハイフン、またはピリオドである必要があります。</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
@@ -272,15 +236,13 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: 項目 '{0}' にメタデータ 'Value' のない項目が含まれており、これらは無視されます。</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: 項目 '{0}' にメタデータ 'Value' のない項目が含まれており、これらは無視されます。</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: ローカル レジストリが使用できませんが、ローカル レジストリへのプッシュが要求されました。</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: ローカル レジストリが使用できませんが、ローカル レジストリへのプッシュが要求されました。</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -294,17 +256,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: レジストリ '{1}' 内の記述子 '{0}'
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: レジストリ '{1}' 内の記述子 '{0}'
           を持つレイヤーは存在しないため、ダウンロードできません。</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort 項目 '{0}' でポート番号が指定されていません。項目の
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: ContainerPort 項目 '{0}' でポート番号が指定されていません。項目の
           Include がポート番号 (e '&lt;ContainerPort Include="80" /&gt;' など) であることを確認してください</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
@@ -404,17 +363,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: 不明なローカル レジストリの種類 '{0}'。有効なローカル コンテナー レジストリの種類は {1}
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: 不明なローカル レジストリの種類 '{0}'。有効なローカル コンテナー レジストリの種類は {1}
           です。</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: レジストリ {0} からの {1}:{2} のマニフェストは不明な種類でした:
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: レジストリ {0} からの {1}:{2} のマニフェストは不明な種類でした:
           {3}。このメッセージを使用して https://github.com/dotnet/sdk-container-builds/issues で問題を発生させてください。</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -1,10 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="ko"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Amazon Elastic Container Registry에 대한 요청이 조기에 실패했습니다. 대상 리포지토리가 레지스트리에 존재하지 않을 때 종종 발생합니다.</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: Amazon Elastic Container Registry에 대한 요청이 조기에
+          실패했습니다. 대상 리포지토리가 레지스트리에 존재하지 않을 때 종종 발생합니다.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
@@ -13,18 +23,26 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs는 ContainerAppCommand를 지정하지 않고 제공됩니다.</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: ContainerAppCommandArgs는 ContainerAppCommand를 지정하지
+          않고 제공됩니다.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommandInstruction이 '{0}'인 경우 ContainerAppCommand 및 ContainerAppCommandArgs가 비어 있어야 합니다.</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommandInstruction이 '{0}'인 경우
+          ContainerAppCommand 및 ContainerAppCommandArgs가 비어 있어야 합니다.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: 기본 이미지에 응용 프로그램을 시작하기 위해 덮어쓸 진입점이 있습니다. 필요한 경우 ContainerAppCommandInstruction을 'Entrypoint'로 설정합니다. 기본 이미지 진입점을 유지하려면 ContainerAppCommandInstruction을 'DefaultArgs'로 설정하세요.</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: 기본 이미지에 응용 프로그램을 시작하기 위해 덮어쓸 진입점이 있습니다. 필요한 경우
+          ContainerAppCommandInstruction을 'Entrypoint'로 설정합니다. 기본 이미지 진입점을 유지하려면
+          ContainerAppCommandInstruction을 'DefaultArgs'로 설정하세요.</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,8 +51,10 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0}은(는) 레지스트리를 지정하지 않으며 Docker Hub에서 끌어오게 됩니다. 이름 앞에 이미지 레지스트리를 추가하세요(예: '{1}/&lt;image&gt;').</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0}은(는) 레지스트리를 지정하지 않으며 Docker Hub에서 끌어오게 됩니다. 이름
+          앞에 이미지 레지스트리를 추가하세요(예: '{1}/&lt;image&gt;').</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
@@ -43,13 +63,16 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: RuntimeIdentifier {1}과(와) 일치하는 {0}에 대해 일치하는 기본 이미지를 찾을 수 없습니다.</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: RuntimeIdentifier {1}과(와) 일치하는 {0}에 대해 일치하는 기본
+          이미지를 찾을 수 없습니다.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: {0}을(를) 사용하여 Blob을 업로드하지 못했습니다. '{1}' 상태 코드를 수신했습니다.</target>
+        <target state="translated">CONTAINER1001: {0}을(를) 사용하여 Blob을 업로드하지 못했습니다. '{1}' 상태 코드를
+          수신했습니다.</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
@@ -87,10 +110,11 @@
         <target state="translated">CONTAINER3002: 도커 정보를 가져오지 못했습니다: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: {0} 프로세스 생성에 실패했습니다.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -103,28 +127,41 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: ContainerEntrypoint 및 ContainerAppCommandArgs가 제공되었습니다. 애플리케이션 시작 방법을 구성하려면 ContainerAppInstruction을 설정해야 합니다. 올바른 지침은 {0}입니다.</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: ContainerEntrypoint 및 ContainerAppCommandArgs가
+          제공되었습니다. 애플리케이션 시작 방법을 구성하려면 ContainerAppInstruction을 설정해야 합니다. 올바른 지침은 {0}입니다.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: ContainerEntrypoint가 제공됩니다. 애플리케이션 시작 방법을 구성하려면 ContainerAppInstruction을 설정해야 합니다. 유효한 지침은 {0}입니다.</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: ContainerEntrypoint가 제공됩니다. 애플리케이션 시작 방법을 구성하려면
+          ContainerAppInstruction을 설정해야 합니다. 유효한 지침은 {0}입니다.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs는 ContainerEntrypoint를 지정하지 않고 제공됩니다.</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: ContainerEntrypointArgs는 ContainerEntrypoint를 지정하지
+          않고 제공됩니다.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet이 제공되었습니다. 항상 설정해야 하는 인수에 ContainerAppCommandArgs를 사용하도록 변경하거나 컨테이너를 만들 때 재정의할 수 있는 인수에 ContainerDefaultArgs를 사용하도록 변경합니다.</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet이 제공되었습니다. 항상 설정해야 하는
+          인수에 ContainerAppCommandArgs를 사용하도록 변경하거나 컨테이너를 만들 때 재정의할 수 있는 인수에 ContainerDefaultArgs를
+          사용하도록 변경합니다.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint는 '{0}' ContainerAppCommandInstruction과 함께 사용할 수 없습니다.</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint는 '{0}'
+          ContainerAppCommandInstruction과 함께 사용할 수 없습니다.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
@@ -153,32 +190,49 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: 유추된 이미지 이름 '{0}'에 완전히 잘못된 문자가 포함되어 있습니다. 이미지 이름의 유효한 문자는 영숫자, -, /또는 _이며 이미지 이름은 영숫자 문자로 시작해야 합니다.</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: 유추된 이미지 이름 '{0}'에 완전히 잘못된 문자가 포함되어 있습니다. 이미지 이름의
+          유효한 문자는 영숫자, -, /또는 _이며 이미지 이름은 영숫자 문자로 시작해야 합니다.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: 이미지 이름 '{0}'의 첫 번째 문자는 소문자 또는 숫자여야 하며 이름의 모든 문자는 영숫자, -, /또는 _여야 합니다.</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: 이미지 이름 '{0}'의 첫 번째 문자는 소문자 또는 숫자여야 하며 이름의 모든 문자는
+          영숫자, -, /또는 _여야 합니다.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: ContainerPort 항목에 잘못된 포트 번호 '{0}'이(가) 제공되었습니다. ContainerPort 항목에는 정수인 Include 값과 'tcp' 또는 'udp'인 Type 값이 있어야 합니다.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: ContainerPort 항목에 잘못된 포트 번호 '{0}'이(가) 제공되었습니다.
+          ContainerPort 항목에는 정수인 Include 값과 'tcp' 또는 'udp'인 Type 값이 있어야 합니다.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 잘못된 포트 번호 '{0}' 및 잘못된 포트 유형 '{1}'과(와) 함께 ContainerPort 항목이 제공되었습니다. ContainerPort 항목에는 정수인 Include 값과 'tcp' 또는 'udp'인 Type 값이 있어야 합니다.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 잘못된 포트 번호 '{0}' 및 잘못된 포트 유형 '{1}'과(와) 함께
+          ContainerPort 항목이 제공되었습니다. ContainerPort 항목에는 정수인 Include 값과 'tcp' 또는 'udp'인 Type 값이 있어야
+          합니다.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 잘못된 포트 유형 '{0}'과(와) 함께 ContainerPort 항목이 제공되었습니다. ContainerPort 항목에는 정수인 Include 값과 'tcp' 또는 'udp'인 Type 값이 있어야 합니다.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 잘못된 포트 유형 '{0}'과(와) 함께 ContainerPort 항목이 제공되었습니다.
+          ContainerPort 항목에는 정수인 Include 값과 'tcp' 또는 'udp'인 Type 값이 있어야 합니다.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
         <target state="translated">CONTAINER2018: 잘못된 SDK 시험판 버전 '{0}' - 'rc' 및 'preview'만 지원됩니다.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -188,13 +242,17 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: 잘못된 {0}이(가) 제공됨: {1}. 이미지 태그는 영숫자, 밑줄, 하이픈 또는 마침표여야 합니다.</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: 잘못된 {0}이(가) 제공됨: {1}. 이미지 태그는 영숫자, 밑줄, 하이픈 또는
+          마침표여야 합니다.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: 잘못된 {0}이(가) 제공됨: {1}. {0}은(는) 세미콜론으로 구분된 유효한 이미지 태그 목록이어야 합니다. 이미지 태그는 영숫자, 밑줄, 하이픈 또는 마침표여야 합니다.</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: 잘못된 {0}이(가) 제공됨: {1}. {0}은(는) 세미콜론으로 구분된 유효한 이미지
+          태그 목록이어야 합니다. 이미지 태그는 영숫자, 밑줄, 하이픈 또는 마침표여야 합니다.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
@@ -203,12 +261,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
         <target state="translated">CONTAINER4005: 항목 '{0}'에는 메타데이터 '값'이 없는 항목이 포함되어 있으며 무시됩니다.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
         <target state="translated">CONTAINER1012: 로컬 레지스트리를 사용할 수 없는데 로컬 레지스트리로 푸시가 요청되었습니다.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -223,13 +283,18 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: '{1}' 레지스트리에서 설명자가 '{0}'인 레이어가 존재하지 않기 때문에 다운로드할 수 없습니다.</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: '{1}' 레지스트리에서 설명자가 '{0}'인 레이어가 존재하지 않기 때문에 다운로드할 수
+          없습니다.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort 항목 '{0}'이(가) 포트 번호를 지정하지 않습니다. 항목의 포함이 포트 번호인지 확인하세요(예: '&lt;ContainerPort Include="80" /&gt;').</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: ContainerPort 항목 '{0}'이(가) 포트 번호를 지정하지 않습니다. 항목의
+          포함이 포트 번호인지 확인하세요(예: '&lt;ContainerPort Include="80" /&gt;').</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -324,17 +389,23 @@
       </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: 알 수 없는 AppCommandInstruction '{0}'. 올바른 지침은 {1}입니다.</target>
+        <target state="translated">CONTAINER2021: 알 수 없는 AppCommandInstruction '{0}'. 올바른 지침은
+          {1}입니다.</target>
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: 알 수 없는 로컬 레지스트리 유형 '{0}'. 유효한 로컬 컨테이너 레지스트리 유형은 {1}입니다.</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: 알 수 없는 로컬 레지스트리 유형 '{0}'. 유효한 로컬 컨테이너 레지스트리 유형은
+          {1}입니다.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: 레지스트리 {2}의 {0}:{1}에 대한 매니페스트가 알 수 없는 유형입니다: {3}. https://github.com/dotnet/sdk-container-builds/issues에서 이 메시지와 함께 문제를 제기하세요.</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: 레지스트리 {2}의 {0}:{1}에 대한 매니페스트가 알 수 없는 유형입니다: {3}.
+          https://github.com/dotnet/sdk-container-builds/issues에서 이 메시지와 함께 문제를 제기하세요.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="ko"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Amazon Elastic Container Registry에 대한 요청이 조기에
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: Amazon Elastic Container Registry에 대한 요청이 조기에
           실패했습니다. 대상 리포지토리가 레지스트리에 존재하지 않을 때 종종 발생합니다.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
@@ -23,16 +14,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs는 ContainerAppCommand를 지정하지
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: ContainerAppCommandArgs는 ContainerAppCommand를 지정하지
           않고 제공됩니다.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommandInstruction이 '{0}'인 경우
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommandInstruction이 '{0}'인 경우
           ContainerAppCommand 및 ContainerAppCommandArgs가 비어 있어야 합니다.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -42,10 +31,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: 기본 이미지에 응용 프로그램을 시작하기 위해 덮어쓸 진입점이 있습니다. 필요한 경우
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: 기본 이미지에 응용 프로그램을 시작하기 위해 덮어쓸 진입점이 있습니다. 필요한 경우
           ContainerAppCommandInstruction을 'Entrypoint'로 설정합니다. 기본 이미지 진입점을 유지하려면
           ContainerAppCommandInstruction을 'DefaultArgs'로 설정하세요.</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
@@ -56,9 +43,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0}은(는) 레지스트리를 지정하지 않으며 Docker Hub에서 끌어오게 됩니다. 이름
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0}은(는) 레지스트리를 지정하지 않으며 Docker Hub에서 끌어오게 됩니다. 이름
           앞에 이미지 레지스트리를 추가하세요(예: '{1}/&lt;image&gt;').</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
@@ -68,9 +54,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: RuntimeIdentifier {1}과(와) 일치하는 {0}에 대해 일치하는 기본
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: RuntimeIdentifier {1}과(와) 일치하는 {0}에 대해 일치하는 기본
           이미지를 찾을 수 없습니다.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -122,9 +107,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: {0} 프로세스 생성에 실패했습니다.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: {0} 프로세스 생성에 실패했습니다.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -137,40 +121,33 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: ContainerEntrypoint 및 ContainerAppCommandArgs가
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: ContainerEntrypoint 및 ContainerAppCommandArgs가
           제공되었습니다. 애플리케이션 시작 방법을 구성하려면 ContainerAppInstruction을 설정해야 합니다. 올바른 지침은 {0}입니다.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: ContainerEntrypoint가 제공됩니다. 애플리케이션 시작 방법을 구성하려면
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: ContainerEntrypoint가 제공됩니다. 애플리케이션 시작 방법을 구성하려면
           ContainerAppInstruction을 설정해야 합니다. 유효한 지침은 {0}입니다.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs는 ContainerEntrypoint를 지정하지
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: ContainerEntrypointArgs는 ContainerEntrypoint를 지정하지
           않고 제공됩니다.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet이 제공되었습니다. 항상 설정해야 하는
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: ContainerEntrypointArgsSet이 제공되었습니다. 항상 설정해야 하는
           인수에 ContainerAppCommandArgs를 사용하도록 변경하거나 컨테이너를 만들 때 재정의할 수 있는 인수에 ContainerDefaultArgs를
           사용하도록 변경합니다.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint는 '{0}'
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint는 '{0}'
           ContainerAppCommandInstruction과 함께 사용할 수 없습니다.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -200,50 +177,39 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: 유추된 이미지 이름 '{0}'에 완전히 잘못된 문자가 포함되어 있습니다. 이미지 이름의
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: 유추된 이미지 이름 '{0}'에 완전히 잘못된 문자가 포함되어 있습니다. 이미지 이름의
           유효한 문자는 영숫자, -, /또는 _이며 이미지 이름은 영숫자 문자로 시작해야 합니다.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: 이미지 이름 '{0}'의 첫 번째 문자는 소문자 또는 숫자여야 하며 이름의 모든 문자는
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: 이미지 이름 '{0}'의 첫 번째 문자는 소문자 또는 숫자여야 하며 이름의 모든 문자는
           영숫자, -, /또는 _여야 합니다.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: ContainerPort 항목에 잘못된 포트 번호 '{0}'이(가) 제공되었습니다.
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: ContainerPort 항목에 잘못된 포트 번호 '{0}'이(가) 제공되었습니다.
           ContainerPort 항목에는 정수인 Include 값과 'tcp' 또는 'udp'인 Type 값이 있어야 합니다.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 잘못된 포트 번호 '{0}' 및 잘못된 포트 유형 '{1}'과(와) 함께
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 잘못된 포트 번호 '{0}' 및 잘못된 포트 유형 '{1}'과(와) 함께
           ContainerPort 항목이 제공되었습니다. ContainerPort 항목에는 정수인 Include 값과 'tcp' 또는 'udp'인 Type 값이 있어야
           합니다.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 잘못된 포트 유형 '{0}'과(와) 함께 ContainerPort 항목이 제공되었습니다.
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 잘못된 포트 유형 '{0}'과(와) 함께 ContainerPort 항목이 제공되었습니다.
           ContainerPort 항목에는 정수인 Include 값과 'tcp' 또는 'udp'인 Type 값이 있어야 합니다.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: 잘못된 SDK 시험판 버전 '{0}' - 'rc' 및 'preview'만 지원됩니다.</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: 잘못된 SDK 시험판 버전 '{0}' - 'rc' 및 'preview'만 지원됩니다.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -252,16 +218,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: 잘못된 {0}이(가) 제공됨: {1}. 이미지 태그는 영숫자, 밑줄, 하이픈 또는
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: 잘못된 {0}이(가) 제공됨: {1}. 이미지 태그는 영숫자, 밑줄, 하이픈 또는
           마침표여야 합니다.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: 잘못된 {0}이(가) 제공됨: {1}. {0}은(는) 세미콜론으로 구분된 유효한 이미지
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: 잘못된 {0}이(가) 제공됨: {1}. {0}은(는) 세미콜론으로 구분된 유효한 이미지
           태그 목록이어야 합니다. 이미지 태그는 영숫자, 밑줄, 하이픈 또는 마침표여야 합니다.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
@@ -271,15 +235,13 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: 항목 '{0}'에는 메타데이터 '값'이 없는 항목이 포함되어 있으며 무시됩니다.</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: 항목 '{0}'에는 메타데이터 '값'이 없는 항목이 포함되어 있으며 무시됩니다.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: 로컬 레지스트리를 사용할 수 없는데 로컬 레지스트리로 푸시가 요청되었습니다.</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: 로컬 레지스트리를 사용할 수 없는데 로컬 레지스트리로 푸시가 요청되었습니다.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -293,17 +255,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: '{1}' 레지스트리에서 설명자가 '{0}'인 레이어가 존재하지 않기 때문에 다운로드할 수
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: '{1}' 레지스트리에서 설명자가 '{0}'인 레이어가 존재하지 않기 때문에 다운로드할 수
           없습니다.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort 항목 '{0}'이(가) 포트 번호를 지정하지 않습니다. 항목의
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: ContainerPort 항목 '{0}'이(가) 포트 번호를 지정하지 않습니다. 항목의
           포함이 포트 번호인지 확인하세요(예: '&lt;ContainerPort Include="80" /&gt;').</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
@@ -404,17 +363,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: 알 수 없는 로컬 레지스트리 유형 '{0}'. 유효한 로컬 컨테이너 레지스트리 유형은
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: 알 수 없는 로컬 레지스트리 유형 '{0}'. 유효한 로컬 컨테이너 레지스트리 유형은
           {1}입니다.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: 레지스트리 {2}의 {0}:{1}에 대한 매니페스트가 알 수 없는 유형입니다: {3}.
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: 레지스트리 {2}의 {0}:{1}에 대한 매니페스트가 알 수 없는 유형입니다: {3}.
           https://github.com/dotnet/sdk-container-builds/issues에서 이 메시지와 함께 문제를 제기하세요.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="pl"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: żądanie do usługi Amazon Elastic Container
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: żądanie do usługi Amazon Elastic Container
           Registry przedwcześnie zakończyło się niepowodzeniem. Jest to często spowodowane tym, że
           repozytorium docelowe nie istnieje w rejestrze.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
@@ -25,16 +16,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: Argumenty ContainerAppCommandArgs są dostarczane
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: Argumenty ContainerAppCommandArgs są dostarczane
           bez określania polecenia ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand i ContainerAppCommandArgs
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommand i ContainerAppCommandArgs
           muszą być puste, gdy element ContainerAppCommandInstruction ma wartość „{0}”.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -44,10 +33,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: Obraz podstawowy ma punkt wejścia, który zostanie
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: Obraz podstawowy ma punkt wejścia, który zostanie
           zastąpiony w celu uruchomienia aplikacji. W razie potrzeby ustaw właściwość
           ContainerAppCommandInstruction na wartość „Entrypoint”. Aby zachować podstawowy punkt
           wejścia obrazu, ustaw właściwość ContainerAppCommandInstruction na wartość „DefaultArgs”.</target>
@@ -59,9 +46,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} nie określa rejestru i zostanie pobrany z
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} nie określa rejestru i zostanie pobrany z
           usługi Docker Hub. Poprzedź nazwę rejestrem obrazów, na przykład: „{1}/&lt;image&gt;”.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
@@ -72,9 +58,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: nie można odnaleźć pasującego obrazu podstawowego
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: nie można odnaleźć pasującego obrazu podstawowego
           dla {0} zgodnego z elementem RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -129,9 +114,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: Nie można utworzyć procesu {0}.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: Nie można utworzyć procesu {0}.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -146,43 +130,36 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Przesłano elementy ContainerEntrypoint i
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: Przesłano elementy ContainerEntrypoint i
           ContainerAppCommandArgs. Aby skonfigurować sposób uruchamiania aplikacji, należy ustawić
           element ContainerAppInstruction. Prawidłowe instrukcje: {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Przesłano element ContainerEntrypoint. Aby
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: Przesłano element ContainerEntrypoint. Aby
           skonfigurować sposób uruchamiania aplikacji, należy ustawić element
           ContainerAppInstruction. Prawidłowe instrukcje to {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: Argumenty ContainerEntrypointArgs są przesyłane
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: Argumenty ContainerEntrypointArgs są przesyłane
           bez określania elementu ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: Przesłano elementy ContainerEntrypointArgsSet.
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: Przesłano elementy ContainerEntrypointArgsSet.
           Zmień, aby używać argumentów ContainerAppCommandArgs dla argumentów, które muszą być
           zawsze ustawione, lub argumentów ContainerDefaultArgs dla argumentów, które mogą zostać
           zastąpione podczas tworzenia kontenera.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: Elementu ContainerEntrypoint nie można łączyć z
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: Elementu ContainerEntrypoint nie można łączyć z
           elementem ContainerAppCommandInstruction „{0}”.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -215,55 +192,44 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Wywnioskowana nazwa obrazu „{0}” zawiera
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: Wywnioskowana nazwa obrazu „{0}” zawiera
           całkowicie nieprawidłowe znaki. Prawidłowe znaki nazwy obrazu to znaki alfanumeryczne oraz
           —, /, lub _, a nazwa obrazu musi zaczynać się znakiem alfanumerycznym.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: Pierwszy znak nazwy obrazu „{0}” musi być małą
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: Pierwszy znak nazwy obrazu „{0}” musi być małą
           literą lub cyfrą, a wszystkie znaki w nazwie muszą być znakami alfanumerycznymi, —, /, lub
           _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: element ContainerPort został dostarczony z
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: element ContainerPort został dostarczony z
           nieprawidłowym numerem portu „{0}”. Elementy ContainerPort muszą mieć wartość Include
           będącą liczbą całkowitą oraz wartość typu „tcp” lub „udp”.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: element ContainerPort został dostarczony z
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: element ContainerPort został dostarczony z
           nieprawidłowym numerem portu „{0}” i nieprawidłowym typem portu „{1}”. Elementy
           ContainerPort muszą mieć wartość Include będącą liczbą całkowitą oraz wartość typu „tcp”
           lub „udp”.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: element ContainerPort został dostarczony z
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: element ContainerPort został dostarczony z
           nieprawidłowym typem portu „{0}”. Elementy ContainerPort muszą mieć wartość Include będącą
           liczbą całkowitą oraz wartość typu „tcp” lub „udp”.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: nieprawidłowa wersja wstępna zestawu SDK „{0}” —
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: nieprawidłowa wersja wstępna zestawu SDK „{0}” —
           obsługiwane są tylko wersje „rc” i „preview”.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -274,16 +240,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: podano nieprawidłowy {0}: {1}. Tagi obrazów muszą
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: podano nieprawidłowy {0}: {1}. Tagi obrazów muszą
           być alfanumeryczne, zawierać podkreślenia, łączniki lub kropki.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: podano nieprawidłowy {0}: {1}. {0} musi być
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: podano nieprawidłowy {0}: {1}. {0} musi być
           rozdzielaną średnikami listą prawidłowych tagów obrazów. Tagi obrazów muszą być
           alfanumeryczne, zawierać podkreślenia, łączniki lub kropki.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
@@ -295,16 +259,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: Element „{0}” zawiera elementy bez metadanych
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: Element „{0}” zawiera elementy bez metadanych
           „Value” i zostaną zignorowane.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: Rejestr lokalny jest niedostępny, ale zażądano
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: Rejestr lokalny jest niedostępny, ale zażądano
           wypchnięcia do rejestru lokalnego.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -319,17 +281,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: nie można pobrać warstwy o deskryptorze „{0}” z
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: nie można pobrać warstwy o deskryptorze „{0}” z
           rejestru „{1}”, ponieważ nie istnieje.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: element ContainerPort „{0}” nie określa numeru
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: element ContainerPort „{0}” nie określa numeru
           portu. Upewnij się, że element Include jest numerem portu, na przykład „&lt;ContainerPort
           Include="80" /&gt;”</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
@@ -434,17 +393,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: Nieznany typ rejestru lokalnego „{0}”. Prawidłowe
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: Nieznany typ rejestru lokalnego „{0}”. Prawidłowe
           typy lokalnego rejestru kontenerów: „{1}”.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: manifest dla {0}:{1} z rejestru {2} był nieznanym
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: manifest dla {0}:{1} z rejestru {2} był nieznanym
           typem: {3}. Zgłoś problem na https://github.com/dotnet/sdk-container-builds/issues za
           pomocą tej wiadomości.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -1,30 +1,51 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="pl"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: żądanie do usługi Amazon Elastic Container Registry przedwcześnie zakończyło się niepowodzeniem. Jest to często spowodowane tym, że repozytorium docelowe nie istnieje w rejestrze.</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: żądanie do usługi Amazon Elastic Container
+          Registry przedwcześnie zakończyło się niepowodzeniem. Jest to często spowodowane tym, że
+          repozytorium docelowe nie istnieje w rejestrze.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
         <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed.</source>
-        <target state="translated">CONTAINER2008: podano {0} i {1}, ale dozwolona jest tylko jedna opcja lub druga.</target>
+        <target state="translated">CONTAINER2008: podano {0} i {1}, ale dozwolona jest tylko jedna
+          opcja lub druga.</target>
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: Argumenty ContainerAppCommandArgs są dostarczane bez określania polecenia ContainerAppCommand.</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: Argumenty ContainerAppCommandArgs są dostarczane
+          bez określania polecenia ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand i ContainerAppCommandArgs muszą być puste, gdy element ContainerAppCommandInstruction ma wartość „{0}”.</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommand i ContainerAppCommandArgs
+          muszą być puste, gdy element ContainerAppCommandInstruction ma wartość „{0}”.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: Obraz podstawowy ma punkt wejścia, który zostanie zastąpiony w celu uruchomienia aplikacji. W razie potrzeby ustaw właściwość ContainerAppCommandInstruction na wartość „Entrypoint”. Aby zachować podstawowy punkt wejścia obrazu, ustaw właściwość ContainerAppCommandInstruction na wartość „DefaultArgs”.</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: Obraz podstawowy ma punkt wejścia, który zostanie
+          zastąpiony w celu uruchomienia aplikacji. W razie potrzeby ustaw właściwość
+          ContainerAppCommandInstruction na wartość „Entrypoint”. Aby zachować podstawowy punkt
+          wejścia obrazu, ustaw właściwość ContainerAppCommandInstruction na wartość „DefaultArgs”.</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,23 +54,29 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} nie określa rejestru i zostanie pobrany z usługi Docker Hub. Poprzedź nazwę rejestrem obrazów, na przykład: „{1}/&lt;image&gt;”.</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} nie określa rejestru i zostanie pobrany z
+          usługi Docker Hub. Poprzedź nazwę rejestrem obrazów, na przykład: „{1}/&lt;image&gt;”.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
-        <target state="translated">CONTAINER2013: element {0} zawierał spacje, zastępując je kreskami.</target>
+        <target state="translated">CONTAINER2013: element {0} zawierał spacje, zastępując je
+          kreskami.</target>
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: nie można odnaleźć pasującego obrazu podstawowego dla {0} zgodnego z elementem RuntimeIdentifier {1}.</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: nie można odnaleźć pasującego obrazu podstawowego
+          dla {0} zgodnego z elementem RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: nie można przekazać obiektu blob przy użyciu {0}; odebrano kod stanu „{1}”.</target>
+        <target state="translated">CONTAINER1001: nie można przekazać obiektu blob przy użyciu {0};
+          odebrano kod stanu „{1}”.</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
@@ -64,7 +91,8 @@
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">
         <source>Building image '{0}' with tags '{1}' on top of base image '{2}'.</source>
-        <target state="translated">Tworzenie obrazu „{0}” z tagami „{1}” nad obrazem podstawowym „{2}”.</target>
+        <target state="translated">Tworzenie obrazu „{0}” z tagami „{1}” nad obrazem podstawowym
+          „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
@@ -79,52 +107,73 @@
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>
-        <target state="translated">CONTAINER3002: nie można pobrać informacji o platformie Docker({0})\n{1}\n{2}</target>
+        <target state="translated">CONTAINER3002: nie można pobrać informacji o platformie
+          Docker({0})\n{1}\n{2}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed_Ex">
         <source>CONTAINER3002: Failed to get docker info: {0}</source>
-        <target state="translated">CONTAINER3002: nie można pobrać informacji o platformie Docker: {0}</target>
+        <target state="translated">CONTAINER3002: nie można pobrać informacji o platformie Docker:
+          {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: Nie można utworzyć procesu {0}.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
-        <target state="translated">CONTAINER4006: właściwość „{0}” jest pusta lub zawiera białe znaki i zostanie zignorowana.</target>
+        <target state="translated">CONTAINER4006: właściwość „{0}” jest pusta lub zawiera białe
+          znaki i zostanie zignorowana.</target>
         <note>{StrBegin="CONTAINER4006: "}</note>
       </trans-unit>
       <trans-unit id="EmptyValuesIgnored">
         <source>CONTAINER4004: Items '{0}' contain empty item(s) which will be ignored.</source>
-        <target state="translated">CONTAINER4004: elementy „{0}” zawierają puste elementy, które zostaną zignorowane.</target>
+        <target state="translated">CONTAINER4004: elementy „{0}” zawierają puste elementy, które
+          zostaną zignorowane.</target>
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Przesłano elementy ContainerEntrypoint i ContainerAppCommandArgs. Aby skonfigurować sposób uruchamiania aplikacji, należy ustawić element ContainerAppInstruction. Prawidłowe instrukcje: {0}.</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: Przesłano elementy ContainerEntrypoint i
+          ContainerAppCommandArgs. Aby skonfigurować sposób uruchamiania aplikacji, należy ustawić
+          element ContainerAppInstruction. Prawidłowe instrukcje: {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Przesłano element ContainerEntrypoint. Aby skonfigurować sposób uruchamiania aplikacji, należy ustawić element ContainerAppInstruction. Prawidłowe instrukcje to {0}.</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: Przesłano element ContainerEntrypoint. Aby
+          skonfigurować sposób uruchamiania aplikacji, należy ustawić element
+          ContainerAppInstruction. Prawidłowe instrukcje to {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: Argumenty ContainerEntrypointArgs są przesyłane bez określania elementu ContainerEntrypoint.</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: Argumenty ContainerEntrypointArgs są przesyłane
+          bez określania elementu ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: Przesłano elementy ContainerEntrypointArgsSet. Zmień, aby używać argumentów ContainerAppCommandArgs dla argumentów, które muszą być zawsze ustawione, lub argumentów ContainerDefaultArgs dla argumentów, które mogą zostać zastąpione podczas tworzenia kontenera.</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: Przesłano elementy ContainerEntrypointArgsSet.
+          Zmień, aby używać argumentów ContainerAppCommandArgs dla argumentów, które muszą być
+          zawsze ustawione, lub argumentów ContainerDefaultArgs dla argumentów, które mogą zostać
+          zastąpione podczas tworzenia kontenera.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: Elementu ContainerEntrypoint nie można łączyć z elementem ContainerAppCommandInstruction „{0}”.</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: Elementu ContainerEntrypoint nie można łączyć z
+          elementem ContainerAppCommandInstruction „{0}”.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
@@ -139,77 +188,114 @@
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: Nie można załadować obrazu z rejestru lokalnego. stdout: {0}</target>
+        <target state="translated">CONTAINER1009: Nie można załadować obrazu z rejestru lokalnego.
+          stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
-        <target state="translated">CONTAINER1010: Ściąganie obrazów z rejestru lokalnego nie jest obsługiwane.</target>
+        <target state="translated">CONTAINER1010: Ściąganie obrazów z rejestru lokalnego nie jest
+          obsługiwane.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
-        <target state="translated">CONTAINER2015: {0}: „{1}” nie jest prawidłową zmienną środowiskową. Ignorowanie.</target>
+        <target state="translated">CONTAINER2015: {0}: „{1}” nie jest prawidłową zmienną
+          środowiskową. Ignorowanie.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Wywnioskowana nazwa obrazu „{0}” zawiera całkowicie nieprawidłowe znaki. Prawidłowe znaki nazwy obrazu to znaki alfanumeryczne oraz —, /, lub _, a nazwa obrazu musi zaczynać się znakiem alfanumerycznym.</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: Wywnioskowana nazwa obrazu „{0}” zawiera
+          całkowicie nieprawidłowe znaki. Prawidłowe znaki nazwy obrazu to znaki alfanumeryczne oraz
+          —, /, lub _, a nazwa obrazu musi zaczynać się znakiem alfanumerycznym.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: Pierwszy znak nazwy obrazu „{0}” musi być małą literą lub cyfrą, a wszystkie znaki w nazwie muszą być znakami alfanumerycznymi, —, /, lub _.</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: Pierwszy znak nazwy obrazu „{0}” musi być małą
+          literą lub cyfrą, a wszystkie znaki w nazwie muszą być znakami alfanumerycznymi, —, /, lub
+          _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: element ContainerPort został dostarczony z nieprawidłowym numerem portu „{0}”. Elementy ContainerPort muszą mieć wartość Include będącą liczbą całkowitą oraz wartość typu „tcp” lub „udp”.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: element ContainerPort został dostarczony z
+          nieprawidłowym numerem portu „{0}”. Elementy ContainerPort muszą mieć wartość Include
+          będącą liczbą całkowitą oraz wartość typu „tcp” lub „udp”.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: element ContainerPort został dostarczony z nieprawidłowym numerem portu „{0}” i nieprawidłowym typem portu „{1}”. Elementy ContainerPort muszą mieć wartość Include będącą liczbą całkowitą oraz wartość typu „tcp” lub „udp”.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: element ContainerPort został dostarczony z
+          nieprawidłowym numerem portu „{0}” i nieprawidłowym typem portu „{1}”. Elementy
+          ContainerPort muszą mieć wartość Include będącą liczbą całkowitą oraz wartość typu „tcp”
+          lub „udp”.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: element ContainerPort został dostarczony z nieprawidłowym typem portu „{0}”. Elementy ContainerPort muszą mieć wartość Include będącą liczbą całkowitą oraz wartość typu „tcp” lub „udp”.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: element ContainerPort został dostarczony z
+          nieprawidłowym typem portu „{0}”. Elementy ContainerPort muszą mieć wartość Include będącą
+          liczbą całkowitą oraz wartość typu „tcp” lub „udp”.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: nieprawidłowa wersja wstępna zestawu SDK „{0}” — obsługiwane są tylko wersje „rc” i „preview”.</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
+        <target state="translated">CONTAINER2018: nieprawidłowa wersja wstępna zestawu SDK „{0}” —
+          obsługiwane są tylko wersje „rc” i „preview”.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
         <source>CONTAINER2019: Invalid SDK semantic version '{0}'.</source>
-        <target state="translated">CONTAINER2019: nieprawidłowa wersja semantyczna zestawu SDK „{0}”.</target>
+        <target state="translated">CONTAINER2019: nieprawidłowa wersja semantyczna zestawu SDK
+          „{0}”.</target>
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: podano nieprawidłowy {0}: {1}. Tagi obrazów muszą być alfanumeryczne, zawierać podkreślenia, łączniki lub kropki.</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: podano nieprawidłowy {0}: {1}. Tagi obrazów muszą
+          być alfanumeryczne, zawierać podkreślenia, łączniki lub kropki.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: podano nieprawidłowy {0}: {1}. {0} musi być rozdzielaną średnikami listą prawidłowych tagów obrazów. Tagi obrazów muszą być alfanumeryczne, zawierać podkreślenia, łączniki lub kropki.</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: podano nieprawidłowy {0}: {1}. {0} musi być
+          rozdzielaną średnikami listą prawidłowych tagów obrazów. Tagi obrazów muszą być
+          alfanumeryczne, zawierać podkreślenia, łączniki lub kropki.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
         <source>CONTAINER1003: Token response had neither token nor access_token.</source>
-        <target state="translated">CONTAINER1003: odpowiedź tokenu nie miała tokenu ani access_token.</target>
+        <target state="translated">CONTAINER1003: odpowiedź tokenu nie miała tokenu ani
+          access_token.</target>
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
-        <target state="translated">CONTAINER4005: Element „{0}” zawiera elementy bez metadanych „Value” i zostaną zignorowane.</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
+        <target state="translated">CONTAINER4005: Element „{0}” zawiera elementy bez metadanych
+          „Value” i zostaną zignorowane.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
-        <target state="translated">CONTAINER1012: Rejestr lokalny jest niedostępny, ale zażądano wypchnięcia do rejestru lokalnego.</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
+        <target state="translated">CONTAINER1012: Rejestr lokalny jest niedostępny, ale zażądano
+          wypchnięcia do rejestru lokalnego.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -223,13 +309,19 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: nie można pobrać warstwy o deskryptorze „{0}” z rejestru „{1}”, ponieważ nie istnieje.</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: nie można pobrać warstwy o deskryptorze „{0}” z
+          rejestru „{1}”, ponieważ nie istnieje.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: element ContainerPort „{0}” nie określa numeru portu. Upewnij się, że element Include jest numerem portu, na przykład „&lt;ContainerPort Include="80" /&gt;”</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: element ContainerPort „{0}” nie określa numeru
+          portu. Upewnij się, że element Include jest numerem portu, na przykład „&lt;ContainerPort
+          Include="80" /&gt;”</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -239,7 +331,8 @@
       </trans-unit>
       <trans-unit id="NormalizedContainerName">
         <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
-        <target state="translated">Nazwa „{0}” nie była prawidłową nazwą obrazu kontenera, została znormalizowana do „{1}”</target>
+        <target state="translated">Nazwa „{0}” nie była prawidłową nazwą obrazu kontenera, została
+          znormalizowana do „{1}”</target>
         <note />
       </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
@@ -284,7 +377,8 @@
       </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
-        <target state="translated">Przekazywanie manifestu do rejestru „{0}” jako obiektu blob „{1}”.</target>
+        <target state="translated">Przekazywanie manifestu do rejestru „{0}” jako obiektu blob
+          „{1}”.</target>
         <note>{0} is the registry name</note>
       </trans-unit>
       <trans-unit id="Registry_ManifestUploaded">
@@ -314,7 +408,8 @@
       </trans-unit>
       <trans-unit id="RequiredPropertyNotSetOrEmpty">
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
-        <target state="translated">CONTAINER4001: wymagana właściwość „{0}” nie została ustawiona lub jest pusta.</target>
+        <target state="translated">CONTAINER4001: wymagana właściwość „{0}” nie została ustawiona
+          lub jest pusta.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TooManyRetries">
@@ -324,17 +419,24 @@
       </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: Nieznana instrukcja AppCommandInstruction „{0}”. Prawidłowe instrukcje to{1}.</target>
+        <target state="translated">CONTAINER2021: Nieznana instrukcja AppCommandInstruction „{0}”.
+          Prawidłowe instrukcje to{1}.</target>
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: Nieznany typ rejestru lokalnego „{0}”. Prawidłowe typy lokalnego rejestru kontenerów: „{1}”.</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: Nieznany typ rejestru lokalnego „{0}”. Prawidłowe
+          typy lokalnego rejestru kontenerów: „{1}”.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: manifest dla {0}:{1} z rejestru {2} był nieznanym typem: {3}. Zgłoś problem na https://github.com/dotnet/sdk-container-builds/issues za pomocą tej wiadomości.</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: manifest dla {0}:{1} z rejestru {2} był nieznanym
+          typem: {3}. Zgłoś problem na https://github.com/dotnet/sdk-container-builds/issues za
+          pomocą tej wiadomości.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="pt-BR"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: a solicitação para o Amazon Elastic Container
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: a solicitação para o Amazon Elastic Container
           Registry falhou prematuramente. Isso geralmente é causado quando o repositório de destino
           não existe no registro.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
@@ -25,16 +16,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs são fornecidos sem
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: ContainerAppCommandArgs são fornecidos sem
           especificar um ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs
           devem estar vazios quando ContainerAppCommandInstruction é '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -44,10 +33,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: A imagem base possui um ponto de entrada que será
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: A imagem base possui um ponto de entrada que será
           substituído para iniciar o aplicativo. Defina ContainerAppCommandInstruction como
           'Entrypoint' se desejar. Para preservar o ponto de entrada da imagem base, defina
           ContainerAppCommandInstruction como 'DefaultArgs'.</target>
@@ -59,9 +46,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} não especifica um registro e será extraído do
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} não especifica um registro e será extraído do
           Docker Hub. Por favor, prefixe o nome com o registro de imagem, por exemplo:
           '{1}/&lt;image&gt;'.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
@@ -72,9 +58,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: Não foi possível encontrar a imagem base
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: Não foi possível encontrar a imagem base
           correspondente para {0} que corresponda ao RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -128,9 +113,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: Falha ao criar {0} processo.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: Falha ao criar {0} processo.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -145,43 +129,36 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Um ContainerEntrypoint e ContainerAppCommandArgs
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: Um ContainerEntrypoint e ContainerAppCommandArgs
           são fornecidos. ContainerAppInstruction deve ser definido para configurar como o
           aplicativo é iniciado. As instruções válidas são {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Um ContainerEntrypoint é fornecido.
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: Um ContainerEntrypoint é fornecido.
           ContainerAppInstruction deve ser definido para configurar como o aplicativo é iniciado. As
           instruções válidas são {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs são fornecidos sem
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: ContainerEntrypointArgs são fornecidos sem
           especificar um ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet são fornecidos. Altere
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: ContainerEntrypointArgsSet são fornecidos. Altere
           para usar ContainerAppCommandArgs para argumentos que sempre devem ser definidos ou
           ContainerDefaultArgs para argumentos que podem ser substituídos quando o contêiner é
           criado.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint não pode ser combinado com
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint não pode ser combinado com
           ContainerAppCommandInstruction '{0}'.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -214,54 +191,43 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: o nome da imagem inferida '{0}' contém caracteres
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: o nome da imagem inferida '{0}' contém caracteres
           totalmente inválidos. Os caracteres válidos para um nome de imagem são caracteres
           alfanuméricos, -, / ou _, e o nome da imagem deve começar com um caractere alfanumérico.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: o primeiro caractere do nome da imagem '{0}' deve
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: o primeiro caractere do nome da imagem '{0}' deve
           ser uma letra minúscula ou um dígito e todos os caracteres do nome devem ser um caractere
           alfanumérico, -, / ou _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Um item ContainerPort foi fornecido com um número
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Um item ContainerPort foi fornecido com um número
           de porta inválido '{0}'. Os itens ContainerPort devem ter um valor Include que seja um
           número inteiro e um valor Type que seja 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Um item ContainerPort foi fornecido com um número
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Um item ContainerPort foi fornecido com um número
           de porta inválido '{0}' e um tipo de porta inválido '{1}'. Os itens ContainerPort devem
           ter um valor Include que seja um número inteiro e um valor Type que seja 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Um item ContainerPort foi fornecido com um tipo de
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Um item ContainerPort foi fornecido com um tipo de
           porta inválido '{0}'. Os itens ContainerPort devem ter um valor Include que seja um número
           inteiro e um valor Type que seja 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: Versão de pré-lançamento inválida do SDK '{0}' -
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: Versão de pré-lançamento inválida do SDK '{0}' -
           apenas 'rc' e 'preview' são suportados.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -271,16 +237,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: Inválido {0} fornecido: {1}. As tags de imagem
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: Inválido {0} fornecido: {1}. As tags de imagem
           devem ser alfanuméricas, sublinhado, hífen ou ponto.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: inválido {0} fornecido: {1}. {0} deve ser uma
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: inválido {0} fornecido: {1}. {0} deve ser uma
           lista delimitada por ponto-e-vírgula de marcas de imagem válidas. As tags de imagem devem
           ser alfanuméricas, sublinhado, hífen ou ponto.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
@@ -292,16 +256,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: O item '{0}' contém itens sem metadados 'Valor' e
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: O item '{0}' contém itens sem metadados 'Valor' e
           eles serão ignorados.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: O registro local não está disponível, mas o push
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: O registro local não está disponível, mas o push
           para um registro local foi solicitado.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -316,17 +278,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: Não foi possível baixar a camada com o descritor
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: Não foi possível baixar a camada com o descritor
           '{0}' do registro '{1}' porque não existe.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: O item ContainerPort '{0}' não especifica o número
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: O item ContainerPort '{0}' não especifica o número
           da porta. Certifique-se de que o Include do item seja um número de porta, por exemplo
           '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
@@ -430,17 +389,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: Tipo de registro local desconhecido '{0}'. Os
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: Tipo de registro local desconhecido '{0}'. Os
           tipos de registro de contêiner local válidos são {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: O manifesto para {0}:{1} do registro {2} era um
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: O manifesto para {0}:{1} do registro {2} era um
           tipo desconhecido:{3}. Levante um problema em
           https://github.com/dotnet/sdk-container-builds/issues com esta mensagem.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -1,30 +1,51 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="pt-BR"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: a solicitação para o Amazon Elastic Container Registry falhou prematuramente. Isso geralmente é causado quando o repositório de destino não existe no registro.</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: a solicitação para o Amazon Elastic Container
+          Registry falhou prematuramente. Isso geralmente é causado quando o repositório de destino
+          não existe no registro.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
         <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed.</source>
-        <target state="translated">CONTAINER2008: Ambos {0} e {1} foram fornecidos, mas apenas um ou outro é permitido.</target>
+        <target state="translated">CONTAINER2008: Ambos {0} e {1} foram fornecidos, mas apenas um ou
+          outro é permitido.</target>
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs são fornecidos sem especificar um ContainerAppCommand.</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: ContainerAppCommandArgs são fornecidos sem
+          especificar um ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs devem estar vazios quando ContainerAppCommandInstruction é '{0}'.</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs
+          devem estar vazios quando ContainerAppCommandInstruction é '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: A imagem base possui um ponto de entrada que será substituído para iniciar o aplicativo. Defina ContainerAppCommandInstruction como 'Entrypoint' se desejar. Para preservar o ponto de entrada da imagem base, defina ContainerAppCommandInstruction como 'DefaultArgs'.</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: A imagem base possui um ponto de entrada que será
+          substituído para iniciar o aplicativo. Defina ContainerAppCommandInstruction como
+          'Entrypoint' se desejar. Para preservar o ponto de entrada da imagem base, defina
+          ContainerAppCommandInstruction como 'DefaultArgs'.</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,8 +54,11 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} não especifica um registro e será extraído do Docker Hub. Por favor, prefixe o nome com o registro de imagem, por exemplo: '{1}/&lt;image&gt;'.</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} não especifica um registro e será extraído do
+          Docker Hub. Por favor, prefixe o nome com o registro de imagem, por exemplo:
+          '{1}/&lt;image&gt;'.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
@@ -43,13 +67,16 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: Não foi possível encontrar a imagem base correspondente para {0} que corresponda ao RuntimeIdentifier {1}.</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: Não foi possível encontrar a imagem base
+          correspondente para {0} que corresponda ao RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: Falha ao carregar o blob usando {0}; código de status recebido '{1}'.</target>
+        <target state="translated">CONTAINER1001: Falha ao carregar o blob usando {0}; código de
+          status recebido '{1}'.</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
@@ -64,7 +91,8 @@
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">
         <source>Building image '{0}' with tags '{1}' on top of base image '{2}'.</source>
-        <target state="translated">Construindo imagem '{0}' com tags '{1}' em cima da imagem base '{2}'.</target>
+        <target state="translated">Construindo imagem '{0}' com tags '{1}' em cima da imagem base
+          '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
@@ -79,7 +107,8 @@
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>
-        <target state="translated">CONTAINER3002: Falha ao obter informações do docker({0})\n{1}\n{2}</target>
+        <target state="translated">CONTAINER3002: Falha ao obter informações do
+          docker({0})\n{1}\n{2}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed_Ex">
@@ -87,44 +116,63 @@
         <target state="translated">CONTAINER3002: Falha ao obter informações do docker: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: Falha ao criar {0} processo.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
-        <target state="translated">CONTAINER4006: A propriedade '{0}' está vazia ou contém espaços em branco e será ignorada.</target>
+        <target state="translated">CONTAINER4006: A propriedade '{0}' está vazia ou contém espaços
+          em branco e será ignorada.</target>
         <note>{StrBegin="CONTAINER4006: "}</note>
       </trans-unit>
       <trans-unit id="EmptyValuesIgnored">
         <source>CONTAINER4004: Items '{0}' contain empty item(s) which will be ignored.</source>
-        <target state="translated">CONTAINER4004: Os itens '{0}' contêm itens vazios que serão ignorados.</target>
+        <target state="translated">CONTAINER4004: Os itens '{0}' contêm itens vazios que serão
+          ignorados.</target>
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: Um ContainerEntrypoint e ContainerAppCommandArgs são fornecidos. ContainerAppInstruction deve ser definido para configurar como o aplicativo é iniciado. As instruções válidas são {0}.</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: Um ContainerEntrypoint e ContainerAppCommandArgs
+          são fornecidos. ContainerAppInstruction deve ser definido para configurar como o
+          aplicativo é iniciado. As instruções válidas são {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: Um ContainerEntrypoint é fornecido. ContainerAppInstruction deve ser definido para configurar como o aplicativo é iniciado. As instruções válidas são {0}.</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: Um ContainerEntrypoint é fornecido.
+          ContainerAppInstruction deve ser definido para configurar como o aplicativo é iniciado. As
+          instruções válidas são {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs são fornecidos sem especificar um ContainerEntrypoint.</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: ContainerEntrypointArgs são fornecidos sem
+          especificar um ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet são fornecidos. Altere para usar ContainerAppCommandArgs para argumentos que sempre devem ser definidos ou ContainerDefaultArgs para argumentos que podem ser substituídos quando o contêiner é criado.</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet são fornecidos. Altere
+          para usar ContainerAppCommandArgs para argumentos que sempre devem ser definidos ou
+          ContainerDefaultArgs para argumentos que podem ser substituídos quando o contêiner é
+          criado.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint não pode ser combinado com ContainerAppCommandInstruction '{0}'.</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint não pode ser combinado com
+          ContainerAppCommandInstruction '{0}'.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
@@ -139,47 +187,72 @@
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: falha ao carregar a imagem do registro local. stdout: {0}</target>
+        <target state="translated">CONTAINER1009: falha ao carregar a imagem do registro local.
+          stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
-        <target state="translated">CONTAINER1010: A extração de imagens do registro local não é suportada.</target>
+        <target state="translated">CONTAINER1010: A extração de imagens do registro local não é
+          suportada.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
-        <target state="translated">CONTAINER2015: {0}: '{1}' não era uma variável de ambiente válida. Ignorando.</target>
+        <target state="translated">CONTAINER2015: {0}: '{1}' não era uma variável de ambiente
+          válida. Ignorando.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: o nome da imagem inferida '{0}' contém caracteres totalmente inválidos. Os caracteres válidos para um nome de imagem são caracteres alfanuméricos, -, / ou _, e o nome da imagem deve começar com um caractere alfanumérico.</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: o nome da imagem inferida '{0}' contém caracteres
+          totalmente inválidos. Os caracteres válidos para um nome de imagem são caracteres
+          alfanuméricos, -, / ou _, e o nome da imagem deve começar com um caractere alfanumérico.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: o primeiro caractere do nome da imagem '{0}' deve ser uma letra minúscula ou um dígito e todos os caracteres do nome devem ser um caractere alfanumérico, -, / ou _.</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: o primeiro caractere do nome da imagem '{0}' deve
+          ser uma letra minúscula ou um dígito e todos os caracteres do nome devem ser um caractere
+          alfanumérico, -, / ou _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Um item ContainerPort foi fornecido com um número de porta inválido '{0}'. Os itens ContainerPort devem ter um valor Include que seja um número inteiro e um valor Type que seja 'tcp' ou 'udp'.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Um item ContainerPort foi fornecido com um número
+          de porta inválido '{0}'. Os itens ContainerPort devem ter um valor Include que seja um
+          número inteiro e um valor Type que seja 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Um item ContainerPort foi fornecido com um número de porta inválido '{0}' e um tipo de porta inválido '{1}'. Os itens ContainerPort devem ter um valor Include que seja um número inteiro e um valor Type que seja 'tcp' ou 'udp'.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Um item ContainerPort foi fornecido com um número
+          de porta inválido '{0}' e um tipo de porta inválido '{1}'. Os itens ContainerPort devem
+          ter um valor Include que seja um número inteiro e um valor Type que seja 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Um item ContainerPort foi fornecido com um tipo de porta inválido '{0}'. Os itens ContainerPort devem ter um valor Include que seja um número inteiro e um valor Type que seja 'tcp' ou 'udp'.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Um item ContainerPort foi fornecido com um tipo de
+          porta inválido '{0}'. Os itens ContainerPort devem ter um valor Include que seja um número
+          inteiro e um valor Type que seja 'tcp' ou 'udp'.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: Versão de pré-lançamento inválida do SDK '{0}' - apenas 'rc' e 'preview' são suportados.</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
+        <target state="translated">CONTAINER2018: Versão de pré-lançamento inválida do SDK '{0}' -
+          apenas 'rc' e 'preview' são suportados.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -188,28 +261,38 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: Inválido {0} fornecido: {1}. As tags de imagem devem ser alfanuméricas, sublinhado, hífen ou ponto.</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: Inválido {0} fornecido: {1}. As tags de imagem
+          devem ser alfanuméricas, sublinhado, hífen ou ponto.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: inválido {0} fornecido: {1}. {0} deve ser uma lista delimitada por ponto-e-vírgula de marcas de imagem válidas. As tags de imagem devem ser alfanuméricas, sublinhado, hífen ou ponto.</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: inválido {0} fornecido: {1}. {0} deve ser uma
+          lista delimitada por ponto-e-vírgula de marcas de imagem válidas. As tags de imagem devem
+          ser alfanuméricas, sublinhado, hífen ou ponto.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
         <source>CONTAINER1003: Token response had neither token nor access_token.</source>
-        <target state="translated">CONTAINER1003: A resposta do token não tinha token nem access_token.</target>
+        <target state="translated">CONTAINER1003: A resposta do token não tinha token nem
+          access_token.</target>
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
-        <target state="translated">CONTAINER4005: O item '{0}' contém itens sem metadados 'Valor' e eles serão ignorados.</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
+        <target state="translated">CONTAINER4005: O item '{0}' contém itens sem metadados 'Valor' e
+          eles serão ignorados.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
-        <target state="translated">CONTAINER1012: O registro local não está disponível, mas o push para um registro local foi solicitado.</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
+        <target state="translated">CONTAINER1012: O registro local não está disponível, mas o push
+          para um registro local foi solicitado.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -223,13 +306,19 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: Não foi possível baixar a camada com o descritor '{0}' do registro '{1}' porque não existe.</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: Não foi possível baixar a camada com o descritor
+          '{0}' do registro '{1}' porque não existe.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: O item ContainerPort '{0}' não especifica o número da porta. Certifique-se de que o Include do item seja um número de porta, por exemplo '&lt;ContainerPort Include="80" /&gt;'</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: O item ContainerPort '{0}' não especifica o número
+          da porta. Certifique-se de que o Include do item seja um número de porta, por exemplo
+          '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -239,7 +328,8 @@
       </trans-unit>
       <trans-unit id="NormalizedContainerName">
         <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
-        <target state="translated">'{0}' não era um nome de imagem de contêiner válido, foi normalizado para '{1}'</target>
+        <target state="translated">'{0}' não era um nome de imagem de contêiner válido, foi
+          normalizado para '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
@@ -314,7 +404,8 @@
       </trans-unit>
       <trans-unit id="RequiredPropertyNotSetOrEmpty">
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
-        <target state="translated">CONTAINER4001: A propriedade obrigatória '{0}' não foi definida ou está vazia.</target>
+        <target state="translated">CONTAINER4001: A propriedade obrigatória '{0}' não foi definida
+          ou está vazia.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TooManyRetries">
@@ -324,17 +415,24 @@
       </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: AppCommandInstruction desconhecido '{0}'. As instruções válidas são {1}.</target>
+        <target state="translated">CONTAINER2021: AppCommandInstruction desconhecido '{0}'. As
+          instruções válidas são {1}.</target>
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: Tipo de registro local desconhecido '{0}'. Os tipos de registro de contêiner local válidos são {1}.</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: Tipo de registro local desconhecido '{0}'. Os
+          tipos de registro de contêiner local válidos são {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: O manifesto para {0}:{1} do registro {2} era um tipo desconhecido:{3}. Levante um problema em https://github.com/dotnet/sdk-container-builds/issues com esta mensagem.</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: O manifesto para {0}:{1} do registro {2} era um
+          tipo desconhecido:{3}. Levante um problema em
+          https://github.com/dotnet/sdk-container-builds/issues com esta mensagem.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -1,30 +1,50 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="ru"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: преждевременный сбой запроса к Реестру контейнеров Amazon Elastic. Это часто происходит из-за отсутствия целевого репозитория в реестре.</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: преждевременный сбой запроса к Реестру контейнеров
+          Amazon Elastic. Это часто происходит из-за отсутствия целевого репозитория в реестре.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
         <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed.</source>
-        <target state="translated">CONTAINER2008: {0} и {1} предоставлены, но разрешен только один из них.</target>
+        <target state="translated">CONTAINER2008: {0} и {1} предоставлены, но разрешен только один
+          из них.</target>
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs предоставлены без указания ContainerAppCommand.</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: ContainerAppCommandArgs предоставлены без указания
+          ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand и ContainerAppCommandArgs должны быть пустыми, если ContainerAppCommandInstruction — "{0}".</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommand и ContainerAppCommandArgs
+          должны быть пустыми, если ContainerAppCommandInstruction — "{0}".</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: базовый образ содержит точку входа, которая будет перезаписана для запуска приложения. При необходимости настройте для ContainerAppCommandInstruction значение "Entrypoint". Чтобы сохранить точку входа базового образа, настройте для ContainerAppCommandInstruction значение "DefaultArgs".</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: базовый образ содержит точку входа, которая будет
+          перезаписана для запуска приложения. При необходимости настройте для
+          ContainerAppCommandInstruction значение "Entrypoint". Чтобы сохранить точку входа базового
+          образа, настройте для ContainerAppCommandInstruction значение "DefaultArgs".</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,8 +53,10 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} не указывает реестр и будет извлечен из Docker Hub. Добавьте для имени префикс в виде реестра образов, например: "{1}/&lt;image&gt;".</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} не указывает реестр и будет извлечен из Docker
+          Hub. Добавьте для имени префикс в виде реестра образов, например: "{1}/&lt;image&gt;".</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
@@ -43,18 +65,22 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: не удалось найти соответствующий базовый образ для {0}, соответствующего RuntimeIdentifier {1}.</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: не удалось найти соответствующий базовый образ для
+          {0}, соответствующего RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: не удалось отправить BLOB-объект с помощью {0}; получен код состояния "{1}".</target>
+        <target state="translated">CONTAINER1001: не удалось отправить BLOB-объект с помощью {0};
+          получен код состояния "{1}".</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
         <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Принудительно отправлен контейнер "{0}" в управляющую программу Docker.</target>
+        <target state="translated">Принудительно отправлен контейнер "{0}" в управляющую программу
+          Docker.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
@@ -64,7 +90,8 @@
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">
         <source>Building image '{0}' with tags '{1}' on top of base image '{2}'.</source>
-        <target state="translated">Выполняется сборка образа "{0}" с тегами "{1}" поверх базового образа "{2}".</target>
+        <target state="translated">Выполняется сборка образа "{0}" с тегами "{1}" поверх базового
+          образа "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
@@ -87,44 +114,63 @@
         <target state="translated">CONTAINER3002: не удалось получить сведения Docker: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: не удалось создать процесс {0}.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
-        <target state="translated">CONTAINER4006: свойство "{0}" пусто или содержит пробелы и будет пропущено.</target>
+        <target state="translated">CONTAINER4006: свойство "{0}" пусто или содержит пробелы и будет
+          пропущено.</target>
         <note>{StrBegin="CONTAINER4006: "}</note>
       </trans-unit>
       <trans-unit id="EmptyValuesIgnored">
         <source>CONTAINER4004: Items '{0}' contain empty item(s) which will be ignored.</source>
-        <target state="translated">CONTAINER4004: элементы "{0}" содержат пустые элементы, которые будут пропущены.</target>
+        <target state="translated">CONTAINER4004: элементы "{0}" содержат пустые элементы, которые
+          будут пропущены.</target>
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: предоставлены ContainerEntrypoint и ContainerAppCommandArgs. Чтобы настроить способ запуска приложения, необходимо настроить ContainerAppInstruction. Допустимые инструкции: {0}.</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: предоставлены ContainerEntrypoint и
+          ContainerAppCommandArgs. Чтобы настроить способ запуска приложения, необходимо настроить
+          ContainerAppInstruction. Допустимые инструкции: {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: предоставлен ContainerEntrypoint. Чтобы настроить способ запуска приложения, необходимо настроить ContainerAppInstruction. Допустимые инструкции: {0}.</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: предоставлен ContainerEntrypoint. Чтобы настроить
+          способ запуска приложения, необходимо настроить ContainerAppInstruction. Допустимые
+          инструкции: {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs предоставлены без указания ContainerEntrypoint.</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: ContainerEntrypointArgs предоставлены без указания
+          ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: предоставлен параметр ContainerEntrypointArgsSet. Измените, чтобы использовать ContainerAppCommandArgs для аргументов, которые всегда должны быть настроены, или ContainerDefaultArgs для аргументов, которые можно переопределить при создании контейнера.</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: предоставлен параметр ContainerEntrypointArgsSet.
+          Измените, чтобы использовать ContainerAppCommandArgs для аргументов, которые всегда должны
+          быть настроены, или ContainerDefaultArgs для аргументов, которые можно переопределить при
+          создании контейнера.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint невозможно объединить с ContainerAppCommandInstruction "{0}".</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint невозможно объединить с
+          ContainerAppCommandInstruction "{0}".</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
@@ -139,47 +185,73 @@
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: не удалось загрузить образ из локального реестра. stdout: {0}</target>
+        <target state="translated">CONTAINER1009: не удалось загрузить образ из локального реестра.
+          stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
-        <target state="translated">CONTAINER1010: извлечение образов из локального реестра не поддерживается.</target>
+        <target state="translated">CONTAINER1010: извлечение образов из локального реестра не
+          поддерживается.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
-        <target state="translated">CONTAINER2015: {0}: "{1}" не является допустимой переменной среды. Пропуск.</target>
+        <target state="translated">CONTAINER2015: {0}: "{1}" не является допустимой переменной
+          среды. Пропуск.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Предполагаемое имя изображения "{0}" содержит совершенно недопустимые символы. Допустимыми символами для имени изображения являются буквенно-цифровые символы, -, / или _, а имя изображения должно начинаться с буквенно-цифрового символа.</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: Предполагаемое имя изображения "{0}" содержит
+          совершенно недопустимые символы. Допустимыми символами для имени изображения являются
+          буквенно-цифровые символы, -, / или _, а имя изображения должно начинаться с
+          буквенно-цифрового символа.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: Первый символ имени изображения "{0}" должен быть строчной буквой или цифрой, а все символы в имени должны быть буквенно-цифровым символом, -, / или _.</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: Первый символ имени изображения "{0}" должен быть
+          строчной буквой или цифрой, а все символы в имени должны быть буквенно-цифровым символом,
+          -, / или _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: элемент ContainerPort предоставлен с недопустимым номером порта "{0}". Элементы ContainerPort должны иметь значение Include, являющееся целым числом, и значением типа "tcp" или "udp".</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: элемент ContainerPort предоставлен с недопустимым
+          номером порта "{0}". Элементы ContainerPort должны иметь значение Include, являющееся
+          целым числом, и значением типа "tcp" или "udp".</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: элемент ContainerPort был предоставлен с недопустимым номером порта "{0}" и недопустимым типом порта "{1}". Элементы ContainerPort должны иметь значение Include, которое является числом, и значение типа "tcp" или "udp".</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: элемент ContainerPort был предоставлен с
+          недопустимым номером порта "{0}" и недопустимым типом порта "{1}". Элементы ContainerPort
+          должны иметь значение Include, которое является числом, и значение типа "tcp" или "udp".</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: элемент ContainerPort предоставлен с недопустимым типом порта "{0}". Элементы ContainerPort должны иметь значение Include, являющееся целым числом, и значением типа "tcp" или "udp".</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: элемент ContainerPort предоставлен с недопустимым
+          типом порта "{0}". Элементы ContainerPort должны иметь значение Include, являющееся целым
+          числом, и значением типа "tcp" или "udp".</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: недопустимая предварительная версия SDK "{0}" — поддерживаются только "rc" и "preview".</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
+        <target state="translated">CONTAINER2018: недопустимая предварительная версия SDK "{0}" —
+          поддерживаются только "rc" и "preview".</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -188,13 +260,18 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: предоставлен недопустимый {0}: {1}. В качестве тегов изображений допускаются буквы, цифры, символы подчеркивания, дефисы и точки.</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: предоставлен недопустимый {0}: {1}. В качестве
+          тегов изображений допускаются буквы, цифры, символы подчеркивания, дефисы и точки.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: предоставлен недопустимый {0}: {1}. {0} должен быть списком допустимых тегов изображений, разделенных точкой с запятой. В качестве тегов изображений допускаются буквы, цифры, символы подчеркивания, дефисы и точки.</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: предоставлен недопустимый {0}: {1}. {0} должен
+          быть списком допустимых тегов изображений, разделенных точкой с запятой. В качестве тегов
+          изображений допускаются буквы, цифры, символы подчеркивания, дефисы и точки.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
@@ -203,13 +280,17 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
-        <target state="translated">CONTAINER4005: элемент "{0}" содержит элементы без метаданных "Value", и они будут пропущены.</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
+        <target state="translated">CONTAINER4005: элемент "{0}" содержит элементы без метаданных
+          "Value", и они будут пропущены.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
-        <target state="translated">CONTAINER1012: локальный реестр недоступен, но была запрошена отправка в локальный реестр.</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
+        <target state="translated">CONTAINER1012: локальный реестр недоступен, но была запрошена
+          отправка в локальный реестр.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -223,13 +304,19 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: не удается скачать слой с дескриптором "{0}" из реестра "{1}", так как он не существует.</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: не удается скачать слой с дескриптором "{0}" из
+          реестра "{1}", так как он не существует.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: элемент ContainerPort "{0}" не указывает номер порта. Убедитесь, что include элемента является номером порта, например "&lt;ContainerPort Include="80" /&gt;"</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: элемент ContainerPort "{0}" не указывает номер
+          порта. Убедитесь, что include элемента является номером порта, например "&lt;ContainerPort
+          Include="80" /&gt;"</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -239,7 +326,8 @@
       </trans-unit>
       <trans-unit id="NormalizedContainerName">
         <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
-        <target state="translated">"{0}" не является допустимым именем образа контейнера, оно нормализовано до "{1}"</target>
+        <target state="translated">"{0}" не является допустимым именем образа контейнера, оно
+          нормализовано до "{1}"</target>
         <note />
       </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
@@ -314,7 +402,8 @@
       </trans-unit>
       <trans-unit id="RequiredPropertyNotSetOrEmpty">
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
-        <target state="translated">CONTAINER4001: обязательное свойство "{0}" не установлено или пусто.</target>
+        <target state="translated">CONTAINER4001: обязательное свойство "{0}" не установлено или
+          пусто.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TooManyRetries">
@@ -324,17 +413,24 @@
       </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: неизвестный элемент AppCommandInstruction "{0}". Допустимые инструкции: {1}.</target>
+        <target state="translated">CONTAINER2021: неизвестный элемент AppCommandInstruction "{0}".
+          Допустимые инструкции: {1}.</target>
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: неизвестный тип локального реестра "{0}". Допустимыми типами реестра локального контейнера являются {1}.</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: неизвестный тип локального реестра "{0}".
+          Допустимыми типами реестра локального контейнера являются {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: манифест для {0}:{1} из реестра{2} был неизвестного типа: {3}. Создайте вопрос на https://github.com/dotnet/sdk-container-builds/issues с этим сообщением.</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: манифест для {0}:{1} из реестра{2} был
+          неизвестного типа: {3}. Создайте вопрос на
+          https://github.com/dotnet/sdk-container-builds/issues с этим сообщением.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="ru"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: преждевременный сбой запроса к Реестру контейнеров
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: преждевременный сбой запроса к Реестру контейнеров
           Amazon Elastic. Это часто происходит из-за отсутствия целевого репозитория в реестре.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
@@ -24,16 +15,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs предоставлены без указания
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: ContainerAppCommandArgs предоставлены без указания
           ContainerAppCommand.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommand и ContainerAppCommandArgs
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommand и ContainerAppCommandArgs
           должны быть пустыми, если ContainerAppCommandInstruction — "{0}".</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -43,10 +32,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: базовый образ содержит точку входа, которая будет
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: базовый образ содержит точку входа, которая будет
           перезаписана для запуска приложения. При необходимости настройте для
           ContainerAppCommandInstruction значение "Entrypoint". Чтобы сохранить точку входа базового
           образа, настройте для ContainerAppCommandInstruction значение "DefaultArgs".</target>
@@ -58,9 +45,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} не указывает реестр и будет извлечен из Docker
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} не указывает реестр и будет извлечен из Docker
           Hub. Добавьте для имени префикс в виде реестра образов, например: "{1}/&lt;image&gt;".</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
@@ -70,9 +56,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: не удалось найти соответствующий базовый образ для
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: не удалось найти соответствующий базовый образ для
           {0}, соответствующего RuntimeIdentifier {1}.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -125,9 +110,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: не удалось создать процесс {0}.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: не удалось создать процесс {0}.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -142,43 +126,36 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: предоставлены ContainerEntrypoint и
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: предоставлены ContainerEntrypoint и
           ContainerAppCommandArgs. Чтобы настроить способ запуска приложения, необходимо настроить
           ContainerAppInstruction. Допустимые инструкции: {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: предоставлен ContainerEntrypoint. Чтобы настроить
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: предоставлен ContainerEntrypoint. Чтобы настроить
           способ запуска приложения, необходимо настроить ContainerAppInstruction. Допустимые
           инструкции: {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs предоставлены без указания
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: ContainerEntrypointArgs предоставлены без указания
           ContainerEntrypoint.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: предоставлен параметр ContainerEntrypointArgsSet.
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: предоставлен параметр ContainerEntrypointArgsSet.
           Измените, чтобы использовать ContainerAppCommandArgs для аргументов, которые всегда должны
           быть настроены, или ContainerDefaultArgs для аргументов, которые можно переопределить при
           создании контейнера.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint невозможно объединить с
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint невозможно объединить с
           ContainerAppCommandInstruction "{0}".</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -211,55 +188,44 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Предполагаемое имя изображения "{0}" содержит
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: Предполагаемое имя изображения "{0}" содержит
           совершенно недопустимые символы. Допустимыми символами для имени изображения являются
           буквенно-цифровые символы, -, / или _, а имя изображения должно начинаться с
           буквенно-цифрового символа.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: Первый символ имени изображения "{0}" должен быть
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: Первый символ имени изображения "{0}" должен быть
           строчной буквой или цифрой, а все символы в имени должны быть буквенно-цифровым символом,
           -, / или _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: элемент ContainerPort предоставлен с недопустимым
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: элемент ContainerPort предоставлен с недопустимым
           номером порта "{0}". Элементы ContainerPort должны иметь значение Include, являющееся
           целым числом, и значением типа "tcp" или "udp".</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: элемент ContainerPort был предоставлен с
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: элемент ContainerPort был предоставлен с
           недопустимым номером порта "{0}" и недопустимым типом порта "{1}". Элементы ContainerPort
           должны иметь значение Include, которое является числом, и значение типа "tcp" или "udp".</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: элемент ContainerPort предоставлен с недопустимым
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: элемент ContainerPort предоставлен с недопустимым
           типом порта "{0}". Элементы ContainerPort должны иметь значение Include, являющееся целым
           числом, и значением типа "tcp" или "udp".</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: недопустимая предварительная версия SDK "{0}" —
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: недопустимая предварительная версия SDK "{0}" —
           поддерживаются только "rc" и "preview".</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -269,16 +235,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: предоставлен недопустимый {0}: {1}. В качестве
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: предоставлен недопустимый {0}: {1}. В качестве
           тегов изображений допускаются буквы, цифры, символы подчеркивания, дефисы и точки.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: предоставлен недопустимый {0}: {1}. {0} должен
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: предоставлен недопустимый {0}: {1}. {0} должен
           быть списком допустимых тегов изображений, разделенных точкой с запятой. В качестве тегов
           изображений допускаются буквы, цифры, символы подчеркивания, дефисы и точки.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
@@ -289,16 +253,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: элемент "{0}" содержит элементы без метаданных
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: элемент "{0}" содержит элементы без метаданных
           "Value", и они будут пропущены.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: локальный реестр недоступен, но была запрошена
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: локальный реестр недоступен, но была запрошена
           отправка в локальный реестр.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -313,17 +275,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: не удается скачать слой с дескриптором "{0}" из
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: не удается скачать слой с дескриптором "{0}" из
           реестра "{1}", так как он не существует.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: элемент ContainerPort "{0}" не указывает номер
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: элемент ContainerPort "{0}" не указывает номер
           порта. Убедитесь, что include элемента является номером порта, например "&lt;ContainerPort
           Include="80" /&gt;"</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
@@ -427,17 +386,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: неизвестный тип локального реестра "{0}".
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: неизвестный тип локального реестра "{0}".
           Допустимыми типами реестра локального контейнера являются {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: манифест для {0}:{1} из реестра{2} был
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: манифест для {0}:{1} из реестра{2} был
           неизвестного типа: {3}. Создайте вопрос на
           https://github.com/dotnet/sdk-container-builds/issues с этим сообщением.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="tr"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Amazon Elastic Container Registry isteği
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: Amazon Elastic Container Registry isteği
           zamanından önce başarısız oldu. Bu durum genellikle hedef depo, kayıt defterinde
           bulunmadığında ortaya çıkar.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
@@ -25,16 +16,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs bir ContainerAppCommand
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: ContainerAppCommandArgs bir ContainerAppCommand
           komutu belirtilmeden sağlanır.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommandInstruction '{0}' olduğunda
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: ContainerAppCommandInstruction '{0}' olduğunda
           ContainerAppCommand ve ContainerAppCommandArgs komutları boş olmalıdır.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -44,10 +33,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: Temel görüntünün, uygulamayı başlatmak için
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: Temel görüntünün, uygulamayı başlatmak için
           üzerine yazılacak bir giriş noktası var. İsteniyorsa ContainerAppCommandInstruction
           komutunu 'Entrypoint' olarak ayarlayın. Temel görüntü giriş noktasını korumak için
           ContainerAppCommandInstruction komutunu 'DefaultArgs' olarak ayarlayın.</target>
@@ -59,9 +46,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} kayıt defteri belirtmiyor ve Docker Hub’dan
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} kayıt defteri belirtmiyor ve Docker Hub’dan
           çekilecek. Lütfen adı görüntü kayıt defterine önek olarak ekleyin, örneğin:
           '{1}/&lt;image&gt;'.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
@@ -73,9 +59,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: RuntimeIdentifier {1} ile eşleşen {0} için eşleşen
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: RuntimeIdentifier {1} ile eşleşen {0} için eşleşen
           temel görüntü bulunamadı.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -128,9 +113,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: {0} işlemi oluşturulamadı.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: {0} işlemi oluşturulamadı.</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -144,43 +128,36 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: ContainerEntrypoint ve ContainerAppCommandArgs
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: ContainerEntrypoint ve ContainerAppCommandArgs
           sağlandı. Uygulamanın nasıl başlatılacağını yapılandırmak için ContainerAppInstruction
           komutu ayarlanmalıdır. Geçerli yönergeler {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: ContainerEntrypoint sağlandı. Uygulamanın nasıl
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: ContainerEntrypoint sağlandı. Uygulamanın nasıl
           başlatılacağını yapılandırmak için ContainerAppInstruction komutu ayarlanmalıdır. Geçerli
           yönergeler {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs bir ContainerEntrypoint
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: ContainerEntrypointArgs bir ContainerEntrypoint
           belirtilmeden sağlanır.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet sağlandı. Her zaman
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: ContainerEntrypointArgsSet sağlandı. Her zaman
           ayarlanması gereken bağımsız değişkenler için ContainerAppCommandArgs komutu veya
           kapsayıcı oluşturulduğunda geçersiz kılınabilen bağımsız değişkenler için
           ContainerDefaultArgs komutu kullanılacak şekilde değiştirin.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint komutu
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint komutu
           ContainerAppCommandInstruction '{0}' ile birleştirilemez.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -213,55 +190,44 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Çıkarsanan '{0}' görüntü adı tamamen geçersiz
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: Çıkarsanan '{0}' görüntü adı tamamen geçersiz
           karakterler içeriyor. Bir görüntü adında geçerli karakterler şunlardan oluşur: alfasayısal
           karakterler, -, /, veya _. Görüntü adı alfasayısal karakterle başlamalıdır.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: '{0}' görüntü adındaki ilk karakter bir küçük harf
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: '{0}' görüntü adındaki ilk karakter bir küçük harf
           veya rakam olmalıdır ve addaki tüm karakterler şunlardan oluşmalıdır: alfasayısal
           karakter, -, /, veya _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Geçersiz bağlantı noktası numarasına ('{0}') sahip
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Geçersiz bağlantı noktası numarasına ('{0}') sahip
           bir ContainerPort öğesi sağlandı. ContainerPort öğeleri, tamsayı olan bir Include değerine
           ve 'tcp' veya 'udp' olan bir Type değerine sahip olmalıdır.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Geçersiz bağlantı noktası numarasına ('{0}') ve
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Geçersiz bağlantı noktası numarasına ('{0}') ve
           geçersiz bağlantı noktası türüne ('{1}') sahip olan bir ContainerPort öğesi sağlandı.
           ContainerPort öğeleri, tamsayı olan bir Include değerine ve 'tcp' veya 'udp' olan bir Type
           değerine sahip olmalıdır.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Geçersiz bağlantı noktası türüne ('{0}') sahip bir
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: Geçersiz bağlantı noktası türüne ('{0}') sahip bir
           ContainerPort öğesi sağlandı. ContainerPort öğeleri, tamsayı olan bir Include değerine ve
           'tcp' veya 'udp' olan bir Type değerine sahip olmalıdır.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: Geçersiz SDK ön sürümü ('{0}') : yalnızca 'rc' ve
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: Geçersiz SDK ön sürümü ('{0}') : yalnızca 'rc' ve
           'preview' destekleniyor.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -271,16 +237,14 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: Geçersiz {0} sağlandı: {1}. Görüntü etiketleri
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: Geçersiz {0} sağlandı: {1}. Görüntü etiketleri
           alfasayısal, alt çizgi, kısa çizgi veya nokta olmalıdır.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: Geçersiz {0} sağlandı: {1}. {0}, geçerli resim
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: Geçersiz {0} sağlandı: {1}. {0}, geçerli resim
           etiketlerinin noktalı virgülle ayrılmış listesi olmalıdır. Resim etiketleri alfasayısal,
           alt çizgi, kısa çizgi veya nokta olmalıdır.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
@@ -291,16 +255,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: '{0}' öğesi 'Value' meta verileri olmayan öğeler
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: '{0}' öğesi 'Value' meta verileri olmayan öğeler
           içeriyor ve yoksayılacak.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: Yerel kayıt defteri kullanılamıyor, ancak yerel
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: Yerel kayıt defteri kullanılamıyor, ancak yerel
           kayıt defterine gönderim isteniyor.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -315,17 +277,14 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: '{0}' tanımlayıcısına sahip katman mevcut
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: '{0}' tanımlayıcısına sahip katman mevcut
           olmadığından '{1}' kayıt defterinden indirilemedi.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort öğesi ('{0}'), bağlantı noktası
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: ContainerPort öğesi ('{0}'), bağlantı noktası
           numarasını belirtmiyor. Lütfen öğenin Include değerinin bir bağlantı noktası numarası
           olduğundan emin olun, örneğin '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
@@ -431,17 +390,14 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: '{0}' yerel kayıt defteri türü bilinmiyor. Geçerli
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: '{0}' yerel kayıt defteri türü bilinmiyor. Geçerli
           yerel kayıt defteri türleri {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: {2} kayıt defterindeki {0} : {1} bildirimi
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: {2} kayıt defterindeki {0} : {1} bildirimi
           bilinmeyen bir türdü: {3}. Lütfen bu iletiyle
           https://github.com/dotnet/sdk-container-builds/issues adresinde bir sorun oluşturun.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -1,30 +1,51 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="tr"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: Amazon Elastic Container Registry isteği zamanından önce başarısız oldu. Bu durum genellikle hedef depo, kayıt defterinde bulunmadığında ortaya çıkar.</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
+        <target state="translated">CONTAINER1002: Amazon Elastic Container Registry isteği
+          zamanından önce başarısız oldu. Bu durum genellikle hedef depo, kayıt defterinde
+          bulunmadığında ortaya çıkar.</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
         <source>CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed.</source>
-        <target state="translated">CONTAINER2008: {0} ve {1} sağlandı, ancak yalnızca birine veya diğerine izin verilir.</target>
+        <target state="translated">CONTAINER2008: {0} ve {1} sağlandı, ancak yalnızca birine veya
+          diğerine izin verilir.</target>
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: ContainerAppCommandArgs bir ContainerAppCommand komutu belirtilmeden sağlanır.</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: ContainerAppCommandArgs bir ContainerAppCommand
+          komutu belirtilmeden sağlanır.</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: ContainerAppCommandInstruction '{0}' olduğunda ContainerAppCommand ve ContainerAppCommandArgs komutları boş olmalıdır.</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: ContainerAppCommandInstruction '{0}' olduğunda
+          ContainerAppCommand ve ContainerAppCommandArgs komutları boş olmalıdır.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: Temel görüntünün, uygulamayı başlatmak için üzerine yazılacak bir giriş noktası var. İsteniyorsa ContainerAppCommandInstruction komutunu 'Entrypoint' olarak ayarlayın. Temel görüntü giriş noktasını korumak için ContainerAppCommandInstruction komutunu 'DefaultArgs' olarak ayarlayın.</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: Temel görüntünün, uygulamayı başlatmak için
+          üzerine yazılacak bir giriş noktası var. İsteniyorsa ContainerAppCommandInstruction
+          komutunu 'Entrypoint' olarak ayarlayın. Temel görüntü giriş noktasını korumak için
+          ContainerAppCommandInstruction komutunu 'DefaultArgs' olarak ayarlayın.</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,23 +54,30 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} kayıt defteri belirtmiyor ve Docker Hub’dan çekilecek. Lütfen adı görüntü kayıt defterine önek olarak ekleyin, örneğin: '{1}/&lt;image&gt;'.</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} kayıt defteri belirtmiyor ve Docker Hub’dan
+          çekilecek. Lütfen adı görüntü kayıt defterine önek olarak ekleyin, örneğin:
+          '{1}/&lt;image&gt;'.</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
         <source>CONTAINER2013: {0} had spaces in it, replacing with dashes.</source>
-        <target state="translated">CONTAINER2013: {0} boşluklar içeriyor ve çizgilerle değiştiriliyor.</target>
+        <target state="translated">CONTAINER2013: {0} boşluklar içeriyor ve çizgilerle
+          değiştiriliyor.</target>
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: RuntimeIdentifier {1} ile eşleşen {0} için eşleşen temel görüntü bulunamadı.</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
+        <target state="translated">CONTAINER1011: RuntimeIdentifier {1} ile eşleşen {0} için eşleşen
+          temel görüntü bulunamadı.</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
         <source>CONTAINER1001: Failed to upload blob using {0}; received status code '{1}'.</source>
-        <target state="translated">CONTAINER1001: Blob, {0} kullanarak karşıya yüklenemedi; '{1}' durum kodu alındı.</target>
+        <target state="translated">CONTAINER1001: Blob, {0} kullanarak karşıya yüklenemedi; '{1}'
+          durum kodu alındı.</target>
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
@@ -64,7 +92,8 @@
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">
         <source>Building image '{0}' with tags '{1}' on top of base image '{2}'.</source>
-        <target state="translated">'{1}' etiketli '{0}' resmi, '{2}' temel görüntüsünün üzerinde oluşturuluyor.</target>
+        <target state="translated">'{1}' etiketli '{0}' resmi, '{2}' temel görüntüsünün üzerinde
+          oluşturuluyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
@@ -87,14 +116,16 @@
         <target state="translated">CONTAINER3002: Docker bilgileri alınamadı: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: {0} işlemi oluşturulamadı.</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
-        <target state="translated">CONTAINER4006: '{0}' özelliği boş veya boşluk içeriyor ve yoksayılacak.</target>
+        <target state="translated">CONTAINER4006: '{0}' özelliği boş veya boşluk içeriyor ve
+          yoksayılacak.</target>
         <note>{StrBegin="CONTAINER4006: "}</note>
       </trans-unit>
       <trans-unit id="EmptyValuesIgnored">
@@ -103,28 +134,44 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: ContainerEntrypoint ve ContainerAppCommandArgs sağlandı. Uygulamanın nasıl başlatılacağını yapılandırmak için ContainerAppInstruction komutu ayarlanmalıdır. Geçerli yönergeler {0}.</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: ContainerEntrypoint ve ContainerAppCommandArgs
+          sağlandı. Uygulamanın nasıl başlatılacağını yapılandırmak için ContainerAppInstruction
+          komutu ayarlanmalıdır. Geçerli yönergeler {0}.</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: ContainerEntrypoint sağlandı. Uygulamanın nasıl başlatılacağını yapılandırmak için ContainerAppInstruction komutu ayarlanmalıdır. Geçerli yönergeler {0}.</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: ContainerEntrypoint sağlandı. Uygulamanın nasıl
+          başlatılacağını yapılandırmak için ContainerAppInstruction komutu ayarlanmalıdır. Geçerli
+          yönergeler {0}.</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: ContainerEntrypointArgs bir ContainerEntrypoint belirtilmeden sağlanır.</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: ContainerEntrypointArgs bir ContainerEntrypoint
+          belirtilmeden sağlanır.</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet sağlandı. Her zaman ayarlanması gereken bağımsız değişkenler için ContainerAppCommandArgs komutu veya kapsayıcı oluşturulduğunda geçersiz kılınabilen bağımsız değişkenler için ContainerDefaultArgs komutu kullanılacak şekilde değiştirin.</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: ContainerEntrypointArgsSet sağlandı. Her zaman
+          ayarlanması gereken bağımsız değişkenler için ContainerAppCommandArgs komutu veya
+          kapsayıcı oluşturulduğunda geçersiz kılınabilen bağımsız değişkenler için
+          ContainerDefaultArgs komutu kullanılacak şekilde değiştirin.</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint komutu ContainerAppCommandInstruction '{0}' ile birleştirilemez.</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint komutu
+          ContainerAppCommandInstruction '{0}' ile birleştirilemez.</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
@@ -139,47 +186,73 @@
       </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
-        <target state="translated">CONTAINER1009: Görüntü yerel kayıt defterinden yüklenemedi. stdout: {0}</target>
+        <target state="translated">CONTAINER1009: Görüntü yerel kayıt defterinden yüklenemedi.
+          stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
-        <target state="translated">CONTAINER1010: Yerel kayıt defterinden görüntü çekme desteklenmiyor.</target>
+        <target state="translated">CONTAINER1010: Yerel kayıt defterinden görüntü çekme
+          desteklenmiyor.</target>
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
-        <target state="translated">CONTAINER2015: {0}: '{1}' geçerli bir Ortam Değişkeni değildi. Görmezden geliniyor.</target>
+        <target state="translated">CONTAINER2015: {0}: '{1}' geçerli bir Ortam Değişkeni değildi.
+          Görmezden geliniyor.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: Çıkarsanan '{0}' görüntü adı tamamen geçersiz karakterler içeriyor. Bir görüntü adında geçerli karakterler şunlardan oluşur: alfasayısal karakterler, -, /, veya _. Görüntü adı alfasayısal karakterle başlamalıdır.</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: Çıkarsanan '{0}' görüntü adı tamamen geçersiz
+          karakterler içeriyor. Bir görüntü adında geçerli karakterler şunlardan oluşur: alfasayısal
+          karakterler, -, /, veya _. Görüntü adı alfasayısal karakterle başlamalıdır.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: '{0}' görüntü adındaki ilk karakter bir küçük harf veya rakam olmalıdır ve addaki tüm karakterler şunlardan oluşmalıdır: alfasayısal karakter, -, /, veya _.</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: '{0}' görüntü adındaki ilk karakter bir küçük harf
+          veya rakam olmalıdır ve addaki tüm karakterler şunlardan oluşmalıdır: alfasayısal
+          karakter, -, /, veya _.</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Geçersiz bağlantı noktası numarasına ('{0}') sahip bir ContainerPort öğesi sağlandı. ContainerPort öğeleri, tamsayı olan bir Include değerine ve 'tcp' veya 'udp' olan bir Type değerine sahip olmalıdır.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Geçersiz bağlantı noktası numarasına ('{0}') sahip
+          bir ContainerPort öğesi sağlandı. ContainerPort öğeleri, tamsayı olan bir Include değerine
+          ve 'tcp' veya 'udp' olan bir Type değerine sahip olmalıdır.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Geçersiz bağlantı noktası numarasına ('{0}') ve geçersiz bağlantı noktası türüne ('{1}') sahip olan bir ContainerPort öğesi sağlandı. ContainerPort öğeleri, tamsayı olan bir Include değerine ve 'tcp' veya 'udp' olan bir Type değerine sahip olmalıdır.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Geçersiz bağlantı noktası numarasına ('{0}') ve
+          geçersiz bağlantı noktası türüne ('{1}') sahip olan bir ContainerPort öğesi sağlandı.
+          ContainerPort öğeleri, tamsayı olan bir Include değerine ve 'tcp' veya 'udp' olan bir Type
+          değerine sahip olmalıdır.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: Geçersiz bağlantı noktası türüne ('{0}') sahip bir ContainerPort öğesi sağlandı. ContainerPort öğeleri, tamsayı olan bir Include değerine ve 'tcp' veya 'udp' olan bir Type değerine sahip olmalıdır.</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: Geçersiz bağlantı noktası türüne ('{0}') sahip bir
+          ContainerPort öğesi sağlandı. ContainerPort öğeleri, tamsayı olan bir Include değerine ve
+          'tcp' veya 'udp' olan bir Type değerine sahip olmalıdır.</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
-        <target state="translated">CONTAINER2018: Geçersiz SDK ön sürümü ('{0}') : yalnızca 'rc' ve 'preview' destekleniyor.</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
+        <target state="translated">CONTAINER2018: Geçersiz SDK ön sürümü ('{0}') : yalnızca 'rc' ve
+          'preview' destekleniyor.</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -188,13 +261,18 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: Geçersiz {0} sağlandı: {1}. Görüntü etiketleri alfasayısal, alt çizgi, kısa çizgi veya nokta olmalıdır.</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2007: Geçersiz {0} sağlandı: {1}. Görüntü etiketleri
+          alfasayısal, alt çizgi, kısa çizgi veya nokta olmalıdır.</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: Geçersiz {0} sağlandı: {1}. {0}, geçerli resim etiketlerinin noktalı virgülle ayrılmış listesi olmalıdır. Resim etiketleri alfasayısal, alt çizgi, kısa çizgi veya nokta olmalıdır.</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: Geçersiz {0} sağlandı: {1}. {0}, geçerli resim
+          etiketlerinin noktalı virgülle ayrılmış listesi olmalıdır. Resim etiketleri alfasayısal,
+          alt çizgi, kısa çizgi veya nokta olmalıdır.</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
@@ -203,13 +281,17 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
-        <target state="translated">CONTAINER4005: '{0}' öğesi 'Value' meta verileri olmayan öğeler içeriyor ve yoksayılacak.</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
+        <target state="translated">CONTAINER4005: '{0}' öğesi 'Value' meta verileri olmayan öğeler
+          içeriyor ve yoksayılacak.</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
-        <target state="translated">CONTAINER1012: Yerel kayıt defteri kullanılamıyor, ancak yerel kayıt defterine gönderim isteniyor.</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
+        <target state="translated">CONTAINER1012: Yerel kayıt defteri kullanılamıyor, ancak yerel
+          kayıt defterine gönderim isteniyor.</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -223,13 +305,19 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
-        <target state="translated">CONTAINER2004: '{0}' tanımlayıcısına sahip katman mevcut olmadığından '{1}' kayıt defterinden indirilemedi.</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
+        <target state="translated">CONTAINER2004: '{0}' tanımlayıcısına sahip katman mevcut
+          olmadığından '{1}' kayıt defterinden indirilemedi.</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort öğesi ('{0}'), bağlantı noktası numarasını belirtmiyor. Lütfen öğenin Include değerinin bir bağlantı noktası numarası olduğundan emin olun, örneğin '&lt;ContainerPort Include="80" /&gt;'</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: ContainerPort öğesi ('{0}'), bağlantı noktası
+          numarasını belirtmiyor. Lütfen öğenin Include değerinin bir bağlantı noktası numarası
+          olduğundan emin olun, örneğin '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -239,7 +327,8 @@
       </trans-unit>
       <trans-unit id="NormalizedContainerName">
         <source>'{0}' was not a valid container image name, it was normalized to '{1}'</source>
-        <target state="translated">'{0}', geçerli bir kapsayıcı görüntüsü adı değildi, '{1}' olarak normalleştirildi</target>
+        <target state="translated">'{0}', geçerli bir kapsayıcı görüntüsü adı değildi, '{1}' olarak
+          normalleştirildi</target>
         <note />
       </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
@@ -259,7 +348,8 @@
       </trans-unit>
       <trans-unit id="Registry_ConfigUploadStarted">
         <source>Uploading config to registry at blob '{0}',</source>
-        <target state="translated">Yapılandırma, blob '{0}' konumundaki kayıt defterine karşıya yükleniyor,</target>
+        <target state="translated">Yapılandırma, blob '{0}' konumundaki kayıt defterine karşıya
+          yükleniyor,</target>
         <note />
       </trans-unit>
       <trans-unit id="Registry_ConfigUploaded">
@@ -279,12 +369,14 @@
       </trans-unit>
       <trans-unit id="Registry_LayerUploaded">
         <source>Finished uploading layer '{0}' to '{1}'.</source>
-        <target state="translated">'{0}' katmanının, '{1}' kayıt defterine karşıya yüklenmesi tamamlandı.</target>
+        <target state="translated">'{0}' katmanının, '{1}' kayıt defterine karşıya yüklenmesi
+          tamamlandı.</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
-        <target state="translated">Bildirim, '{0}' kayıt defterine '{1}' blob olarak karşıya yükleniyor.</target>
+        <target state="translated">Bildirim, '{0}' kayıt defterine '{1}' blob olarak karşıya
+          yükleniyor.</target>
         <note>{0} is the registry name</note>
       </trans-unit>
       <trans-unit id="Registry_ManifestUploaded">
@@ -324,17 +416,24 @@
       </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
-        <target state="translated">CONTAINER2021: AppCommandInstruction '{0}' bilinmiyor. Geçerli yönergeler {1}.</target>
+        <target state="translated">CONTAINER2021: AppCommandInstruction '{0}' bilinmiyor. Geçerli
+          yönergeler {1}.</target>
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
-        <target state="translated">CONTAINER2002: '{0}' yerel kayıt defteri türü bilinmiyor. Geçerli yerel kayıt defteri türleri {1}.</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
+        <target state="translated">CONTAINER2002: '{0}' yerel kayıt defteri türü bilinmiyor. Geçerli
+          yerel kayıt defteri türleri {1}.</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: {2} kayıt defterindeki {0} : {1} bildirimi bilinmeyen bir türdü: {3}. Lütfen bu iletiyle https://github.com/dotnet/sdk-container-builds/issues adresinde bir sorun oluşturun.</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: {2} kayıt defterindeki {0} : {1} bildirimi
+          bilinmeyen bir türdü: {3}. Lütfen bu iletiyle
+          https://github.com/dotnet/sdk-container-builds/issues adresinde bir sorun oluşturun.</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,9 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="zh-Hans"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
         <target state="translated">CONTAINER1002: 对 Amazon 弹性容器注册表的请求过早失败。当注册表中不存在目标存储库时，通常会导致这种情况。</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
@@ -13,18 +22,26 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: 提供了 ContainerAppCommandArgs，但未指定 ContainerAppCommand。</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: 提供了 ContainerAppCommandArgs，但未指定
+          ContainerAppCommand。</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: 当 ContainerAppCommandInstruction 为“{0}”时，ContainerAppCommand 和 ContainerAppCommandArgs 必须为空。</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: 当 ContainerAppCommandInstruction
+          为“{0}”时，ContainerAppCommand 和 ContainerAppCommandArgs 必须为空。</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: 基础映像具有一个入口点，该入口点将被覆盖以启动应用程序。如果需要，请将 ContainerAppCommandInstruction 设置为 "Entrypoint"。若要保留基础映像入口点，请将 ContainerAppCommandInstruction 设置为 "DefaultArgs"。</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: 基础映像具有一个入口点，该入口点将被覆盖以启动应用程序。如果需要，请将
+          ContainerAppCommandInstruction 设置为 "Entrypoint"。若要保留基础映像入口点，请将
+          ContainerAppCommandInstruction 设置为 "DefaultArgs"。</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,8 +50,10 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} 未指定注册表，将从 Docker Hub 中拉取。请在名称前面添加映像注册表，例如: "{1}/&lt;image&gt;"。</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} 未指定注册表，将从 Docker Hub 中拉取。请在名称前面添加映像注册表，例如:
+          "{1}/&lt;image&gt;"。</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
@@ -43,7 +62,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
         <target state="translated">CONTAINER1011: 找不到与 RuntimeIdentifier 匹配的 {0} 匹配基映像 {1}。</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -87,10 +107,11 @@
         <target state="translated">CONTAINER3002: 无法获取 docker 信息: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: 未能创建 {0} 进程。</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -103,28 +124,40 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: 提供了 ContainerEntrypoint 和 ContainerAppCommandArgs。必须设置 ContainerAppInstruction 以配置应用程序的启动方式。有效说明为 {0}。</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: 提供了 ContainerEntrypoint 和
+          ContainerAppCommandArgs。必须设置 ContainerAppInstruction 以配置应用程序的启动方式。有效说明为 {0}。</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: 提供了 ContainerEntrypoint。必须设置 ContainerAppInstruction 以配置应用程序的启动方式。有效说明为 {0}。</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: 提供了 ContainerEntrypoint。必须设置
+          ContainerAppInstruction 以配置应用程序的启动方式。有效说明为 {0}。</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: 提供了 ContainerEntrypointArgs，但未指定 ContainerEntrypoint。</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: 提供了 ContainerEntrypointArgs，但未指定
+          ContainerEntrypoint。</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: 提供了 ContainerEntrypointArgsSet。对于必须始终设置的参数，请更改为使用 ContainerAppCommandArgs；对于可在创建容器时替代的参数，请更改为使用 ContainerDefaultArgs。</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: 提供了 ContainerEntrypointArgsSet。对于必须始终设置的参数，请更改为使用
+          ContainerAppCommandArgs；对于可在创建容器时替代的参数，请更改为使用 ContainerDefaultArgs。</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint 不能与 ContainerAppCommandInstruction“{0}”一起使用。</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint 不能与
+          ContainerAppCommandInstruction“{0}”一起使用。</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
@@ -153,32 +186,48 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: 推断的图像名称“{0}”包含完全无效的字符。图像名称的有效字符包括字母数字字符、-、/ 或 _，图像名称必须以字母数字字符开头。</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: 推断的图像名称“{0}”包含完全无效的字符。图像名称的有效字符包括字母数字字符、-、/ 或
+          _，图像名称必须以字母数字字符开头。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: 图像名称“{0}”的第一个字符必须是小写字母或数字，并且名称中的所有字符都必须是字母数字字符、-、/ 或 _。</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: 图像名称“{0}”的第一个字符必须是小写字母或数字，并且名称中的所有字符都必须是字母数字字符、-、/
+          或 _。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 为 ContainerPort 项提供了无效的端口数字 "{0}"。ContainerPort 项必须具有作为整数的 Include 值，以及 "tcp" 或 "udp" 的 Type 值。</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 为 ContainerPort 项提供了无效的端口数字 "{0}"。ContainerPort
+          项必须具有作为整数的 Include 值，以及 "tcp" 或 "udp" 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 为 ContainerPort 项提供了无效的端口号 {0} 和无效的端口类型 "{1}"。ContainerPort 项必须具有作为整数的 Include 值，以及“tcp”或“udp”的 Type 值。</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 为 ContainerPort 项提供了无效的端口号 {0} 和无效的端口类型
+          "{1}"。ContainerPort 项必须具有作为整数的 Include 值，以及“tcp”或“udp”的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 为 ContainerPort 项提供了无效的端口类型 "{0}"。ContainerPort 项必须具有作为整数的 Include 值，以及 "tcp" 或 "udp" 的 Type 值。</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 为 ContainerPort 项提供了无效的端口类型 "{0}"。ContainerPort
+          项必须具有作为整数的 Include 值，以及 "tcp" 或 "udp" 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
         <target state="translated">CONTAINER2018: SDK 预发行版本“{0}”无效 - 仅支持“rc”和“preview”。</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -188,13 +237,16 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
         <target state="translated">CONTAINER2007: 提供的 {0} 无效: {1}。图像标记必须是字母数字、下划线、连字符或句点。</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: 提供的 {0} 无效: {1}。{0} 必须是有效图像标记的分号分隔列表。图像标记必须是字母数字、下划线、连字符或句点。</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: 提供的 {0} 无效: {1}。{0}
+          必须是有效图像标记的分号分隔列表。图像标记必须是字母数字、下划线、连字符或句点。</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
@@ -203,12 +255,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
         <target state="translated">CONTAINER4005: 项 "{0}" 包含没有元数据 "Value" 的项，它们将被忽略。</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
         <target state="translated">CONTAINER1012: 本地注册表不可用，但请求推送到本地注册表。</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -223,13 +277,17 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
         <target state="translated">CONTAINER2004: 无法从注册表“{1}”下载描述符为“{0}”的层，因为它不存在。</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort 项“{0}”未指定端口号。请确保项的 Include 是端口号，例如 "&lt;ContainerPort Include="80" /&gt;"</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: ContainerPort 项“{0}”未指定端口号。请确保项的 Include 是端口号，例如
+          "&lt;ContainerPort Include="80" /&gt;"</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -328,13 +386,17 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
         <target state="translated">CONTAINER2002: 本地注册表类型“{0}”未知。有效的本地容器注册表类型为 {1}。</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: 注册表 {2} 中 {0} {1} 的清单是未知类型: {3}。请在 https://github.com/dotnet/sdk-container-builds/issues 上提出问题，并附上此消息。</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: 注册表 {2} 中 {0} {1} 的清单是未知类型: {3}。请在
+          https://github.com/dotnet/sdk-container-builds/issues 上提出问题，并附上此消息。</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="zh-Hans"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: 对 Amazon 弹性容器注册表的请求过早失败。当注册表中不存在目标存储库时，通常会导致这种情况。</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: 对 Amazon 弹性容器注册表的请求过早失败。当注册表中不存在目标存储库时，通常会导致这种情况。</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
@@ -22,16 +13,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: 提供了 ContainerAppCommandArgs，但未指定
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: 提供了 ContainerAppCommandArgs，但未指定
           ContainerAppCommand。</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: 当 ContainerAppCommandInstruction
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: 当 ContainerAppCommandInstruction
           为“{0}”时，ContainerAppCommand 和 ContainerAppCommandArgs 必须为空。</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -41,10 +30,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: 基础映像具有一个入口点，该入口点将被覆盖以启动应用程序。如果需要，请将
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: 基础映像具有一个入口点，该入口点将被覆盖以启动应用程序。如果需要，请将
           ContainerAppCommandInstruction 设置为 "Entrypoint"。若要保留基础映像入口点，请将
           ContainerAppCommandInstruction 设置为 "DefaultArgs"。</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
@@ -55,9 +42,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} 未指定注册表，将从 Docker Hub 中拉取。请在名称前面添加映像注册表，例如:
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} 未指定注册表，将从 Docker Hub 中拉取。请在名称前面添加映像注册表，例如:
           "{1}/&lt;image&gt;"。</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
@@ -67,9 +53,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: 找不到与 RuntimeIdentifier 匹配的 {0} 匹配基映像 {1}。</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: 找不到与 RuntimeIdentifier 匹配的 {0} 匹配基映像 {1}。</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
@@ -119,9 +104,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: 未能创建 {0} 进程。</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: 未能创建 {0} 进程。</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -134,39 +118,32 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: 提供了 ContainerEntrypoint 和
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: 提供了 ContainerEntrypoint 和
           ContainerAppCommandArgs。必须设置 ContainerAppInstruction 以配置应用程序的启动方式。有效说明为 {0}。</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: 提供了 ContainerEntrypoint。必须设置
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: 提供了 ContainerEntrypoint。必须设置
           ContainerAppInstruction 以配置应用程序的启动方式。有效说明为 {0}。</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: 提供了 ContainerEntrypointArgs，但未指定
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: 提供了 ContainerEntrypointArgs，但未指定
           ContainerEntrypoint。</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: 提供了 ContainerEntrypointArgsSet。对于必须始终设置的参数，请更改为使用
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: 提供了 ContainerEntrypointArgsSet。对于必须始终设置的参数，请更改为使用
           ContainerAppCommandArgs；对于可在创建容器时替代的参数，请更改为使用 ContainerDefaultArgs。</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint 不能与
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint 不能与
           ContainerAppCommandInstruction“{0}”一起使用。</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -196,49 +173,38 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: 推断的图像名称“{0}”包含完全无效的字符。图像名称的有效字符包括字母数字字符、-、/ 或
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: 推断的图像名称“{0}”包含完全无效的字符。图像名称的有效字符包括字母数字字符、-、/ 或
           _，图像名称必须以字母数字字符开头。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: 图像名称“{0}”的第一个字符必须是小写字母或数字，并且名称中的所有字符都必须是字母数字字符、-、/
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: 图像名称“{0}”的第一个字符必须是小写字母或数字，并且名称中的所有字符都必须是字母数字字符、-、/
           或 _。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 为 ContainerPort 项提供了无效的端口数字 "{0}"。ContainerPort
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 为 ContainerPort 项提供了无效的端口数字 "{0}"。ContainerPort
           项必须具有作为整数的 Include 值，以及 "tcp" 或 "udp" 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 为 ContainerPort 项提供了无效的端口号 {0} 和无效的端口类型
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 为 ContainerPort 项提供了无效的端口号 {0} 和无效的端口类型
           "{1}"。ContainerPort 项必须具有作为整数的 Include 值，以及“tcp”或“udp”的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 为 ContainerPort 项提供了无效的端口类型 "{0}"。ContainerPort
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 为 ContainerPort 项提供了无效的端口类型 "{0}"。ContainerPort
           项必须具有作为整数的 Include 值，以及 "tcp" 或 "udp" 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: SDK 预发行版本“{0}”无效 - 仅支持“rc”和“preview”。</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: SDK 预发行版本“{0}”无效 - 仅支持“rc”和“preview”。</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -247,15 +213,13 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: 提供的 {0} 无效: {1}。图像标记必须是字母数字、下划线、连字符或句点。</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: 提供的 {0} 无效: {1}。图像标记必须是字母数字、下划线、连字符或句点。</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: 提供的 {0} 无效: {1}。{0}
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: 提供的 {0} 无效: {1}。{0}
           必须是有效图像标记的分号分隔列表。图像标记必须是字母数字、下划线、连字符或句点。</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
@@ -265,15 +229,13 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: 项 "{0}" 包含没有元数据 "Value" 的项，它们将被忽略。</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: 项 "{0}" 包含没有元数据 "Value" 的项，它们将被忽略。</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: 本地注册表不可用，但请求推送到本地注册表。</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: 本地注册表不可用，但请求推送到本地注册表。</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -287,16 +249,13 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: 无法从注册表“{1}”下载描述符为“{0}”的层，因为它不存在。</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: 无法从注册表“{1}”下载描述符为“{0}”的层，因为它不存在。</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort 项“{0}”未指定端口号。请确保项的 Include 是端口号，例如
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: ContainerPort 项“{0}”未指定端口号。请确保项的 Include 是端口号，例如
           "&lt;ContainerPort Include="80" /&gt;"</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
@@ -396,16 +355,13 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: 本地注册表类型“{0}”未知。有效的本地容器注册表类型为 {1}。</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: 本地注册表类型“{0}”未知。有效的本地容器注册表类型为 {1}。</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: 注册表 {2} 中 {0} {1} 的清单是未知类型: {3}。请在
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: 注册表 {2} 中 {0} {1} 的清单是未知类型: {3}。请在
           https://github.com/dotnet/sdk-container-builds/issues 上提出问题，并附上此消息。</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,19 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff
-    xmlns="urn:oasis:names:tc:xliff:document:1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="1.2"
-    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file
-      datatype="xml"
-      source-language="en"
-      target-language="zh-Hant"
-      original="../Strings.resx">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
-          is often caused when the target repository does not exist in the registry.</source>
-        <target state="translated">CONTAINER1002: 對 Amazon 彈性容器登錄的要求提前失敗。這通常是在目標存放庫不存在於登錄中時所導致。</target>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <target state="needs-review-translation">CONTAINER1002: 對 Amazon 彈性容器登錄的要求提前失敗。這通常是在目標存放庫不存在於登錄中時所導致。</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
       <trans-unit id="AmbiguousTags">
@@ -22,16 +13,14 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
-          ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: 提供了 ContainerAppCommandArgs 但未指定
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
+        <target state="needs-review-translation">CONTAINER2025: 提供了 ContainerAppCommandArgs 但未指定
           ContainerAppCommand。</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
-          ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: 當 ContainerAppCommandInstruction 為 '{0}'
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2026: 當 ContainerAppCommandInstruction 為 '{0}'
           時，ContainerAppCommand 和 ContainerAppCommandArgs 必須是空白。</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
@@ -41,10 +30,8 @@
         <note>{0} is the path to the file written</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
-          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
-          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: 基礎映像有一個進入點，將被覆寫以啟動應用程式。如果這是預期的行為，請將
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="needs-review-translation">CONTAINER2022: 基礎映像有一個進入點，將被覆寫以啟動應用程式。如果這是預期的行為，請將
           ContainerAppCommandInstruction 設定為 'Entrypoint'。若要保留基礎映像進入點，請將
           ContainerAppCommandInstruction 設定為 'DefaultArgs'。</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
@@ -55,9 +42,8 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
-          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} 未指定登錄，並將從 Docker Hub 提取。請在名稱前面加上映像登錄，例如:
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="needs-review-translation">CONTAINER2020: {0} 未指定登錄，並將從 Docker Hub 提取。請在名稱前面加上映像登錄，例如:
           '{1}/&lt;image&gt;'。</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
@@ -67,9 +53,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
-          RuntimeIdentifier {1}.</source>
-        <target state="translated">CONTAINER1011: 找不到 {0} 符合 RuntimeIdentifier 的 {1} 相符基本映像。</target>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <target state="needs-review-translation">CONTAINER1011: 找不到 {0} 符合 RuntimeIdentifier 的 {1} 相符基本映像。</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
       <trans-unit id="BlobUploadFailed">
@@ -119,9 +104,8 @@
       </trans-unit>
       <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
-        <target state="translated">CONTAINER3001: 無法建立 {0} 程序。</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
-          'podman'.</note>
+        <target state="needs-review-translation">CONTAINER3001: 無法建立 {0} 程序。</target>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -134,39 +118,32 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
-          ContainerAppInstruction must be set to configure how the application is started. Valid
-          instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: 提供了 ContainerEntrypoint 和
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2023: 提供了 ContainerEntrypoint 和
           ContainerAppCommandArgs。必須設定 ContainerAppInstruction 以設定應用程式的啟動方式。有效的指示為 {0}。</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
-          set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: 提供了 ContainerEntrypoint。必須設定
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="needs-review-translation">CONTAINER2027: 提供了 ContainerEntrypoint。必須設定
           ContainerAppInstruction 以設定應用程式的啟動方式。有效的指示為 {0}。</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
-          ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: 提供了 ContainerEntrypointArgs 但未指定
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
+        <target state="needs-review-translation">CONTAINER2024: 提供了 ContainerEntrypointArgs 但未指定
           ContainerEntrypoint。</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
-          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
-          arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: 提供了 ContainerEntrypointArgsSet。請針對一律必須設定的引數變更為使用
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
+        <target state="needs-review-translation">CONTAINER2029: 提供了 ContainerEntrypointArgsSet。請針對一律必須設定的引數變更為使用
           ContainerAppCommandArgs，或針對建立容器時可覆寫的引數使用 ContainerDefaultArgs。</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
-          ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint 無法與
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
+        <target state="needs-review-translation">CONTAINER2028: ContainerEntrypoint 無法與
           ContainerAppCommandInstruction '{0}' 結合。</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
@@ -196,49 +173,38 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
-          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
-          image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: 推斷的映像名稱 '{0}' 包含完全無效字元。映像名稱的有效字元是英數字元、-、/ 或
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
+        <target state="needs-review-translation">CONTAINER2005: 推斷的映像名稱 '{0}' 包含完全無效字元。映像名稱的有效字元是英數字元、-、/ 或
           _，並且映像名稱必須以英數字元開頭。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
-          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
-          or _.</source>
-        <target state="translated">CONTAINER2005: 映像名稱 '{0}' 的首字元必須是小寫字母或數字，並且名稱中的所有字元都必須是英數字元、-、/ 或
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
+        <target state="needs-review-translation">CONTAINER2005: 映像名稱 '{0}' 的首字元必須是小寫字母或數字，並且名稱中的所有字元都必須是英數字元、-、/ 或
           _。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠號碼 '{0}'。ContainerPort
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠號碼 '{0}'。ContainerPort
           項目必須具有為整數的 Include 值，以及 'tcp' 或 'udp' 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
-          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
-          integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠號碼 '{0}' 和無效的連接埠類型
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠號碼 '{0}' 和無效的連接埠類型
           '{1}'。ContainerPort 項目必須具有為整數的 Include 值，以及 'tcp' 或 'udp' 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
-          ContainerPort items must have an Include value that is an integer, and a Type value that
-          is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠類型 '{0}'。ContainerPort
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="needs-review-translation">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠類型 '{0}'。ContainerPort
           項目必須具有為整數的 Include 值，以及 'tcp' 或 'udp' 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
-          supported.</source>
-        <target state="translated">CONTAINER2018: 無效的 SDK 發行前版本 '{0}' - 只支援 'rc' 和 'preview'。</target>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <target state="needs-review-translation">CONTAINER2018: 無效的 SDK 發行前版本 '{0}' - 只支援 'rc' 和 'preview'。</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkVersion">
@@ -247,15 +213,13 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
-          underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2007: 提供的 {0} 無效: {1}。映像標記必須是英數字元、底線、連字號或句號。</target>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2007: 提供的 {0} 無效: {1}。映像標記必須是英數字元、底線、連字號或句號。</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
-          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: 提供的 {0} 無效: {1}。{0}
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="needs-review-translation">CONTAINER2010: 提供的 {0} 無效: {1}。{0}
           必須是有效映像標記的分號分隔清單。映像標記必須是英數字元、底線、連字號或句號。</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
@@ -265,15 +229,13 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
-          ignored.</source>
-        <target state="translated">CONTAINER4005: 項目 '{0}' 包含沒有中繼資料 'Value' 的項目，將忽略這些項目。</target>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <target state="needs-review-translation">CONTAINER4005: 項目 '{0}' 包含沒有中繼資料 'Value' 的項目，將忽略這些項目。</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
-          was requested.</source>
-        <target state="translated">CONTAINER1012: 本機登錄無法使用，但已要求推送至本機登錄。</target>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <target state="needs-review-translation">CONTAINER1012: 本機登錄無法使用，但已要求推送至本機登錄。</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
       <trans-unit id="LocalDocker_FailedToGetConfig">
@@ -287,16 +249,13 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
-          because it does not exist.</source>
-        <target state="translated">CONTAINER2004: 無法從登錄 '{1}' 下載描述元為 '{0}' 的層，因為它不存在。</target>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <target state="needs-review-translation">CONTAINER2004: 無法從登錄 '{1}' 下載描述元為 '{0}' 的層，因為它不存在。</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
-          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
-          /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort 項目 '{0}' 未指定連接埠號碼。請確保項目的 Include
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
+        <target state="needs-review-translation">CONTAINER2016: ContainerPort 項目 '{0}' 未指定連接埠號碼。請確保項目的 Include
           是連接埠號碼，例如 '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
@@ -396,16 +355,13 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
-          types are {1}.</source>
-        <target state="translated">CONTAINER2002: 不明的本機登錄類型 '{0}'。有效的本機容器註冊類型為 {1}。</target>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <target state="needs-review-translation">CONTAINER2002: 不明的本機登錄類型 '{0}'。有效的本機容器註冊類型為 {1}。</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
-          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
-          message.</source>
-        <target state="translated">CONTAINER2003: 來自登錄 {2} 用於 {0}:{1} 的資訊清單是未知的類型: {3}。請使用此訊息在
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
+        <target state="needs-review-translation">CONTAINER2003: 來自登錄 {2} 用於 {0}:{1} 的資訊清單是未知的類型: {3}。請使用此訊息在
           https://github.com/dotnet/sdk-container-builds/issues 提出問題。</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,9 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.2"
+    xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file
+      datatype="xml"
+      source-language="en"
+      target-language="zh-Hant"
+      original="../Strings.resx">
     <body>
       <trans-unit id="AmazonRegistryFailed">
-        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.</source>
+        <source>CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This
+          is often caused when the target repository does not exist in the registry.</source>
         <target state="translated">CONTAINER1002: 對 Amazon 彈性容器登錄的要求提前失敗。這通常是在目標存放庫不存在於登錄中時所導致。</target>
         <note>{StrBegin="CONTAINER1002: "}</note>
       </trans-unit>
@@ -13,18 +22,26 @@
         <note>{StrBegin="CONTAINER2008: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandArgsSetNoAppCommand">
-        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand.</source>
-        <target state="translated">CONTAINER2025: 提供了 ContainerAppCommandArgs 但未指定 ContainerAppCommand。</target>
+        <source>CONTAINER2025: ContainerAppCommandArgs are provided without specifying a
+          ContainerAppCommand.</source>
+        <target state="translated">CONTAINER2025: 提供了 ContainerAppCommandArgs 但未指定
+          ContainerAppCommand。</target>
         <note>{StrBegin="CONTAINER2025: "}</note>
       </trans-unit>
       <trans-unit id="AppCommandSetNotUsed">
-        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is '{0}'.</source>
-        <target state="translated">CONTAINER2026: 當 ContainerAppCommandInstruction 為 '{0}' 時，ContainerAppCommand 和 ContainerAppCommandArgs 必須是空白。</target>
+        <source>CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when
+          ContainerAppCommandInstruction is '{0}'.</source>
+        <target state="translated">CONTAINER2026: 當 ContainerAppCommandInstruction 為 '{0}'
+          時，ContainerAppCommand 和 ContainerAppCommandArgs 必須是空白。</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
-        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
-        <target state="translated">CONTAINER2022: 基礎映像有一個進入點，將被覆寫以啟動應用程式。如果這是預期的行為，請將 ContainerAppCommandInstruction 設定為 'Entrypoint'。若要保留基礎映像進入點，請將 ContainerAppCommandInstruction 設定為 'DefaultArgs'。</target>
+        <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start
+          the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To
+          preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
+        <target state="translated">CONTAINER2022: 基礎映像有一個進入點，將被覆寫以啟動應用程式。如果這是預期的行為，請將
+          ContainerAppCommandInstruction 設定為 'Entrypoint'。若要保留基礎映像進入點，請將
+          ContainerAppCommandInstruction 設定為 'DefaultArgs'。</target>
         <note>{StrBegin="CONTAINER2022: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameParsingFailed">
@@ -33,8 +50,10 @@
         <note>{StrBegin="CONTAINER2009: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameRegistryFallback">
-        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
-        <target state="translated">CONTAINER2020: {0} 未指定登錄，並將從 Docker Hub 提取。請在名稱前面加上映像登錄，例如: '{1}/&lt;image&gt;'。</target>
+        <source>CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub.
+          Please prefix the name with the image registry, for example: '{1}/&lt;image&gt;'.</source>
+        <target state="translated">CONTAINER2020: {0} 未指定登錄，並將從 Docker Hub 提取。請在名稱前面加上映像登錄，例如:
+          '{1}/&lt;image&gt;'。</target>
         <note>{StrBegin="CONTAINER2020: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNameWithSpaces">
@@ -43,7 +62,8 @@
         <note>{StrBegin="CONTAINER2013: "}</note>
       </trans-unit>
       <trans-unit id="BaseImageNotFound">
-        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}.</source>
+        <source>CONTAINER1011: Couldn't find matching base image for {0} that matches
+          RuntimeIdentifier {1}.</source>
         <target state="translated">CONTAINER1011: 找不到 {0} 符合 RuntimeIdentifier 的 {1} 相符基本映像。</target>
         <note>{StrBegin="CONTAINER1011: "}</note>
       </trans-unit>
@@ -87,10 +107,11 @@
         <target state="translated">CONTAINER3002: 無法取得 Docker 資訊: {0}</target>
         <note>{StrBegin="CONTAINER3002: "}</note>
       </trans-unit>
-      <trans-unit id="DockerProcessCreationFailed">
+      <trans-unit id="ContainerRuntimeProcessCreationFailed">
         <source>CONTAINER3001: Failed creating {0} process.</source>
         <target state="translated">CONTAINER3001: 無法建立 {0} 程序。</target>
-        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or 'podman'.</note>
+        <note>CONTAINER3001: {0} is the name of the command we failed to run, usually 'docker' or
+          'podman'.</note>
       </trans-unit>
       <trans-unit id="EmptyOrWhitespacePropertyIgnored">
         <source>CONTAINER4006: Property '{0}' is empty or contains whitespace and will be ignored.</source>
@@ -103,28 +124,40 @@
         <note>{StrBegin="CONTAINER4004: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointAndAppCommandArgsSetNoAppCommandInstruction">
-        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2023: 提供了 ContainerEntrypoint 和 ContainerAppCommandArgs。必須設定 ContainerAppInstruction 以設定應用程式的啟動方式。有效的指示為 {0}。</target>
+        <source>CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided.
+          ContainerAppInstruction must be set to configure how the application is started. Valid
+          instructions are {0}.</source>
+        <target state="translated">CONTAINER2023: 提供了 ContainerEntrypoint 和
+          ContainerAppCommandArgs。必須設定 ContainerAppInstruction 以設定應用程式的啟動方式。有效的指示為 {0}。</target>
         <note>{StrBegin="CONTAINER2023: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointSetNoAppCommandInstruction">
-        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}.</source>
-        <target state="translated">CONTAINER2027: 提供了 ContainerEntrypoint。必須設定 ContainerAppInstruction 以設定應用程式的啟動方式。有效的指示為 {0}。</target>
+        <source>CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be
+          set to configure how the application is started. Valid instructions are {0}.</source>
+        <target state="translated">CONTAINER2027: 提供了 ContainerEntrypoint。必須設定
+          ContainerAppInstruction 以設定應用程式的啟動方式。有效的指示為 {0}。</target>
         <note>{StrBegin="CONTAINER2027: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetNoEntrypoint">
-        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint.</source>
-        <target state="translated">CONTAINER2024: 提供了 ContainerEntrypointArgs 但未指定 ContainerEntrypoint。</target>
+        <source>CONTAINER2024: ContainerEntrypointArgs are provided without specifying a
+          ContainerEntrypoint.</source>
+        <target state="translated">CONTAINER2024: 提供了 ContainerEntrypointArgs 但未指定
+          ContainerEntrypoint。</target>
         <note>{StrBegin="CONTAINER2024: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointArgsSetPreferAppCommandArgs">
-        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created.</source>
-        <target state="translated">CONTAINER2029: 提供了 ContainerEntrypointArgsSet。請針對一律必須設定的引數變更為使用 ContainerAppCommandArgs，或針對建立容器時可覆寫的引數使用 ContainerDefaultArgs。</target>
+        <source>CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use
+          ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for
+          arguments that can be overridden when the container is created.</source>
+        <target state="translated">CONTAINER2029: 提供了 ContainerEntrypointArgsSet。請針對一律必須設定的引數變更為使用
+          ContainerAppCommandArgs，或針對建立容器時可覆寫的引數使用 ContainerDefaultArgs。</target>
         <note>{StrBegin="CONTAINER2029: "}</note>
       </trans-unit>
       <trans-unit id="EntrypointConflictAppCommand">
-        <source>CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction '{0}'.</source>
-        <target state="translated">CONTAINER2028: ContainerEntrypoint 無法與 ContainerAppCommandInstruction '{0}' 結合。</target>
+        <source>CONTAINER2028: ContainerEntrypoint can not be combined with
+          ContainerAppCommandInstruction '{0}'.</source>
+        <target state="translated">CONTAINER2028: ContainerEntrypoint 無法與
+          ContainerAppCommandInstruction '{0}' 結合。</target>
         <note>{StrBegin="CONTAINER2028: "}</note>
       </trans-unit>
       <trans-unit id="FailedRetrievingCredentials">
@@ -153,32 +186,48 @@
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
-        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</source>
-        <target state="translated">CONTAINER2005: 推斷的映像名稱 '{0}' 包含完全無效字元。映像名稱的有效字元是英數字元、-、/ 或 _，並且映像名稱必須以英數字元開頭。</target>
+        <source>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters.
+          The valid characters for an image name are alphanumeric characters, -, /, or _, and the
+          image name must start with an alphanumeric character.</source>
+        <target state="translated">CONTAINER2005: 推斷的映像名稱 '{0}' 包含完全無效字元。映像名稱的有效字元是英數字元、-、/ 或
+          _，並且映像名稱必須以英數字元開頭。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidImageName_NonAlphanumericStartCharacter">
-        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _.</source>
-        <target state="translated">CONTAINER2005: 映像名稱 '{0}' 的首字元必須是小寫字母或數字，並且名稱中的所有字元都必須是英數字元、-、/ 或 _。</target>
+        <source>CONTAINER2005: The first character of the image name '{0}' must be a lowercase
+          letter or a digit and all characters in the name must be an alphanumeric character, -, /,
+          or _.</source>
+        <target state="translated">CONTAINER2005: 映像名稱 '{0}' 的首字元必須是小寫字母或數字，並且名稱中的所有字元都必須是英數字元、-、/ 或
+          _。</target>
         <note>{StrBegin="CONTAINER2005: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Number">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠號碼 '{0}'。ContainerPort 項目必須具有為整數的 Include 值，以及 'tcp' 或 'udp' 的 Type 值。</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠號碼 '{0}'。ContainerPort
+          項目必須具有為整數的 Include 值，以及 'tcp' 或 'udp' 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_NumberAndType">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}' and an invalid port type '{1}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠號碼 '{0}' 和無效的連接埠類型 '{1}'。ContainerPort 項目必須具有為整數的 Include 值，以及 'tcp' 或 'udp' 的 Type 值。</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port number '{0}'
+          and an invalid port type '{1}'. ContainerPort items must have an Include value that is an
+          integer, and a Type value that is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠號碼 '{0}' 和無效的連接埠類型
+          '{1}'。ContainerPort 項目必須具有為整數的 Include 值，以及 'tcp' 或 'udp' 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidPort_Type">
-        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'. ContainerPort items must have an Include value that is an integer, and a Type value that is either 'tcp' or 'udp'.</source>
-        <target state="translated">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠類型 '{0}'。ContainerPort 項目必須具有為整數的 Include 值，以及 'tcp' 或 'udp' 的 Type 值。</target>
+        <source>CONTAINER2017: A ContainerPort item was provided with an invalid port type '{0}'.
+          ContainerPort items must have an Include value that is an integer, and a Type value that
+          is either 'tcp' or 'udp'.</source>
+        <target state="translated">CONTAINER2017: 提供的 ContainerPort 項目具有無效的連接埠類型 '{0}'。ContainerPort
+          項目必須具有為整數的 Include 值，以及 'tcp' 或 'udp' 的 Type 值。</target>
         <note>{StrBegin="CONTAINER2017: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkPrereleaseVersion">
-        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are supported.</source>
+        <source>CONTAINER2018: Invalid SDK prerelease version '{0}' - only 'rc' and 'preview' are
+          supported.</source>
         <target state="translated">CONTAINER2018: 無效的 SDK 發行前版本 '{0}' - 只支援 'rc' 和 'preview'。</target>
         <note>{StrBegin="CONTAINER2018: "}</note>
       </trans-unit>
@@ -188,13 +237,16 @@
         <note>{StrBegin="CONTAINER2019: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTag">
-        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <source>CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric,
+          underscore, hyphen, or period.</source>
         <target state="translated">CONTAINER2007: 提供的 {0} 無效: {1}。映像標記必須是英數字元、底線、連字號或句號。</target>
         <note>{StrBegin="CONTAINER2007: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTags">
-        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
-        <target state="translated">CONTAINER2010: 提供的 {0} 無效: {1}。{0} 必須是有效映像標記的分號分隔清單。映像標記必須是英數字元、底線、連字號或句號。</target>
+        <source>CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of
+          valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.</source>
+        <target state="translated">CONTAINER2010: 提供的 {0} 無效: {1}。{0}
+          必須是有效映像標記的分號分隔清單。映像標記必須是英數字元、底線、連字號或句號。</target>
         <note>{StrBegin="CONTAINER2010: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTokenResponse">
@@ -203,12 +255,14 @@
         <note>{StrBegin="CONTAINER1003: "}</note>
       </trans-unit>
       <trans-unit id="ItemsWithoutMetadata">
-        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be ignored.</source>
+        <source>CONTAINER4005: Item '{0}' contains items without metadata 'Value', and they will be
+          ignored.</source>
         <target state="translated">CONTAINER4005: 項目 '{0}' 包含沒有中繼資料 'Value' 的項目，將忽略這些項目。</target>
         <note>{StrBegin="CONTAINER4005: "}</note>
       </trans-unit>
       <trans-unit id="LocalRegistryNotAvailable">
-        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.</source>
+        <source>CONTAINER1012: The local registry is not available, but pushing to a local registry
+          was requested.</source>
         <target state="translated">CONTAINER1012: 本機登錄無法使用，但已要求推送至本機登錄。</target>
         <note>{StrBegin="CONTAINER1012: "}</note>
       </trans-unit>
@@ -223,13 +277,17 @@
         <note>{0} are the list of messages, each message starts with new line</note>
       </trans-unit>
       <trans-unit id="MissingLinkToRegistry">
-        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</source>
+        <source>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}'
+          because it does not exist.</source>
         <target state="translated">CONTAINER2004: 無法從登錄 '{1}' 下載描述元為 '{0}' 的層，因為它不存在。</target>
         <note>{StrBegin="CONTAINER2004: "}</note>
       </trans-unit>
       <trans-unit id="MissingPortNumber">
-        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</source>
-        <target state="translated">CONTAINER2016: ContainerPort 項目 '{0}' 未指定連接埠號碼。請確保項目的 Include 是連接埠號碼，例如 '&lt;ContainerPort Include="80" /&gt;'</target>
+        <source>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please
+          ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80"
+          /&gt;'</source>
+        <target state="translated">CONTAINER2016: ContainerPort 項目 '{0}' 未指定連接埠號碼。請確保項目的 Include
+          是連接埠號碼，例如 '&lt;ContainerPort Include="80" /&gt;'</target>
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -328,13 +386,17 @@
         <note>{StrBegin="CONTAINER2021: "}</note>
       </trans-unit>
       <trans-unit id="UnknownLocalRegistryType">
-        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry types are {1}.</source>
+        <source>CONTAINER2002: Unknown local registry type '{0}'. Valid local container registry
+          types are {1}.</source>
         <target state="translated">CONTAINER2002: 不明的本機登錄類型 '{0}'。有效的本機容器註冊類型為 {1}。</target>
         <note>{StrBegin="CONTAINER2002: "}</note>
       </trans-unit>
       <trans-unit id="UnknownMediaType">
-        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.</source>
-        <target state="translated">CONTAINER2003: 來自登錄 {2} 用於 {0}:{1} 的資訊清單是未知的類型: {3}。請使用此訊息在 https://github.com/dotnet/sdk-container-builds/issues 提出問題。</target>
+        <source>CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}.
+          Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this
+          message.</source>
+        <target state="translated">CONTAINER2003: 來自登錄 {2} 用於 {0}:{1} 的資訊清單是未知的類型: {3}。請使用此訊息在
+          https://github.com/dotnet/sdk-container-builds/issues 提出問題。</target>
         <note>{StrBegin="CONTAINER2003: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedMediaType">

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -52,7 +52,7 @@ public class CreateNewImageTests
         task.BaseImageTag = "7.0";
 
         task.OutputRegistry = "localhost:5010";
-        task.LocalRegistry = "Docker";
+        task.LocalRegistry = DockerAvailableFactAttribute.LocalRegistry;
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-arm64", "publish");
         task.Repository = "dotnet/create-new-image-baseline";
         task.ImageTags = new[] { "latest" };
@@ -197,7 +197,7 @@ public class CreateNewImageTests
         cni.ContainerEnvironmentVariables = pcp.NewContainerEnvironmentVariables;
         cni.ContainerRuntimeIdentifier = "linux-x64";
         cni.RuntimeIdentifierGraphPath = ToolsetUtils.GetRuntimeGraphFilePath();
-        cni.LocalRegistry = global::Microsoft.NET.Build.Containers.KnownLocalRegistryTypes.Docker;
+        cni.LocalRegistry = DockerAvailableFactAttribute.LocalRegistry;
 
         Assert.True(cni.Execute(), FormatBuildMessages(errors));
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchInlineData.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchInlineData.cs
@@ -13,7 +13,7 @@ public class DockerSupportsArchInlineData : DataAttribute
     private static string[] LinuxPlatforms = GetSupportedLinuxPlatforms();
 
     // another optimization - daemons don't switch types easily or quickly, so this is as good as static
-    private static bool IsWindowsDaemon = GetIsWindowsDaemon();
+    private static bool IsWindowsDockerDaemon = GetIsWindowsDockerDaemon();
 
     private readonly string _arch;
     private readonly object[] _data;
@@ -41,7 +41,7 @@ public class DockerSupportsArchInlineData : DataAttribute
         }
         else
         {
-            if (IsWindowsDaemon && arch.StartsWith("windows", StringComparison.OrdinalIgnoreCase))
+            if (IsWindowsDockerDaemon && arch.StartsWith("windows", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -68,11 +68,15 @@ public class DockerSupportsArchInlineData : DataAttribute
         }
     }
 
-    private static bool GetIsWindowsDaemon()
+    private static bool GetIsWindowsDockerDaemon()
     {
+        if (ContainerCli.IsPodman)
+        {
+            return false;
+        }
         // the config json has an OSType property that is either "linux" or "windows" -
         // we can't use this for linux arch detection because that isn't enough information.
-        var config = DockerCli.GetConfig();
+        var config = DockerCli.GetDockerConfig();
         if (config.RootElement.TryGetProperty("OSType", out JsonElement osTypeProperty))
         {
             return osTypeProperty.GetString() == "windows";

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerAvailableUtils.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerAvailableUtils.cs
@@ -5,6 +5,8 @@ namespace Microsoft.NET.Build.Containers.UnitTests;
 
 public class DockerAvailableTheoryAttribute : TheoryAttribute
 {
+    public static string LocalRegistry => DockerCliStatus.LocalRegistry;
+
     public DockerAvailableTheoryAttribute(bool skipPodman = false)
     {
         if (!DockerCliStatus.IsAvailable)
@@ -21,6 +23,8 @@ public class DockerAvailableTheoryAttribute : TheoryAttribute
 
 public class DockerAvailableFactAttribute : FactAttribute
 {
+    public static string LocalRegistry => DockerCliStatus.LocalRegistry;
+
     public DockerAvailableFactAttribute(bool skipPodman = false)
     {
         if (!DockerCliStatus.IsAvailable)
@@ -41,6 +45,9 @@ file static class DockerCliStatus
 {
     public static readonly bool IsAvailable;
     public static readonly string? Command;
+    public static string LocalRegistry
+        => Command == DockerCli.PodmanCommand ? KnownLocalRegistryTypes.Podman
+                                              : KnownLocalRegistryTypes.Docker;
 
     static DockerCliStatus()
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/494

There was an assumption that both docker and podman wouldn't be installed at the same time (or if they were, the docker binary was actually an alias to the podman binary). This PR changes the logic to prefer docker when both are present (and the `docker` binary isn't just an alias to the podman binary), which should restore behavior from earlier previews.