### PR TITLE
Make HelpCommand use the runtime to launch HTML

### DIFF
--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -23,13 +23,13 @@ namespace Microsoft.DotNet.Cli
         /// more situations that want to show help into Parsing Errors (which trigger help in the default System.CommandLine pipeline)
         /// or custom Invocation Middleware, so we can more easily create our version of a HelpResult type.
         ///</remarks>
-        public static void ShowHelp(this ParseResult parseResult)
+        public static int ShowHelp(this ParseResult parseResult)
         {
             // take from the start of the list until we hit an option/--/unparsed token
             // since commands can have arguments, we must take those as well in order to get accurate help
             var tokenList = parseResult.Tokens.TakeWhile(token => token.Type == CliTokenType.Argument || token.Type == CliTokenType.Command || token.Type == CliTokenType.Directive).Select(t => t.Value).ToList();
             tokenList.Add("-h");
-            Parser.Instance.Parse(tokenList).Invoke();
+            return Parser.Instance.Parse(tokenList).Invoke();
         }
 
         public static void ShowHelpOrErrorIfAppropriate(this ParseResult parseResult)

--- a/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -67,40 +67,25 @@ namespace Microsoft.DotNet.Tools.Help
             if (innerParseResult.CommandResult is { } commandResult)
             {
 
-                if (commandResult.Command is DocumentedCommand documentedCommand)
+                if (commandResult.Command is DocumentedCommand documentedCommand
+                    && !string.IsNullOrEmpty(documentedCommand.DocsLink))
                 {
-                    if (!string.IsNullOrEmpty(documentedCommand.DocsLink))
+                    var process = ConfigureProcess(documentedCommand.DocsLink);
+                    try
                     {
-                        var process = ConfigureProcess(documentedCommand.DocsLink);
-                        try
+                        process.Start();
+                        process.WaitForExit();
+                        if (process.ExitCode == 0)
                         {
-                            process.Start();
-                            process.WaitForExit();
-                            if (process.ExitCode != 0)
-                            {
-                                // if the 'open browser' process fails, we should fallback to
-                                // calling `--help` for that command and outputting that
-                                return innerParseResult.ShowHelp();
-                            }
-                            else
-                            {
-                                return process.ExitCode;
-                            }
-                        }
-                        catch 
-                        {
-                            return innerParseResult.ShowHelp();
+                            return process.ExitCode;
                         }
                     }
-                    else
-                    {
-                        return innerParseResult.ShowHelp();
-                    }
+                    catch { }
                 }
-                else
-                {
-                    return innerParseResult.ShowHelp();
-                }
+
+                // if the 'open browser' process fails, we should fallback to
+                // calling `--help` for that command and outputting that
+                return innerParseResult.ShowHelp();
             }
             else
             {

--- a/src/Cli/dotnet/commands/dotnet-help/HelpCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpCommandParser.cs
@@ -10,10 +10,9 @@ namespace Microsoft.DotNet.Tools.Help
     {
         public static readonly string DocsLink = "https://aka.ms/dotnet-help";
 
-        public static readonly CliArgument<string> Argument = new(LocalizableStrings.CommandArgumentName)
+        public static readonly CliArgument<string[]> Arguments = new(LocalizableStrings.CommandArgumentName)
         {
-            Description = LocalizableStrings.CommandArgumentDescription,
-            Arity = ArgumentArity.ZeroOrOne
+            Description = LocalizableStrings.CommandArgumentDescription
         };
 
         private static readonly CliCommand Command = ConstructCommand();
@@ -27,7 +26,7 @@ namespace Microsoft.DotNet.Tools.Help
         {
             DocumentedCommand command = new("help", DocsLink, LocalizableStrings.AppFullName);
 
-            command.Arguments.Add(Argument);
+            command.Arguments.Add(Arguments);
 
             command.SetAction(HelpCommand.Run);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/35248

This does a few specific things:
* defer to the runtime to launch the help pages, instead of using older lists of what tools to use for this
* if that launch process fails, fallback to emitting the CLI help
* if help is called on a command that isn't a documented command (e.g. `dotnet workload install`) emit the CLI help
* BONUS: we also support using `dotnet help` with subcommands now