### PR TITLE
Meaningful error on runtime identifier mismatch in project.assets.json

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -948,5 +948,9 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1213: Targeting .NET 8.0 or higher in Visual Studio 2022 17.7 is not supported.</value>
     <comment>{StrBegin="NETSDK1213: "}</comment>
   </data>
-  <!-- The latest message added is Net8NotCompatibleWithDev177. Please update this value with each PR to catch parallel PRs both adding a new message -->
+  <data name="AssetsFileRuntimeIdentifierMismatch" xml:space="preserve">
+    <value>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</value>
+    <comment>{StrBegin="NETSDK1214: "}</comment>
+  </data>
+  <!-- The latest message added is AssetsFileRuntimeIdentifierMismatch. Please update this value with each PR to catch parallel PRs both adding a new message -->
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: Cesta k souboru prostředků {0} není uvedena od kořene. Podporované jsou jen celé cesty.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: Je potřeba zadat alespoň jednu možnou cílovou architekturu.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: Die Ressourcendateipfad "{0}" hat keinen Stamm. Nur vollständige Pfade werden unterstützt.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: Geben Sie mindestens ein mögliches Zielframework an.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: La ruta de acceso del archivo de recursos "{0}" no tiene raíz. Solo se admiten rutas de acceso completas.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: Debe especificarse al menos una plataforma de destino posible.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: Le chemin du fichier de composants '{0}' n'est pas associé à une racine. Seuls les chemins complets sont pris en charge.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: Vous devez spécifier au moins un framework cible.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: il percorso dei file di risorse '{0}' non contiene una radice. Sono supportati solo percorsi completi.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: è necessario specificare almeno un framework di destinazione possibile.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: 資産ファイル パス '{0}' にルートが指定されていません。完全パスのみがサポートされます。</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: 可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: 자산 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: 가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: Ścieżka pliku zasobów „{0}” nie prowadzi do katalogu głównego. Tylko pełne ścieżki są obsługiwane.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: Należy określić co najmniej jedną możliwą platformę docelową.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: O caminho de arquivo de ativos '{0}' não tem raiz. Há suporte apenas para caminhos completos.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: É necessário especificar pelo menos uma estrutura de destino possível.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: путь к файлу ресурсов "{0}" относительный. Поддерживаются только полные пути.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: необходимо указать хотя бы одну целевую платформу.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: '{0}' varlık dosyası yolunun kökü belirtilmemiş. Yalnızca tam yollar desteklenir.</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: En az bir olası hedef çerçeve belirtilmelidir.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: 资产文件路径“{0}”不是根路径。仅支持完整路径。</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: 必须指定至少一个可能的目标框架。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -107,6 +107,11 @@
         <target state="translated">NETSDK1006: 資產檔案路徑 '{0}' 並非根目錄。僅支援完整的路徑。</target>
         <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
