### PR TITLE
APICompat - Use compatible assembly references

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/Suppression.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/Suppression.cs
@@ -57,8 +57,16 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         /// the property won't be serialized to keep the baseline file minimal. The method's name is important as
         /// XmlSerializer will look for methods called ShouldSerializeX to determine if properties should be serialized.
         /// </summary>
-        /// <returns>Returns true if IsBaselineSuppression should be serialized</returns>
+        /// <returns>Returns true when IsBaselineSuppression should be serialized.</returns>
         public bool ShouldSerializeIsBaselineSuppression() => IsBaselineSuppression;
+
+        /// <summary>
+        /// Only serialize the DiagnosticId property when it is not empty. This can happen when a global suppression
+        /// without a diagnostic id was manually added to the suppression file. The method's name is important as
+        /// XmlSerializer will look for methods called ShouldSerializeX to determine if properties should be serialized.
+        /// </summary>
+        /// <returns>Returns true when DiagnosticId should be serialized.</returns>
+        public bool ShouldSerializeDiagnosticId() => DiagnosticId != string.Empty;
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) => Equals(obj as Suppression);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -78,17 +78,22 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
                 // - DiagnosticId, Target, IsBaselineSuppression
                 Suppression globalTargetSuppression = new(error.DiagnosticId, error.Target, isBaselineSuppression: error.IsBaselineSuppression);
 
+                // - Left, Right, IsBaselineSuppression
+                Suppression globalLeftRightSuppression = new(string.Empty, left: error.Left, right: error.Right, isBaselineSuppression: error.IsBaselineSuppression);
+
                 // - DiagnosticId, Left, Right, IsBaselineSuppression
-                Suppression globalLeftRightSuppression = new(error.DiagnosticId, left: error.Left, right: error.Right, isBaselineSuppression: error.IsBaselineSuppression);
+                Suppression globalDiagnosticIdLeftRightSuppression = new(error.DiagnosticId, left: error.Left, right: error.Right, isBaselineSuppression: error.IsBaselineSuppression);
 
                 if (_suppressions.Contains(globalTargetSuppression) ||
-                    _suppressions.Contains(globalLeftRightSuppression))
+                    _suppressions.Contains(globalLeftRightSuppression) ||
+                    _suppressions.Contains(globalDiagnosticIdLeftRightSuppression))
                 {
                     return true;
                 }
 
                 if (_baselineSuppressions.TryGetValue(globalTargetSuppression, out Suppression? globalSuppression) ||
-                    _baselineSuppressions.TryGetValue(globalLeftRightSuppression, out globalSuppression))
+                    _baselineSuppressions.TryGetValue(globalLeftRightSuppression, out globalSuppression) ||
+                    _baselineSuppressions.TryGetValue(globalDiagnosticIdLeftRightSuppression, out globalSuppression))
                 {
                     AddSuppression(globalSuppression);
                     return true;

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
@@ -144,11 +144,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
         public void SuppressionEngine_IsErrorSuppressed_SupportsGlobalSuppressions()
         {
             SuppressionEngine engine = new();
+
             // Engine has a suppression with no left and no right. This should be treated global for any left and any right.
             engine.AddSuppression(new Suppression("CP0001", "T:A.B", isBaselineSuppression: true));
             engine.AddSuppression(new Suppression("CP0001", "T:A.C"));
-            // Engine has a suppression with no target. Should be treated globally for any target with that left and right.
-            engine.AddSuppression(new Suppression("CP0003", null, "ref/net6.0/myleft.dll", "lib/net6.0/myright.dll", isBaselineSuppression: false));
 
             Assert.True(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
             Assert.False(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
@@ -156,10 +155,20 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             Assert.True(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
             Assert.False(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
 
+            // Engine has a suppression with no target. Should be treated globally for any target with that left and right.
+            engine.AddSuppression(new Suppression("CP0003", null, "ref/net6.0/myleft.dll", "lib/net6.0/myright.dll", isBaselineSuppression: false));
+
             Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.B", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
             Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.C", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
             Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
             Assert.False(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll", isBaselineSuppression: true)));
+
+            // Engine has a suppression with no diagnostic id and target. Should be treated globally for any diagnostic id and target with that left and right.
+            engine.AddSuppression(new Suppression(string.Empty, null, "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: false));
+            engine.AddSuppression(new Suppression(string.Empty, null, "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: true));
+
+            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0009", "T:A.B.C.D.E", "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: false)));
+            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0009", "T:A.B.C.D.E", "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: true)));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/35214

When performing baseline validation, assembly references from the right hand side are considered when the left hand side doesn't provide references.

To make sure that only compatible (equal or newer) assembly references are considered, add a TFM check and find the nearest newer references.

Manually tested on dotnet/winforms and dotnet/runtime. This change should to be backported into .NET 8 as it reduces noise from https://github.com/dotnet/sdk/commit/c47af12ab3cd5f5ce35b221a55400bf6769bda9f which already is part of .NET 8.