### PR TITLE
Include NuGet.Packaging in ApiCompat.Task package

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -42,7 +42,7 @@
     <ProjectReference Include="..\Microsoft.DotNet.PackageValidation\Microsoft.DotNet.PackageValidation.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" />
     <!-- We carry NuGet as part of the package in case the package is used with an older SDKs or with full framework MSBuild. -->
-    <PackageReference Include="NuGet.Packaging" PrivateAssets="All"/>
+    <PackageReference Include="NuGet.Packaging" PrivateAssets="All" Publish="true"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes issue raised https://github.com/dotnet/sdk/pull/35467#issuecomment-1724225959

The SDK will filter which references will actually publish when `PrivateAssets` is set, but only for direct references.  Here's that feature:
https://github.com/dotnet/sdk/blob/8dfacada1686acac8cfb88971fe2f49adacd9e04/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Shared.targets#L50-L60
I'm not sure I really agree with that behavior -- since all the transitive references are still Private, but not filtered -- but it is what it is.  This explains why the project previously set `Publish` metadata.

Here's the diff after this change, compared to the latest RC2 package: https://www.diffchecker.com/fmxLyhv6/

The removal of NuGet.Protocols and its closure is expected.  Nothing was using that anymore after we removed the task that fetched the latest version from NuGet long ago.  I intentionally dropped this in the original PR.  There are no assembly references to this assembly in the task or its dependencies.