### PR TITLE
Container Build: Add tar.gz (Docker Archive) file writing 

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -165,7 +165,7 @@ public static class ContainerBuilder
         try
         {
             await containerRegistry.LoadAsync(builtImage, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
-            logger.LogInformation(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference);
+            logger.LogInformation(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, containerRegistry);
         }
         catch (Exception ex)
         {

--- a/src/Containers/Microsoft.NET.Build.Containers/DestinationImageReference.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/DestinationImageReference.cs
@@ -1,25 +1,102 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Logging;
+using Microsoft.NET.Build.Containers.LocalDaemons;
+
 namespace Microsoft.NET.Build.Containers;
+
+/// <summary>
+/// Lists the different kinds of <see cref="DestinationImageReference"/> to which
+/// a container image might be pushed to.
+/// </summary>
+internal enum DestinationImageReferenceKind
+{
+    LocalRegistry,
+    RemoteRegistry
+}
 
 /// <summary>
 /// Represents a push destination reference to a Docker image.
 /// A push destination reference is made of a registry, a repository (aka the image name) and multiple tags.
 /// (unlike the <see cref="SourceImageReference"/> which has a single tag)
 /// </summary>
-internal readonly record struct DestinationImageReference(Registry? Registry, string Repository, string[] Tags)
+internal readonly record struct DestinationImageReference
 {
-    public override string ToString()
+    public DestinationImageReferenceKind Kind { get; }
+    public Registry? RemoteRegistry { get; }
+    public ILocalRegistry? LocalRegistry { get; }
+    public string Repository { get; }
+    public string[] Tags { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DestinationImageReference"/> class representing
+    /// a destination on a remote registry.
+    /// </summary>
+    /// <param name="remoteRegistry">The remote registry to push to.</param>
+    /// <param name="repository">The repository (aka. image name) at the destination.</param>
+    /// <param name="tags">The tags at the destination.</param>
+    public DestinationImageReference(Registry remoteRegistry, string repository, string[] tags)
     {
-        string tagList = string.Join(", ", Tags);
-        if (Registry is { } reg)
+        Kind = DestinationImageReferenceKind.RemoteRegistry;
+        RemoteRegistry = remoteRegistry;
+        Repository = repository;
+        Tags = tags;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DestinationImageReference"/> class representing
+    /// a destination at the local registry (e.g. docker daemon).
+    /// </summary>
+    /// <param name="localRegistry">The local registry to push to.</param>
+    /// <param name="repository">The repository (aka. image name) at the destination.</param>
+    /// <param name="tags">The tags at the destination.</param>
+    public DestinationImageReference(ILocalRegistry localRegistry, string repository, string[] tags)
+    {
+        Kind = DestinationImageReferenceKind.LocalRegistry;
+        LocalRegistry = localRegistry;
+        Repository = repository;
+        Tags = tags;
+    }
+
+
+    public static DestinationImageReference CreateFromSettings(
+        string repository,
+        string[] imageTags,
+        ILoggerFactory loggerFactory,
+        string? archiveOutputPath,
+        string? outputRegistry,
+        string? localRegistryCommand)
+    {
+        DestinationImageReference destinationImageReference;
+        if (!string.IsNullOrEmpty(archiveOutputPath))
         {
-            return $"{reg.RegistryName}/{Repository}:{tagList}";
+            destinationImageReference = new DestinationImageReference(new ArchiveFileRegistry(archiveOutputPath), repository, imageTags);
+        }
+        else if (!string.IsNullOrEmpty(outputRegistry))
+        {
+            destinationImageReference = new DestinationImageReference(new Registry(outputRegistry, loggerFactory.CreateLogger<Registry>()), repository, imageTags);
         }
         else
         {
-            return $"{Repository}:{tagList}";
+            ILocalRegistry localRegistry = KnownLocalRegistryTypes.CreateLocalRegistry(localRegistryCommand, loggerFactory);
+            destinationImageReference = new DestinationImageReference(localRegistry, repository, imageTags);
+        }
+
+        return destinationImageReference;
+    }
+
+    public override string ToString()
+    {
+        string tagList = string.Join(", ", Tags);
+        switch (Kind)
+        {
+            case DestinationImageReferenceKind.LocalRegistry:
+                return $"{LocalRegistry}/{Repository}:{tagList}";
+            case DestinationImageReferenceKind.RemoteRegistry:
+                return $"{RemoteRegistry}/{Repository}:{tagList}";
+            default:
+                return $"{Kind}/{Repository}:{tagList}";
         }
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/DestinationImageReference.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/DestinationImageReference.cs
@@ -89,14 +89,6 @@ internal readonly record struct DestinationImageReference
     public override string ToString()
     {
         string tagList = string.Join(", ", Tags);
-        switch (Kind)
-        {
-            case DestinationImageReferenceKind.LocalRegistry:
-                return $"{LocalRegistry}/{Repository}:{tagList}";
-            case DestinationImageReferenceKind.RemoteRegistry:
-                return $"{RemoteRegistry}/{Repository}:{tagList}";
-            default:
-                return $"{Kind}/{Repository}:{tagList}";
-        }
+        return $"{Repository}:{tagList}";
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
@@ -21,18 +21,16 @@ internal class ArchiveFileRegistry : ILocalRegistry
         var fullPath = Path.GetFullPath(_archiveOutputPath);
 
         // pointing to a directory? -> append default name
-        if (Directory.Exists(fullPath))
+        if (Directory.Exists(fullPath) || _archiveOutputPath.EndsWith("/"))
         {
-            fullPath = Path.Combine(fullPath, destinationReference.Repository.Length + ".tar.gz");
+            fullPath = Path.Combine(fullPath, destinationReference.Repository + ".tar.gz");
         }
-        // otherwise consider it as full path and ensure parent directory exists
-        else
+
+        // create parent directory if required.
+        var parentDirectory = Path.GetDirectoryName(fullPath);
+        if (parentDirectory != null)
         {
-            var parentDirectory = Path.GetDirectoryName(fullPath);
-            if (parentDirectory != null)
-            {
-                Directory.CreateDirectory(parentDirectory);
-            }
+            Directory.CreateDirectory(parentDirectory);
         }
 
         await using var fileStream = File.Create(fullPath);

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
@@ -2,26 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
+using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers.LocalDaemons;
 
 internal class ArchiveFileRegistry : ILocalRegistry
 {
-    private readonly string _archiveOutputPath;
+    public string ArchiveOutputPath { get; private set; }
 
     public ArchiveFileRegistry(string archiveOutputPath)
     {
-        _archiveOutputPath = archiveOutputPath;
+        ArchiveOutputPath = archiveOutputPath;
     }
 
     public async Task LoadAsync(BuiltImage image, SourceImageReference sourceReference,
         DestinationImageReference destinationReference,
         CancellationToken cancellationToken)
     {
-        var fullPath = Path.GetFullPath(_archiveOutputPath);
+        var fullPath = Path.GetFullPath(ArchiveOutputPath);
 
         // pointing to a directory? -> append default name
-        if (Directory.Exists(fullPath) || _archiveOutputPath.EndsWith("/") || _archiveOutputPath.EndsWith("\\"))
+        if (Directory.Exists(fullPath) || ArchiveOutputPath.EndsWith("/") || ArchiveOutputPath.EndsWith("\\"))
         {
             fullPath = Path.Combine(fullPath, destinationReference.Repository + ".tar.gz");
         }
@@ -33,6 +34,7 @@ internal class ArchiveFileRegistry : ILocalRegistry
             Directory.CreateDirectory(parentDirectory);
         }
 
+        ArchiveOutputPath = fullPath;
         await using var fileStream = File.Create(fullPath);
         await DockerCli.WriteImageToStreamAsync(
             image,
@@ -46,5 +48,9 @@ internal class ArchiveFileRegistry : ILocalRegistry
 
     public bool IsAvailable() => true;
 
-    public override string ToString() => "Archive File";
+
+    public override string ToString()
+    {
+        return string.Format(Strings.ArchiveRegistry_PushInfo, ArchiveOutputPath);
+    }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.NET.Build.Containers.LocalDaemons;
+
+internal class ArchiveFileRegistry : ILocalRegistry
+{
+    private readonly string _archiveOutputPath;
+
+    public ArchiveFileRegistry(string archiveOutputPath)
+    {
+        _archiveOutputPath = archiveOutputPath;
+    }
+
+    public async Task LoadAsync(BuiltImage image, SourceImageReference sourceReference,
+        DestinationImageReference destinationReference,
+        CancellationToken cancellationToken)
+    {
+        var fullPath = Path.GetFullPath(_archiveOutputPath);
+
+        // pointing to a directory? -> append default name
+        if (Directory.Exists(fullPath))
+        {
+            fullPath = Path.Combine(fullPath, destinationReference.Repository.Length + ".tar.gz");
+        }
+        // otherwise consider it as full path and ensure parent directory exists
+        else
+        {
+            var parentDirectory = Path.GetDirectoryName(fullPath);
+            if (parentDirectory != null)
+            {
+                Directory.CreateDirectory(parentDirectory);
+            }
+        }
+
+        await using var fileStream = File.Create(fullPath);
+        await DockerCli.WriteImageToStreamAsync(
+            image,
+            sourceReference,
+            destinationReference,
+            fileStream,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<bool> IsAvailableAsync(CancellationToken cancellationToken) => Task.FromResult(true);
+
+    public bool IsAvailable() => true;
+
+    public override string ToString() => "Archive File";
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
@@ -21,14 +21,14 @@ internal class ArchiveFileRegistry : ILocalRegistry
         var fullPath = Path.GetFullPath(_archiveOutputPath);
 
         // pointing to a directory? -> append default name
-        if (Directory.Exists(fullPath) || _archiveOutputPath.EndsWith("/"))
+        if (Directory.Exists(fullPath) || _archiveOutputPath.EndsWith("/") || _archiveOutputPath.EndsWith("\\"))
         {
             fullPath = Path.Combine(fullPath, destinationReference.Repository + ".tar.gz");
         }
 
         // create parent directory if required.
         var parentDirectory = Path.GetDirectoryName(fullPath);
-        if (parentDirectory != null)
+        if (parentDirectory != null && !Directory.Exists(parentDirectory))
         {
             Directory.CreateDirectory(parentDirectory);
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -22,7 +22,7 @@ internal sealed class DockerCli : ILocalRegistry
     private readonly ILogger _logger;
     private string? _commandPath;
 
-    public DockerCli(string? command, ILoggerFactory logger)
+    public DockerCli(string? command, ILoggerFactory loggerFactory)
     {
         if (!(command == null ||
               command == PodmanCommand ||
@@ -32,7 +32,7 @@ internal sealed class DockerCli : ILocalRegistry
         }
 
         this._commandPath = command;
-        this._logger = logger.CreateLogger<DockerCli>();
+        this._logger = loggerFactory.CreateLogger<DockerCli>();
     }
 
     public DockerCli(ILoggerFactory loggerFactory) : this(null, loggerFactory)
@@ -196,7 +196,7 @@ internal sealed class DockerCli : ILocalRegistry
 
     private static void Proc_OutputDataReceived(object sender, DataReceivedEventArgs e) => throw new NotImplementedException();
 
-    private static async Task WriteImageToStreamAsync(BuiltImage image, SourceImageReference sourceReference, DestinationImageReference destinationReference, Stream imageStream, CancellationToken cancellationToken)
+    public static async Task WriteImageToStreamAsync(BuiltImage image, SourceImageReference sourceReference, DestinationImageReference destinationReference, Stream imageStream, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         using TarWriter writer = new(imageStream, TarEntryFormat.Pax, leaveOpen: true);
@@ -311,4 +311,5 @@ internal sealed class DockerCli : ILocalRegistry
         }
     }
 
+    public override string ToString() => _commandPath ?? "unknown local registry";
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -311,5 +311,8 @@ internal sealed class DockerCli : ILocalRegistry
         }
     }
 
-    public override string ToString() => _commandPath ?? "unknown local registry";
+    public override string ToString()
+    {
+        return string.Format(Strings.DockerCli_PushInfo, _commandPath);
+    }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -66,6 +66,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerManifest.g
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerManifest.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerDigest.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerDigest.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedArchiveOutputPath.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedArchiveOutputPath.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Repository.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Repository.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageTags.get -> string![]!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -76,6 +76,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalRegistry.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalRegistry.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ArchiveOutputPath.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ArchiveOutputPath.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.RuntimeIdentifierGraphPath.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -157,6 +157,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerManifest.g
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerManifest.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerDigest.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerDigest.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedArchiveOutputPath.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedArchiveOutputPath.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Repository.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Repository.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageTags.get -> string![]!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -3,7 +3,7 @@ const Microsoft.NET.Build.Containers.KnownLocalRegistryTypes.Podman = "Podman" -
 Microsoft.NET.Build.Containers.BaseImageNotFoundException
 Microsoft.NET.Build.Containers.Constants
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageTag.ComputeDotnetBaseImageTag() -> void
-static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! publishDirectory, string! workingDir, string! baseRegistry, string! baseImageName, string! baseImageTag, string![]! entrypoint, string![]! entrypointArgs, string![]! defaultArgs, string![]! appCommand, string![]! appCommandArgs, string! appCommandInstruction, string! imageName, string![]! imageTags, string? outputRegistry, System.Collections.Generic.Dictionary<string!, string!>! labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, System.Collections.Generic.Dictionary<string!, string!>! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localRegistry, string? containerUser, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>!
+static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! publishDirectory, string! workingDir, string! baseRegistry, string! baseImageName, string! baseImageTag, string![]! entrypoint, string![]! entrypointArgs, string![]! defaultArgs, string![]! appCommand, string![]! appCommandArgs, string! appCommandInstruction, string! imageName, string![]! imageTags, string? outputRegistry, System.Collections.Generic.Dictionary<string!, string!>! labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, System.Collections.Generic.Dictionary<string!, string!>! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localRegistry, string? containerUser, string? archiveOutputPath, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>!
 static readonly Microsoft.NET.Build.Containers.Constants.Version -> string!
 Microsoft.NET.Build.Containers.ContainerBuilder
 Microsoft.NET.Build.Containers.ContainerHelpers
@@ -167,6 +167,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalRegistry.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.LocalRegistry.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.OutputRegistry.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ArchiveOutputPath.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ArchiveOutputPath.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.RuntimeIdentifierGraphPath.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -364,7 +364,7 @@ internal sealed class Registry
     public async Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        Registry destinationRegistry = destination.Registry!;
+        Registry destinationRegistry = destination.RemoteRegistry!;
 
         Func<Descriptor, Task> uploadLayerFunc = async (descriptor) =>
         {

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -88,11 +88,56 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand..
+        /// </summary>
+        internal static string AppCommandArgsSetNoAppCommand {
+            get {
+                return ResourceManager.GetString("AppCommandArgsSetNoAppCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is &apos;{0}&apos;..
+        /// </summary>
+        internal static string AppCommandSetNotUsed {
+            get {
+                return ResourceManager.GetString("AppCommandSetNotUsed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to local archive at &apos;{0}&apos;.
+        /// </summary>
+        internal static string ArchiveRegistry_PushInfo {
+            get {
+                return ResourceManager.GetString("ArchiveRegistry_PushInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to &apos;Entrypoint&apos; if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to &apos;DefaultArgs&apos;..
+        /// </summary>
+        internal static string BaseEntrypointOverwritten {
+            get {
+                return ResourceManager.GetString("BaseEntrypointOverwritten", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CONTAINER2009: Could not parse {0}: {1}.
         /// </summary>
         internal static string BaseImageNameParsingFailed {
             get {
                 return ResourceManager.GetString("BaseImageNameParsingFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: &apos;{1}/&lt;image&gt;&apos;..
+        /// </summary>
+        internal static string BaseImageNameRegistryFallback {
+            get {
+                return ResourceManager.GetString("BaseImageNameRegistryFallback", resourceCulture);
             }
         }
         
@@ -105,15 +150,6 @@ namespace Microsoft.NET.Build.Containers.Resources {
             }
         }
         
-        /// <summary>
-        ///   Looks up a localized string similar to CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: '{1}/<image>'..
-        /// </summary>
-        internal static string BaseImageNameRegistryFallback {
-            get {
-                return ResourceManager.GetString("BaseImageNameRegistryFallback", resourceCulture);
-            }
-        }
-
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1011: Couldn&apos;t find matching base image for {0} that matches RuntimeIdentifier {1}..
         /// </summary>
@@ -178,6 +214,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to local registry via &apos;{0}&apos;.
+        /// </summary>
+        internal static string DockerCli_PushInfo {
+            get {
+                return ResourceManager.GetString("DockerCli_PushInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}.
         /// </summary>
         internal static string DockerInfoFailed {
@@ -196,7 +241,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER3001: Failed creating docker process..
+        ///   Looks up a localized string similar to CONTAINER3001: Failed creating {0} process..
         /// </summary>
         internal static string DockerProcessCreationFailed {
             get {
@@ -223,6 +268,51 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}..
+        /// </summary>
+        internal static string EntrypointAndAppCommandArgsSetNoAppCommandInstruction {
+            get {
+                return ResourceManager.GetString("EntrypointAndAppCommandArgsSetNoAppCommandInstruction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint..
+        /// </summary>
+        internal static string EntrypointArgsSetNoEntrypoint {
+            get {
+                return ResourceManager.GetString("EntrypointArgsSetNoEntrypoint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created..
+        /// </summary>
+        internal static string EntrypointArgsSetPreferAppCommandArgs {
+            get {
+                return ResourceManager.GetString("EntrypointArgsSetPreferAppCommandArgs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction &apos;{0}&apos;..
+        /// </summary>
+        internal static string EntrypointConflictAppCommand {
+            get {
+                return ResourceManager.GetString("EntrypointConflictAppCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}..
+        /// </summary>
+        internal static string EntrypointSetNoAppCommandInstruction {
+            get {
+                return ResourceManager.GetString("EntrypointSetNoAppCommandInstruction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CONTAINER1008: Failed retrieving credentials for &quot;{0}&quot;: {1}.
         /// </summary>
         internal static string FailedRetrievingCredentials {
@@ -241,7 +331,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER1009: Failed to load image to local registry. stdout: {0}.
+        ///   Looks up a localized string similar to CONTAINER1009: Failed to load image from local registry. stdout: {0}.
         /// </summary>
         internal static string ImageLoadFailed {
             get {
@@ -367,15 +457,6 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER1012: The local registry is not available, but pushing to a local registry was requested.
-        /// </summary>
-        internal static string LocalRegistryNotAvailable {
-            get {
-                return ResourceManager.GetString("LocalRegistryNotAvailable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Error while reading daemon config: {0}.
         /// </summary>
         internal static string LocalDocker_FailedToGetConfig {
@@ -390,6 +471,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
         internal static string LocalDocker_LocalDaemonErrors {
             get {
                 return ResourceManager.GetString("LocalDocker_LocalDaemonErrors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER1012: The local registry is not available, but pushing to a local registry was requested..
+        /// </summary>
+        internal static string LocalRegistryNotAvailable {
+            get {
+                return ResourceManager.GetString("LocalRegistryNotAvailable", resourceCulture);
             }
         }
         
@@ -529,7 +619,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER1005: Registry push failed..
+        ///   Looks up a localized string similar to CONTAINER1005: Registry push failed; received status code &apos;{0}&apos;..
         /// </summary>
         internal static string RegistryPushFailed {
             get {
@@ -574,6 +664,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2021: Unknown AppCommandInstruction &apos;{0}&apos;. Valid instructions are {1}..
+        /// </summary>
+        internal static string UnknownAppCommandInstruction {
+            get {
+                return ResourceManager.GetString("UnknownAppCommandInstruction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CONTAINER2002: Unknown local registry type &apos;{0}&apos;. Valid local container registry types are {1}..
         /// </summary>
         internal static string UnknownLocalRegistryType {
@@ -597,60 +696,6 @@ namespace Microsoft.NET.Build.Containers.Resources {
         internal static string UnrecognizedMediaType {
             get {
                 return ResourceManager.GetString("UnrecognizedMediaType", resourceCulture);
-            }
-        }
-
-        internal static string UnknownAppCommandInstruction {
-            get {
-                return ResourceManager.GetString("UnknownAppCommandInstruction", resourceCulture);
-            }
-        }
-
-        internal static string BaseEntrypointOverwritten {
-            get {
-                return ResourceManager.GetString("BaseEntrypointOverwritten", resourceCulture);
-            }
-        }
-
-        internal static string EntrypointAndAppCommandArgsSetNoAppCommandInstruction {
-            get {
-                return ResourceManager.GetString("EntrypointAndAppCommandArgsSetNoAppCommandInstruction", resourceCulture);
-            }
-        }
-
-        internal static string EntrypointArgsSetNoEntrypoint {
-            get {
-                return ResourceManager.GetString("EntrypointArgsSetNoEntrypoint", resourceCulture);
-            }
-        }
-
-        internal static string AppCommandArgsSetNoAppCommand {
-            get {
-                return ResourceManager.GetString("AppCommandArgsSetNoAppCommand", resourceCulture);
-            }
-        }
-
-        internal static string AppCommandSetNotUsed {
-            get {
-                return ResourceManager.GetString("AppCommandSetNotUsed", resourceCulture);
-            }
-        }
-
-        internal static string EntrypointSetNoAppCommandInstruction {
-            get {
-                return ResourceManager.GetString("EntrypointSetNoAppCommandInstruction", resourceCulture);
-            }
-        }
-
-        internal static string EntrypointConflictAppCommand {
-            get {
-                return ResourceManager.GetString("EntrypointConflictAppCommand", resourceCulture);
-            }
-        }
-
-        internal static string EntrypointArgsSetPreferAppCommandArgs {
-            get {
-                return ResourceManager.GetString("EntrypointArgsSetPreferAppCommandArgs", resourceCulture);
             }
         }
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -169,7 +169,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pushed container &apos;{0}&apos; to Docker daemon..
+        ///   Looks up a localized string similar to Pushed image &apos;{0}&apos; to {1}..
         /// </summary>
         internal static string ContainerBuilder_ImageUploadedToLocalDaemon {
             get {
@@ -178,7 +178,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pushed container &apos;{0}&apos; to registry &apos;{1}&apos;..
+        ///   Looks up a localized string similar to Pushed image &apos;{0}&apos; to registry &apos;{1}&apos;..
         /// </summary>
         internal static string ContainerBuilder_ImageUploadedToRegistry {
             get {

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -332,10 +332,10 @@
     <comment>Used only for unit tests</comment>
   </data>
   <data name="ContainerBuilder_ImageUploadedToLocalDaemon" xml:space="preserve">
-    <value>Pushed container '{0}' to Docker daemon.</value>
+    <value>Pushed image '{0}' to {1}.</value>
   </data>
   <data name="ContainerBuilder_ImageUploadedToRegistry" xml:space="preserve">
-    <value>Pushed container '{0}' to registry '{1}'.</value>
+    <value>Pushed image '{0}' to registry '{1}'.</value>
   </data>
   <data name="ContainerBuilder_StartBuildingImage" xml:space="preserve">
     <value>Building image '{0}' with tags '{1}' on top of base image '{2}'.</value>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -385,4 +385,12 @@
     <value>CONTAINER2005: The inferred image name '{0}' contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character.</value>
     <comment>{StrBegin="CONTAINER2005: "}</comment>
   </data>
+  <data name="ArchiveRegistry_PushInfo" xml:space="preserve">
+    <value>local archive at '{0}'</value>
+    <comment>{0} is the path to the file written</comment>
+  </data>
+  <data name="DockerCli_PushInfo" xml:space="preserve">
+    <value>local registry via '{0}'</value>
+    <comment>{0} is the command used</comment>
+  </data>
 </root>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Kontejner {0} se odeslal do démona Dockeru.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">Kontejner {0} se odeslal do registru {1}.</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">Kontejner {0} se odeslal do registru {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommand a ContainerAppCommandArgs musí být prázdné, pokud je ContainerAppCommandInstruction „{0}“.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: Základní image má vstupní bod, který se přepíše, aby se aplikace spustila. Pokud je to žádoucí, nastavte ContainerAppCommandInstruction na „Entrypoint“. Pokud chcete zachovat vstupní bod základní image, nastavte ContainerAppCommandInstruction na „DefaultArgs“.</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: Nelze rozpoznat registr '{0}'.</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Der Container „{0}“ wurde per Push an den Docker-Daemon übertragen.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">Der Container „{0}“ wurde in die Registrierung „{1}“ gepusht.</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">Der Container „{0}“ wurde in die Registrierung „{1}“ gepusht.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommand und ContainerAppCommandArgs müssen leer sein, wenn "ContainerAppCommandInstruction" den Wert "{0}" aufweist.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: Das Basisimage verfügt über einen Einstiegspunkt, der überschrieben wird, um die Anwendung zu starten. Legen Sie "ContainerAppCommandInstruction" auf "Entrypoint" fest, wenn dies gewünscht ist. Um den Einstiegspunkt des Basisimages beizubehalten, legen Sie "ContainerAppCommandInstruction" auf "DefaultArgs" fest.</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: Die Registrierung „{0}“ wurde nicht erkannt.</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommand y ContainerAppCommandArgs deben estar vacíos cuando ContainerAppCommandInstruction es '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: la imagen base tiene un punto de entrada que se sobrescribirá para iniciar la aplicación. Establezca ContainerAppCommandInstruction en "Entrypoint" si lo desea. Para conservar el punto de entrada de la imagen base, establezca ContainerAppCommandInstruction en "DefaultArgs".</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: No se pudo reconocer el registro "{0}".</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Se insertó el contenedor "{0}" en el demonio de Docker.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">Se insertó el contenedor "{0}" en el registro "{1}".</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">Se insertó el contenedor "{0}" en el registro "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommand et ContainerAppCommandArgs doivent être vides lorsque ContainerAppCommandInstruction est '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: L'image de base a un point d'entrée qui sera écrasé pour démarrer l'application. Définissez ContainerAppCommandInstruction sur 'Entrypoint' si vous le souhaitez. Pour conserver le point d'entrée de l'image de base, définissez ContainerAppCommandInstruction sur "DefaultArgs".</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: impossible de reconnaître le registre '{0}'.</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Le conteneur «{0}» a été envoyé au démon Docker.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">Le conteneur «{0}» a été envoyé au registre «{1}».</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">Le conteneur «{0}» a été envoyé au registre «{1}».</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs devono essere vuoti quando ContainerAppCommandInstruction è '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: l'immagine di base contiene un punto di ingresso che verrà sovrascritto per avviare l'applicazione. Impostare ContainerAppCommandInstruction su 'Entrypoint', se necessario. Per mantenere il punto di ingresso dell'immagine di base, impostare ContainerAppCommandInstruction su 'DefaultArgs'.</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: non è stato possibile riconoscere il registro '{0}'.</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">È stato eseguito il push del contenitore '{0}' nel daemon Docker.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">È stato eseguito il push del contenitore '{0}' nel registro '{1}'.</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">È stato eseguito il push del contenitore '{0}' nel registro '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommandInstruction が '{0}' の場合、ContainerAppCommand と ContainerAppCommandArgs を空にする必要があります。</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: 基本イメージに、アプリケーションの開始時に上書きされるエントリ ポイントがあります。このまま上書きする場合は、ContainerAppCommandInstruction を 'Entrypoint' に設定します。基本イメージのエントリ ポイントを保持するには、ContainerAppCommandInstruction を 'DefaultArgs' に設定します。</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: レジストリ '{0}' を認識できませんでした。</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">コンテナー '{0}' を Docker デーモンにプッシュしました。</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">コンテナー '{0}' をレジストリ '{1}' にプッシュしました。</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">コンテナー '{0}' をレジストリ '{1}' にプッシュしました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Docker 디먼에 '{0}' 컨테이너를 푸시했습니다.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">'{1}' 레지스트리에 '{0}' 컨테이너를 푸시했습니다.</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">'{1}' 레지스트리에 '{0}' 컨테이너를 푸시했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommandInstruction이 '{0}'인 경우 ContainerAppCommand 및 ContainerAppCommandArgs가 비어 있어야 합니다.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: 기본 이미지에 응용 프로그램을 시작하기 위해 덮어쓸 진입점이 있습니다. 필요한 경우 ContainerAppCommandInstruction을 'Entrypoint'로 설정합니다. 기본 이미지 진입점을 유지하려면 ContainerAppCommandInstruction을 'DefaultArgs'로 설정하세요.</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: 레지스트리 '{0}'을(를) 인식할 수 없습니다.</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommand i ContainerAppCommandArgs muszą być puste, gdy element ContainerAppCommandInstruction ma wartość „{0}”.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: Obraz podstawowy ma punkt wejścia, który zostanie zastąpiony w celu uruchomienia aplikacji. W razie potrzeby ustaw właściwość ContainerAppCommandInstruction na wartość „Entrypoint”. Aby zachować podstawowy punkt wejścia obrazu, ustaw właściwość ContainerAppCommandInstruction na wartość „DefaultArgs”.</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: nie można rozpoznać rejestru „{0}”.</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Wypchnięto kontener „{0}” do demona platformy Docker.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">Wypchnęliśmy 'kontener „{0}” do rejestru „{1}”.</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">Wypchnęliśmy 'kontener „{0}” do rejestru „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommand e ContainerAppCommandArgs devem estar vazios quando ContainerAppCommandInstruction é '{0}'.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: A imagem base possui um ponto de entrada que será substituído para iniciar o aplicativo. Defina ContainerAppCommandInstruction como 'Entrypoint' se desejar. Para preservar o ponto de entrada da imagem base, defina ContainerAppCommandInstruction como 'DefaultArgs'.</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: não foi possível reconhecer o registro '{0}'.</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Enviou o contêiner '{0}' para o daemon do Docker.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">Contêiner empurrado '{0}' para o registro '{1}'.</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">Contêiner empurrado '{0}' para o registro '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommand и ContainerAppCommandArgs должны быть пустыми, если ContainerAppCommandInstruction — "{0}".</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: базовый образ содержит точку входа, которая будет перезаписана для запуска приложения. При необходимости настройте для ContainerAppCommandInstruction значение "Entrypoint". Чтобы сохранить точку входа базового образа, настройте для ContainerAppCommandInstruction значение "DefaultArgs".</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: не удалось распознать реестр "{0}".</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">Принудительно отправлен контейнер "{0}" в управляющую программу Docker.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">Принудительно отправлен контейнер "{0}" в реестр "{1}".</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">Принудительно отправлен контейнер "{0}" в реестр "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">'{0}' kapsayıcısı, Docker daemon'a gönderildi.</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">'{0}' kapsayıcısı, '{1}' kayıt defterine gönderildi.</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">'{0}' kapsayıcısı, '{1}' kayıt defterine gönderildi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: ContainerAppCommandInstruction '{0}' olduğunda ContainerAppCommand ve ContainerAppCommandArgs komutları boş olmalıdır.</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: Temel görüntünün, uygulamayı başlatmak için üzerine yazılacak bir giriş noktası var. İsteniyorsa ContainerAppCommandInstruction komutunu 'Entrypoint' olarak ayarlayın. Temel görüntü giriş noktasını korumak için ContainerAppCommandInstruction komutunu 'DefaultArgs' olarak ayarlayın.</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: '{0}' kayıt defteri tanınamadı.</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: 当 ContainerAppCommandInstruction 为“{0}”时，ContainerAppCommand 和 ContainerAppCommandArgs 必须为空。</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: 基础映像具有一个入口点，该入口点将被覆盖以启动应用程序。如果需要，请将 ContainerAppCommandInstruction 设置为 "Entrypoint"。若要保留基础映像入口点，请将 ContainerAppCommandInstruction 设置为 "DefaultArgs"。</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: 无法识别注册表“{0}”。</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">已将容器“{0}”推送到 Docker 守护程序。</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">已将容器“{0}”推送到注册表“{1}”。</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">已将容器“{0}”推送到注册表“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -58,13 +58,13 @@
         <note>{StrBegin="CONTAINER1001: "}</note>
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToLocalDaemon">
-        <source>Pushed container '{0}' to Docker daemon.</source>
-        <target state="translated">已推送容器 '{0}' 至 Docker 精靈。</target>
+        <source>Pushed image '{0}' to {1}.</source>
+        <target state="new">Pushed image '{0}' to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_ImageUploadedToRegistry">
-        <source>Pushed container '{0}' to registry '{1}'.</source>
-        <target state="translated">已將容器 '{0}' 推送至登錄 '{1}'。</target>
+        <source>Pushed image '{0}' to registry '{1}'.</source>
+        <target state="needs-review-translation">已將容器 '{0}' 推送至登錄 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerBuilder_StartBuildingImage">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">CONTAINER2026: 當 ContainerAppCommandInstruction 為 '{0}' 時，ContainerAppCommand 和 ContainerAppCommandArgs 必須是空白。</target>
         <note>{StrBegin="CONTAINER2026: "}</note>
       </trans-unit>
+      <trans-unit id="ArchiveRegistry_PushInfo">
+        <source>local archive at '{0}'</source>
+        <target state="new">local archive at '{0}'</target>
+        <note>{0} is the path to the file written</note>
+      </trans-unit>
       <trans-unit id="BaseEntrypointOverwritten">
         <source>CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to 'Entrypoint' if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to 'DefaultArgs'.</source>
         <target state="translated">CONTAINER2022: 基礎映像有一個進入點，將被覆寫以啟動應用程式。如果這是預期的行為，請將 ContainerAppCommandInstruction 設定為 'Entrypoint'。若要保留基礎映像進入點，請將 ContainerAppCommandInstruction 設定為 'DefaultArgs'。</target>
@@ -76,6 +81,11 @@
         <source>CONTAINER2012: Could not recognize registry '{0}'.</source>
         <target state="translated">CONTAINER2012: 無法識別登錄 '{0}'。</target>
         <note>{StrBegin="CONTAINER2012: "}</note>
+      </trans-unit>
+      <trans-unit id="DockerCli_PushInfo">
+        <source>local registry via '{0}'</source>
+        <target state="new">local registry via '{0}'</target>
+        <note>{0} is the command used</note>
       </trans-unit>
       <trans-unit id="DockerInfoFailed">
         <source>CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -155,6 +155,9 @@ partial class CreateNewImage
     [Output]
     public string GeneratedContainerDigest { get; set; }
 
+    [Output]
+    public string GeneratedArchiveOutputPath { get; set; }
+
     public CreateNewImage()
     {
         ContainerizeDirectory = "";
@@ -186,6 +189,7 @@ partial class CreateNewImage
         GeneratedContainerConfiguration = "";
         GeneratedContainerManifest = "";
         GeneratedContainerDigest = "";
+        GeneratedArchiveOutputPath = "";
 
         TaskResources = Resource.Manager;
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -43,6 +43,11 @@ partial class CreateNewImage
     public string OutputRegistry { get; set; }
 
     /// <summary>
+    /// The file path to which to write a tar.gz archive of the container image.
+    /// </summary>
+    public string ArchiveOutputPath { get; set; }
+
+    /// <summary>
     /// The kind of local registry to use, if any.
     /// </summary>
     public string LocalRegistry { get; set; }
@@ -159,6 +164,7 @@ partial class CreateNewImage
         BaseImageName = "";
         BaseImageTag = "";
         OutputRegistry = "";
+        ArchiveOutputPath = "";
         Repository = "";
         ImageTags = Array.Empty<string>();
         PublishDirectory = "";

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -80,7 +80,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             return !Log.HasLoggedErrors;
         }
 
-        SafeLog("Building image '{0}' with tags {1} on top of base image {2}", Repository, String.Join(",", ImageTags), sourceImageReference);
+        SafeLog(Strings.ContainerBuilder_StartBuildingImage, Repository, String.Join(",", ImageTags), sourceImageReference);
 
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows);
         imageBuilder.AddLayer(newLayer);
@@ -152,7 +152,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         try
         {
             await localRegistry.LoadAsync(builtImage, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
-            SafeLog("Pushed image '{0}' to {1}", destinationImageReference, localRegistry);
+            SafeLog(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, localRegistry);
 
             if (localRegistry is ArchiveFileRegistry archive)
             {
@@ -176,7 +176,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
                 sourceImageReference,
                 destinationImageReference,
                 cancellationToken).ConfigureAwait(false);
-            SafeLog("Pushed image '{0}' to registry '{1}'", destinationImageReference, OutputRegistry);
+            SafeLog(Strings.ContainerBuilder_ImageUploadedToRegistry, destinationImageReference, OutputRegistry);
         }
         catch (ContainerHttpException e)
         {

--- a/src/Containers/containerize/ContainerizeCommand.cs
+++ b/src/Containers/containerize/ContainerizeCommand.cs
@@ -41,6 +41,12 @@ internal class ContainerizeCommand : CliRootCommand
         Required = false
     };
 
+    internal CliOption<string> ArchiveOutputPathOption { get; } = new("--archiveoutputpath")
+    {
+        Description = "The file path to which to write a tar.gz archive of the container image.",
+        Required = false
+    };
+
     internal CliOption<string> RepositoryOption { get; } = new("--repository")
     {
         Description = "The name of the output container repository that will be pushed to the registry.",
@@ -187,6 +193,7 @@ internal class ContainerizeCommand : CliRootCommand
         this.Options.Add(BaseImageNameOption);
         this.Options.Add(BaseImageTagOption);
         this.Options.Add(OutputRegistryOption);
+        this.Options.Add(ArchiveOutputPathOption);
         this.Options.Add(RepositoryOption);
         this.Options.Add(ImageTagsOption);
         this.Options.Add(WorkingDirectoryOption);
@@ -212,6 +219,7 @@ internal class ContainerizeCommand : CliRootCommand
             string _baseName = parseResult.GetValue(BaseImageNameOption)!;
             string _baseTag = parseResult.GetValue(BaseImageTagOption)!;
             string? _outputReg = parseResult.GetValue(OutputRegistryOption);
+            string? _archiveOutputPath = parseResult.GetValue(ArchiveOutputPathOption);
             string _name = parseResult.GetValue(RepositoryOption)!;
             string[] _tags = parseResult.GetValue(ImageTagsOption)!;
             string _workingDir = parseResult.GetValue(WorkingDirectoryOption)!;
@@ -256,6 +264,7 @@ internal class ContainerizeCommand : CliRootCommand
                 _ridGraphPath,
                 _localContainerDaemon,
                 _containerUser,
+                _archiveOutputPath,
                 loggerFactory,
                 cancellationToken).ConfigureAwait(false);
         });

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -225,6 +225,7 @@
       <Output TaskParameter="GeneratedContainerManifest" PropertyName="GeneratedContainerManifest" />
       <Output TaskParameter="GeneratedContainerConfiguration" PropertyName="GeneratedContainerConfiguration" />
       <Output TaskParameter="GeneratedContainerDigest" PropertyName="GeneratedContainerDigest" />
+      <Output TaskParameter="GeneratedArchiveOutputPath" PropertyName="GeneratedArchiveOutputPath" />
     </CreateNewImage>
   </Target>
 </Project>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -204,6 +204,7 @@
                     BaseImageTag="$(ContainerBaseTag)"
                     LocalRegistry="$(LocalRegistry)"
                     OutputRegistry="$(ContainerRegistry)"
+                    ArchiveOutputPath="$(ContainerArchiveOutputPath)"
                     Repository="$(ContainerRepository)"
                     ImageTags="@(ContainerImageTags)"
                     PublishDirectory="$(PublishDir)"

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
@@ -31,6 +31,9 @@ static class ContainerCli
     public static RunExeCommand InspectCommand(ITestOutputHelper log, params string[] args)
       => CreateCommand(log, "inspect", args);
 
+    public static RunExeCommand LoadCommand(ITestOutputHelper log, params string[] args)
+      => CreateCommand(log, "load", args);
+
     private static RunExeCommand CreateCommand(ITestOutputHelper log, string command, string[] args)
     {
         string commandPath = IsPodman ? "podman" : "docker";


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/283, https://github.com/dotnet/sdk-container-builds/issues/431 (partially)

This PR introduces a new feature which allows developers to write tar.gz archives as understood by Docker (and podman) in a `docker load` operation. 

The effective changes are: 

- Extended the DestinationImageReference to hold the `ILocalRegistry` like the `Registry` (representing the remote registry) and also providing a way to determine which kind of refernce we are having (similar to the OneOf generation in Protobuf). 
- Added a `ILocalRegistry` implementation which dumps the tar.gz to disk (creating of these archives already exists from the DockerCli implementation)
- Add a new MSBuild Parameter `ArchiveOutputPath` which developers would point to the absolute path where they wanna have the archive written. 
- Added an integration test for this workflow.
- Reorganized a bit the code regarding the different `DestinationImageReferenceKind`s

To be discussed and agreed: 

- The final naming of the property
- Considering adapting the logs and error messages.
- Mid term (not this PR): Support of [OCI Image archives](https://github.com/opencontainers/image-spec/blob/3131ecd26bfc92a41f3fbf0d13d4d9063f0f36c2/image-layout.md#oci-image-layout-specification) beside the [Docker Archive](https://github.com/moby/moby/blob/master/image/spec/spec.md)
- Long term (not this PR): would be great if we can internally unify the `ContainerBuilder` and `CreateNewImage` workflows. Didn't like this duplication of code and workflow - DRY is a bit violated here and it also makes testing tricky.  
