### PR TITLE
Msbuild.Test.Utilites build fix for VS

### DIFF
--- a/src/Tests/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
+++ b/src/Tests/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\Cli\Microsoft.DotNet.Cli.Sln.Internal\Microsoft.DotNet.Cli.Sln.Internal.csproj" />
     <ProjectReference Include="..\..\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
     <ProjectReference Include="..\..\Cli\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,13 +24,4 @@
     <PackageReference Include="System.Security.Cryptography.X509Certificates" />
   </ItemGroup>
 
-  <!-- Global usings removal -->
-  <!-- See: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#using -->
-  <ItemGroup>
-    <Using Remove="Microsoft.NET.TestFramework" />
-    <Using Remove="Microsoft.NET.TestFramework.Assertions" />
-    <Using Remove="Microsoft.NET.TestFramework.Commands" />
-    <Using Remove="Microsoft.NET.TestFramework.ProjectConstruction" />
-    <Using Remove="Microsoft.NET.TestFramework.Utilities" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/pull/34659

## Summary
This is a problem that was in `main` but I fixed it in the PR above when I ran `dotnet format`. The fix for this problem doesn't exist in `release/8.0.1xx`, though. Adding just this fix so building in VS on this branch works properly. Without this fix, this project doesn't build in VS.

## Details
This project uses a shared `Program.cs` file that depends on `Microsoft.NET.TestFramework` to compile. Adding the project reference and utilizing the global using fixes the build problem in VS. This is what VS shows for the situation without these changes:
![image](https://github.com/dotnet/sdk/assets/17788297/217d0c52-7106-4c2c-b193-a05a08e749f4)