### PR TITLE
[release/8.0.1xx] Use MicrosoftAspNetCoreComponentsSdkAnalyzersPackageVersion for aspnetcore version

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,7 +6,7 @@
         "$(VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion)"
       ],
       "aspnetcore": [
-        "$(MicrosoftAspNetCoreAppRefPackageVersion)"
+        "$(MicrosoftAspNetCoreComponentsSdkAnalyzersPackageVersion)"
       ]
     },
     "vs-opt": {


### PR DESCRIPTION
Aspnetcore version should be referencing an unstable package that is shipped every release. Fixes https://dev.azure.com/dnceng/internal/_build/results?buildId=2272009&view=logs&j=fa59fe4e-195c-56fa-189b-58fd241f10dd&t=71146b80-38e1-5fea-9b74-ba1045aac3e1&l=132