### PR TITLE
Update Verify.Xunit package version

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <!--Test dependencies-->
-    <PackageVersion Include="Verify.Xunit" Version="20.4.0" />
+    <PackageVersion Include="Verify.Xunit" Version="21.0.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="2.2.1" />
     <PackageVersion Include="FakeItEasy" Version="7.4.0" />
     <PackageVersion Include="Wcwidth.Sources" Version="1.0.0" />

--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -8,10 +8,18 @@
     <IsUnitTestProject>true</IsUnitTestProject>
     <EnableStyleCopAnalyzer>true</EnableStyleCopAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- NU1608: Disable dependency constraints. Make packages referenced by the project directly rather than packages from other sources. -->
+    <!-- NETSDK1023: Disable implicit reference so that packages can be referenced in the project. -->
+    <NoWarn>$(NoWarn);NU1608;NETSDK1023</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="TemplateInstallTests/TestTemplates/**/*" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.core" VersionOverride="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
+++ b/src/Tests/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
@@ -8,6 +8,10 @@
     <Nullable>enable</Nullable>
     <EnableStyleCopAnalyzer>true</EnableStyleCopAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- NU1608: Disable dependency constraints. Make packages referenced by the project directly rather than packages from other sources. -->
+    <!-- NETSDK1023: Disable implicit reference so that packages can be referenced in the project. -->
+    <NoWarn>$(NoWarn);NU1608;NETSDK1023</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="xunit.core" VersionOverride="2.5.0" />
     <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.6.0" VersionOverride="6.0.*" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.7.0" VersionOverride="7.0.*-*" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Web.ProjectTemplates.6.0" VersionOverride="6.0.*" GeneratePathProperty="true" />


### PR DESCRIPTION
1. Force update the xunit.core package to 2.5.0.
2. Add NU1608 and NETSDK1023 to NoWarn to avoid warnings.