### PR TITLE
Container Build: Handle multiple tags wtihin one image

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -43,11 +43,11 @@ public static class ContainerBuilder
 
         bool isLocalPull = string.IsNullOrEmpty(baseRegistry);
         Registry? sourceRegistry = isLocalPull ? null : new Registry(baseRegistry, logger);
-        ImageReference sourceImageReference = new(sourceRegistry, baseImageName, baseImageTag);
+        SourceImageReference sourceImageReference = new(sourceRegistry, baseImageName, baseImageTag);
 
         bool isLocalPush = string.IsNullOrEmpty(outputRegistry);
         Registry? destinationRegistry = isLocalPush ? null : new Registry(outputRegistry!, logger);
-        IEnumerable<ImageReference> destinationImageReferences = imageTags.Select(t => new ImageReference(destinationRegistry, imageName, t));
+        DestinationImageReference destinationImageReference = new DestinationImageReference(destinationRegistry, imageName, imageTags);
 
         ImageBuilder? imageBuilder;
         if (sourceRegistry is { } registry)
@@ -120,47 +120,44 @@ public static class ContainerBuilder
         BuiltImage builtImage = imageBuilder.Build();
         cancellationToken.ThrowIfCancellationRequested();
 
-        foreach (ImageReference destinationImageReference in destinationImageReferences)
+        if (isLocalPush)
         {
-            if (isLocalPush)
+            ILocalRegistry containerRegistry = KnownLocalRegistryTypes.CreateLocalRegistry(localRegistry, loggerFactory);
+            if (!(await containerRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
             {
-                ILocalRegistry containerRegistry = KnownLocalRegistryTypes.CreateLocalRegistry(localRegistry, loggerFactory);
-                if (!(await containerRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
-                {
-                    Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.LocalRegistryNotAvailable)));
-                    return 7;
-                }
+                Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.LocalRegistryNotAvailable)));
+                return 7;
+            }
 
-                try
+            try
+            {
+                await containerRegistry.LoadAsync(builtImage, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
+                logger.LogInformation(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.RegistryOutputPushFailed), ex.Message));
+                return 1;
+            }
+        }
+        else
+        {
+            try
+            {
+                if (destinationImageReference.Registry is not null)
                 {
-                    await containerRegistry.LoadAsync(builtImage, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
-                    logger.LogInformation(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference.RepositoryAndTag);
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.RegistryOutputPushFailed), ex.Message));
-                    return 1;
+                    await (destinationImageReference.Registry.PushAsync(
+                        builtImage,
+                        sourceImageReference,
+                        destinationImageReference,
+                        cancellationToken)).ConfigureAwait(false);
+                    logger.LogInformation(Strings.ContainerBuilder_ImageUploadedToRegistry, destinationImageReference, destinationImageReference.Registry.RegistryName);
                 }
             }
-            else
+            catch (Exception e)
             {
-                try
-                {
-                    if (destinationImageReference.Registry is not null)
-                    {
-                        await (destinationImageReference.Registry.PushAsync(
-                            builtImage,
-                            sourceImageReference,
-                            destinationImageReference,
-                            cancellationToken)).ConfigureAwait(false);
-                        logger.LogInformation(Strings.ContainerBuilder_ImageUploadedToRegistry, destinationImageReference.RepositoryAndTag, destinationImageReference.Registry.RegistryName);
-                    }
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.RegistryOutputPushFailed), e.Message));
-                    return 1;
-                }
+                Console.WriteLine(DiagnosticMessage.ErrorFromResourceWithCode(nameof(Strings.RegistryOutputPushFailed), e.Message));
+                return 1;
             }
         }
         return 0;

--- a/src/Containers/Microsoft.NET.Build.Containers/DestinationImageReference.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/DestinationImageReference.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Build.Containers;
+
+/// <summary>
+/// Represents a push destination reference to a Docker image.
+/// A push destination reference is made of a registry, a repository (aka the image name) and multiple tags.
+/// (unlike the <see cref="SourceImageReference"/> which has a single tag)
+/// </summary>
+internal readonly record struct DestinationImageReference(Registry? Registry, string Repository, string[] Tags)
+{
+    public override string ToString()
+    {
+        string tagList = string.Join(", ", Tags);
+        if (Registry is { } reg)
+        {
+            return $"{reg.RegistryName}/{Repository}:{tagList}";
+        }
+        else
+        {
+            return $"{Repository}:{tagList}";
+        }
+    }
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -57,7 +57,7 @@ internal sealed class DockerCli : ILocalRegistry
         return command;
     }
 
