### PR TITLE
Add mac signing to the other fork of the code path

### DIFF
--- a/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
+++ b/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
@@ -48,7 +48,8 @@ namespace Microsoft.DotNet.ShellShim
                                          appHostDestinationFilePath: appHostDestinationFilePath,
                                          appBinaryFilePath: appBinaryFilePath,
                                          windowsGraphicalUserInterface: (windowsGraphicalUserInterfaceBit == WindowsGUISubsystem) && OperatingSystem.IsWindows(),
-                                         assemblyToCopyResourcesFrom: entryPointFullPath);
+                                         assemblyToCopyResourcesFrom: entryPointFullPath,
+                                         enableMacOSCodeSign: OperatingSystem.IsMacOS());
             }
             else
             {


### PR DESCRIPTION
https://github.com/dotnet/runtime/commit/a3e38ffc72ad7a3a96edc308febbde91d3182348#diff-43c865d74da4a9b865e6d52bc43aeff8566dc6850b4e23a2786ceefc50b6d3ffL189-L214 caused the first part of the if statement to be hit instead of the second. 

There are three parameters that are different in that part of the if. Two relate to windows and we believe won't impact anything but @elinor-fung  should review.

The last parameter is a missing macos signing parameter.  As such, global tools weren't getting signed on macs and so won't run on M1s (or macs with signing checks enabled)