### PR TITLE
Expose CallCountThreshold and CallCountingDelayMs config knobs

### DIFF
--- a/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -35,6 +35,8 @@
     <TieredCompilation>true</TieredCompilation>
     <TieredCompilationQuickJit>true</TieredCompilationQuickJit>
     <TieredCompilationQuickJitForLoops>true</TieredCompilationQuickJitForLoops>
+    <TieredCompilationCallCountThreshold>30</TieredCompilationCallCountThreshold>
+    <TieredCompilationCallCountingDelayMs>100</TieredCompilationCallCountingDelayMs>
     <TieredPGO>true</TieredPGO>
     <StartupHookSupport>false</StartupHookSupport>
     <EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -612,6 +612,14 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Condition="'$(TieredCompilationQuickJitForLoops)' != ''"
                                     Value="$(TieredCompilationQuickJitForLoops)" />
 
+    <RuntimeHostConfigurationOption Include="System.Runtime.TieredCompilation.CallCountThreshold"
+                                    Condition="'$(TieredCompilationCallCountThreshold)' != ''"
+                                    Value="$(TieredCompilationCallCountThreshold)" />
+
+    <RuntimeHostConfigurationOption Include="System.Runtime.TieredCompilation.CallCountingDelayMs"
+                                    Condition="'$(TieredCompilationCallCountingDelayMs)' != ''"
+                                    Value="$(TieredCompilationCallCountingDelayMs)" />
+
     <RuntimeHostConfigurationOption Include="System.Runtime.TieredPGO"
                                     Condition="'$(TieredPGO)' != ''"
                                     Value="$(TieredPGO)" />

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -80,6 +80,8 @@ namespace Microsoft.NET.Publish.Tests
             ""System.Runtime.TieredCompilation"": true,
             ""System.Runtime.TieredCompilation.QuickJit"": true,
             ""System.Runtime.TieredCompilation.QuickJitForLoops"": true,
+            ""System.Runtime.TieredCompilation.CallCountThreshold"": 30,
+            ""System.Runtime.TieredCompilation.CallCountingDelayMs"": 100,
             ""System.Runtime.TieredPGO"": true,
             ""System.StartupHookProvider.IsSupported"": false,
             ""System.Text.Encoding.EnableUnsafeUTF7Encoding"": false,


### PR DESCRIPTION
This PR exposes `System.Runtime.TieredCompilation.CallCountThreshold` and `System.Runtime.TieredCompilation.CallCountingDelayMs` config knobs as public properties.

With .NET 8.0 we ship Dynamic PGO enabled by default and these knobs are designed to potentially mitigate some startup issues users might encounter. Also, this was requested by an internal customer.