### PR TITLE
Add escape hatch for PublishAot without RuntimeIdentifier. Fixes #33414.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -221,7 +221,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                 FormatArguments="PublishSingleFile"/>
 
-    <NETSdkError Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true'"
+    <NETSdkError Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true' and '$(AllowPublishAotWithoutRuntimeIdentifier)' != 'true'"
                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                 FormatArguments="PublishAot"/>
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -380,5 +380,48 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
         }
+
+        [Fact]
+        public void PublishFailsWithPublishAotAndNoRuntimeIdentifier()
+        {
+            var targetFramework = ToolsetInfo.CurrentTargetFramework;
+            var testProject = new TestProject()
+            {
+                IsExe = true,
+                TargetFrameworks = targetFramework
+            };
+
+            testProject.AdditionalProperties["PublishAot"] = "true";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1191");
+        }
+
+        [Fact]
+        public void PublishSuccessfullyWithPublishAotAndNoRuntimeIdentifierWithEscapeHatch()
+        {
+            var targetFramework = ToolsetInfo.CurrentTargetFramework;
+            var testProject = new TestProject()
+            {
+                IsExe = true,
+                TargetFrameworks = targetFramework
+            };
+
+            testProject.AdditionalProperties["PublishAot"] = "true";
+            testProject.AdditionalProperties["AllowPublishAotWithoutRuntimeIdentifier"] = "true";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
     }
 }

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -380,50 +380,5 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
         }
-
-        [Fact]
-        public void PublishFailsWithPublishAotAndNoRuntimeIdentifier()
-        {
-            var targetFramework = ToolsetInfo.CurrentTargetFramework;
-            var testProject = new TestProject()
-            {
-                IsExe = true,
-                TargetFrameworks = targetFramework
-            };
-
-            testProject.AdditionalProperties["PublishAot"] = "true";
-            testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "false"; // Make sure the RuntimeIdentifier isn't inferred
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-
-            var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand
-                .Execute()
-                .Should()
-                .Fail()
-                .And
-                .HaveStdOutContaining("NETSDK1191");
-        }
-
-        [Fact]
-        public void PublishSuccessfullyWithPublishAotAndNoRuntimeIdentifierWithEscapeHatch()
-        {
-            var targetFramework = ToolsetInfo.CurrentTargetFramework;
-            var testProject = new TestProject()
-            {
-                IsExe = true,
-                TargetFrameworks = targetFramework
-            };
-
-            testProject.AdditionalProperties["PublishAot"] = "true";
-            testProject.AdditionalProperties["AllowPublishAotWithoutRuntimeIdentifier"] = "true";
-            testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "false"; // Make sure the RuntimeIdentifier isn't inferred
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-
-            var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand
-                .Execute()
-                .Should()
-                .Pass();
-        }
     }
 }

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -392,6 +392,7 @@ namespace Microsoft.NET.Publish.Tests
             };
 
             testProject.AdditionalProperties["PublishAot"] = "true";
+            testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "false"; // Make sure the RuntimeIdentifier isn't inferred
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
@@ -415,6 +416,7 @@ namespace Microsoft.NET.Publish.Tests
 
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["AllowPublishAotWithoutRuntimeIdentifier"] = "true";
+            testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "false"; // Make sure the RuntimeIdentifier isn't inferred
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));


### PR DESCRIPTION
This adds an escape hatch for a sanity check when trying to use PublishAot without a RuntimeIdentifier, because the check is not valid when building universal apps for macOS and Mac Catalyst (the netX-macos and netX-maccatalyst target frameworks).

When building such an app, the project file will set RuntimeIdentifiers (plural):

    <TargetFramework>net8.0-macos</TargetFramework>
    <RuntimeIdentifiers>osx-x64;osx-arm</RuntimeIdentifiers>

and then during the build, the macOS SDK will run two inner builds, with RuntimeIdentifiers unset, and RuntimeIdentifier set to each of the rids (and at the end merge the result into a single app).

The problem is that the outer build, where RuntimeIdentifiers is set, but RuntimeIdentifier isn't, triggers the sanity check, and that fails the build.

I attempted to unset PublishAot for the outer build, but that doesn't work for two reasons:

* It can't be unset if customers pass /p:PublishAot=true on the command line.
* The package restore won't restore the NativeAOT packages nor include them in the build, and thus effectively NativeAOT is turned off for the inner builds as well, even if we set PublishAot=true for them.

So instead add an escape hatch for the sanity check.

Fixes https://github.com/dotnet/sdk/issues/33414.