### PR TITLE
Fix typo in MSBuildAllProject(File)s

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -41,7 +41,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target
     Name="_GenerateDesignerDepsFile"
-    Inputs="$(MSBuildAllProjectFiles);$(ProjectAssetsFile)"
+    Inputs="$(MSBuildAllProjects);$(ProjectAssetsFile)"
     Outputs="$(_DesignerDepsFilePath)"
     Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
     >
@@ -85,7 +85,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target
     Name="_GenerateDesignerRuntimeConfigFile"
-    Inputs="$(MSBuildAllProjectFiles);$(ProjectAssetsFile)"
+    Inputs="$(MSBuildAllProjects);$(ProjectAssetsFile)"
     Outputs="$(_DesignerRuntimeConfigFilePath)"
     Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
     >


### PR DESCRIPTION
MSBuildAllProjects is a property MSBuild uses and updates. MSBuildAllProjectFiles doesn't exist, as far as MSBuild is concerned.

This tweaks the .targets file to use the right property name.

Fixes #23480