### PR TITLE
[release/8.0.1xx] Validate this extension methods and member types in APICompat

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddAbstractMember.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddAbstractMember.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         leftMetadata,
                         rightMetadata,
                         DiagnosticIds.CannotAddAbstractMember,
-                        string.Format(Resources.CannotAddAbstractMember, right.ToDisplayString(), rightMetadata, leftMetadata),
+                        string.Format(Resources.CannotAddAbstractMember, right.ToDisplayString(SymbolExtensions.DisplayFormat), rightMetadata, leftMetadata),
                         DifferenceType.Added,
                         right));
                 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddMemberToInterface.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiSymbolExtensions;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
@@ -39,7 +40,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         leftMetadata,
                         rightMetadata,
                         DiagnosticIds.CannotAddMemberToInterface,
-                        string.Format(Resources.CannotAddMemberToInterface, right.ToDisplayString(), rightMetadata, leftMetadata),
+                        string.Format(Resources.CannotAddMemberToInterface, right.ToDisplayString(SymbolExtensions.DisplayFormat), rightMetadata, leftMetadata),
                         DifferenceType.Added,
                         right));
                 }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotRemoveBaseTypeOrInterface.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotRemoveBaseTypeOrInterface.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 leftMetadata,
                 rightMetadata,
                 DiagnosticIds.CannotRemoveBaseType,
-                string.Format(Resources.CannotRemoveBaseType, left.ToDisplayString(), leftBaseType.ToDisplayString(), rightName, leftName),
+                string.Format(Resources.CannotRemoveBaseType, left.ToDisplayString(SymbolExtensions.DisplayFormat), leftBaseType.ToDisplayString(SymbolExtensions.DisplayFormat), rightName, leftName),
                 DifferenceType.Changed,
                 right));
         }
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         leftMetadata,
                         rightMetadata,
                         DiagnosticIds.CannotRemoveBaseInterface,
-                        string.Format(Resources.CannotRemoveBaseInterface, left.ToDisplayString(), leftInterface.ToDisplayString(), rightName, leftName),
+                        string.Format(Resources.CannotRemoveBaseInterface, left.ToDisplayString(SymbolExtensions.DisplayFormat), leftInterface.ToDisplayString(SymbolExtensions.DisplayFormat), rightName, leftName),
                         DifferenceType.Changed,
                         right));
                     return;

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotSealType.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotSealType.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     leftMetadata,
                     rightMetadata,
                     DiagnosticIds.CannotSealType,
-                    string.Format(GetResourceStringForTypeState(right), right.ToDisplayString(), rightMetadata, leftMetadata),
+                    string.Format(GetResourceStringForTypeState(right), right.ToDisplayString(SymbolExtensions.DisplayFormat), rightMetadata, leftMetadata),
                     DifferenceType.Changed,
                     right));
             }
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     leftMetadata,
                     rightMetadata,
                     DiagnosticIds.CannotSealType,
-                    string.Format(GetResourceStringForTypeState(left), left.ToDisplayString(), leftMetadata, rightMetadata),
+                    string.Format(GetResourceStringForTypeState(left), left.ToDisplayString(SymbolExtensions.DisplayFormat), leftMetadata, rightMetadata),
                     DifferenceType.Changed,
                     left));
             }

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     leftMetadata,
                     rightMetadata,
                     DiagnosticIds.TypeMustExist,
-                    string.Format(Resources.TypeMissingOnSide, left.ToDisplayString(), leftMetadata, rightMetadata),
+                    string.Format(Resources.TypeMissingOnSide, left.ToDisplayString(SymbolExtensions.DisplayFormat), leftMetadata, rightMetadata),
                     DifferenceType.Removed,
                     left));
             }
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     leftMetadata,
                     rightMetadata,
                     DiagnosticIds.TypeMustExist,
-                    string.Format(Resources.TypeMissingOnSide, right.ToDisplayString(), rightMetadata, leftMetadata),
+                    string.Format(Resources.TypeMissingOnSide, right.ToDisplayString(SymbolExtensions.DisplayFormat), rightMetadata, leftMetadata),
                     DifferenceType.Added,
                     right));
             }
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         leftMetadata,
                         rightMetadata,
                         DiagnosticIds.MemberMustExist,
-                        string.Format(Resources.MemberExistsOnLeft, left.ToDisplayString(), leftMetadata, rightMetadata),
+                        string.Format(Resources.MemberExistsOnLeft, left.ToDisplayString(SymbolExtensions.DisplayFormat), leftMetadata, rightMetadata),
                         DifferenceType.Removed,
                         left));
                 }
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         leftMetadata,
                         rightMetadata,
                         DiagnosticIds.MemberMustExist,
