### PR TITLE
Change containers publish target to require IsPublishable (and explicit SDK Container support)

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -189,7 +189,7 @@
     </PublishContainerDependsOn>
   </PropertyGroup>
 
-  <Target Name="PublishContainer" DependsOnTargets="$(PublishContainerDependsOn)">
+  <Target Name="PublishContainer" DependsOnTargets="$(PublishContainerDependsOn)" Condition="'$(EnableSdkContainerSupport)' == 'true' and '$(IsPublishable)' == 'true'">
 
     <PropertyGroup Condition="'$(DOTNET_HOST_PATH)' == ''">
       <DotNetHostDirectory>$(NetCoreRoot)</DotNetHostDirectory>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -189,7 +189,10 @@
     </PublishContainerDependsOn>
   </PropertyGroup>
 
-  <Target Name="PublishContainer" DependsOnTargets="$(PublishContainerDependsOn)" Condition="'$(EnableSdkContainerSupport)' == 'true' and '$(IsPublishable)' == 'true'">
+  <!-- TODO: change this comparison from IsPublishing != false to IsPublishing == true when console apps Import the Publish SDK -->
+  <Target Name="PublishContainer"
+    DependsOnTargets="$(PublishContainerDependsOn)"
+    Condition="'$(EnableSdkContainerSupport)' == 'true' and '$(IsPublishable)' != 'false'">
 
     <PropertyGroup Condition="'$(DOTNET_HOST_PATH)' == ''">
       <DotNetHostDirectory>$(NetCoreRoot)</DotNetHostDirectory>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -189,10 +189,10 @@
     </PublishContainerDependsOn>
   </PropertyGroup>
 
-  <!-- TODO: change this comparison from IsPublishing != false to IsPublishing == true when console apps Import the Publish SDK -->
+  <!-- TODO: change this comparison to include $(EnableSdkContainerSupport) == true when console apps Import the Publish SDK -->
   <Target Name="PublishContainer"
     DependsOnTargets="$(PublishContainerDependsOn)"
-    Condition="'$(EnableSdkContainerSupport)' == 'true' and '$(IsPublishable)' != 'false'">
+    Condition="'$(IsPublishable)' == 'true'">
 
     <PropertyGroup Condition="'$(DOTNET_HOST_PATH)' == ''">
       <DotNetHostDirectory>$(NetCoreRoot)</DotNetHostDirectory>


### PR DESCRIPTION
Closes https://github.com/dotnet/sdk-container-builds/issues/464

This change brings containers in line with other publish outputs in respecting user opt outs for this property.