### PR TITLE
Find dotnet.exe from VS's MSBuild

### DIFF
--- a/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
+++ b/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
@@ -290,6 +290,16 @@ namespace Microsoft.NET.Sdk.Razor.Tool
 #else
                 expectedPath = Process.GetCurrentProcess().MainModule.FileName;
 #endif
+
+                if (!Path.GetFileNameWithoutExtension(expectedPath).Equals("dotnet"))
+                {
+                    // We were running from Visual Studio and found MSBuild instead of dotnet. Reroute to dotnet...
+                    expectedPath = Path.Combine(Path.GetDirectoryName(expectedPath), "..", "..", "..", "dotnet");
+                    var directory = new DirectoryInfo(expectedPath);
+
+                    // The runtime is part of the path. Get the latest runtime available.
+                    expectedPath = Path.Combine(directory.EnumerateDirectories().Last().FullName, "runtime", "dotnet.exe");
+                }
             }
 
             var argumentList = new string[]


### PR DESCRIPTION
Fixes [AB#1872193](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1872193)

/cc: @jjonescz

@dsplaisted, can you review this please? I'm not 100% confident of this change or if there's a better way to do this.