### PR TITLE
Containers: don't push manifest digest when pushing manifest tags.

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -361,7 +361,10 @@ internal sealed class Registry
 
     }
 
-    public async Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, CancellationToken cancellationToken)
+    public Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, CancellationToken cancellationToken)
+        => PushAsync(builtImage, source, destination, pushTags: true, cancellationToken);
+
+    private async Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, bool pushTags, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         Registry destinationRegistry = destination.RemoteRegistry!;
@@ -418,18 +421,25 @@ internal sealed class Registry
             _logger.LogInformation(Strings.Registry_ConfigUploaded);
         }
 
-        //manifest upload
-        string manifestDigest = builtImage.Manifest.GetDigest();
-        _logger.LogInformation(Strings.Registry_ManifestUploadStarted, RegistryName, manifestDigest);
-        await _registryAPI.Manifest.PutAsync(destination.Repository, manifestDigest, builtImage.Manifest, cancellationToken).ConfigureAwait(false);
-        _logger.LogInformation(Strings.Registry_ManifestUploaded, RegistryName);
-
-        //tag upload
-        foreach (string tag in destination.Tags)
+        // Tags can refer to an image manifest or an image manifest list.
+        // In the first case, we push tags to the registry.
+        // In the second case, we push the manifest digest so the manifest list can refer to it.
+        if (pushTags)
         {
-            _logger.LogInformation(Strings.Registry_TagUploadStarted, tag, RegistryName);
-            await _registryAPI.Manifest.PutAsync(destination.Repository, tag, builtImage.Manifest, cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation(Strings.Registry_TagUploaded, tag, RegistryName);
+            Debug.Assert(destination.Tags.Length > 0);
+            foreach (string tag in destination.Tags)
+            {
+                _logger.LogInformation(Strings.Registry_TagUploadStarted, tag, RegistryName);
+                await _registryAPI.Manifest.PutAsync(destination.Repository, tag, builtImage.Manifest, cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation(Strings.Registry_TagUploaded, tag, RegistryName);
+            }
+        }
+        else
+        {
+            string manifestDigest = builtImage.Manifest.GetDigest();
+            _logger.LogInformation(Strings.Registry_ManifestUploadStarted, RegistryName, manifestDigest);
+            await _registryAPI.Manifest.PutAsync(destination.Repository, manifestDigest, builtImage.Manifest, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(Strings.Registry_ManifestUploaded, RegistryName);
         }
     }
 }


### PR DESCRIPTION
This behavior is consistent with CLI tools and fixes an issue with the OpenShift internal image repository.

Fixes https://github.com/dotnet/sdk/issues/35431.

@baronfel ptal.