### PR TITLE
Add Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100 as a dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -47,10 +47,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>a6c64c3c26417f579022e20cbcee992b4814ed2c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-alpha.1.23457.3" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100" Version="9.0.0-alpha.1.23457.3" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>7da45c33d57a762de5756f2c090e84327dae143f</Sha>
-      <SourceBuild RepoName="emsdk" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="17.8.0-preview-23468-06">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -207,8 +207,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Workloads from dotnet/emsdk -->
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportPackageVersion>9.0.0-alpha.1.23457.3</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportPackageVersion>
-    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportPackageVersion)</EmscriptenWorkloadManifestVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest90100PackageVersion>9.0.0-alpha.1.23457.3</MicrosoftNETWorkloadEmscriptenCurrentManifest90100PackageVersion>
+    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100PackageVersion)</EmscriptenWorkloadManifestVersion>
     <!-- emsdk workload prerelease version band must match the emsdk feature band -->
     <EmscriptenWorkloadFeatureBand>9.0.100$([System.Text.RegularExpressions.Regex]::Match($(EmscriptenWorkloadManifestVersion), `-[A-z]*[\.]*\d*`))</EmscriptenWorkloadFeatureBand>
     <!-- Workloads from dotnet/runtime use MicrosoftNETCoreAppRefPackageVersion because it has a stable name that does not include the full feature band -->


### PR DESCRIPTION
Add Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100 as a dependency and use its version for microsoft.net.workload.emscripten.current, since it stabilizes. Fixes: https://dev.azure.com/dnceng/internal/_build/results?buildId=2268247&view=logs&j=6781b346-0bd1-5062-714a-0158c8df1d42&t=28240f7a-11a7-53df-bdd9-fb54c991f1ba&l=589