### PR TITLE
Enable Razor server to quickly find dotnet.exe from VS

### DIFF
--- a/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
+++ b/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
@@ -281,6 +281,40 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             }
         }
 
+        private static string FindDotNetExecutable()
+        {
+            var expectedPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+            if (!string.IsNullOrEmpty(expectedPath))
+            {
+                return expectedPath;
+            }
+
+#if NET
+            expectedPath = System.Environment.ProcessPath;
+#else
+            expectedPath = Process.GetCurrentProcess().MainModule.FileName;
+#endif
+
+            if ("dotnet".Equals(Path.GetFileNameWithoutExtension(expectedPath), StringComparison.Ordinal))
+            {
+                return expectedPath;
+            }
+
+            // We were probably running from Visual Studio or Build Tools and found MSBuild instead of dotnet. Use the PATH...
+            var paths = Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator);
+            var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+            foreach (string path in paths)
+            {
+                var dotnetPath = Path.Combine(path, exeName);
+                if (File.Exists(dotnetPath))
+                {
+                    return dotnetPath;
+                }
+            }
+
+            return exeName;
+        }
+
         // Internal for testing.
         internal static bool TryCreateServerCore(string clientDir, string pipeName, out int? processId, bool debug = false)
         {
@@ -289,15 +323,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             // The server should be in the same directory as the client
             var expectedCompilerPath = Path.Combine(clientDir, ServerName);
 
-            var expectedPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
-            if (string.IsNullOrEmpty(expectedPath))
-            {
-#if NET
-                expectedPath = System.Environment.ProcessPath;
-#else
-                expectedPath = Process.GetCurrentProcess().MainModule.FileName;
-#endif
-            }
+            var expectedPath = FindDotNetExecutable();
 
             var argumentList = new string[]
             {


### PR DESCRIPTION
Fixes [AB#1872193](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1872193)

**Customer Impact**
When building a Razor project from Visual Studio or using VS Build Tools, the Razor server attempts to connect to MSBuild.exe instead of dotnet.exe. This fails after a long delay, causing a build that should take a couple seconds to take a couple minutes—that is, the amount of time for the server to time out plus a couple seconds for the fallback (building without the server) to complete.

**Testing**
I spoke with @jjonescz, who was able to test the changes. He confirmed that with these changes, the bug no longer reproduces, and it now finds a full path to the dotnet executable as desired.

**Risk**
Low. This adds new ways to find the dotnet executable along with some validation that we really found a dotnet executable. If all else fails, it falls back to essentially the code that existed prior to the security change.