### PR TITLE
Improve test logging, reliability

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -111,6 +111,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             var hotReloadService = new WatchHotReloadService(services, hotReloadCapabilities);
             await hotReloadService.StartSessionAsync(initialSolution, cancellationToken);
+
+            reporter.Verbose("Hot Reload session started.", emoji: "🔥");
             return hotReloadService;
         }
 

--- a/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -142,20 +142,11 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             var partitionedWorkItem = new List<ITaskItem>();
             foreach (var assemblyPartitionInfo in assemblyPartitionInfos)
             {
-                var identity = assemblyPartitionInfo.DisplayName + testIdentityDifferentiator;
-                var testResultsDir = IsPosixShell ? @"$HELIX_WORKITEM_UPLOAD_ROOT/" : @"%HELIX_WORKITEM_UPLOAD_ROOT%\";
-
-                string command;
+                string command = $"{driver} exec {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml {assemblyPartitionInfo.ClassListArgumentString} {arguments}";
                 if (netFramework)
                 {
                     var testFilter = String.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
-                    command = $"{driver} test {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory {testResultsDir} --logger trx {testFilter}";
-                }
-                else
-                {
-                    command  =
-                        $"{driver} exec {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} " +
-                        $"-html \"{testResultsDir}{identity}.html\" {assemblyPartitionInfo.ClassListArgumentString} {arguments}";
+                    command = $"{driver} test {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .\\ --logger trx {testFilter}";
                 }
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");
@@ -169,9 +160,9 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                     }
                 }
 
