### PR TITLE
Add `.mono` to `.gitingore`

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -18,6 +18,7 @@
 
 # Mono auto generated files
 mono_crash.*
+.mono/
 
 # Build results
 [Dd]ebug/
@@ -403,6 +404,7 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 .idea
+
 
 ##
 ## Visual studio for Mac

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -405,7 +405,6 @@ FodyWeavers.xsd
 *.sln.iml
 .idea
 
-
 ##
 ## Visual studio for Mac
 ##


### PR DESCRIPTION
I recently started using https://github.com/dotnet/vscode-csharp and it adds a folder `.mono` to the repository. 

I guess this should also be part of the template