### PR TITLE
Enable interceptors feature when ConfigurationBindingGenerator is enabled

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -31,6 +31,28 @@ namespace Microsoft.NET.Build.Tests
             VerifyInterceptorsFeatureEnabled(asset, isEnabled);
         }
 
+        [Theory]
+        [InlineData("WebApp", false)]
+        [InlineData("WebApp", true)]
+        [InlineData("WebApp", null)]
+        public void It_resolves_configbindinggenerator_correctly(string testAssetName, bool? isEnabled)
+        {
+            var asset = _testAssetsManager
+                .CopyTestAsset(testAssetName, identifier: isEnabled.ToString())
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    if (isEnabled != null)
+                    {
+                        var ns = project.Root.Name.Namespace;
+                        project.Root.Add(new XElement(ns + "PropertyGroup", new XElement("EnableConfigurationBindingGenerator", isEnabled)));
+                    }
+                });
+
+            VerifyConfigBindingGeneratorIsUsed(asset, isEnabled);
+            VerifyInterceptorsFeatureEnabled(asset, isEnabled);
+        }
+
         [Fact]
         public void It_enables_requestdelegategenerator_and_configbindinggenerator_for_PublishAot()
         {

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -59,8 +59,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableConfigurationBindingGenerator Condition="'$(EnableConfigurationBindingGenerator)' == ''">true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 
-  <!-- Enable the interceptors compiler feature by default for projects that use the RequestDelegateGenerator. -->
-  <PropertyGroup Condition="'$(EnableRequestDelegateGenerator)' == 'true'">
+  <!-- Enable the interceptors compiler feature by default for projects that use the RequestDelegateGenerator or the ConfigurationBindingGenerator. -->
+  <PropertyGroup Condition="'$(EnableRequestDelegateGenerator)' == 'true' Or '$(EnableConfigurationBindingGenerator)' == 'true'">
     <Features>$(Features);InterceptorsPreview</Features>
   </PropertyGroup>
 


### PR DESCRIPTION
Porting https://github.com/dotnet/sdk/pull/34840 to RC-2. Ideally should be merged to RC-2 before https://github.com/dotnet/sdk/pull/35024, so that git history shows the right progression of the feature & to include the unit test for config binding.