### PR TITLE
RunCommand prints "Building..." by default if it needs to build

### DIFF
--- a/src/Assets/TestProjects/TestAppThatWaits/Properties/launchSettings.json
+++ b/src/Assets/TestProjects/TestAppThatWaits/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "TestAppThatWaits": {
+      "commandName": "Project",
+      "dotnetRunMessages": "false",
+      "commandLineArgs": "TestAppCommandLineArguments SecondTestAppCommandLineArguments",
+      "environmentVariables": {
+        "MyCoolEnvironmentVariableKey": "MyCoolEnvironmentVariableValue"
+      }
+    }
+  }
+}

--- a/src/Assets/TestProjects/TestAppWithLaunchSettingsAndDotNetRunMessagesIsFalse/Program.cs
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettingsAndDotNetRunMessagesIsFalse/Program.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello world");
+            Console.WriteLine($"MyCoolEnvironmentVariableKey={Environment.GetEnvironmentVariable("MyCoolEnvironmentVariableKey")}");
+            Console.WriteLine($"DOTNET_LAUNCH_PROFILE={Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")}");
+            if (args.Length > 0)
+            {
+                Console.WriteLine(args[0]);
+            }
+            if (args.Length > 1)
+            {
+                Console.WriteLine(args[1]);
+            }
+        }
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithLaunchSettingsAndDotNetRunMessagesIsFalse/Properties/launchSettings.json
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettingsAndDotNetRunMessagesIsFalse/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "TestAppWithLaunchSettings": {
+      "commandName": "Project",
+      "dotnetRunMessages": "false",
+      "commandLineArgs": "TestAppCommandLineArguments SecondTestAppCommandLineArguments",
+      "environmentVariables": {
+        "MyCoolEnvironmentVariableKey": "MyCoolEnvironmentVariableValue"
+      }
+    }
+  }
+}

--- a/src/Assets/TestProjects/TestAppWithLaunchSettingsAndDotNetRunMessagesIsFalse/TestAppWithLaunchSettingsAndDotNetRunMessagesIsFalse.csproj
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettingsAndDotNetRunMessagesIsFalse/TestAppWithLaunchSettingsAndDotNetRunMessagesIsFalse.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tools.Run
 
             if (ShouldBuild)
             {
-                if (string.Equals("true", launchSettings?.DotNetRunMessages, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals("true", launchSettings?.DotNetRunMessages, StringComparison.OrdinalIgnoreCase) || launchSettings?.DotNetRunMessages is null)
                 {
                     Reporter.Output.WriteLine(LocalizableStrings.RunCommandBuilding);
                 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -848,6 +848,16 @@ class Program
         Console.WriteLine(str);
     }
 }";
+            // disabling "Building..." message
+            testProject.SourceFiles["Properties/launchSettings.json"] = @"
+{
+    ""profiles"": {
+        ""TestApp"": {
+            ""commandName"": ""Project"",
+            ""dotnetRunMessages"": ""false""
+        }
+    }
+}";
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFrameworkVersion);
             var buildCommand = new BuildCommand(testAsset);
             buildCommand.WithWorkingDirectory(testAsset.Path)

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -421,7 +421,15 @@ namespace {safeThisName}
             {
                 foreach (var kvp in SourceFiles)
                 {
-                    File.WriteAllText(Path.Combine(targetFolder, kvp.Key), kvp.Value);
+                    var path = Path.Combine(targetFolder, kvp.Key);
+
+                    var fi = new FileInfo(path);
+                    if (!fi.Directory.Exists) 
+                    {
+                        fi.Directory.Create();
+                    }
+
+                    File.WriteAllText(path, kvp.Value);
                 }
             }
 

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute("--framework", ToolsetInfo.CurrentTargetFramework)
                 .Should().Pass()
-                         .And.HaveStdOut("Hello World!");
+                         .And.HaveStdOutContaining("Hello World!");
         }
 
         [Fact]
@@ -783,9 +783,9 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
-        public void ItDoesNotPrintBuildingMessageByDefault()
+        public void ItPrintsBuildingMessageByDefault()
         {
-            var expectedValue = "Building...";
+            var expectedValue = LocalizableStrings.RunCommandBuilding;
             var testAppName = "TestAppSimple";
             var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
                 .WithSource();
@@ -796,13 +796,13 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                .Should()
                .Pass()
                .And
-               .NotHaveStdOutContaining(expectedValue);
+               .HaveStdOutContaining(expectedValue);
         }
 
         [Fact]
         public void ItPrintsBuildingMessageIfLaunchSettingHasDotnetRunMessagesSet()
         {
-            var expectedValue = "Building...";
+            var expectedValue = LocalizableStrings.RunCommandBuilding;
             var testAppName = "TestAppWithLaunchSettings";
             var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
                 .WithSource();
@@ -814,6 +814,40 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                .Pass()
                .And
                .HaveStdOutContaining(expectedValue);
+        }
+
+        [Fact]
+        public void ItPrintsBuildingMessageIfNoLaunchSettings()
+        {
+            var expectedValue = LocalizableStrings.RunCommandBuilding;
+            var testAppName = "TestAppSimple";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            new DotnetCommand(Log, "run")
+               .WithWorkingDirectory(testInstance.Path)
+               .Execute()
+               .Should()
+               .Pass()
+               .And
+               .HaveStdOutContaining(expectedValue);
+        }
+
+        [Fact]
+        public void ItDoesNotPrintBuildingMessageIfLaunchSettingIsFalse()
+        {
+            var expectedValue = LocalizableStrings.RunCommandBuilding;
+            var testAppName = "TestAppWithLaunchSettingsAndDotNetRunMessagesIsFalse";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            new DotnetCommand(Log, "run")
+               .WithWorkingDirectory(testInstance.Path)
+               .Execute()
+               .Should()
+               .Pass()
+               .And
+               .NotHaveStdOutContaining(expectedValue);
         }
 
         [Fact]


### PR DESCRIPTION
When ```dotnet run``` needs to build the project it will now print the ```Building...``` message by default unless dotnetRunMessages is set to false.

- added test project that has dotnetRunMessages set to false
- added a test to ensure it is printed when dotnetRunMessage is true
- added a test to ensure it isn't printed when dotnetRunMessage is false
- changed test to ensure it is printed by default/no launch settings

I found it confusing that certain project templates would print the ```Building...``` message and others wouldn't.

It seems more consistent to have ```dotnet run``` print ```Building...``` by default.  This also mirrors the behavior of ```dotnet watch```