### PR TITLE
[release/8.0.1xx] Update dependencies from https://github.com/dotnet/deployment-tools build 20230913.1

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -344,9 +344,9 @@
       <Sha>3dd2c0ef203db8fe0e849557960b4cd009afbaac</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview.6.23407.1">
+    <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="2.0.0-preview.1.23463.1">
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
-      <Sha>850f61abed37b617a41fd59b63a37c284af6801d</Sha>
+      <Sha>5957c5c5f85f17c145e7fab4ece37ad6aafcded9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Tasks.Git" Version="8.0.0-beta.23466.2">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
@@ -375,9 +375,9 @@
     </Dependency>
     <!-- Explicit dependency because Microsoft.Deployment.DotNet.Releases has different versioning
          than the SB intermediate -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.deployment-tools" Version="8.0.0-preview.6.23407.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.deployment-tools" Version="8.0.0-preview.6.23463.1">
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
-      <Sha>850f61abed37b617a41fd59b63a37c284af6801d</Sha>
+      <Sha>5957c5c5f85f17c145e7fab4ece37ad6aafcded9</Sha>
       <SourceBuild RepoName="deployment-tools" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.symreader" Version="2.0.0-beta-23228-03">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,7 +43,7 @@
     <SystemReflectionMetadataLoadContextVersion>8.0.0-rc.2.23466.4</SystemReflectionMetadataLoadContextVersion>
     <SystemManagementPackageVersion>4.6.0</SystemManagementPackageVersion>
     <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
-    <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview.6.23407.1</MicrosoftDeploymentDotNetReleasesVersion>
+    <MicrosoftDeploymentDotNetReleasesVersion>2.0.0-preview.1.23463.1</MicrosoftDeploymentDotNetReleasesVersion>
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>3.2.2146</MicrosoftVisualStudioSetupConfigurationInteropVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Cherry picked changed from https://github.com/dotnet/sdk/pull/35475 as there is no darc dependency flow defined for 8.0.  This upgrade is needed to address a source build issue.

Microsoft.Deployment.DotNet.Releases , Microsoft.SourceBuild.Intermediate.deployment-tools
 From Version 1.0.0-preview.6.23430.3 -> To Version 2.0.0-preview.1.23463.1