### PR TITLE
Fix possible NullReferenceException due to &/&& typo

### DIFF
--- a/src/WebSdk/Publish/Tasks/MsDeploy/CommonUtility.cs
+++ b/src/WebSdk/Publish/Tasks/MsDeploy/CommonUtility.cs
@@ -650,7 +650,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         {
             if (string.IsNullOrEmpty(quote))
             {
-                if (value != null & value.IndexOfAny(s_specialCharactersForCmd) >= 0)
+                if (value != null && value.IndexOfAny(s_specialCharactersForCmd) >= 0)
                 {
                     // any command line special characters, we use doubld quote by default
                     quote = "\"";


### PR DESCRIPTION
I was looking for usages of `bool operator&(bool, bool)` in a few codebases and noticed a possible bug here. I didn't investigate in-depth (e.g. to see if `value` could ever actually be `null` here.)