### PR TITLE
Allow ArtifactsPath telemetry to flow

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.Tools.MSBuild
         internal const string SelfContainedTelemetryPropertyKey = "SelfContained";
         internal const string UseApphostTelemetryPropertyKey = "UseApphost";
         internal const string OutputTypeTelemetryPropertyKey = "OutputType";
+        internal const string UseArtifactsOutputTelemetryPropertyKey = "UseArtifactsOutput";
+        internal const string ArtifactsPathLocationTypeTelemetryPropertyKey = "ArtifactsPathLocationType";
 
         public MSBuildLogger()
         {
@@ -99,7 +101,9 @@ namespace Microsoft.DotNet.Tools.MSBuild
                             RuntimeIdentifierTelemetryPropertyKey,
                             SelfContainedTelemetryPropertyKey,
                             UseApphostTelemetryPropertyKey,
-                            OutputTypeTelemetryPropertyKey
+                            OutputTypeTelemetryPropertyKey,
+                            UseArtifactsOutputTelemetryPropertyKey,
+                            ArtifactsPathLocationTypeTelemetryPropertyKey
                         })
                         {
                             if (args.Properties.TryGetValue(key, out string value))


### PR DESCRIPTION
This is the same as https://github.com/dotnet/sdk/pull/34660, which was approved but we didn't find a way to make it into RC1 with.