-                        string.Format(Resources.MemberExistsOnRight, right.ToDisplayString(), leftMetadata, rightMetadata),
+                        string.Format(Resources.MemberExistsOnRight, right.ToDisplayString(SymbolExtensions.DisplayFormat), leftMetadata, rightMetadata),
                         DifferenceType.Added,
                         right));
                 }

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         {
             // This is the default format for symbol.ToDisplayString;
             SymbolDisplayFormat format = SymbolDisplayFormat.CSharpErrorMessageFormat;
+            format = format.WithMemberOptions(format.MemberOptions | SymbolDisplayMemberOptions.IncludeType);
 
             DisplayFormat = format.WithParameterOptions(format.ParameterOptions | SymbolDisplayParameterOptions.IncludeExtensionThis);
 

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
@@ -7,12 +7,15 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
 {
     public static class SymbolExtensions
     {
-        public static SymbolDisplayFormat Format { get; } = GetSymbolDisplayFormat();
+        private static readonly SymbolDisplayFormat s_comparisonFormat;
+        public static readonly SymbolDisplayFormat DisplayFormat;
 
-        public static SymbolDisplayFormat GetSymbolDisplayFormat()
+        static SymbolExtensions()
         {
             // This is the default format for symbol.ToDisplayString;
             SymbolDisplayFormat format = SymbolDisplayFormat.CSharpErrorMessageFormat;
+
+            DisplayFormat = format.WithParameterOptions(format.ParameterOptions | SymbolDisplayParameterOptions.IncludeExtensionThis);
 
             // Remove ? annotations from reference types as we want to map the APIs without nullable annotations
             // and have a special rule to catch those differences.
@@ -24,11 +27,11 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
                 ~SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
 
             // Remove ref/out from parameters to compare APIs when building the mappers.
-            return format.WithParameterOptions(format.ParameterOptions & ~SymbolDisplayParameterOptions.IncludeParamsRefOut);
+            s_comparisonFormat = format.WithParameterOptions((format.ParameterOptions | SymbolDisplayParameterOptions.IncludeExtensionThis) & ~SymbolDisplayParameterOptions.IncludeParamsRefOut);
         }
 
         public static string ToComparisonDisplayString(this ISymbol symbol) =>
-            symbol.ToDisplayString(Format)
+            symbol.ToDisplayString(s_comparisonFormat)
                   .Replace("System.IntPtr", "nint") // Treat IntPtr and nint as the same
                   .Replace("System.UIntPtr", "nuint"); // Treat UIntPtr and nuint as the same
 

--- a/src/Tests/Microsoft.DotNet.ApiCompat.IntegrationTests/CompatibleFrameworkInPackageValidatorIntegrationTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompat.IntegrationTests/CompatibleFrameworkInPackageValidatorIntegrationTests.cs
@@ -64,7 +64,7 @@ namespace PackageValidationTests
             Assert.NotEmpty(log.errors);
             // TODO: add asserts for assembly and header metadata.
             string assemblyName = $"{asset.TestProject.Name}.dll";
-            Assert.Contains($"CP0002 Member 'PackageValidationTests.First.test(string)' exists on lib/netstandard2.0/{assemblyName} but not on lib/{ToolsetInfo.CurrentTargetFramework}/{assemblyName}", log.errors);
+            Assert.Contains($"CP0002 Member 'void PackageValidationTests.First.test(string)' exists on lib/netstandard2.0/{assemblyName} but not on lib/{ToolsetInfo.CurrentTargetFramework}/{assemblyName}", log.errors);
         }
 
         [Fact]
@@ -105,8 +105,8 @@ namespace PackageValidationTests
             Assert.NotEmpty(log.errors);
             string assemblyName = $"{asset.TestProject.Name}.dll";
             // TODO: add asserts for assembly and header metadata.
-            Assert.Contains($"CP0002 Member 'PackageValidationTests.First.test(string)' exists on lib/netstandard2.0/{assemblyName} but not on lib/netcoreapp3.1/{assemblyName}", log.errors);
-            Assert.Contains($"CP0002 Member 'PackageValidationTests.First.test(bool)' exists on lib/netcoreapp3.1/{assemblyName} but not on lib/{ToolsetInfo.CurrentTargetFramework}/{assemblyName}", log.errors);
+            Assert.Contains($"CP0002 Member 'void PackageValidationTests.First.test(string)' exists on lib/netstandard2.0/{assemblyName} but not on lib/netcoreapp3.1/{assemblyName}", log.errors);
+            Assert.Contains($"CP0002 Member 'void PackageValidationTests.First.test(bool)' exists on lib/netcoreapp3.1/{assemblyName} but not on lib/{ToolsetInfo.CurrentTargetFramework}/{assemblyName}", log.errors);
         }
     }
 }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
@@ -497,5 +497,39 @@ namespace CompatTests
 
             Assert.Empty(differences);
         }
+
+        [Fact]
+        public void ThisExtensionMethodModifierRemovalFlagged()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public static class First
+  {
+    public static void F(this string s) {}
+  }
+}
+";
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public static class First
+  {
+    public static void F(string s) {}
+  }
+}
+";
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new(s_ruleFactory);
+
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
+
+            Assert.Equal(new[]
+            {
+                // The call to GetDocumentationCommentId doesn't return a string that includes the "this" keyword.
+                CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.F(System.String)")
+            }, differences);
+        }
     }
 }


### PR DESCRIPTION
Backport of d0a4bf1daed3d04e95c48a6b0b9c3287dea2daf9 and 6fad359f6c2f34d2afc18c9db7d3ff2f2ad773dc

### Customer Impact
Customers use APICompat / PackageValidation to validate their public API changes. While we already have a large set of compatibility rules, we were missing two major cases: a) member type validation (i.e. `public string a` -> `public bool a` which is a breaking change) and b) the "this" modifier for extension methods (`public static void ExtMethod(this string a)` -> `public static void ExtMethod(string a)` which also is a breaking change).

By taking this change, we increase our customer's confidence in our shipping tooling by validating these two common scenarios. This was reported by a customer and by dotnet/runtime folks.

### Testing
Tests were added for both scenarios and they are running in CI. I also tested the changes in dotnet/runtime manually and its main branch already uses an APICompat version with these changes.

### Risk
Low to Medium. Existing scenarios are validated by tests. In general, new validation in APICompat is considered a breaking change as customers need to react to those. But that's exactly the reason why customers use APICompat as they want their API changes to be validated and APICompat to error out for incompatible changes.