### PR TITLE
Remove SelfContained set to false for -a

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -201,8 +201,7 @@ namespace Microsoft.DotNet.Cli
                 return Array.Empty<string>();
             }
 
-            var selfContainedSpecified = (parseResult.GetResult(SelfContainedOption) ?? parseResult.GetResult(NoSelfContainedOption)) is not null;
-            return ResolveRidShorthandOptions(null, arg, selfContainedSpecified);
+            return ResolveRidShorthandOptions(null, arg);
         }
 
         internal static IEnumerable<string> ResolveOsOptionToRuntimeIdentifier(string arg, ParseResult parseResult)
@@ -212,24 +211,12 @@ namespace Microsoft.DotNet.Cli
                 throw new GracefulException(CommonLocalizableStrings.CannotSpecifyBothRuntimeAndOsOptions);
             }
 
-            var selfContainedSpecified = (parseResult.GetResult(SelfContainedOption) ?? parseResult.GetResult(NoSelfContainedOption)) is not null;
-            if (parseResult.BothArchAndOsOptionsSpecified())
-            {
-                return ResolveRidShorthandOptions(arg, ArchOptionValue(parseResult), selfContainedSpecified);
-            }
-
-            return ResolveRidShorthandOptions(arg, null, selfContainedSpecified);
+            var arch = parseResult.BothArchAndOsOptionsSpecified() ? ArchOptionValue(parseResult) : null;
+            return ResolveRidShorthandOptions(arg, arch);
         }
 
-        private static IEnumerable<string> ResolveRidShorthandOptions(string os, string arch, bool userSpecifiedSelfContainedOption)
-        {
-            var properties = new string[] { $"-property:RuntimeIdentifier={ResolveRidShorthandOptionsToRuntimeIdentifier(os, arch)}" };
-            if (!userSpecifiedSelfContainedOption)
-            {
-                properties = properties.Append("-property:SelfContained=false").ToArray();
-            }
-            return properties;
-        }
+        private static IEnumerable<string> ResolveRidShorthandOptions(string os, string arch) =>
+            new string[] { $"-property:RuntimeIdentifier={ResolveRidShorthandOptionsToRuntimeIdentifier(os, arch)}" };
 
         internal static string ResolveRidShorthandOptionsToRuntimeIdentifier(string os, string arch)
         {

--- a/src/Tests/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
+++ b/src/Tests/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\Cli\Microsoft.DotNet.Cli.Sln.Internal\Microsoft.DotNet.Cli.Sln.Internal.csproj" />
     <ProjectReference Include="..\..\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
     <ProjectReference Include="..\..\Cli\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,13 +24,4 @@
     <PackageReference Include="System.Security.Cryptography.X509Certificates" />
   </ItemGroup>
 
-  <!-- Global usings removal -->
-  <!-- See: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#using -->
-  <ItemGroup>
-    <Using Remove="Microsoft.NET.TestFramework" />
-    <Using Remove="Microsoft.NET.TestFramework.Assertions" />
-    <Using Remove="Microsoft.NET.TestFramework.Commands" />
-    <Using Remove="Microsoft.NET.TestFramework.ProjectConstruction" />
-    <Using Remove="Microsoft.NET.TestFramework.Utilities" />
-  </ItemGroup>
 </Project>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 var expectedArch = RuntimeInformation.ProcessArchitecture.Equals(Architecture.Arm64) ? "arm64" : Environment.Is64BitOperatingSystem ? "x64" : "x86";
                 command.GetArgumentsToMSBuild()
                     .Should()
-                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch} -property:SelfContained=false");
+                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch}");
             });
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 }
                 command.GetArgumentsToMSBuild()
                     .Should()
-                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier={expectedOs}-arch -property:SelfContained=false");
+                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier={expectedOs}-arch");
             });
         }
 
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 var command = BuildCommand.FromArgs(new string[] { "--arch", "arch", "--os", "os" }, msbuildPath);
                 command.GetArgumentsToMSBuild()
                     .Should()
-                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-arch -property:SelfContained=false");
+                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-arch");
             });
         }
 
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 var command = BuildCommand.FromArgs(new string[] { "--arch", "amd64", "--os", "os" }, msbuildPath);
                 command.GetArgumentsToMSBuild()
                     .Should()
-                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-x64 -property:SelfContained=false");
+                    .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-x64");
             });
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/34026

> **Note**
> PR https://github.com/dotnet/sdk/pull/35281 is contained within this. Once merged, the changes to `Msbuild.Tests.Utilities.csproj` will not be present.

## Summary
When using `-a`, we were forcing `SelfContained` to be set to `false`. This is considered a breaking change, but the current functionality isn't desired. So, we change that here to no longer update the `SelfContained` property.

## Details
This change is thematically the same as https://github.com/dotnet/sdk/pull/30038. [`-a`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#options) sets the RID and we changed RID handling to no longer update the `SelfContained` property to `true`. Here in this situation, it was doing the same but changing it to `false` instead. This was only specific to the `-a` option unlike the other set of changes.


 