### PR TITLE
Added JavaScript import after

### DIFF
--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.JavaScript.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.JavaScript.targets
@@ -1,0 +1,11 @@
+﻿<Project>
+
+  <Target Name="IgnoreJavaScriptOutputAssembly" BeforeTargets="AssignProjectConfiguration">
+      <ItemGroup>
+        <ProjectReference Condition="'%(Extension)' == '.esproj'">
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        </ProjectReference>
+      </ItemGroup>
+  </Target>
+
+</Project>


### PR DESCRIPTION
Esprojs may be referenced by ASP.Net projects (or others). When this happens, the .net project will have to not reference output assembly on the esproj, because there is no output assembly. This targets file provides that behavior.