### PR TITLE
Find dotnet.exe from VS's MSBuild

### DIFF
--- a/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
+++ b/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
@@ -274,6 +274,40 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             }
         }
 
+        private static string FindDotNetExecutable()
+        {
+            var expectedPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+            if (!string.IsNullOrEmpty(expectedPath))
+            {
+                return expectedPath;
+            }
+
+#if NET
+            expectedPath = System.Environment.ProcessPath;
+#else
+            expectedPath = Process.GetCurrentProcess().MainModule.FileName;
+#endif
+
+            if ("dotnet".Equals(Path.GetFileNameWithoutExtension(expectedPath), StringComparison.Ordinal))
+            {
+                return expectedPath;
+            }
+
+            // We were probably running from Visual Studio or Build Tools and found MSBuild instead of dotnet. Use the PATH...
+            var paths = Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator);
+            var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+            foreach (string path in paths)
+            {
+                var dotnetPath = Path.Combine(path, exeName);
+                if (File.Exists(dotnetPath))
+                {
+                    return dotnetPath;
+                }
+            }
+
+            return exeName;
+        }
+
         // Internal for testing.
         internal static bool TryCreateServerCore(string clientDir, string pipeName, out int? processId, bool debug = false)
         {
@@ -282,15 +316,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             // The server should be in the same directory as the client
             var expectedCompilerPath = Path.Combine(clientDir, ServerName);
 
-            var expectedPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
-            if (string.IsNullOrEmpty(expectedPath))
-            {
-#if NET
-                expectedPath = System.Environment.ProcessPath;
-#else
-                expectedPath = Process.GetCurrentProcess().MainModule.FileName;
-#endif
-            }
+            var expectedPath = FindDotNetExecutable();
 
             var argumentList = new string[]
             {


### PR DESCRIPTION
Fixes [AB#1872193](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1872193)

/cc: @jjonescz

@dsplaisted, can you review this please? I'm not 100% confident of this change or if there's a better way to do this.

Sorry for pinging on two PRs; I mistargeted the first one.