### PR TITLE
Fix workload info

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Cli
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, IWorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null)
         {
-            if(workloadInfoHelper != null)
+            if (workloadInfoHelper != null)
             {
                 workloadInfoHelper ??= new WorkloadInfoHelper(parseResult != null ? parseResult.HasOption(SharedOptions.InteractiveOption) : false);
             }
@@ -43,13 +43,13 @@ namespace Microsoft.DotNet.Cli
             reporter ??= Cli.Utils.Reporter.Output;
             string dotnetPath = dotnetDir ?? Path.GetDirectoryName(Environment.ProcessPath);
 
-            if (!installedList.Any())
+            if (installedWorkloads.Count == 0)
             {
                 reporter.WriteLine(CommonStrings.NoWorkloadsInstalledInfoWarning);
                 return;
             }
 
-            var manifestInfoDict =  workloadInfoHelper.WorkloadResolver.GetInstalledManifests().ToDictionary(info => info.Id, StringComparer.OrdinalIgnoreCase);
+            var manifestInfoDict = workloadInfoHelper.WorkloadResolver.GetInstalledManifests().ToDictionary(info => info.Id, StringComparer.OrdinalIgnoreCase);
 
             foreach (var workload in installedWorkloads.AsEnumerable())
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/list/InstalledWorkloadsCollection.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/InstalledWorkloadsCollection.cs
@@ -10,6 +10,11 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         private Dictionary<string, string> _workloads;
 
         /// <summary>
+        /// Gets the number of workloads in the collection.
+        /// </summary>
+        public int Count => _workloads.Count;
+
+        /// <summary>
         /// Creates a new <see cref="InstalledWorkloadsCollection"/> instance using a collection of workload IDs
         /// and a common installation source.
         /// </summary>


### PR DESCRIPTION
# Description

When workloads are installed by VS, `dotnet --info` and `dotnet workload --info` fail to display the installed workloads. Unlike list, the commands are only checking if there are workloads installed by the SDK. If so, they will then display the full set of installed workloads, including the ones from Visual Studio.

Below is from an internal build of VS with RC1:

`dotnet --info`

![image](https://github.com/dotnet/sdk/assets/7409981/ed1c976e-ec45-480e-a542-f9f827d77a8e)

`dotnet workload list`

![image](https://github.com/dotnet/sdk/assets/7409981/9083bdb9-7ece-4593-942a-5909e0c6a60b)