-                partitionedWorkItem.Add(new Microsoft.Build.Utilities.TaskItem(identity, new Dictionary<string, string>()
+                partitionedWorkItem.Add(new Microsoft.Build.Utilities.TaskItem(assemblyPartitionInfo.DisplayName + testIdentityDifferentiator, new Dictionary<string, string>()
                     {
-                        { "Identity", identity},
+                        { "Identity", assemblyPartitionInfo.DisplayName + testIdentityDifferentiator},
                         { "PayloadDirectory", publishDirectory },
                         { "Command", command },
                         { "Timeout", timeout.ToString() },

--- a/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;
 using NuGet.Frameworks;
@@ -141,11 +142,20 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             var partitionedWorkItem = new List<ITaskItem>();
             foreach (var assemblyPartitionInfo in assemblyPartitionInfos)
             {
-                string command = $"{driver} exec {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml {assemblyPartitionInfo.ClassListArgumentString} {arguments}";
+                var identity = assemblyPartitionInfo.DisplayName + testIdentityDifferentiator;
+                var testResultsDir = IsPosixShell ? @"$HELIX_WORKITEM_UPLOAD_ROOT/" : @"%HELIX_WORKITEM_UPLOAD_ROOT%\";
+
+                string command;
                 if (netFramework)
                 {
                     var testFilter = String.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
-                    command = $"{driver} test {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .\\ --logger trx {testFilter}";
+                    command = $"{driver} test {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory {testResultsDir} --logger trx {testFilter}";
+                }
+                else
+                {
+                    command  =
+                        $"{driver} exec {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} " +
+                        $"-html \"{testResultsDir}{identity}.html\" {assemblyPartitionInfo.ClassListArgumentString} {arguments}";
                 }
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");
@@ -159,9 +169,9 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                     }
                 }
 
-                partitionedWorkItem.Add(new Microsoft.Build.Utilities.TaskItem(assemblyPartitionInfo.DisplayName + testIdentityDifferentiator, new Dictionary<string, string>()
+                partitionedWorkItem.Add(new Microsoft.Build.Utilities.TaskItem(identity, new Dictionary<string, string>()
                     {
-                        { "Identity", assemblyPartitionInfo.DisplayName + testIdentityDifferentiator},
+                        { "Identity", identity},
                         { "PayloadDirectory", publishDirectory },
                         { "Command", command },
                         { "Timeout", timeout.ToString() },

--- a/src/Tests/Microsoft.DotNet.ApiCompat.Tests/RegexStringTransformerTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompat.Tests/RegexStringTransformerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
 
             string output = new RegexStringTransformer(CaptureGroupPattern, ReplacementPattern).Transform(Input);
 
-            Assert.NotEqual(ReplacementPattern, output);
+            Assert.Equal(ReplacementPattern, output);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.DotNet.ApiCompat.Tests/RegexStringTransformerTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompat.Tests/RegexStringTransformerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
 
             string output = new RegexStringTransformer(CaptureGroupPattern, ReplacementPattern).Transform(Input);
 
-            Assert.Equal(ReplacementPattern, output);
+            Assert.NotEqual(ReplacementPattern, output);
         }
 
         [Fact]

--- a/src/Tests/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/src/Tests/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             File.WriteAllText(Path.Combine(testAsset.Path, "App", "Update.cs"), newSrc);
 
-            await App.AssertOutputLineStartsWith("Updated types: PrinterX");
+            await App.AssertOutputLineStartsWith("Updated types: Printer");
         }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/src/Tests/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -40,7 +40,6 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("WatchAppTypeLoadFailure")
                 .WithSource();
 
-            App.DotnetWatchArgs.Add("--verbose");
             await App.StartWatcherAsync(testAsset, "App");
 
             await App.WaitForSessionStarted();

--- a/src/Tests/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/src/Tests/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Watcher.Tests
@@ -14,14 +14,13 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task ChangeFileInDependency()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
-                .WithSource()
-                .Path;
+                .WithSource();
 
-            var projectDir = Path.Combine(testAsset, "AppWithDeps");
-            var dependencyDir = Path.Combine(testAsset, "Dependency");
+            var dependencyDir = Path.Combine(testAsset.Path, "Dependency");
 
-            await App.StartWatcherAsync(projectDir);
-            await App.AssertOutputLineStartsWith("Hello!");
+            await App.StartWatcherAsync(testAsset, "AppWithDeps");
+
+            await App.WaitForSessionStarted();
 
             var newSrc = """
                 public class Lib
@@ -35,18 +34,16 @@ namespace Microsoft.DotNet.Watcher.Tests
             await App.AssertOutputLineStartsWith("Changed!");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/35264")]
+        [Fact]
         public async Task HandleTypeLoadFailure()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchAppTypeLoadFailure")
-                .WithSource()
-                .Path;
-
-            var projectDir = Path.Combine(testAsset, "App");
+                .WithSource();
 
             App.DotnetWatchArgs.Add("--verbose");
-            await App.StartWatcherAsync(projectDir);
-            await App.AssertOutputLineStartsWith("Hello!");
+            await App.StartWatcherAsync(testAsset, "App");
+
+            await App.WaitForSessionStarted();
 
             var newSrc = """
                 class DepSubType : Dep
@@ -61,9 +58,9 @@ namespace Microsoft.DotNet.Watcher.Tests
                         Console.WriteLine("Changed!");
                     }
                 }
-                """;
+                """;    
 
-            File.WriteAllText(Path.Combine(projectDir, "Update.cs"), newSrc);
+            File.WriteAllText(Path.Combine(testAsset.Path, "App", "Update.cs"), newSrc);
 
             await App.AssertOutputLineStartsWith("Updated types: Printer");
         }

--- a/src/Tests/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/src/Tests/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             File.WriteAllText(Path.Combine(testAsset.Path, "App", "Update.cs"), newSrc);
 
-            await App.AssertOutputLineStartsWith("Updated types: Printer");
+            await App.AssertOutputLineStartsWith("Updated types: PrinterX");
         }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
+++ b/src/Tests/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
@@ -70,6 +70,9 @@ namespace Microsoft.DotNet.Watcher.Tools
         {
             using var cancellationOnFailure = new CancellationTokenSource();
 
+            // cancel just before we hit 2 minute time out used on CI (sdk\src\Tests\UnitTests.proj)
+            cancellationOnFailure.CancelAfter(TimeSpan.FromSeconds(110));
+
             var failedLineCount = 0;
             while (!_source.Completion.IsCompleted && failedLineCount == 0)
             {

--- a/src/Tests/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
@@ -18,8 +18,6 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset(AppName)
                 .WithSource();
 
-            App.DotnetWatchArgs.Add("--verbose");
-
             await App.StartWatcherAsync(testAsset, testFlags: TestFlags.BrowserRequired);
 
             // Verify we launched the browser.
@@ -33,8 +31,6 @@ namespace Microsoft.DotNet.Watcher.Tests
                 .WithSource();
 
             App.EnvironmentVariables.Add("DOTNET_WATCH_BROWSER_PATH", "mycustombrowser.bat");
-
-            App.DotnetWatchArgs.Add("--verbose");
 
             await App.StartWatcherAsync(testAsset, testFlags: TestFlags.BrowserRequired);
 

--- a/src/Tests/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
@@ -16,8 +16,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task LaunchesBrowserOnStart()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
+                .WithSource();
 
             App.DotnetWatchArgs.Add("--verbose");
 
@@ -31,8 +30,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task UsesBrowserSpecifiedInEnvironment()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
+                .WithSource();
 
             App.EnvironmentVariables.Add("DOTNET_WATCH_BROWSER_PATH", "mycustombrowser.bat");
 

--- a/src/Tests/dotnet-watch.Tests/Watch/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/DotNetWatcherTests.cs
@@ -91,8 +91,6 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
                 .WithSource();
 
-            App.DotnetWatchArgs.Add("--verbose");
-
             await App.StartWatcherAsync(testAsset);
 
             await App.AssertOutputLineEquals("Environment: Development");
@@ -106,7 +104,6 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             var directoryInfo = new DirectoryInfo(testAsset.Path);
 
-            App.DotnetWatchArgs.Add("--verbose");
             App.DotnetWatchArgs.Add("--project");
             App.DotnetWatchArgs.Add(Path.Combine(directoryInfo.Name, "WatchAppWithLaunchSettings.csproj"));
 
@@ -123,7 +120,6 @@ namespace Microsoft.DotNet.Watcher.Tests
                 .WithSource();
 
             App.EnvironmentVariables.Add("READ_INPUT", "true");
-            App.DotnetWatchArgs.Add("--verbose");
             App.DotnetWatchArgs.Add("--non-interactive");
 
             await App.StartWatcherAsync(testAsset);

--- a/src/Tests/dotnet-watch.Tests/Watch/DotNetWatcherTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/DotNetWatcherTests.cs
@@ -20,8 +20,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_WATCH")), "DOTNET_WATCH cannot be set already when this test is running");
 
             var testAsset = TestAssets.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
+                .WithSource();
 
             await App.StartWatcherAsync(testAsset);
             Assert.Equal("1", await App.AssertOutputLineStartsWith("DOTNET_WATCH = "));
@@ -33,8 +32,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
 
             var testAsset = TestAssets.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
+                .WithSource();
 
             await App.StartWatcherAsync(testAsset);
             Assert.Equal("<<<First>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
@@ -46,10 +44,9 @@ namespace Microsoft.DotNet.Watcher.Tests
             Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
 
             var testAsset = TestAssets.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
+                .WithSource();
 
-            await App.StartWatcherAsync(testAsset, [ "--launch-profile", "Second"]);
+            await App.StartWatcherAsync(testAsset, applicationArguments: [ "--launch-profile", "Second"]);
             Assert.Equal("<<<Second>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
         }
 
@@ -59,10 +56,9 @@ namespace Microsoft.DotNet.Watcher.Tests
             Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
 
             var testAsset = TestAssets.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
+                .WithSource();
 
-            await App.StartWatcherAsync(testAsset, ["--launch-profile", "Third"]);
+            await App.StartWatcherAsync(testAsset, applicationArguments: ["--launch-profile", "Third"]);
             Assert.Equal("<<<First>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
         }
 
@@ -70,11 +66,10 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task RunsWithIterationEnvVariable()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
+                .WithSource();
 
             await App.StartWatcherAsync(testAsset);
-            var source = Path.Combine(testAsset, "Program.cs");
+            var source = Path.Combine(testAsset.Path, "Program.cs");
             var contents = File.ReadAllText(source);
             const string messagePrefix = "DOTNET_WATCH_ITERATION = ";
 
@@ -94,8 +89,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
-                .WithSource()
-                .Path;
+                .WithSource();
 
             App.DotnetWatchArgs.Add("--verbose");
 
@@ -108,10 +102,9 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings_WhenUsingProjectOption()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
-                .WithSource()
-                .Path;
+                .WithSource();
 
-            var directoryInfo = new DirectoryInfo(testAsset);
+            var directoryInfo = new DirectoryInfo(testAsset.Path);
 
             App.DotnetWatchArgs.Add("--verbose");
             App.DotnetWatchArgs.Add("--project");
@@ -127,8 +120,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task Run_WithHotReloadEnabled_DoesNotReadConsoleIn_InNonInteractiveMode()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
-                .WithSource()
-                .Path;
+                .WithSource();
 
             App.EnvironmentVariables.Add("READ_INPUT", "true");
             App.DotnetWatchArgs.Add("--verbose");

--- a/src/Tests/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
@@ -20,15 +20,14 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task ChangeCompiledFile(bool usePollingWatcher)
         {
             var testAsset = TestAssets.CopyTestAsset(AppName, identifier: usePollingWatcher.ToString())
-               .WithSource()
-               .Path;
+               .WithSource();
 
             App.UsePollingWatcher = usePollingWatcher;
             await App.StartWatcherAsync(testAsset);
 
             await AssertCompiledAppDefinedTypes(expected: 2);
 
-            var fileToChange = Path.Combine(testAsset, "include", "Foo.cs");
+            var fileToChange = Path.Combine(testAsset.Path, "include", "Foo.cs");
             var programCs = File.ReadAllText(fileToChange);
             File.WriteAllText(fileToChange, programCs);
 
@@ -41,14 +40,13 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task DeleteCompiledFile()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-               .WithSource()
-               .Path;
+               .WithSource();
 
             await App.StartWatcherAsync(testAsset);
 
             await AssertCompiledAppDefinedTypes(expected: 2);
 
-            var fileToChange = Path.Combine(testAsset, "include", "Foo.cs");
+            var fileToChange = Path.Combine(testAsset.Path, "include", "Foo.cs");
             File.Delete(fileToChange);
 
             await App.AssertRestarted();
@@ -59,14 +57,13 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task DeleteSourceFolder()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-               .WithSource()
-               .Path;
+               .WithSource();
 
             await App.StartWatcherAsync(testAsset);
 
             await AssertCompiledAppDefinedTypes(expected: 2);
 
-            var folderToDelete = Path.Combine(testAsset, "include");
+            var folderToDelete = Path.Combine(testAsset.Path, "include");
             Directory.Delete(folderToDelete, recursive: true);
 
             await App.AssertRestarted();
@@ -77,13 +74,12 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task RenameCompiledFile()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-               .WithSource()
-               .Path;
+               .WithSource();
 
             await App.StartWatcherAsync(testAsset);
 
-            var oldFile = Path.Combine(testAsset, "include", "Foo.cs");
-            var newFile = Path.Combine(testAsset, "include", "Foo_new.cs");
+            var oldFile = Path.Combine(testAsset.Path, "include", "Foo.cs");
+            var newFile = Path.Combine(testAsset.Path, "include", "Foo_new.cs");
             File.Move(oldFile, newFile);
 
             await App.AssertRestarted();
@@ -93,12 +89,11 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task ChangeExcludedFile()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-               .WithSource()
-               .Path;
+               .WithSource();
 
             await App.StartWatcherAsync(testAsset);
 
-            var changedFile = Path.Combine(testAsset, "exclude", "Baz.cs");
+            var changedFile = Path.Combine(testAsset.Path, "exclude", "Baz.cs");
             File.WriteAllText(changedFile, "");
 
             var fileChanged = App.AssertFileChanged();
@@ -110,15 +105,14 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task ListsFiles()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-               .WithSource()
-               .Path;
+               .WithSource();
 
             App.Start(testAsset, new[] { "--list" });
             var lines = await App.Process.GetAllOutputLinesAsync(CancellationToken.None);
             var files = lines.Where(l => !l.StartsWith("watch :"));
 
             AssertEx.EqualFileList(
-                testAsset,
+                testAsset.Path,
                 new[]
                 {
                     "Program.cs",

--- a/src/Tests/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
@@ -107,6 +107,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset(AppName)
                .WithSource();
 
+            App.DotnetWatchArgs.Clear();
             App.Start(testAsset, new[] { "--list" });
             var lines = await App.Process.GetAllOutputLinesAsync(CancellationToken.None);
             var files = lines.Where(l => !l.StartsWith("watch :"));

--- a/src/Tests/dotnet-watch.Tests/Watch/NoDepsAppTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/NoDepsAppTests.cs
@@ -16,14 +16,13 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task RestartProcessOnFileChange()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
+                .WithSource();
 
-            await App.StartWatcherAsync(testAsset, new[] { "--no-hot-reload", "--no-exit" });
+            await App.StartWatcherAsync(testAsset, applicationArguments: ["--no-hot-reload", "--no-exit"]);
             var processIdentifier = await App.AssertOutputLineStartsWith("Process identifier =");
 
             // Then wait for it to restart when we change a file
-            var fileToChange = Path.Combine(testAsset, "Program.cs");
+            var fileToChange = Path.Combine(testAsset.Path, "Program.cs");
             var programCs = File.ReadAllText(fileToChange);
             File.WriteAllText(fileToChange, programCs);
 
@@ -38,15 +37,14 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task RestartProcessThatTerminatesAfterFileChange()
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
-                .WithSource()
-                .Path;
+                .WithSource();
 
             await App.StartWatcherAsync(testAsset);
             var processIdentifier = await App.AssertOutputLineStartsWith("Process identifier =");
             await App.AssertExited(); // process should exit after run
             await App.AssertWaitingForFileChange();
 
-            var fileToChange = Path.Combine(testAsset, "Program.cs");
+            var fileToChange = Path.Combine(testAsset.Path, "Program.cs");
 
             try
             {

--- a/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -60,6 +60,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppMultiTfm")
                 .WithSource();
 
+            App.DotnetWatchArgs.Clear();
             App.Start(testAsset, arguments: new[]
             {
                 "--no-hot-reload",

--- a/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -47,8 +47,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task Arguments(string[] arguments, string expectedApplicationArgs)
         {
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: string.Join(",", arguments))
-                .WithSource()
-                .Path;
+                .WithSource();
 
             App.Start(testAsset, arguments);
 
@@ -59,8 +58,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task RunArguments_NoHotReload()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppMultiTfm")
-                .WithSource()
-                .Path;
+                .WithSource();
 
             App.Start(testAsset, arguments: new[]
             {
@@ -94,8 +92,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task RunArguments_HotReload()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppMultiTfm")
-                .WithSource()
-                .Path;
+                .WithSource();
 
             App.Start(testAsset, arguments: new[]
             {
@@ -127,8 +124,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task ArgumentsFromLaunchSettings_Watch(string profileName, string expectedArgs)
         {
             var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
-                .WithSource()
-                .Path;
+                .WithSource();
 
             App.Start(testAsset, arguments: new[]
             {
@@ -150,8 +146,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task ArgumentsFromLaunchSettings_HotReload(string profileName, string expectedArgs)
         {
             var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
-                .WithSource()
-                .Path;
+                .WithSource();
 
             App.Start(testAsset, arguments: new[]
             {

--- a/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Watcher.Tests
 
         public AwaitableProcess Process { get; private set; }
 
-        public List<string> DotnetWatchArgs { get; } = new List<string>();
+        public List<string> DotnetWatchArgs { get; } = new() { "--verbose" };
 
         public Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
 
@@ -100,7 +100,6 @@ namespace Microsoft.DotNet.Watcher.Tests
             var args = new List<string>
             {
                 "watch",
-                "--verbose",
             };
             args.AddRange(DotnetWatchArgs);
             args.AddRange(arguments);

--- a/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         private const string WatchErrorOutputEmoji = "❌";
         private const string WaitingForFileChangeMessage = "dotnet watch ⏳ Waiting for a file to change";
         private const string WatchFileChanged = "dotnet watch ⌚ File changed:";
+        private const string HotReloadSessionStarted = "dotnet watch 🔥 Hot Reload session started.";
 
         public readonly ITestOutputHelper Logger;
         private bool _prepared;
@@ -57,6 +58,14 @@ namespace Microsoft.DotNet.Watcher.Tests
         public Task AssertRestarted()
             => AssertOutputLineEquals(StartedMessage);
 
+        /// <summary>
+        ///  Must be called before updating any source files.
+        ///  Document content is captured at session start and if any source files are updated before that
+        ///  changes will not be detected since the captured file content won't match the PDB checksums.
+        /// </summary>
+        public Task WaitForSessionStarted()
+            => AssertOutputLineStartsWith(HotReloadSessionStarted);
+
         public Task AssertWaitingForFileChange()
             => AssertOutputLineStartsWith(WaitingForFileChangeMessage);
 
@@ -69,22 +78,24 @@ namespace Microsoft.DotNet.Watcher.Tests
             await AssertOutputLineStartsWith(WatchExitedMessage);
         }
 
-        private void Prepare(string projectRootPath)
+        private void Prepare(string projectDirectory)
         {
             if (_prepared)
             {
                 return;
             }
 
-            var buildCommand = new BuildCommand(Logger, projectRootPath);
+            var buildCommand = new BuildCommand(Logger, projectDirectory);
             buildCommand.Execute().Should().Pass();
 
             _prepared = true;
         }
 
-        public void Start(string projectRootPath, IEnumerable<string> arguments, string workingDirectory = null, TestFlags testFlags = TestFlags.RunningAsTest, string name = null)
+        public void Start(TestAsset asset, IEnumerable<string> arguments, string relativeProjectDirectory = null, string workingDirectory = null, TestFlags testFlags = TestFlags.RunningAsTest)
         {
-            Prepare(projectRootPath);
+            var projectDirectory = Path.Combine(asset.Path, relativeProjectDirectory);
+
+            Prepare(projectDirectory);
 
             var args = new List<string>
             {
@@ -95,11 +106,17 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             var commandSpec = new DotnetCommand(Logger, args.ToArray())
             {
-                WorkingDirectory = workingDirectory ?? projectRootPath,
+                WorkingDirectory = workingDirectory ?? projectDirectory,
             };
 
             commandSpec.WithEnvironmentVariable("DOTNET_USE_POLLING_FILE_WATCHER", "true");
             commandSpec.WithEnvironmentVariable("__DOTNET_WATCH_TEST_FLAGS", testFlags.ToString());
+
+            var encLogPath = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT") is { } ciOutputRoot
+                ? Path.Combine(".hotreload", ciOutputRoot, asset.Name)
+                : Path.Combine(asset.Path, ".hotreload");
+
+            commandSpec.WithEnvironmentVariable("Microsoft_CodeAnalysis_EditAndContinue_LogDir", encLogPath);
 
             foreach (var env in EnvironmentVariables)
             {
@@ -111,11 +128,11 @@ namespace Microsoft.DotNet.Watcher.Tests
         }
 
         public async Task StartWatcherAsync(
-            string projectRootPath,
+            TestAsset asset,
+            string relativeProjectDirectory = null,
             IEnumerable<string> applicationArguments = null,
             string workingDirectory = null,
-            TestFlags testFlags = TestFlags.RunningAsTest,
-            [CallerMemberName] string name = null)
+            TestFlags testFlags = TestFlags.RunningAsTest)
         {
             var args = new[] { "run", "--" };
             if (applicationArguments != null)
@@ -123,7 +140,7 @@ namespace Microsoft.DotNet.Watcher.Tests
                 args = args.Concat(applicationArguments).ToArray();
             }
 
-            Start(projectRootPath, args, workingDirectory, testFlags, name);
+            Start(asset, args, relativeProjectDirectory, workingDirectory, testFlags);
 
             await AssertOutputLineStartsWith(WatchStartedMessage);
         }

--- a/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -93,13 +93,14 @@ namespace Microsoft.DotNet.Watcher.Tests
 
         public void Start(TestAsset asset, IEnumerable<string> arguments, string relativeProjectDirectory = null, string workingDirectory = null, TestFlags testFlags = TestFlags.RunningAsTest)
         {
-            var projectDirectory = Path.Combine(asset.Path, relativeProjectDirectory);
+            var projectDirectory = (relativeProjectDirectory != null) ? Path.Combine(asset.Path, relativeProjectDirectory) : asset.Path;
 
             Prepare(projectDirectory);
 
             var args = new List<string>
             {
                 "watch",
+                "--verbose",
             };
             args.AddRange(DotnetWatchArgs);
             args.AddRange(arguments);

--- a/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             commandSpec.WithEnvironmentVariable("__DOTNET_WATCH_TEST_FLAGS", testFlags.ToString());
 
             var encLogPath = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT") is { } ciOutputRoot
-                ? Path.Combine(".hotreload", ciOutputRoot, asset.Name)
+                ? Path.Combine(ciOutputRoot, ".hotreload", asset.Name)
                 : Path.Combine(asset.Path, ".hotreload");
 
             commandSpec.WithEnvironmentVariable("Microsoft_CodeAnalysis_EditAndContinue_LogDir", encLogPath);


### PR DESCRIPTION
A few improvements to testing in SDK repo and dotnet watch.

1) Store test output file in HTML format to `HELIX_WORKITEM_UPLOAD_ROOT` directory when running on CI. The file can be accessed via Artifacts tab in test results.
2) Store Roslyn EnC logs to `HELIX_WORKITEM_UPLOAD_ROOT` when running dotnet watch Hot Reload tests. These will also be available in Artifacts tab.
3) Cancel dotnet watch tests if the time exceeds 2 minutes - 10 seconds. Helix terminates test process at 2 minutes. Since XUnit does not flush test output it won't be available if the process is terminated. By cancelling 10 seconds before the Helix timeout we ensure that test output is available.
4) Hot Reload tests that update source files must wait for the Hot Reload session to start, otherwise changes won't be detected.
Fixes https://github.com/dotnet/sdk/issues/35264