-    public async Task LoadAsync(BuiltImage image, ImageReference sourceReference, ImageReference destinationReference, CancellationToken cancellationToken)
+    public async Task LoadAsync(BuiltImage image, SourceImageReference sourceReference, DestinationImageReference destinationReference, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         string dockerPath = FindFullPathFromPath("docker") ?? "docker";
@@ -196,7 +196,7 @@ internal sealed class DockerCli : ILocalRegistry
 
     private static void Proc_OutputDataReceived(object sender, DataReceivedEventArgs e) => throw new NotImplementedException();
 
-    private static async Task WriteImageToStreamAsync(BuiltImage image, ImageReference sourceReference, ImageReference destinationReference, Stream imageStream, CancellationToken cancellationToken)
+    private static async Task WriteImageToStreamAsync(BuiltImage image, SourceImageReference sourceReference, DestinationImageReference destinationReference, Stream imageStream, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         using TarWriter writer = new(imageStream, TarEntryFormat.Pax, leaveOpen: true);
@@ -241,10 +241,11 @@ internal sealed class DockerCli : ILocalRegistry
         }
 
         // Add manifest
-        JsonArray tagsNode = new()
+        JsonArray tagsNode = new();
+        foreach (string tag in destinationReference.Tags)
         {
-            destinationReference.RepositoryAndTag
-        };
+            tagsNode.Add($"{destinationReference.Repository}:{tag}");
+        }
 
         JsonNode manifestNode = new JsonArray(new JsonObject
         {

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalRegistry.cs
@@ -11,7 +11,7 @@ internal interface ILocalRegistry {
     /// <summary>
     /// Loads an image (presumably from a tarball) into the local registry.
     /// </summary>
-    public Task LoadAsync(BuiltImage image, ImageReference sourceReference, ImageReference destinationReference, CancellationToken cancellationToken);
+    public Task LoadAsync(BuiltImage image, SourceImageReference sourceReference, DestinationImageReference destinationReference, CancellationToken cancellationToken);
 
     /// <summary>
     /// Checks to see if the local registry is available. This is used to give nice errors to the user.

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -361,7 +361,7 @@ internal sealed class Registry
 
     }
 
-    public async Task PushAsync(BuiltImage builtImage, ImageReference source, ImageReference destination, CancellationToken cancellationToken)
+    public async Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         Registry destinationRegistry = destination.Registry!;
@@ -425,8 +425,11 @@ internal sealed class Registry
         _logger.LogInformation(Strings.Registry_ManifestUploaded, RegistryName);
 
         //tag upload
-        _logger.LogInformation(Strings.Registry_TagUploadStarted, destination.Tag, RegistryName);
-        await _registryAPI.Manifest.PutAsync(destination.Repository, destination.Tag, builtImage.Manifest, cancellationToken).ConfigureAwait(false);
-        _logger.LogInformation(Strings.Registry_TagUploaded, destination.Tag, RegistryName);
+        foreach (string tag in destination.Tags)
+        {
+            _logger.LogInformation(Strings.Registry_TagUploadStarted, tag, RegistryName);
+            await _registryAPI.Manifest.PutAsync(destination.Repository, tag, builtImage.Manifest, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(Strings.Registry_TagUploaded, tag, RegistryName);
+        }
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/SourceImageReference.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/SourceImageReference.cs
@@ -6,12 +6,16 @@ namespace Microsoft.NET.Build.Containers;
 /// <summary>
 /// Represents a reference to a Docker image. A reference is made of a registry, a repository (aka the image name) and a tag.
 /// </summary>
-internal readonly record struct ImageReference(Registry? Registry, string Repository, string Tag) {
+internal readonly record struct SourceImageReference(Registry? Registry, string Repository, string Tag)
+{
     public override string ToString()
     {
-        if (Registry is { } reg) {
+        if (Registry is { } reg) 
+        {
             return $"{reg.RegistryName}/{Repository}:{Tag}";
-        } else {
+        } 
+        else 
+        {
             return RepositoryAndTag;
         }
     }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -239,8 +239,8 @@ public class CreateNewImageTests
 
         BuiltImage builtImage = imageBuilder.Build();
 
-        var sourceReference = new ImageReference(registry, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net8PreviewImageTag);
-        var destinationReference = new ImageReference(registry, RootlessBase, "latest");
+        var sourceReference = new SourceImageReference(registry, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net8PreviewImageTag);
+        var destinationReference = new DestinationImageReference(registry, RootlessBase, new[] { "latest" });
 
         await registry.PushAsync(builtImage, sourceReference, destinationReference, cancellationToken: default).ConfigureAwait(false);
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
@@ -77,8 +77,8 @@ public class DockerRegistryTests
             var ridgraphfile = ToolsetUtils.GetRuntimeGraphFilePath();
             Registry mcr = new Registry(DockerRegistryManager.BaseImageSource, logger);
 
-            var sourceImage = new ImageReference(mcr, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net6ImageTag);
-            var destinationImage = new ImageReference(localAuthed, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net6ImageTag);
+            var sourceImage = new SourceImageReference(mcr, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net6ImageTag);
+            var destinationImage = new DestinationImageReference(localAuthed, DockerRegistryManager.RuntimeBaseImage,new[] { DockerRegistryManager.Net6ImageTag });
             ImageBuilder? downloadedImage = await mcr.GetImageManifestAsync(
                 DockerRegistryManager.RuntimeBaseImage,
                 DockerRegistryManager.Net6ImageTag,


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/379 

Main changes: 

- Split of `ImageReference` into `SourceImageReference` (single tag) and `DestinationImageReference` (multiple tags)
- Extension of remote registry push to push the manifest for each tag
- Extension of local docker registry implementation to contain all tags in one `manifest.json`
- Extended EndToEndTests to use multiple tags to verify functionality.