### PR TITLE
Update NuGet certificate thumbprints

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/FirstPartyNuGetPackageSigningVerifier.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/FirstPartyNuGetPackageSigningVerifier.cs
@@ -15,11 +15,16 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             new(StringComparer.OrdinalIgnoreCase)
             {
                 "3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE",
-                "AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27"
+                "AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27",
+                "566A31882BE208BE4422F7CFD66ED09F5D4524A5994F50CCC8B05EC0528C1353"
             };
 
         private readonly HashSet<string> _upperFirstPartyCertificateThumbprints =
-            new(StringComparer.OrdinalIgnoreCase) {"51044706BD237B91B89B781337E6D62656C69F0FCFFBE8E43741367948127862"};
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                "51044706BD237B91B89B781337E6D62656C69F0FCFFBE8E43741367948127862",
+                "46011EDE1C147EB2BC731A539B7C047B7EE93E48B9D3C3BA710CE132BBDFAC6B"
+            };
 
         private const string FirstPartyCertificateSubject =
             "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";

--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
@@ -288,10 +288,12 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         {
             var iosSamplePackage = DownloadSamplePackage(new PackageId("Microsoft.iOS.Ref"));
             var androidSamplePackage = DownloadSamplePackage(new PackageId("Microsoft.Android.Ref"));
+            var mauiSamplePackage = DownloadSamplePackage(new PackageId("Microsoft.NET.Sdk.Maui.Manifest-8.0.100-rc.1.Msi.x64"));
 
             var package = new FirstPartyNuGetPackageSigningVerifier();
             package.IsFirstParty(new FilePath(iosSamplePackage)).Should().BeTrue();
             package.IsFirstParty(new FilePath(androidSamplePackage)).Should().BeTrue();
+            package.IsFirstParty(new FilePath(mauiSamplePackage)).Should().BeTrue();
         }
 
         private string GetShaFromSamplePackage(string samplePackage)


### PR DESCRIPTION
## Description

Microsoft authored packages on NuGet are being signed using an [updated certificate](https://devblogs.microsoft.com/nuget/microsoft-author-signing-certificate-update-2023/). The CLI verifies the certificate thumbprint when acquiring packages related to workloads. This apply to both file-based and admin installs on Windows. The new certificate  thumbprint is unknown and the CLI needs to be updated to include thumbprints for both the leaf and intermediate nodes - the latter is a fallback mechanism in the CLI.

## Testing

Unit tests have been updated to verify a package signed with the new certificate.

## Workaround

Users can turn of sign verification when installing workloads through the CLI by passing the `--skip-sign-check` option, but this is not ideal and won't work if the policy key was specified on Windows to block bypassing signature validation for workload packages.
