### PR TITLE
[release/6.0.4xx] Bump System.Security.Cryptography.Pkcs to 6.0.4

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -285,6 +285,10 @@
       <Sha>10d0f7e94aa45889155c312f51cfc01bf326b853</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="6.0.4">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>e37fab9fc9f7bce120a7165491ed392a73f8ab51</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.23408.5">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,6 +28,7 @@
     <NewtonsoftJsonVersion>$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersion>
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
     <SystemReflectionMetadataVersion>6.0.0</SystemReflectionMetadataVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>6.0.4</SystemSecurityCryptographyPkcsPackageVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.23408.5</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -43,5 +43,6 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsPackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is a port of https://github.com/dotnet/sdk/pull/34144 for the release/6.0.4xx branch.  release/6.0.4xx already has System.Security.Cryptography.Pkcs 6.0.1 not 6.0.4.  This change bumps System.Security.Cryptography.Pkcs from 6.0.1 to 6.0.4.

CC @marcpopMSFT, @aortiz-msft