### PR TITLE
Add explicit reference to Microsoft.SourceBuild.Intermediate.templating

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,11 +4,15 @@
     <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="9.0.100-alpha.1.23428.1">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>9dfddc30a1e9101f7e44dcda57d95902073e444c</Sha>
-      <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Mocks" Version="9.0.100-alpha.1.23428.1">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>9dfddc30a1e9101f7e44dcda57d95902073e444c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.templating" Version="9.0.100-alpha.1.23428.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>9dfddc30a1e9101f7e44dcda57d95902073e444c</Sha>
+      <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-rc.1.23421.3">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -124,6 +124,7 @@
     <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
     <MicrosoftTemplateEngineUtilsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineUtilsPackageVersion>
     <MicrosoftTemplateSearchCommonPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftSourceBuildIntermediatetemplatingPackageVersion>9.0.100-alpha.1.23428.1</MicrosoftSourceBuildIntermediatetemplatingPackageVersion>
     <!-- test dependencies -->
     <MicrosoftTemplateEngineMocksPackageVersion>9.0.100-alpha.1.23428.1</MicrosoftTemplateEngineMocksPackageVersion>
     <MicrosoftTemplateEngineTestHelperPackageVersion>$(MicrosoftTemplateEngineMocksPackageVersion)</MicrosoftTemplateEngineTestHelperPackageVersion>


### PR DESCRIPTION
This PR fixes  https://dev.azure.com/dnceng/internal/_build/results?buildId=2265097&view=logs&j=2f0d093c-1064-5c86-fc5b-b7b1eca8e66a&t=d2b639a6-cb19-5f1f-66fd-8047f66b3026, which was caught during the Test Build