+      <trans-unit id="AssetsFileRuntimeIdentifierMismatch">
+        <source>NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</source>
+        <target state="new">NETSDK1214: Runtime Identifier {0} is not present in project.assets.json. Please ensure the Runtime Identifier is specified in your project file (e.g., &lt;RuntimeIdentifier&gt;{0}&lt;/RuntimeIdentifier&gt;) and the project was restored before invoking the command.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="translated">NETSDK1001: 至少必須指定一個可能的目標架構。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACheckRuntimeIdentifierTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACheckRuntimeIdentifierTask.cs
@@ -1,0 +1,252 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests;
+
+public class GivenACheckRuntimeIdentifierTask : SdkTest
+{
+    private const string AssetsFileName = "project.assets.json";
+    private const string TargetFramework = "net8.0";
+    private const string UbuntuX64RuntimeIdentifier = "ubuntu-x64";
+    private const string WindowsX64RuntimeIdentifier = "win-x64";
+    private const string ExpectedErrorCode = "NETSDK1214";
+
+    private readonly CheckRuntimeIdentifier _task;
+    private readonly string _assetsFilePath;
+
+    public GivenACheckRuntimeIdentifierTask(ITestOutputHelper log) : base(log)
+    {
+        var testDirectory = _testAssetsManager.CreateTestDirectory();
+        _assetsFilePath = Path.Combine(testDirectory.Path, AssetsFileName);
+        _task = new CheckRuntimeIdentifier
+        {
+            ProjectAssetsFile = _assetsFilePath,
+            TargetFramework = TargetFramework,
+            BuildEngine = new MockBuildEngine()
+        };
+    }
+
+    [Fact]
+    public void ItShouldFailWithABuildErrorIfAssetsFileIsMissingTargetRuntimeIdentifier()
+    {
+        WriteToAssetsFile(AssetsJsonWithoutAddedRuntimeIdentifiers);
+        _task.RuntimeIdentifier = WindowsX64RuntimeIdentifier;
+        _task.Execute();
+        AssertThatTaskThrewExpectedBuildError();
+    }
+
+    [Fact]
+    public void ItShouldExecuteWithoutErrorsIfRuntimeIdentifierIsPresentInAssetsFile()
+    {
+        WriteToAssetsFile(AssetsJsonWithWithAddedWinX64RuntimeIdentifier);
+        _task.RuntimeIdentifier = WindowsX64RuntimeIdentifier;
+        _task.Execute();
+        AssertThatTaskThrewNoErrors();
+    }
+
+    [Fact]
+    public void ItShouldFailWithABuildErrorIfTargetIdentifierDiffersFromCurrentOne()
+    {
+        WriteToAssetsFile(AssetsJsonWithWithAddedWinX64RuntimeIdentifier);
+        _task.RuntimeIdentifier = UbuntuX64RuntimeIdentifier;
+        _task.Execute();
+        AssertThatTaskThrewExpectedBuildError();
+    }
+
+    [Fact]
+    public void ItShouldNotFailIfRuntimeIdentifierIsMissing()
+    {
+        WriteToAssetsFile(AssetsJsonWithWithAddedWinX64RuntimeIdentifier);
+        _task.RuntimeIdentifier = null;
+        _task.Execute();
+        AssertThatTaskThrewNoErrors();
+    }
+
+    private void WriteToAssetsFile(string content) => File.WriteAllText(_assetsFilePath, content);
+
+    private void AssertThatTaskThrewExpectedBuildError()
+    {
+        var engine = (MockBuildEngine)_task.BuildEngine;
+        engine.Errors.Should().HaveCount(1);
+        var error = engine.Errors.Single();
+        error.Code.Should().Be(ExpectedErrorCode);
+    }
+
+    private void AssertThatTaskThrewNoErrors()
+    {
+        var engine = (MockBuildEngine)_task.BuildEngine;
+        engine.Errors.Should().HaveCount(0);
+    }
+
+    private const string AssetsJsonWithoutAddedRuntimeIdentifiers = @"
+    {
+      ""version"": 3,
+      ""targets"": {
+        ""net8.0"": {}
+      },
+      ""libraries"": {},
+      ""projectFileDependencyGroups"": {
+        ""net8.0"": []
+      },
+      ""packageFolders"": {
+        ""C:\\Users\\user\\.nuget\\packages\\"": {},
+        ""C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"": {}
+      },
+      ""project"": {
+        ""version"": ""1.0.0"",
+        ""restore"": {
+          ""projectUniqueName"": ""C:\\Users\\user\\test\\another\\another.csproj"",
+          ""projectName"": ""another"",
+          ""projectPath"": ""C:\\Users\\user\\test\\another\\another.csproj"",
+          ""packagesPath"": ""C:\\Users\\user\\.nuget\\packages\\"",
+          ""outputPath"": ""C:\\Users\\user\\test\\another\\obj\\"",
+          ""projectStyle"": ""PackageReference"",
+          ""fallbackFolders"": [
+            ""C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages""
+          ],
+          ""configFilePaths"": [
+            ""C:\\Users\\user\\AppData\\Roaming\\NuGet\\NuGet.Config"",
+            ""C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config"",
+            ""C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config""
+          ],
+          ""originalTargetFrameworks"": [
+            ""net8.0""
+          ],
+          ""sources"": {
+            ""C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\"": {},
+            ""https://api.nuget.org/v3/index.json"": {}
+          },
+          ""frameworks"": {
+            ""net8.0"": {
+              ""targetAlias"": ""net8.0"",
+              ""projectReferences"": {}
+            }
+          },
+          ""warningProperties"": {
+            ""warnAsError"": [
+              ""NU1605""
+            ]
+          }
+        },
+        ""frameworks"": {
+          ""net8.0"": {
+            ""targetAlias"": ""net8.0"",
+            ""imports"": [
+              ""net461"",
+              ""net462"",
+              ""net47"",
+              ""net471"",
+              ""net472"",
+              ""net48"",
+              ""net481""
+            ],
+            ""assetTargetFallback"": true,
+            ""warn"": true,
+            ""frameworkReferences"": {
+              ""Microsoft.NETCore.App"": {
+                ""privateAssets"": ""all""
+              }
+            },
+            ""runtimeIdentifierGraphPath"": ""C:\\Program Files\\dotnet\\sdk\\8.0.100-preview.3.23178.7\\RuntimeIdentifierGraph.json""
+          }
+        }
+      }
+    }";
+
+
+    private const string AssetsJsonWithWithAddedWinX64RuntimeIdentifier = @"
+    {
+      ""version"": 3,
+      ""targets"": {
+        ""net8.0"": {},
+        ""net8.0/win-x64"": {}
+      },
+      ""libraries"": {},
+      ""projectFileDependencyGroups"": {
+        ""net8.0"": []
+      },
+      ""packageFolders"": {
+        ""C:\\Users\\user\\.nuget\\packages\\"": {},
+        ""C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"": {}
+      },
+      ""project"": {
+        ""version"": ""1.0.0"",
+        ""restore"": {
+          ""projectUniqueName"": ""c:\\Users\\user\\test\\test.csproj"",
+          ""projectName"": ""test"",
+          ""projectPath"": ""c:\\Users\\user\\test\\test.csproj"",
+          ""packagesPath"": ""C:\\Users\\user\\.nuget\\packages\\"",
+          ""outputPath"": ""c:\\Users\\user\\test\\obj\\"",
+          ""projectStyle"": ""PackageReference"",
+          ""fallbackFolders"": [
+            ""C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages""
+          ],
+          ""configFilePaths"": [
+            ""C:\\Users\\user\\AppData\\Roaming\\NuGet\\NuGet.Config"",
+            ""C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config"",
+            ""C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config""
+          ],
+          ""originalTargetFrameworks"": [""net8.0""],
+          ""sources"": {
+            ""C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\"": {},
+            ""https://api.nuget.org/v3/index.json"": {}
+          },
+          ""frameworks"": {
+            ""net8.0"": {
+              ""targetAlias"": ""net8.0"",
+              ""projectReferences"": {}
+            }
+          },
+          ""warningProperties"": {
+            ""warnAsError"": [""NU1605""]
+          }
+        },
+        ""frameworks"": {
+          ""net8.0"": {
+            ""targetAlias"": ""net8.0"",
+            ""imports"": [
+              ""net461"",
+              ""net462"",
+              ""net47"",
+              ""net471"",
+              ""net472"",
+              ""net48"",
+              ""net481""
+            ],
+            ""assetTargetFallback"": true,
+            ""warn"": true,
+            ""downloadDependencies"": [
+              {
+                ""name"": ""Microsoft.AspNetCore.App.Runtime.win-x64"",
+                ""version"": ""[8.0.0-preview.3.23177.8, 8.0.0-preview.3.23177.8]""
+              },
+              {
+                ""name"": ""Microsoft.NETCore.App.Runtime.win-x64"",
+                ""version"": ""[8.0.0-preview.3.23174.8, 8.0.0-preview.3.23174.8]""
+              },
+              {
+                ""name"": ""Microsoft.WindowsDesktop.App.Runtime.win-x64"",
+                ""version"": ""[8.0.0-preview.3.23178.1, 8.0.0-preview.3.23178.1]""
+              }
+            ],
+            ""frameworkReferences"": {
+              ""Microsoft.NETCore.App"": {
+                ""privateAssets"": ""all""
+              }
+            },
+            ""runtimeIdentifierGraphPath"": ""C:\\Program Files\\dotnet\\sdk\\8.0.100-preview.3.23178.7\\RuntimeIdentifierGraph.json""
+          }
+        },
+        ""runtimes"": {
+          ""win-x64"": {
+            ""#import"": []
+          }
+        }
+      }
+    }";
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACheckRuntimeIdentifierTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACheckRuntimeIdentifierTask.cs
@@ -43,7 +43,7 @@ public class GivenACheckRuntimeIdentifierTask : SdkTest
     [Fact]
     public void ItShouldFailIfTargetIdentifierDiffersFromAssetsFile()
     {
-        var assetsFilePath = CreateProjectAssetsJsonFile(AssetsJsonWithoutAddedRuntimeIdentifiers,
+        var assetsFilePath = CreateProjectAssetsJsonFile(AssetsJsonWithWithAddedWinX64RuntimeIdentifier,
             nameof(ItShouldFailIfTargetIdentifierDiffersFromAssetsFile));
 
         var task = CreateTaskWithRuntimeIdentifier(assetsFilePath, UbuntuX64RuntimeIdentifier);

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACheckRuntimeIdentifierTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACheckRuntimeIdentifierTask.cs
@@ -21,7 +21,7 @@ public class GivenACheckRuntimeIdentifierTask : SdkTest
 
     public GivenACheckRuntimeIdentifierTask(ITestOutputHelper log) : base(log)
     {
-        var testDirectory = _testAssetsManager.CreateTestDirectory();
+        var testDirectory = _testAssetsManager.CreateTestDirectory(nameof(GivenACheckRuntimeIdentifierTask));
         _assetsFilePath = Path.Combine(testDirectory.Path, AssetsFileName);
         _task = new CheckRuntimeIdentifier
         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
@@ -15,6 +15,7 @@ namespace Microsoft.NET.Build.Tasks
         /// <summary>
         /// Path to assets.json.
         /// </summary>
+        [Required]
         public string ProjectAssetsFile { get; set; }
         /// <summary>
         /// TargetFramework to use for compile-time assets.
@@ -25,39 +26,24 @@ namespace Microsoft.NET.Build.Tasks
         /// RID to use for runtime assets (may be empty)
         /// </summary>
         public string RuntimeIdentifier { get; set; }
+
         #endregion
 
         protected override void ExecuteCore()
         {
-            if (string.IsNullOrEmpty(ProjectAssetsFile))
-            {
-                return; // can't check RuntimeIdentifier without ProjectAssetsFile
-            }
-
             if (string.IsNullOrEmpty(RuntimeIdentifier))
             {
                 return; // can't check RuntimeIdentifier if it is null
             }
 
-            if (LockFileHasMatchingRuntimeIdentifier())
-            {
-                return;
-            }
-
-            ThrowRuntimeIdentifierMismatchError();
-        }
-
-        private bool LockFileHasMatchingRuntimeIdentifier()
-        {
             var lockFile = new LockFileCache(this).GetLockFile(ProjectAssetsFile);
             var target = lockFile.GetTargetAndReturnNullIfNotFound(TargetFramework, RuntimeIdentifier);
-            return target != null;
-        }
 
-        private void ThrowRuntimeIdentifierMismatchError()
-        {
-            var ridMismatchMessage = string.Format(Strings.AssetsFileRuntimeIdentifierMismatch, RuntimeIdentifier);
-            throw new BuildErrorException(ridMismatchMessage);
+            if (target is null)
+            {
+                var ridMismatchMessage = string.Format(Strings.AssetsFileRuntimeIdentifierMismatch, RuntimeIdentifier);
+                throw new BuildErrorException(ridMismatchMessage);
+            }
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
@@ -6,8 +6,8 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks
 {
     /// <summary>
-    /// Check if Runtime Identifier of the current MSBuild task matches the targets of projects.assets.json.
-    /// Without this check MSBuild targets that rely on RID (e.g. Clean) fail with a cryptic error.
+    /// Check if Runtime Identifier of the current MSBuild task exists in the targets of the project.assets.json.
+    /// Throw an error if RID is not present in the targets.
     /// </summary>
     public sealed class CheckRuntimeIdentifier : TaskBase
     {
@@ -60,10 +60,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private void ThrowRuntimeIdentifierMismatchError()
         {
-            var ridMismatchMessage = string.Format(Strings.AssetsFileMissingRuntimeIdentifier,
-                ProjectAssetsFile, $"{TargetFramework}/{RuntimeIdentifier}",
-                TargetFramework, RuntimeIdentifier);
-
+            var ridMismatchMessage = string.Format(Strings.AssetsFileRuntimeIdentifierMismatch, RuntimeIdentifier);
             throw new BuildErrorException(ridMismatchMessage);
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// todo
+    /// </summary>
+    public sealed class CheckRuntimeIdentifier : TaskBase
+    {
+        #region Input Items
+
+        /// <summary>
+        /// Path to assets.json.
+        /// </summary>
+        public string ProjectAssetsFile { get; set; }
+
+        /// <summary>
+        /// TargetFramework to use for compile-time assets.
+        /// </summary>
+        [Required]
+        public string TargetFramework { get; set; }
+
+        /// <summary>
+        /// RID to use for runtime assets (may be empty)
+        /// </summary>
+        public string RuntimeIdentifier { get; set; }
+
+        #endregion
+
+        protected override void ExecuteCore()
+        {
+            if (string.IsNullOrEmpty(ProjectAssetsFile))
+            {
+                return; // can't check RuntimeIdentifier without ProjectAssetsFile
+            }
+
+            if (string.IsNullOrEmpty(RuntimeIdentifier))
+            {
+                return; // can't check RuntimeIdentifier if it is null
+            }
+
+            if (LockFileHasMatchingRuntimeIdentifier())
+            {
+                return;
+            }
+
+            ThrowRuntimeIdentifierMismatchError();
+        }
+
+        private bool LockFileHasMatchingRuntimeIdentifier()
+        {
+            var lockFile = new LockFileCache(this).GetLockFile(ProjectAssetsFile);
+            var target = lockFile.GetTargetAndReturnNullIfNotFound(TargetFramework, RuntimeIdentifier);
+            return target != null;
+        }
+
+        private void ThrowRuntimeIdentifierMismatchError()
+        {
+            var message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, ProjectAssetsFile, "todo", TargetFramework, RuntimeIdentifier);
+            throw new BuildErrorException(message);
+        }
+    }
+}
+
+

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
@@ -6,7 +6,8 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks
 {
     /// <summary>
-    /// todo
+    /// Check if Runtime Identifier of the current MSBuild task matches the targets of projects.assets.json.
+    /// Without this check MSBuild targets that rely on RID (e.g. Clean) fail with a cryptic error.
     /// </summary>
     public sealed class CheckRuntimeIdentifier : TaskBase
     {
@@ -59,8 +60,11 @@ namespace Microsoft.NET.Build.Tasks
 
         private void ThrowRuntimeIdentifierMismatchError()
         {
-            var message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, ProjectAssetsFile, "todo", TargetFramework, RuntimeIdentifier);
-            throw new BuildErrorException(message);
+            var ridMismatchMessage = string.Format(Strings.AssetsFileMissingRuntimeIdentifier,
+                ProjectAssetsFile, $"{TargetFramework}/{RuntimeIdentifier}",
+                TargetFramework, RuntimeIdentifier);
+
+            throw new BuildErrorException(ridMismatchMessage);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
@@ -12,23 +12,19 @@ namespace Microsoft.NET.Build.Tasks
     public sealed class CheckRuntimeIdentifier : TaskBase
     {
         #region Input Items
-
         /// <summary>
         /// Path to assets.json.
         /// </summary>
         public string ProjectAssetsFile { get; set; }
-
         /// <summary>
         /// TargetFramework to use for compile-time assets.
         /// </summary>
         [Required]
         public string TargetFramework { get; set; }
-
         /// <summary>
         /// RID to use for runtime assets (may be empty)
         /// </summary>
         public string RuntimeIdentifier { get; set; }
-
         #endregion
 
         protected override void ExecuteCore()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckRuntimeIdentifier.cs
@@ -23,23 +23,19 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string TargetFramework { get; set; }
         /// <summary>
-        /// RID to use for runtime assets (may be empty)
+        /// RID to use for runtime assets.
         /// </summary>
+        [Required]
         public string RuntimeIdentifier { get; set; }
 
         #endregion
 
         protected override void ExecuteCore()
         {
-            if (string.IsNullOrEmpty(RuntimeIdentifier))
-            {
-                return; // can't check RuntimeIdentifier if it is null
-            }
-
             var lockFile = new LockFileCache(this).GetLockFile(ProjectAssetsFile);
             var target = lockFile.GetTargetAndReturnNullIfNotFound(TargetFramework, RuntimeIdentifier);
-
-            if (target is null)
+            var targetNotFound = target is null;
+            if (targetNotFound)
             {
                 var ridMismatchMessage = string.Format(Strings.AssetsFileRuntimeIdentifierMismatch, RuntimeIdentifier);
                 throw new BuildErrorException(ridMismatchMessage);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -175,6 +175,8 @@ Copyright (c) .NET Foundation. All rights reserved.
            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.ResolvePackageAssets"
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.CheckRuntimeIdentifier"
+            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   
   <!-- The condition on this target causes it to be skipped during design-time builds if
         the restore operation hasn't run yet.  This is to avoid displaying an error in
@@ -225,6 +227,17 @@ Copyright (c) .NET Foundation. All rights reserved.
       <CompilerApiVersion>roslyn$(_RoslynApiVersion)</CompilerApiVersion>
     </PropertyGroup>
     
+  </Target>
+
+  <!-- Throws an error when currently used runtime identifier is not present in project.assets.json. -->
+  <Target Name="CheckRuntimeIdentifier" BeforeTargets="ResolvePackageAssets" Condition="'$(DesignTimeBuild)' != 'true'">
+
+    <CheckRuntimeIdentifier
+      TargetFramework="$(TargetFramework)"
+      ProjectAssetsFile="$(ProjectAssetsFile)"
+      RuntimeIdentifier="$(RuntimeIdentifier)">
+    </CheckRuntimeIdentifier>
+
   </Target>
 
   <Target Name="ResolvePackageAssets"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -231,7 +231,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Throws an error when currently used runtime identifier is not present in project.assets.json. -->
   <Target Name="CheckRuntimeIdentifier"
-          Condition="'$(DesignTimeBuild)' != 'true'"
+          Condition="'$(DesignTimeBuild)' != 'true' And Exists('$(ProjectAssetsFile)')"
           BeforeTargets="ResolvePackageAssets">
 
     <CheckRuntimeIdentifier

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -231,7 +231,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Throws an error when currently used runtime identifier is not present in project.assets.json. -->
   <Target Name="CheckRuntimeIdentifier"
-          Condition="'$(DesignTimeBuild)' != 'true' And Exists('$(ProjectAssetsFile)')"
+          Condition="'$(DesignTimeBuild)' != 'true' And Exists('$(ProjectAssetsFile)') And '$(RuntimeIdentifier)' != '' And '$(DOTNET_CLI_DISABLE_RUNTIME_ASSETS_RESTORE_CHECK)'!='true'"
           BeforeTargets="ResolvePackageAssets">
 
     <CheckRuntimeIdentifier

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -230,7 +230,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!-- Throws an error when currently used runtime identifier is not present in project.assets.json. -->
-  <Target Name="CheckRuntimeIdentifier" BeforeTargets="ResolvePackageAssets" Condition="'$(DesignTimeBuild)' != 'true'">
+  <Target Name="CheckRuntimeIdentifier"
+          Condition="'$(DesignTimeBuild)' != 'true'"
+          BeforeTargets="ResolvePackageAssets">
 
     <CheckRuntimeIdentifier
       TargetFramework="$(TargetFramework)"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -507,7 +507,7 @@ namespace FrameworkReferenceTest
             //  If we do the work in https://github.com/dotnet/cli/issues/10528,
             //  then we should add a new error message here indicating that the runtime pack hasn't
             //  been downloaded.
-            string expectedErrorCode = "NETSDK1047";
+            string expectedErrorCode = "NETSDK1214";
 
             buildCommand
                 .ExecuteWithoutRestore($"/p:RuntimeIdentifier={runtimeIdentifier}")

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
@nagilson
Resolves #30199

Since the error appeared in the `ResolvePackageAssets` task of `Microsoft.PackageDependencyResolution.targets` I have added RID validation before it. `CheckRuntimeIdentifier` task handles the situations when there is a mismatch between the runtime identifier of the project and project.assets.json targets. More descriptive build error is now shown when `dotnet clean` is invoked.

Here is a screenshot of the updated error message (and current workflow):
![image](https://github.com/dotnet/sdk/assets/71710108/4990c320-8669-4b77-bc04-ce2bda4ae8ae)


