### PR TITLE
Parse -d command differently based on position

### DIFF
--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -75,18 +75,16 @@ namespace Microsoft.DotNet.Cli
             {
                 return true;
             }
-            else
+
+            for (var i = 0; i < args.Length; i++)
             {
-                for (var i = 0; i < args.Length; i++)
+                if (args[i].Equals(subCommand))
                 {
-                    if (args[i].Equals(subCommand))
-                    {
-                        return false;
-                    }
-                    else if (DiagOption.Aliases.Contains(args[i]))
-                    {
-                        return true;
-                    }
+                    return false;
+                }
+                else if (DiagOption.Aliases.Contains(args[i]))
+                {
+                    return true;
                 }
             }
 

--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -69,6 +69,30 @@ namespace Microsoft.DotNet.Cli
             return subargs.Concat(runArgs).ToArray();
         }
 
+        public static bool DiagOptionPrecedesSubcommand(this string[] args, string subCommand)
+        {
+            if (string.IsNullOrEmpty(subCommand))
+            {
+                return true;
+            }
+            else
+            {
+                for (var i = 0; i < args.Length; i++)
+                {
+                    if (args[i].Equals(subCommand))
+                    {
+                        return false;
+                    }
+                    else if (DiagOption.Aliases.Contains(args[i]))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         private static string GetSymbolResultValue(ParseResult parseResult, SymbolResult symbolResult)
         {
             if (symbolResult.Token() == null)

--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Cli
             var runArgs = subargs.Contains("--") ? subargs.GetRange(subargs.IndexOf("--"), subargs.Count() - subargs.IndexOf("--")) : new List<string>();
             subargs = subargs.Contains("--") ? subargs.GetRange(0, subargs.IndexOf("--")) : subargs;
 
-            subargs.RemoveAll(arg => DiagOption.Aliases.Contains(arg));
+            subargs.SkipWhile(arg => DiagOption.Aliases.Contains(arg));
             if (subargs[0].Equals("dotnet"))
             {
                 subargs.RemoveAt(0);

--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -61,12 +61,15 @@ namespace Microsoft.DotNet.Cli
             var subargs = args.ToList();
 
             // Don't remove any arguments that are being passed to the app in dotnet run
-            var runArgs = subargs.Contains("--") ? subargs.GetRange(subargs.IndexOf("--"), subargs.Count() - subargs.IndexOf("--")) : new List<string>();
-            subargs = subargs.Contains("--") ? subargs.GetRange(0, subargs.IndexOf("--")) : subargs;
+            var dashDashIndex = subargs.IndexOf("--");
+            var runArgs = dashDashIndex > -1 ? subargs.GetRange(dashDashIndex, subargs.Count() - dashDashIndex) : new List<string>(0);
+            subargs = dashDashIndex > -1 ? subargs.GetRange(0, dashDashIndex) : subargs;
 
-            subargs = subargs.SkipWhile(arg => DiagOption.Aliases.Contains(arg) || arg.Equals("dotnet")).ToList();
-            subargs.RemoveAt(0); // remove top level command (ex build or publish)
-            return subargs.Concat(runArgs).ToArray();
+            return subargs
+                .SkipWhile(arg => DiagOption.Aliases.Contains(arg) || arg.Equals("dotnet"))
+                .Skip(1) // remove top level command (ex build or publish)
+                .Concat(runArgs)
+                .ToArray();
         }
 
         public static bool DiagOptionPrecedesSubcommand(this string[] args, string subCommand)

--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Cli
             var runArgs = subargs.Contains("--") ? subargs.GetRange(subargs.IndexOf("--"), subargs.Count() - subargs.IndexOf("--")) : new List<string>();
             subargs = subargs.Contains("--") ? subargs.GetRange(0, subargs.IndexOf("--")) : subargs;
 
-            subargs.SkipWhile(arg => DiagOption.Aliases.Contains(arg));
+            subargs = subargs.SkipWhile(arg => DiagOption.Aliases.Contains(arg)).ToList();
             if (subargs[0].Equals("dotnet"))
             {
                 subargs.RemoveAt(0);

--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -64,11 +64,7 @@ namespace Microsoft.DotNet.Cli
             var runArgs = subargs.Contains("--") ? subargs.GetRange(subargs.IndexOf("--"), subargs.Count() - subargs.IndexOf("--")) : new List<string>();
             subargs = subargs.Contains("--") ? subargs.GetRange(0, subargs.IndexOf("--")) : subargs;
 
-            subargs = subargs.SkipWhile(arg => DiagOption.Aliases.Contains(arg)).ToList();
-            if (subargs[0].Equals("dotnet"))
-            {
-                subargs.RemoveAt(0);
-            }
+            subargs = subargs.SkipWhile(arg => DiagOption.Aliases.Contains(arg) || arg.Equals("dotnet")).ToList();
             subargs.RemoveAt(0); // remove top level command (ex build or publish)
             return subargs.Concat(runArgs).ToArray();
         }

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -139,9 +139,14 @@ namespace Microsoft.DotNet.Cli
                             ToolPathSentinelFileName)));
                 if (parseResult.ValueForOption<bool>(Parser.DiagOption) && parseResult.IsDotnetBuiltInCommand())
                 {
-                    Environment.SetEnvironmentVariable(CommandContext.Variables.Verbose, bool.TrueString);
-                    CommandContext.SetVerbose(true);
-                    Reporter.Reset();
+                    // We found --diagnostic or -d, but we still need to determine whether the option should
+                    // be attached to the dotnet command or the subcommand.
+                    if (args.DiagOptionPrecedesSubcommand(parseResult.RootSubCommandResult()))
+                    {
+                        Environment.SetEnvironmentVariable(CommandContext.Variables.Verbose, bool.TrueString);
+                        CommandContext.SetVerbose(true);
+                        Reporter.Reset();
+                    }
                 }
                 if (parseResult.HasOption(Parser.VersionOption) && parseResult.IsTopLevelDotnetCommand())
                 {

--- a/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
         [Theory]
         [InlineData(new string[] { "dotnet", "build" }, new string[] { })]
         [InlineData(new string[] { "build" }, new string[] { })]
-        [InlineData(new string[] { "dotnet", "test", "-d" }, new string[] { })]
+        [InlineData(new string[] { "dotnet", "test", "-d" }, new string[] { "-d" })]
         [InlineData(new string[] { "dotnet", "publish", "-o", "foo" }, new string[] { "-o", "foo" })]
         [InlineData(new string[] { "publish", "-o", "foo" }, new string[] { "-o", "foo" })]
         [InlineData(new string[] { "dotnet", "add", "package", "-h" }, new string[] { "package", "-h" })]


### PR DESCRIPTION
Fixes #29839

**Description**
If -d is at the beginning of the list of subarguments, that is, before the subcommand, it should be associated with 'dotnet' and therefore ignored when getting at the list of subarguments. If it's after the subcommand, however, it should be parsed as part of the subcommand.

This differentiates between the two positionings.

**Impact**
Some users specify -d, intending to get diagnostic-verbosity output. Other specify it as a subcommand for dotnet-ef to indicate that it should use attributes to configure the model. There is currently no way to disambiguate between the two, and dotnet (as the initial command) takes preference, automatically stripping any -d anywhere in the input, preventing users from using it as an option to their subcommands (in this case dotnet-ef).

**Changes**
Alter -d parsing to parse the -d as diagnostic if it comes before the subcommand but as an option to the subcommand if it comes after it.

**Risk**
Some people might append -d to the end of their command, intending to get diagnostic output, and that would no longer work as intended. I don't know how common that is.

**Testing**
I changed a unit test to ensure -d is parsed as intended.