### PR TITLE
We don't need this 🙃

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
@@ -130,7 +130,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             foreach (FilterOptionDefinition filterDef in filtersToSetup)
             {
                 CliOption newOption = GetFilterOption(filterDef);
-                this.Options.Add(newOption);
+                Options.Add(newOption);
                 options[filterDef] = newOption;
             }
             return options;
@@ -141,8 +141,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         /// </summary>
         protected void SetupTabularOutputOptions(ITabularOutputCommand command)
         {
-            this.Options.Add(command.ColumnsAllOption);
-            this.Options.Add(command.ColumnsOption);
+            Options.Add(command.ColumnsAllOption);
+            Options.Add(command.ColumnsOption);
         }
 
         private static async Task HandleGlobalOptionsAsync(

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.Legacy.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.Legacy.cs
@@ -135,33 +135,33 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         private void BuildLegacySymbols(Func<ParseResult, ITemplateEngineHost> hostBuilder)
         {
-            this.Arguments.Add(ShortNameArgument);
-            this.Arguments.Add(RemainingArguments);
+            Arguments.Add(ShortNameArgument);
+            Arguments.Add(RemainingArguments);
 
             //legacy options
             Dictionary<FilterOptionDefinition, CliOption> options = new();
             foreach (var filterDef in LegacyFilterDefinitions)
             {
                 options[filterDef] = filterDef.OptionFactory().AsHidden();
-                this.Options.Add(options[filterDef]);
+                Options.Add(options[filterDef]);
             }
             LegacyFilters = options;
 
-            this.Options.Add(InteractiveOption);
-            this.Options.Add(AddSourceOption);
-            this.Options.Add(ColumnsAllOption);
-            this.Options.Add(ColumnsOption);
+            Options.Add(InteractiveOption);
+            Options.Add(AddSourceOption);
+            Options.Add(ColumnsAllOption);
+            Options.Add(ColumnsOption);
 
-            this.TreatUnmatchedTokensAsErrors = true;
+            TreatUnmatchedTokensAsErrors = true;
 
-            this.Add(new LegacyInstallCommand(this, hostBuilder));
-            this.Add(new LegacyUninstallCommand(this, hostBuilder));
-            this.Add(new LegacyUpdateCheckCommand(this, hostBuilder));
-            this.Add(new LegacyUpdateApplyCommand(this, hostBuilder));
-            this.Add(new LegacySearchCommand(this, hostBuilder));
-            this.Add(new LegacyListCommand(this, hostBuilder));
-            this.Add(new LegacyAliasAddCommand(hostBuilder));
-            this.Add(new LegacyAliasShowCommand(hostBuilder));
+            Add(new LegacyInstallCommand(this, hostBuilder));
+            Add(new LegacyUninstallCommand(this, hostBuilder));
+            Add(new LegacyUpdateCheckCommand(this, hostBuilder));
+            Add(new LegacyUpdateApplyCommand(this, hostBuilder));
+            Add(new LegacySearchCommand(this, hostBuilder));
+            Add(new LegacyListCommand(this, hostBuilder));
+            Add(new LegacyAliasAddCommand(hostBuilder));
+            Add(new LegacyAliasShowCommand(hostBuilder));
         }
     }
 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.cs
@@ -15,33 +15,33 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(hostBuilder, commandName, SymbolStrings.Command_New_Description)
         {
-            this.TreatUnmatchedTokensAsErrors = true;
+            TreatUnmatchedTokensAsErrors = true;
 
             //it is important that legacy commands are built before non-legacy, as non legacy commands are building validators that rely on legacy stuff
             BuildLegacySymbols(hostBuilder);
 
-            this.Add(new InstantiateCommand(this, hostBuilder));
-            this.Add(new InstallCommand(this, hostBuilder));
-            this.Add(new UninstallCommand(this, hostBuilder));
-            this.Add(new UpdateCommand(this, hostBuilder));
-            this.Add(new SearchCommand(this, hostBuilder));
-            this.Add(new ListCommand(this, hostBuilder));
-            this.Add(new AliasCommand(hostBuilder));
-            this.Add(new DetailsCommand(hostBuilder));
+            Add(new InstantiateCommand(this, hostBuilder));
+            Add(new InstallCommand(this, hostBuilder));
+            Add(new UninstallCommand(this, hostBuilder));
+            Add(new UpdateCommand(this, hostBuilder));
+            Add(new SearchCommand(this, hostBuilder));
+            Add(new ListCommand(this, hostBuilder));
+            Add(new AliasCommand(hostBuilder));
+            Add(new DetailsCommand(hostBuilder));
 
-            this.Options.Add(DebugCustomSettingsLocationOption);
-            this.Options.Add(DebugVirtualizeSettingsOption);
-            this.Options.Add(DebugAttachOption);
-            this.Options.Add(DebugReinitOption);
-            this.Options.Add(DebugRebuildCacheOption);
-            this.Options.Add(DebugShowConfigOption);
+            Options.Add(DebugCustomSettingsLocationOption);
+            Options.Add(DebugVirtualizeSettingsOption);
+            Options.Add(DebugAttachOption);
+            Options.Add(DebugReinitOption);
+            Options.Add(DebugRebuildCacheOption);
+            Options.Add(DebugShowConfigOption);
 
-            this.Options.Add(SharedOptions.OutputOption);
-            this.Options.Add(SharedOptions.NameOption);
-            this.Options.Add(SharedOptions.DryRunOption);
-            this.Options.Add(SharedOptions.ForceOption);
-            this.Options.Add(SharedOptions.NoUpdateCheckOption);
-            this.Options.Add(SharedOptions.ProjectPathOption);
+            Options.Add(SharedOptions.OutputOption);
+            Options.Add(SharedOptions.NameOption);
+            Options.Add(SharedOptions.DryRunOption);
+            Options.Add(SharedOptions.ForceOption);
+            Options.Add(SharedOptions.NoUpdateCheckOption);
+            Options.Add(SharedOptions.ProjectPathOption);
         }
 
         internal static CliOption<string?> DebugCustomSettingsLocationOption { get; } = new("--debug:custom-hive")

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/alias/AliasCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/alias/AliasCommand.cs
@@ -14,8 +14,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             : base(hostBuilder, "alias", SymbolStrings.Command_Alias_Description)
         {
             Hidden = true;
-            this.Add(new AliasAddCommand(hostBuilder));
-            this.Add(new AliasShowCommand(hostBuilder));
+            Add(new AliasAddCommand(hostBuilder));
+            Add(new AliasShowCommand(hostBuilder));
         }
 
         protected override Task<NewCommandStatus> ExecuteAsync(

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs
@@ -19,23 +19,23 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(hostBuilder, "create", SymbolStrings.Command_Instantiate_Description)
         {
-            this.Arguments.Add(ShortNameArgument);
-            this.Arguments.Add(RemainingArguments);
+            Arguments.Add(ShortNameArgument);
+            Arguments.Add(RemainingArguments);
 
-            this.Options.Add(SharedOptions.OutputOption);
-            this.Options.Add(SharedOptions.NameOption);
-            this.Options.Add(SharedOptions.DryRunOption);
-            this.Options.Add(SharedOptions.ForceOption);
-            this.Options.Add(SharedOptions.NoUpdateCheckOption);
-            this.Options.Add(SharedOptions.ProjectPathOption);
+            Options.Add(SharedOptions.OutputOption);
+            Options.Add(SharedOptions.NameOption);
+            Options.Add(SharedOptions.DryRunOption);
+            Options.Add(SharedOptions.ForceOption);
+            Options.Add(SharedOptions.NoUpdateCheckOption);
+            Options.Add(SharedOptions.ProjectPathOption);
 
             parentCommand.AddNoLegacyUsageValidators(this);
-            this.Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.OutputOption));
-            this.Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.NameOption));
-            this.Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.DryRunOption));
-            this.Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.ForceOption));
-            this.Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.NoUpdateCheckOption));
-            this.Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.ProjectPathOption));
+            Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.OutputOption));
+            Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.NameOption));
+            Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.DryRunOption));
+            Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.ForceOption));
+            Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.NoUpdateCheckOption));
+            Validators.Add(symbolResult => parentCommand.ValidateOptionUsage(symbolResult, SharedOptions.ProjectPathOption));
         }
 
         internal static CliArgument<string> ShortNameArgument { get; } = new CliArgument<string>("template-short-name")

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InvalidTemplateOptionResult.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InvalidTemplateOptionResult.cs
@@ -78,7 +78,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         public bool Equals(InvalidTemplateOptionResult? other)
         {
-            return this.Equals(other as object);
+            return Equals(other as object);
         }
 
         internal static InvalidTemplateOptionResult FromParseError(TemplateOption option, ParseResult parseResult, ParseError error)

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -49,11 +49,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 Aliases.Add(item);
             }
 
-            this.Options.Add(SharedOptions.OutputOption);
-            this.Options.Add(SharedOptions.NameOption);
-            this.Options.Add(SharedOptions.DryRunOption);
-            this.Options.Add(SharedOptions.ForceOption);
-            this.Options.Add(SharedOptions.NoUpdateCheckOption);
+            Options.Add(SharedOptions.OutputOption);
+            Options.Add(SharedOptions.NameOption);
+            Options.Add(SharedOptions.DryRunOption);
+            Options.Add(SharedOptions.ForceOption);
+            Options.Add(SharedOptions.NoUpdateCheckOption);
 
             string? templateLanguage = template.GetLanguage();
             string? defaultLanguage = environmentSettings.GetDefaultLanguage();
@@ -77,7 +77,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     }
                     );
                 }
-                this.Options.Add(LanguageOption);
+                Options.Add(LanguageOption);
             }
 
             string? templateType = template.GetTemplateType();
@@ -87,7 +87,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 TypeOption = SharedOptionsFactory.CreateTypeOption();
                 TypeOption.Description = SymbolStrings.TemplateCommand_Option_Type;
                 TypeOption.FromAmongCaseInsensitive(new[] { templateType });
-                this.Options.Add(TypeOption);
+                Options.Add(TypeOption);
             }
 
             if (template.BaselineInfo.Any(b => !string.IsNullOrWhiteSpace(b.Key)))
@@ -95,7 +95,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 BaselineOption = SharedOptionsFactory.CreateBaselineOption();
                 BaselineOption.Description = SymbolStrings.TemplateCommand_Option_Baseline;
                 BaselineOption.FromAmongCaseInsensitive(template.BaselineInfo.Select(b => b.Key).Where(b => !string.IsNullOrWhiteSpace(b)).ToArray());
-                this.Options.Add(BaselineOption);
+                Options.Add(BaselineOption);
             }
 
             if (HasRunScriptPostActionDefined(template))
@@ -106,7 +106,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     Arity = new ArgumentArity(1, 1)
                 };
                 AllowScriptsOption.DefaultValueFactory = (_) => AllowRunScripts.Prompt;
-                this.Options.Add(AllowScriptsOption);
+                Options.Add(AllowScriptsOption);
             }
 
             AddTemplateOptionsToCommand(template);
@@ -311,7 +311,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             foreach ((CliTemplateParameter parameter, IReadOnlySet<string> aliases, IReadOnlyList<string> _) in parametersWithAliasAssignments)
             {
                 TemplateOption option = new TemplateOption(parameter, aliases);
-                this.Options.Add(option.Option);
+                Options.Add(option.Option);
                 _templateSpecificOptions[parameter.Name] = option;
             }
         }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
@@ -16,10 +16,10 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             : base(hostBuilder, commandName, SymbolStrings.Command_Install_Description)
         {
             ParentCommand = parentCommand;
-            this.Arguments.Add(NameArgument);
-            this.Options.Add(InteractiveOption);
-            this.Options.Add(AddSourceOption);
-            this.Options.Add(ForceOption);
+            Arguments.Add(NameArgument);
+            Options.Add(InteractiveOption);
+            Options.Add(AddSourceOption);
+            Options.Add(ForceOption);
         }
 
         internal static CliArgument<string[]> NameArgument { get; } = new("package")

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/LegacyInstallCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/LegacyInstallCommand.cs
@@ -12,8 +12,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         public LegacyInstallCommand(NewCommand parentCommand, Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(parentCommand, hostBuilder, "--install")
         {
-            this.Hidden = true;
-            this.Aliases.Add("-i");
+            Hidden = true;
+            Aliases.Add("-i");
 
             parentCommand.AddNoLegacyUsageValidators(this, except: new CliOption[] { InteractiveOption, AddSourceOption });
         }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/BaseListCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/BaseListCommand.cs
@@ -27,10 +27,10 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             ParentCommand = parentCommand;
             Filters = SetupFilterOptions(SupportedFilters);
 
-            this.Arguments.Add(NameArgument);
-            this.Options.Add(IgnoreConstraintsOption);
-            this.Options.Add(SharedOptions.OutputOption);
-            this.Options.Add(SharedOptions.ProjectPathOption);
+            Arguments.Add(NameArgument);
+            Options.Add(IgnoreConstraintsOption);
+            Options.Add(SharedOptions.OutputOption);
+            Options.Add(SharedOptions.ProjectPathOption);
             SetupTabularOutputOptions(this);
         }
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/LegacyListCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/LegacyListCommand.cs
@@ -15,9 +15,9 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(parentCommand, hostBuilder, "--list")
         {
-            this.Hidden = true;
-            this.Aliases.Add("-l");
-            this.Validators.Add(ValidateParentCommandArguments);
+            Hidden = true;
+            Aliases.Add("-l");
+            Validators.Add(ValidateParentCommandArguments);
 
             parentCommand.AddNoLegacyUsageValidators(this, except: Filters.Values.Concat(new CliSymbol[] { ColumnsAllOption, ColumnsOption, NewCommand.ShortNameArgument }).ToArray());
         }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/search/BaseSearchCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/search/BaseSearchCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             ParentCommand = parentCommand;
             Filters = SetupFilterOptions(SupportedFilters);
 
-            this.Arguments.Add(NameArgument);
+            Arguments.Add(NameArgument);
             SetupTabularOutputOptions(this);
         }
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/search/LegacySearchCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/search/LegacySearchCommand.cs
@@ -13,8 +13,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         public LegacySearchCommand(NewCommand parentCommand, Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(parentCommand, hostBuilder, "--search")
         {
-            this.Hidden = true;
-            this.Validators.Add(ValidateParentCommandArguments);
+            Hidden = true;
+            Validators.Add(ValidateParentCommandArguments);
 
             parentCommand.AddNoLegacyUsageValidators(this, except: Filters.Values.Concat(new CliSymbol[] { ColumnsAllOption, ColumnsOption, NewCommand.ShortNameArgument }).ToArray());
         }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/uninstall/BaseUninstallCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/uninstall/BaseUninstallCommand.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             string commandName)
             : base(hostBuilder, commandName, SymbolStrings.Command_Uninstall_Description)
         {
-            this.Arguments.Add(NameArgument);
+            Arguments.Add(NameArgument);
         }
 
         internal static CliArgument<string[]> NameArgument { get; } = new("package")

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/uninstall/LegacyUninstallCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/uninstall/LegacyUninstallCommand.cs
@@ -14,8 +14,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(hostBuilder, "--uninstall")
         {
-            this.Hidden = true;
-            this.Aliases.Add("-u");
+            Hidden = true;
+            Aliases.Add("-u");
 
             parentCommand.AddNoLegacyUsageValidators(this);
         }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/update/BaseUpdateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/update/BaseUpdateCommand.cs
@@ -17,8 +17,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             : base(hostBuilder, commandName, description)
         {
             ParentCommand = parentCommand;
-            this.Options.Add(InteractiveOption);
-            this.Options.Add(AddSourceOption);
+            Options.Add(InteractiveOption);
+            Options.Add(AddSourceOption);
         }
 
         internal virtual CliOption<bool> InteractiveOption { get; } = SharedOptionsFactory.CreateInteractiveOption();

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/update/LegacyUpdateApplyCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/update/LegacyUpdateApplyCommand.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(parentCommand, hostBuilder, "--update-apply", SymbolStrings.Command_Legacy_Update_Check_Description)
         {
-            this.Hidden = true;
+            Hidden = true;
             parentCommand.AddNoLegacyUsageValidators(this, except: new CliOption[] { InteractiveOption, AddSourceOption });
         }
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/update/LegacyUpdateCheckCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/update/LegacyUpdateCheckCommand.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(parentCommand, hostBuilder, "--update-check", SymbolStrings.Command_Update_Description)
         {
-            this.Hidden = true;
+            Hidden = true;
             parentCommand.AddNoLegacyUsageValidators(this, except: new CliOption[] { InteractiveOption, AddSourceOption });
         }
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/update/UpdateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/update/UpdateCommand.cs
@@ -15,7 +15,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             : base(parentCommand, hostBuilder, "update", SymbolStrings.Command_Update_Description)
         {
             parentCommand.AddNoLegacyUsageValidators(this);
-            this.Options.Add(CheckOnlyOption);
+            Options.Add(CheckOnlyOption);
         }
 
         internal static CliOption<bool> CheckOnlyOption { get; } = new("--check-only", "--dry-run")

--- a/src/Cli/dotnet-new3/CompleteCommand.cs
+++ b/src/Cli/dotnet-new3/CompleteCommand.cs
@@ -21,11 +21,11 @@ namespace Dotnet_new3
 
         internal CompleteCommand() : base("complete", "tab completion")
         {
-            this.Arguments.Add(PathArgument);
-            this.Options.Add(PositionOption);
+            Arguments.Add(PathArgument);
+            Options.Add(PositionOption);
 
-            this.SetAction(Run);
-            this.Hidden = true;
+            SetAction(Run);
+            Hidden = true;
         }
 
         public Task<int> Run(ParseResult result, CancellationToken cancellationToken)

--- a/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProvider.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.Tools.New
 
         internal OptionalWorkloadProvider(ITemplatePackageProviderFactory factory, IEngineEnvironmentSettings settings)
         {
-            this.Factory = factory;
-            this._environmentSettings = settings;
+            Factory = factory;
+            _environmentSettings = settings;
         }
 
         public ITemplatePackageProviderFactory Factory { get; }

--- a/src/Containers/Microsoft.NET.Build.Containers/AuthHandshakeMessageHandler.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/AuthHandshakeMessageHandler.cs
@@ -123,8 +123,8 @@ internal sealed partial class AuthHandshakeMessageHandler : DelegatingHandler
         public string ResolvedToken => token ?? access_token ?? throw new ArgumentException(Resource.GetString(nameof(Strings.InvalidTokenResponse)));
         public DateTimeOffset ResolvedExpiration {
             get {
-                var issueTime = this.issued_at ?? DateTimeOffset.UtcNow; // per spec, if no issued_at use the current time
-                var validityDuration = this.expires_in ?? 60; // per spec, if no expires_in use 60 seconds
+                var issueTime = issued_at ?? DateTimeOffset.UtcNow; // per spec, if no issued_at use the current time
+                var validityDuration = expires_in ?? 60; // per spec, if no expires_in use 60 seconds
                 var expirationTime = issueTime.AddSeconds(validityDuration);
                 return expirationTime;
             }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -32,8 +32,8 @@ internal sealed class DockerCli : ILocalRegistry
             throw new ArgumentException($"{command} is an unknown command.");
         }
 
-        this._command = command;
-        this._logger = loggerFactory.CreateLogger<DockerCli>();
+        _command = command;
+        _logger = loggerFactory.CreateLogger<DockerCli>();
     }
 
     public DockerCli(ILoggerFactory loggerFactory) : this(null, loggerFactory)
@@ -110,7 +110,7 @@ internal sealed class DockerCli : ILocalRegistry
 
     public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken)
     {
-        bool commandPathWasUnknown = this._command is null; // avoid running the version command twice.
+        bool commandPathWasUnknown = _command is null; // avoid running the version command twice.
         string? command = await GetCommandAsync(cancellationToken);
         if (command is null)
         {

--- a/src/Containers/containerize/ContainerizeCommand.cs
+++ b/src/Containers/containerize/ContainerizeCommand.cs
@@ -188,31 +188,31 @@ internal class ContainerizeCommand : CliRootCommand
     internal ContainerizeCommand() : base("Containerize an application without Docker.")
     {
         PublishDirectoryArgument.AcceptLegalFilePathsOnly();
-        this.Arguments.Add(PublishDirectoryArgument);
-        this.Options.Add(BaseRegistryOption);
-        this.Options.Add(BaseImageNameOption);
-        this.Options.Add(BaseImageTagOption);
-        this.Options.Add(OutputRegistryOption);
-        this.Options.Add(ArchiveOutputPathOption);
-        this.Options.Add(RepositoryOption);
-        this.Options.Add(ImageTagsOption);
-        this.Options.Add(WorkingDirectoryOption);
-        this.Options.Add(EntrypointOption);
-        this.Options.Add(EntrypointArgsOption);
-        this.Options.Add(DefaultArgsOption);
-        this.Options.Add(AppCommandOption);
-        this.Options.Add(AppCommandArgsOption);
-        this.Options.Add(AppCommandInstructionOption);
-        this.Options.Add(LabelsOption);
-        this.Options.Add(PortsOption);
-        this.Options.Add(EnvVarsOption);
-        this.Options.Add(RidOption);
-        this.Options.Add(RidGraphPathOption);
+        Arguments.Add(PublishDirectoryArgument);
+        Options.Add(BaseRegistryOption);
+        Options.Add(BaseImageNameOption);
+        Options.Add(BaseImageTagOption);
+        Options.Add(OutputRegistryOption);
+        Options.Add(ArchiveOutputPathOption);
+        Options.Add(RepositoryOption);
+        Options.Add(ImageTagsOption);
+        Options.Add(WorkingDirectoryOption);
+        Options.Add(EntrypointOption);
+        Options.Add(EntrypointArgsOption);
+        Options.Add(DefaultArgsOption);
+        Options.Add(AppCommandOption);
+        Options.Add(AppCommandArgsOption);
+        Options.Add(AppCommandInstructionOption);
+        Options.Add(LabelsOption);
+        Options.Add(PortsOption);
+        Options.Add(EnvVarsOption);
+        Options.Add(RidOption);
+        Options.Add(RidGraphPathOption);
         LocalRegistryOption.AcceptOnlyFromAmong(KnownLocalRegistryTypes.SupportedLocalRegistryTypes);
-        this.Options.Add(LocalRegistryOption);
-        this.Options.Add(ContainerUserOption);
+        Options.Add(LocalRegistryOption);
+        Options.Add(ContainerUserOption);
 
-        this.SetAction(async (parseResult, cancellationToken) =>
+        SetAction(async (parseResult, cancellationToken) =>
         {
             DirectoryInfo _publishDir = parseResult.GetValue(PublishDirectoryArgument)!;
             string _baseReg = parseResult.GetValue(BaseRegistryOption)!;

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
@@ -95,7 +95,7 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
                         return null;
                 }
 
-                throw new InvalidOperationException("Unknown resolutionResult type: " + this.GetType());
+                throw new InvalidOperationException("Unknown resolutionResult type: " + GetType());
             }
         }
 

--- a/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
@@ -27,9 +27,9 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
 
         public ConflictResolver(PackageRank packageRank, PackageOverrideResolver<TConflictItem> packageOverrideResolver, Logger log)
         {
-            this._log = log;
-            this._packageRank = packageRank;
-            this._packageOverrideResolver = packageOverrideResolver;
+            _log = log;
+            _packageRank = packageRank;
+            _packageOverrideResolver = packageOverrideResolver;
         }
 
         public void ResolveConflicts(IEnumerable<TConflictItem> conflictItems, Func<TConflictItem, string> getItemKey,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 var implicitPackageReferenceVersion = new ImplicitPackageReferenceVersion(item);
 
-                if (implicitPackageReferenceVersion.TargetFrameworkVersion == this.TargetFrameworkVersion)
+                if (implicitPackageReferenceVersion.TargetFrameworkVersion == TargetFrameworkVersion)
                 {
                     result.Add(implicitPackageReferenceVersion.Name, implicitPackageReferenceVersion);
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -341,7 +341,7 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     foreach (var runtimeIdentifier in RuntimeIdentifiers)
                     {
-                        if (processedPrimaryRuntimeIdentifier && runtimeIdentifier == this.RuntimeIdentifier)
+                        if (processedPrimaryRuntimeIdentifier && runtimeIdentifier == RuntimeIdentifier)
                         {
                             //  We've already processed this RID
                             continue;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -136,8 +136,8 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         throw new BuildErrorException($"Culture not set in runtime manifest for {assetPath}");
                     }
-                    if (this.SatelliteResourceLanguages.Length >= 1 &&
-                        !this.SatelliteResourceLanguages.Any(lang => string.Equals(lang.ItemSpec, culture, StringComparison.OrdinalIgnoreCase)))
+                    if (SatelliteResourceLanguages.Length >= 1 &&
+                        !SatelliteResourceLanguages.Any(lang => string.Equals(lang.ItemSpec, culture, StringComparison.OrdinalIgnoreCase)))
                     {
                         continue;
                     }

--- a/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
+++ b/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             {
                 if (ActionCalledTime != ActionCalledTime.FirstRun && _tellTheActionIsRun())
                 {
-                    this.ActionCalledTime = ActionCalledTime.SecondRun;
+                    ActionCalledTime = ActionCalledTime.SecondRun;
                 }
             }
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData(false, false)]
         public void RunPublishItemsOutputGroupTest(bool specifyRid, bool singleFile)
         {
-            var testProject = this.SetupProject(specifyRid, singleFile);
+            var testProject = SetupProject(specifyRid, singleFile);
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: specifyRid.ToString() + singleFile.ToString());
 
             var restoreCommand = new RestoreCommand(testAsset);
@@ -89,7 +89,7 @@ namespace Microsoft.NET.Publish.Tests
         [Fact]
         public void GroupBuildsWithoutPublish()
         {
-            var testProject = this.SetupProject();
+            var testProject = SetupProject();
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var restoreCommand = new RestoreCommand(testAsset);

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/CoreMSBuildAndWindowsOnlyFactAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/CoreMSBuildAndWindowsOnlyFactAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                this.Skip = "This test requires Core MSBuild and Windows to run";
+                Skip = "This test requires Core MSBuild and Windows to run";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/CoreMSBuildAndWindowsOnlyTheoryAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/CoreMSBuildAndWindowsOnlyTheoryAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                this.Skip = "This test requires Core MSBuild and Windows to run";
+                Skip = "This test requires Core MSBuild and Windows to run";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/CoreMSBuildOnlyFactAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/CoreMSBuildOnlyFactAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
             {
-                this.Skip = "This test requires Core MSBuild to run";
+                Skip = "This test requires Core MSBuild to run";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/CoreMSBuildOnlyTheoryAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/CoreMSBuildOnlyTheoryAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
             {
-                this.Skip = "This test requires Core MSBuild to run";
+                Skip = "This test requires Core MSBuild to run";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/FullMSBuildOnlyFactAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/FullMSBuildOnlyFactAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (!TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
             {
-                this.Skip = "This test requires Full MSBuild to run";
+                Skip = "This test requires Full MSBuild to run";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/FullMSBuildOnlyTheoryAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/FullMSBuildOnlyTheoryAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (!TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
             {
-                this.Skip = "This test requires Full MSBuild to run";
+                Skip = "This test requires Full MSBuild to run";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/PlatformSpecificFact.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/PlatformSpecificFact.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (ShouldSkip(platforms))
             {
-                this.Skip = "This test is not supported on this platform.";
+                Skip = "This test is not supported on this platform.";
             }
         }
 

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/PlatformSpecificTheory.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/PlatformSpecificTheory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (PlatformSpecificFact.ShouldSkip(platforms))
             {
-                this.Skip = "This test is not supported on this platform.";
+                Skip = "This test is not supported on this platform.";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/RequiresSpecificFrameworkFactAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/RequiresSpecificFrameworkFactAttribute.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (!EnvironmentInfo.SupportsTargetFramework(framework))
             {
-                this.Skip = $"This test requires a shared framework that isn't present: {framework}";
+                Skip = $"This test requires a shared framework that isn't present: {framework}";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/RequiresSpecificFrameworkTheoryAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/RequiresSpecificFrameworkTheoryAttribute.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (!EnvironmentInfo.SupportsTargetFramework(framework))
             {
-                this.Skip = $"This test requires a shared framework that isn't present: {framework}";
+                Skip = $"This test requires a shared framework that isn't present: {framework}";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/WindowsOnlyRequiresMSBuildVersionFactAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/WindowsOnlyRequiresMSBuildVersionFactAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                this.Skip = "This test requires Windows to run";
+                Skip = "This test requires Windows to run";
             }
 
             RequiresMSBuildVersionTheoryAttribute.CheckForRequiredMSBuildVersion(this, version);

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/WindowsOnlyRequiresMSBuildVersionTheoryAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/WindowsOnlyRequiresMSBuildVersionTheoryAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                this.Skip = "This test requires Windows to run";
+                Skip = "This test requires Windows to run";
             }
 
             RequiresMSBuildVersionTheoryAttribute.CheckForRequiredMSBuildVersion(this, version);

--- a/src/Tests/Microsoft.NET.TestFramework/MacOsOnlyFactAttribute.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/MacOsOnlyFactAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.TestFramework
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                this.Skip = "This test requires macos to run";
+                Skip = "This test requires macos to run";
             }
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -127,10 +127,10 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         internal void Create(TestAsset targetTestAsset, string testProjectsSourceFolder, string targetExtension = ".csproj")
         {
-            string targetFolder = Path.Combine(targetTestAsset.Path, this.Name);
+            string targetFolder = Path.Combine(targetTestAsset.Path, Name);
             Directory.CreateDirectory(targetFolder);
 
-            string targetProjectPath = Path.Combine(targetFolder, this.Name + targetExtension);
+            string targetProjectPath = Path.Combine(targetFolder, Name + targetExtension);
 
             string sourceProject;
             string sourceProjectBase = Path.Combine(testProjectsSourceFolder, "ProjectConstruction");
@@ -211,30 +211,30 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
             if (IsSdkProject)
             {
-                if (this.TargetFrameworks.Contains(";"))
+                if (TargetFrameworks.Contains(";"))
                 {
-                    propertyGroup.Add(new XElement(ns + "TargetFrameworks", this.TargetFrameworks));
+                    propertyGroup.Add(new XElement(ns + "TargetFrameworks", TargetFrameworks));
                 }
                 else
                 {
-                    propertyGroup.Add(new XElement(ns + "TargetFramework", this.TargetFrameworks));
+                    propertyGroup.Add(new XElement(ns + "TargetFramework", TargetFrameworks));
                 }
 
-                if (!string.IsNullOrEmpty(this.RuntimeFrameworkVersion))
+                if (!string.IsNullOrEmpty(RuntimeFrameworkVersion))
                 {
-                    propertyGroup.Add(new XElement(ns + "RuntimeFrameworkVersion", this.RuntimeFrameworkVersion));
+                    propertyGroup.Add(new XElement(ns + "RuntimeFrameworkVersion", RuntimeFrameworkVersion));
                 }
 
-                if (!string.IsNullOrEmpty(this.RuntimeIdentifier))
+                if (!string.IsNullOrEmpty(RuntimeIdentifier))
                 {
-                    propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", this.RuntimeIdentifier));
+                    propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", RuntimeIdentifier));
                 }
             }
             else
             {
-                if (!string.IsNullOrEmpty(this.TargetFrameworkProfile))
+                if (!string.IsNullOrEmpty(TargetFrameworkProfile))
                 {
-                    propertyGroup.Add(new XElement(ns + "TargetFrameworkProfile", this.TargetFrameworkProfile));
+                    propertyGroup.Add(new XElement(ns + "TargetFrameworkProfile", TargetFrameworkProfile));
 
                     //  To construct an accurate PCL project file, we must modify the import of the CSharp targets;
                     //    building/testing the SDK requires a VSDev command prompt which sets 'VSINSTALLDIR'
@@ -242,7 +242,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                     importGroup.Attribute("Project").Value = "$(VSINSTALLDIR)\\MSBuild\\Microsoft\\Portable\\$(TargetFrameworkVersion)\\Microsoft.Portable.CSharp.targets";
                 }
 
-                propertyGroup.Element(ns + "TargetFrameworkVersion").SetValue(this.TargetFrameworkVersion);
+                propertyGroup.Element(ns + "TargetFrameworkVersion").SetValue(TargetFrameworkVersion);
             }
 
             foreach (var additionalProperty in AdditionalProperties)
@@ -267,21 +267,21 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 }
             }
 
-            if (this.IsExe && !this.IsWinExe)
+            if (IsExe && !IsWinExe)
             {
                 propertyGroup.Element(ns + "OutputType").SetValue("Exe");
             }
-            else if (this.IsWinExe)
+            else if (IsWinExe)
             {
                 propertyGroup.Element(ns + "OutputType").SetValue("WinExe");
             }
 
-            if (this.SelfContained != "")
+            if (SelfContained != "")
             {
-                propertyGroup.Add(new XElement(ns + "SelfContained", String.Equals(this.SelfContained, "true", StringComparison.OrdinalIgnoreCase) ? "true" : "false"));
+                propertyGroup.Add(new XElement(ns + "SelfContained", String.Equals(SelfContained, "true", StringComparison.OrdinalIgnoreCase) ? "true" : "false"));
             }
 
-            if (this.ReferencedProjects.Any())
+            if (ReferencedProjects.Any())
             {
                 var projectReferenceItemGroup = projectXml.Root.Elements(ns + "ItemGroup")
                     .FirstOrDefault(itemGroup => itemGroup.Elements(ns + "ProjectReference").Count() > 0);
@@ -297,7 +297,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 }
             }
 
-            if (this.References.Any())
+            if (References.Any())
             {
                 var referenceItemGroup = projectXml.Root.Elements(ns + "ItemGroup")
                     .FirstOrDefault(itemGroup => itemGroup.Elements(ns + "Reference").Count() > 0);
@@ -314,7 +314,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 }
             }
 
-            if (this.FrameworkReferences.Any())
+            if (FrameworkReferences.Any())
             {
                 var frameworkReferenceItemGroup = new XElement(ns + "ItemGroup");
                 projectXml.Root.Add(frameworkReferenceItemGroup);
@@ -325,7 +325,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 }
             }
 
-            if (this.CopyFilesTargets.Any())
+            if (CopyFilesTargets.Any())
             {
                 foreach (var copyFilesTarget in CopyFilesTargets)
                 {
@@ -359,7 +359,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
             if (SourceFiles.Count == 0)
             {
-                if (this.IsExe || this.IsWinExe)
+                if (IsExe || IsWinExe)
                 {
                     string source =
     @"using System;
@@ -371,7 +371,7 @@ class Program
         Console.WriteLine(""Hello World!"");
 ";
 
-                    foreach (var dependency in this.ReferencedProjects)
+                    foreach (var dependency in ReferencedProjects)
                     {
                         string safeDependencyName = dependency.Name.Replace('.', '_');
 
@@ -382,13 +382,13 @@ class Program
                     source +=
     @"    }
 }";
-                    string sourcePath = Path.Combine(targetFolder, this.Name + "Program.cs");
+                    string sourcePath = Path.Combine(targetFolder, Name + "Program.cs");
 
                     File.WriteAllText(sourcePath, source);
                 }
 
                 {
-                    string safeThisName = this.Name.Replace('.', '_');
+                    string safeThisName = Name.Replace('.', '_');
                     string source =
     $@"using System;
 using System.Collections.Generic;
@@ -397,10 +397,10 @@ namespace {safeThisName}
 {{
     public class {safeThisName}Class
     {{
-        public static string Name {{ get {{ return ""{this.Name}""; }} }}
+        public static string Name {{ get {{ return ""{Name}""; }} }}
         public static List<string> List {{ get {{ return null; }} }}
 ";
-                    foreach (var dependency in this.ReferencedProjects)
+                    foreach (var dependency in ReferencedProjects)
                     {
                         string safeDependencyName = dependency.Name.Replace('.', '_');
 
@@ -411,7 +411,7 @@ namespace {safeThisName}
                     source +=
     @"    }
 }";
-                    string sourcePath = Path.Combine(targetFolder, this.Name + ".cs");
+                    string sourcePath = Path.Combine(targetFolder, Name + ".cs");
 
                     File.WriteAllText(sourcePath, source);
                 }

--- a/src/Tests/Microsoft.NET.TestFramework/SharedTestOutputHelper.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/SharedTestOutputHelper.cs
@@ -15,7 +15,7 @@ public class SharedTestOutputHelper : ITestOutputHelper
 
     public SharedTestOutputHelper(IMessageSink sink)
     {
-        this._sink = sink;
+        _sink = sink;
     }
 
     public void WriteLine(string message)

--- a/src/Tests/Microsoft.NET.TestFramework/TestAsset.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAsset.cs
@@ -99,10 +99,10 @@ namespace Microsoft.NET.TestFramework
 
             foreach (string[] property in Properties)
             {
-                this.UpdateProjProperty(property[0], property[1], property[2]);
+                UpdateProjProperty(property[0], property[1], property[2]);
             }
 
-            this.ReplaceTheNewtonsoftJsonPackageVersionVariable();
+            ReplaceTheNewtonsoftJsonPackageVersionVariable();
 
             return this;
         }

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -271,7 +271,7 @@ namespace Microsoft.NET.TestFramework
 
         public void WriteGlobalJson(string path)
         {
-            WriteGlobalJson(path, this.SdkVersion);
+            WriteGlobalJson(path, SdkVersion);
         }
 
         public static void WriteGlobalJson(string path, string sdkVersion)

--- a/src/Tests/Microsoft.NET.TestFramework/TestPackageReference.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestPackageReference.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NET.TestFramework
         public bool UpdatePackageReference { get; private set; }
         public bool NuGetPackageExists()
         {
-            return File.Exists(Path.Combine(this.NupkgPath, String.Concat(this.ID + "." + this.Version + ".nupkg")));
+            return File.Exists(Path.Combine(NupkgPath, String.Concat(ID + "." + Version + ".nupkg")));
         }
     }
 }

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [Fact]
         public void MSTestSingleTFM()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("3");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("3");
 
             // Call test
             CommandResult result = new DotnetTestCommand(Log)
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         public void ItAcceptsMultipleLoggersAsCliArguments()
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("10");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("10");
             var trxFileNamePattern = "custom*.trx";
             string trxLoggerDirectory = Path.Combine(testProjectDirectory, "RD");
 
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         public void TestWillNotBuildTheProjectIfNoBuildArgsIsGiven()
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("5");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("5");
             string configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
             string expectedError = Path.Combine(testProjectDirectory, "bin",
                                    configuration, ToolsetInfo.CurrentTargetFramework, "VSTestCore.dll");
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         public void TestWillCreateTrxLoggerInTheSpecifiedResultsDirectoryBySwitch()
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("6");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("6");
 
             string trxLoggerDirectory = Path.Combine(testProjectDirectory, "TR", "x.y");
 
@@ -256,7 +256,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         public void ItCreatesTrxReportInTheSpecifiedResultsDirectoryByArgs()
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("7");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("7");
             var trxFileNamePattern = "custom*.trx";
             string trxLoggerDirectory = Path.Combine(testProjectDirectory, "RD");
 
@@ -342,7 +342,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         public void ItUsesVerbosityPassedToDefineVerbosityOfConsoleLoggerOfTheTests(string verbosity, bool shouldShowPassedTests)
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp($"9_{verbosity}");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp($"9_{verbosity}");
 
             // Call test
             CommandResult result = new DotnetTestCommand(Log)
@@ -414,7 +414,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         public void ItAcceptsNoLogoAsCliArguments()
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("14");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("14");
 
             // Call test with logger enable
             CommandResult result = new DotnetTestCommand(Log)
@@ -434,7 +434,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [PlatformSpecificFact(TestPlatforms.Windows)]
         public void ItCreatesCoverageFileWhenCodeCoverageEnabledByRunsettings()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("11");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("11");
 
             string resultsDirectory = Path.Combine(testProjectDirectory, "RD");
 
@@ -475,7 +475,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.Linux)]
         public void ItCreatesCoverageFileInResultsDirectory()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("12");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("12");
 
             string resultsDirectory = Path.Combine(testProjectDirectory, "RD");
 
@@ -511,7 +511,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.Linux)]
         public void ItCreatesCoberturaFileProvidedByCommandInResultsDirectory()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("15");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("15");
 
             string resultsDirectory = Path.Combine(testProjectDirectory, "RD");
 
@@ -547,7 +547,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [PlatformSpecificFact(TestPlatforms.Windows)]
         public void ItHandlesMultipleCollectCommandInResultsDirectory()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("16");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("16");
 
             string resultsDirectory = Path.Combine(testProjectDirectory, "RD");
 
@@ -588,7 +588,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [PlatformSpecificFact(TestPlatforms.FreeBSD)]
         public void ItShouldShowWarningMessageOnCollectCodeCoverage()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("13");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("13");
 
             // Call test
             CommandResult result = new DotnetTestCommand(Log)
@@ -612,7 +612,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [PlatformSpecificFact(TestPlatforms.Linux, Skip = "https://github.com/dotnet/sdk/issues/22865")]
         public void ItShouldShowWarningMessageOnCollectCodeCoverageThatProfilerWasNotInitialized()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("13");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("13");
 
             // Call test
             CommandResult result = new DotnetTestCommand(Log)

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [Fact]
         public void GivenAProjectAndMultipleTestRunParametersItPassesThemToVStestConsoleInTheCorrectFormat()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("2");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("2");
 
             // Call test
             CommandResult result = new DotnetTestCommand(Log)
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [Fact]
         public void GivenADllAndMultipleTestRunParametersItPassesThemToVStestConsoleInTheCorrectFormat()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("3");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("3");
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
 

--- a/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
+++ b/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
         [Fact]
         public void GivenADllAndMultipleTestRunParametersItPassesThemToVStestConsoleInTheCorrectFormat()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("1");
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("1");
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
 
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
         [Fact]
         public void ItShouldAcceptMultipleLoggers()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp();
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
 
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
         [Fact]
         public void ItShouldAcceptNoLoggers()
         {
-            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp();
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
 

--- a/src/WebSdk/Publish/Tasks/MsDeploy/VsMSDeployObject.cs
+++ b/src/WebSdk/Publish/Tasks/MsDeploy/VsMSDeployObject.cs
@@ -278,7 +278,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
                         else
                         {
                             // these are provider option
-                            this.SetProviderOption(m_provider, name, value);
+                            SetProviderOption(m_provider, name, value);
                         }
                     }
                 }
@@ -354,38 +354,38 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         // property used to call Deployment.DeploymentManager.CreateObject
         public virtual string Root
         {
-            get { return this.m_root; }
-            set { this.m_root = value; }
+            get { return m_root; }
+            set { m_root = value; }
         }
         public virtual string Provider
         {
-            get { return this.m_provider; }
-            set { this.m_provider = value; }
+            get { return m_provider; }
+            set { m_provider = value; }
         }
 
 
         // property use to create the LocationInfo
         public virtual bool IsLocal
         {
-            get { return string.IsNullOrEmpty(this.ComputerName) && string.IsNullOrEmpty(this.MSDeployServiceUrl); }
+            get { return string.IsNullOrEmpty(ComputerName) && string.IsNullOrEmpty(MSDeployServiceUrl); }
 
         }
         public virtual bool UseSeparatedCredential
         {
-            get { return !string.IsNullOrEmpty(this.UserName); }
+            get { return !string.IsNullOrEmpty(UserName); }
         }
 
 
         public virtual string DisableLinks
         {
-            get { return this.m_disableLinks; }
-            set { this.m_disableLinks = value; }
+            get { return m_disableLinks; }
+            set { m_disableLinks = value; }
         }
 
         public virtual string EnableLinks
         {
-            get { return this.m_enableLinks; }
-            set { this.m_enableLinks = value; }
+            get { return m_enableLinks; }
+            set { m_enableLinks = value; }
         }
 
 
@@ -491,14 +491,14 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
 
         public int RetryAttempts
         {
-            get { return this.m_retryAttempts; }
-            set { this.m_retryAttempts = value; }
+            get { return m_retryAttempts; }
+            set { m_retryAttempts = value; }
         }
 
         public int RetryInterval
         {
-            get { return this.m_retryInterval; }
-            set { this.m_retryInterval = value; }
+            get { return m_retryInterval; }
+            set { m_retryInterval = value; }
         }
 
         public string UserAgent { get; set; }
@@ -572,18 +572,18 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             //$BUGBUG lmchen, there is only set to source provider?
             // set up the provider setting
             /*Deployment.DeploymentProviderOptions*/
-            dynamic srcProviderConfig = MSWebDeploymentAssembly.DynamicAssembly.CreateObject("Microsoft.Web.Deployment.DeploymentProviderOptions", new object[]{this.Provider.ToString()});
-            srcProviderConfig.Path = this.Root;
-            MsDeploy.Utility.AddProviderOptions(srcProviderConfig, this.ProviderOptions, _host);
+            dynamic srcProviderConfig = MSWebDeploymentAssembly.DynamicAssembly.CreateObject("Microsoft.Web.Deployment.DeploymentProviderOptions", new object[]{Provider.ToString()});
+            srcProviderConfig.Path = Root;
+            MsDeploy.Utility.AddProviderOptions(srcProviderConfig, ProviderOptions, _host);
 
-            using (/*Deployment.DeploymentObject*/ dynamic srcObj =  MSWebDeploymentAssembly.DynamicAssembly.CallStaticMethod("Microsoft.Web.Deployment.DeploymentManager", "CreateObject", new object[]{srcProviderConfig, this.BaseOptions}))
+            using (/*Deployment.DeploymentObject*/ dynamic srcObj =  MSWebDeploymentAssembly.DynamicAssembly.CallStaticMethod("Microsoft.Web.Deployment.DeploymentManager", "CreateObject", new object[]{srcProviderConfig, BaseOptions}))
             {
 
                 //$BUGBUG lmchen, there is only set to source provider?
                 // set up the parameter
-                MsDeploy.Utility.AddSetParametersFilesToObject(srcObj, this.SetParametersFiles, _host);
-                MsDeploy.Utility.AddSimpleSetParametersToObject(srcObj, this.Parameters, _host);
-                MsDeploy.Utility.AddSetParametersToObject(srcObj, this.EntryParameters, _host);
+                MsDeploy.Utility.AddSetParametersFilesToObject(srcObj, SetParametersFiles, _host);
+                MsDeploy.Utility.AddSimpleSetParametersToObject(srcObj, Parameters, _host);
+                MsDeploy.Utility.AddSetParametersToObject(srcObj, EntryParameters, _host);
                 
                 /*Deployment.DeploymentProviderOptions*/ dynamic destProviderConfig = MSWebDeploymentAssembly.DynamicAssembly.CreateObject("Microsoft.Web.Deployment.DeploymentProviderOptions", new object[]{destObject.Provider.ToString()});
                 destProviderConfig.Path = destObject.Root;

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/ImportParameterFile.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/ImportParameterFile.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tasks.MsDeploy
         [Framework.Output]
         public Framework.ITaskItem[] Result
         {
-            get { return this.m_parametersList.ToArray(); }
+            get { return m_parametersList.ToArray(); }
         }
 
 

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/MSDeploy.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/MSDeploy.cs
@@ -296,33 +296,33 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
 
         public string DisableRule
         {
-            get { return this.m_disableRule; }
-            set { this.m_disableRule = value; }
+            get { return m_disableRule; }
+            set { m_disableRule = value; }
         }
 
         [Framework.Required]
         public string Verb
         {
-            get { return this.m_verb; }
-            set { this.m_verb = value; }
+            get { return m_verb; }
+            set { m_verb = value; }
         }
 
         [Framework.Required]
         public Framework.ITaskItem[] Source
         {
-            get { return this.m_sourceITaskItem; }
-            set { this.m_sourceITaskItem = value; }
+            get { return m_sourceITaskItem; }
+            set { m_sourceITaskItem = value; }
         }
 
         public Framework.ITaskItem[] Destination
         {
-            get { return this.m_destITaskItem; }
-            set { this.m_destITaskItem = value; }
+            get { return m_destITaskItem; }
+            set { m_destITaskItem = value; }
         }
         public bool WhatIf
         {
-            get { return this.m_whatif; }
-            set { this.m_whatif = value; }
+            get { return m_whatif; }
+            set { m_whatif = value; }
         }
 
         public bool OptimisticParameterDefaultValue { get; set; }
@@ -335,79 +335,79 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
 
         public bool AllowUntrusted
         {
-            get { return this.m_allowUntrusted; }
-            set { this.m_allowUntrusted = value; }
+            get { return m_allowUntrusted; }
+            set { m_allowUntrusted = value; }
         }
 
         public bool Verbose
         {
-            get { return this.m_verbose; }
-            set { this.m_verbose = value; }
+            get { return m_verbose; }
+            set { m_verbose = value; }
         }
         public string FailureLevel
         {
-            get { return this.m_failureLevel; }
-            set { this.m_failureLevel = value; }
+            get { return m_failureLevel; }
+            set { m_failureLevel = value; }
         }
         public bool Xml
         {
-            get { return this.m_xml; }
-            set { this.m_xml = value; }
+            get { return m_xml; }
+            set { m_xml = value; }
         }
         public string XPath
         {
-            get { return this.m_xpath; }
-            set { this.m_xpath = value; }
+            get { return m_xpath; }
+            set { m_xpath = value; }
         }
         public string EnableRule
         {
-            get { return this.m_enableRule; }
-            set { this.m_enableRule = value; }
+            get { return m_enableRule; }
+            set { m_enableRule = value; }
         }
         public string Replace
         {
-            get { return this.m_replace; }
-            set { this.m_replace = value; }
+            get { return m_replace; }
+            set { m_replace = value; }
         }
         public string Skip
         {
-            get { return this.m_skip; }
-            set { this.m_skip = value; }
+            get { return m_skip; }
+            set { m_skip = value; }
         }
         public string DisableLink
         {
-            get { return this.m_disableLink; }
-            set { this.m_disableLink = value; }
+            get { return m_disableLink; }
+            set { m_disableLink = value; }
         }
 
         public string EnableLink
         {
-            get { return this.m_enableLink; }
-            set { this.m_enableLink = value; }
+            get { return m_enableLink; }
+            set { m_enableLink = value; }
         }
 
         public bool EnableTransaction
         {
-            get { return this.m_enableTransaction; }
-            set { this.m_enableTransaction = value; }
+            get { return m_enableTransaction; }
+            set { m_enableTransaction = value; }
         }
         public int RetryAttempts
         {
-            get { return this.m_retryAttempts; }
-            set { this.m_retryAttempts = value; }
+            get { return m_retryAttempts; }
+            set { m_retryAttempts = value; }
         }
         public int RetryInterval
         {
-            get { return this.m_retryInterval; }
-            set { this.m_retryInterval = value; }
+            get { return m_retryInterval; }
+            set { m_retryInterval = value; }
         }
 
         public bool UseDoubleQuoteForValue
         {
-            get { return this.m_useDoubleQuoteForValue; }
+            get { return m_useDoubleQuoteForValue; }
             set
             {
-                this.m_useDoubleQuoteForValue = value;
+                m_useDoubleQuoteForValue = value;
                 m_strValueQuote = (m_useDoubleQuoteForValue) ? "\"" : null;
             }
         }
@@ -415,56 +415,56 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         public Framework.ITaskItem[] ReplaceRuleItems
         {
             get { return m_replaceRuleItemsITaskItem; }
-            set { this.m_replaceRuleItemsITaskItem = value; }
+            set { m_replaceRuleItemsITaskItem = value; }
         }
 
         public Framework.ITaskItem[] SkipRuleItems
         {
             get { return m_skipRuleItemsITaskItem; }
-            set { this.m_skipRuleItemsITaskItem = value; }
+            set { m_skipRuleItemsITaskItem = value; }
         }
 
         public string DisableSkipDirective
         {
             get { return m_disableSkipDirective; }
-            set { this.m_disableSkipDirective = value; }
+            set { m_disableSkipDirective = value; }
         }
 
         public string EnableSkipDirective
         {
             get { return m_enableSkipDirective; }
-            set { this.m_enableSkipDirective = value; }
+            set { m_enableSkipDirective = value; }
         }
 
         public Framework.ITaskItem[] DeclareParameterItems
         {
             get { return m_declareParameterItems; }
-            set { this.m_declareParameterItems = value; }
+            set { m_declareParameterItems = value; }
         }
         public Framework.ITaskItem[] ImportDeclareParametersItems
         {
             get { return m_importDeclareParametersItems; }
-            set { this.m_importDeclareParametersItems = value; }
+            set { m_importDeclareParametersItems = value; }
         }
 
 
         public Framework.ITaskItem[] ImportSetParametersItems
         {
             get { return m_importSetParametersItems; }
-            set { this.m_importSetParametersItems = value; }
+            set { m_importSetParametersItems = value; }
         }
 
         public Framework.ITaskItem[] SimpleSetParameterItems
         {
             get { return m_simpleSetParamterItems; }
-            set { this.m_simpleSetParamterItems = value; }
+            set { m_simpleSetParamterItems = value; }
         }
 
 
         public Framework.ITaskItem[] SetParameterItems
         {
             get { return m_setParamterItems; }
-            set { this.m_setParamterItems = value; }
+            set { m_setParamterItems = value; }
         }
 
         public Framework.ITaskItem[] AdditionalDestinationProviderOptions { get; set; }
@@ -516,18 +516,18 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         {
             get
             {
-                return this.m_previewOnly;
+                return m_previewOnly;
             }
             set
             {
-                this.m_previewOnly = value;
+                m_previewOnly = value;
             }
         }
 
         // controlling whether a task should be execute.
         protected override bool SkipTaskExecution()
         {
-            if (this.PreviewCommandLineOnly)
+            if (PreviewCommandLineOnly)
                 return true;
             else
                 return base.SkipTaskExecution();
@@ -549,7 +549,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         public override bool Execute()
         {
             bool bSuccess = false;
-            if (this.PreviewCommandLineOnly)
+            if (PreviewCommandLineOnly)
             {
                 // useful information about what was wrong with the parameters.
                 if (!ValidateParameters())
@@ -579,14 +579,14 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
                 string type = string.Empty;
                 string path = string.Empty;
                 Framework.ITaskItem taskItem = null;
-                if (this.Destination != null && this.Destination.GetLength(0) == 1)
+                if (Destination != null && Destination.GetLength(0) == 1)
                 {
-                    taskItem = this.Destination[0];
+                    taskItem = Destination[0];
                 }
                 else
                 {
-                    if (this.Source != null)
-                        taskItem = this.Source[0];
+                    if (Source != null)
+                        taskItem = Source[0];
                 }
                 if (taskItem != null)
                 {
@@ -990,9 +990,9 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         protected override string GenerateCommandLineCommands()
         {
             Utilities.CommandLineBuilder commandLine = new Utilities.CommandLineBuilder();
-            IncorporateSettingsFromHostObject(ref m_skipRuleItemsITaskItem, this.Destination, HostObject as System.Collections.Generic.IEnumerable<Framework.ITaskItem>);
-            AddDestinationProviderSettingToObject(commandLine, "-source:", this.Source, m_strValueQuote, null, this);
-            AddDestinationProviderSettingToObject(commandLine, "-dest:", this.Destination, m_strValueQuote, AdditionalDestinationProviderOptions, this);
+            IncorporateSettingsFromHostObject(ref m_skipRuleItemsITaskItem, Destination, HostObject as System.Collections.Generic.IEnumerable<Framework.ITaskItem>);
+            AddDestinationProviderSettingToObject(commandLine, "-source:", Source, m_strValueQuote, null, this);
+            AddDestinationProviderSettingToObject(commandLine, "-dest:", Destination, m_strValueQuote, AdditionalDestinationProviderOptions, this);
 
             commandLine.AppendSwitchUnquotedIfNotNull("-verb:", m_verb);
             commandLine.AppendSwitchUnquotedIfNotNull("-failureLevel:", m_failureLevel);
@@ -1080,13 +1080,13 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         /// <returns>true if arguments are corrent enough to continue processing, false otherwise</returns>
         protected override bool ValidateParameters()
         {
-            if (this.Source != null && this.Source.GetLength(0) > 1)
+            if (Source != null && Source.GetLength(0) > 1)
             {
                 Log.LogError(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.MSDEPLOY_InvalidSourceCount, Source.GetLength(0)), null);
                 return false;
             }
 
-            if (this.Destination != null && this.Destination.GetLength(0) > 1)
+            if (Destination != null && Destination.GetLength(0) > 1)
             {
                 Log.LogError(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.MSDEPLOY_InvalidDestinationCount, Destination.GetLength(0)), null);
                 return false;
@@ -1095,7 +1095,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             {
                 string[] validVerbs = null;
                 bool fNullDestination = false;
-                if (this.Destination == null || this.Destination.GetLength(0) == 0)
+                if (Destination == null || Destination.GetLength(0) == 0)
                 {
                     fNullDestination = true;
                     validVerbs = new string[] {
@@ -1105,7 +1105,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
                         "getSystemInfo",
                     };
                 }
-                if (this.Source == null || this.Source.GetLength(0) == 0)
+                if (Source == null || Source.GetLength(0) == 0)
                 {
                     validVerbs = new string[] {
                         "delete",
@@ -1123,13 +1123,13 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
                 {
                     foreach (string verb in validVerbs)
                     {
-                        if (string.Compare(this.Verb, verb, System.StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Compare(Verb, verb, System.StringComparison.OrdinalIgnoreCase) == 0)
                         {
                             return true;
                         }
                     }
                 }
-                Log.LogError(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.MSDEPLOY_InvalidVerbForTheInput, this.Verb, this.Source[0].ItemSpec, (fNullDestination) ? null : this.Destination[0].ItemSpec), null);
+                Log.LogError(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.MSDEPLOY_InvalidVerbForTheInput, Verb, Source[0].ItemSpec, (fNullDestination) ? null : Destination[0].ItemSpec), null);
                 return false;
             }
         }

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/NormalizeServiceUrl.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/NormalizeServiceUrl.cs
@@ -27,37 +27,37 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         [Required]
         public string ServiceUrl
         {
-            get { return this._serviceUrl; }
-            set { this._serviceUrl = value; }
+            get { return _serviceUrl; }
+            set { _serviceUrl = value; }
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "WMSVC", Justification = "Special term that used by MSDeploy team for remote service")]
         [Required]
         public bool UseWMSVC
         {
-            get { return this._useWMSVC; }
-            set { this._useWMSVC = value; }
+            get { return _useWMSVC; }
+            set { _useWMSVC = value; }
         }
 
         [Required]
         public bool UseRemoteAgent
         {
-            get { return this._useRemoteAgent; }
-            set { this._useRemoteAgent = value; }
+            get { return _useRemoteAgent; }
+            set { _useRemoteAgent = value; }
         }
 
         [Required]
         public string SiteName
         {
-            get { return this._siteName; }
-            set { this._siteName = value; }
+            get { return _siteName; }
+            set { _siteName = value; }
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings", Justification = "This is interface with the Msbuild method, all argument is basically pass by string")]
         [Output]
         public string ResultUrl
         {
-            get { return this._resultUrl; }
+            get { return _resultUrl; }
         }
 
         public override bool Execute()

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/VsMsdeploy.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/VsMsdeploy.cs
@@ -602,7 +602,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             : base(src, dest, host)
         {
             if (host.GetProperty("HighImportanceEventTypes") != null)
-                this.HighImportanceEventTypes = host.GetProperty("HighImportanceEventTypes").ToString();
+                HighImportanceEventTypes = host.GetProperty("HighImportanceEventTypes").ToString();
         }
     }
 
@@ -642,8 +642,8 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         [Framework.Required]
         public Framework.ITaskItem[] Source
         {
-            get { return this.m_sourceITaskItem; }
-            set { this.m_sourceITaskItem = value; }
+            get { return m_sourceITaskItem; }
+            set { m_sourceITaskItem = value; }
         }
 
         public string HighImportanceEventTypes
@@ -654,8 +654,8 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
 
         public Framework.ITaskItem[] Destination
         {
-            get { return this.m_destITaskItem; }
-            set { this.m_destITaskItem = value; }
+            get { return m_destITaskItem; }
+            set { m_destITaskItem = value; }
         }
 
         public bool AllowUntrustedCertificate
@@ -718,46 +718,46 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         public string DisableSkipDirective
         {
             get { return _disableSkipDirective; }
-            set { this._disableSkipDirective = value; }
+            set { _disableSkipDirective = value; }
         }
 
         public string EnableSkipDirective
         {
             get { return _enableSkipDirective; }
-            set { this._enableSkipDirective = value; }
+            set { _enableSkipDirective = value; }
         }
 
         public int RetryAttempts
         {
-            get { return this.m_retryAttempts; }
-            set { this.m_retryAttempts = value; }
+            get { return m_retryAttempts; }
+            set { m_retryAttempts = value; }
         }
 
         public int RetryInterval
         {
-            get { return this.m_retryInterval; }
-            set { this.m_retryInterval = value; }
+            get { return m_retryInterval; }
+            set { m_retryInterval = value; }
         }
 
 
         public Framework.ITaskItem[] ReplaceRuleItems
         {
             get { return m_replaceRuleItemsITaskItem; }
-            set { this.m_replaceRuleItemsITaskItem = value; }
+            set { m_replaceRuleItemsITaskItem = value; }
         }
 
 
         public Framework.ITaskItem[] SkipRuleItems
         {
             get { return m_skipRuleItemsITaskItem; }
-            set { this.m_skipRuleItemsITaskItem = value; }
+            set { m_skipRuleItemsITaskItem = value; }
         }
 
 
         public Framework.ITaskItem[] DeclareParameterItems
         {
-            get { return this.m_declareParameterItems; }
-            set { this.m_declareParameterItems = value; }
+            get { return m_declareParameterItems; }
+            set { m_declareParameterItems = value; }
         }
 
         public bool OptimisticParameterDefaultValue { get; set; }
@@ -766,25 +766,25 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         public Framework.ITaskItem[] ImportDeclareParametersItems
         {
             get { return m_importDeclareParametersItems; }
-            set { this.m_importDeclareParametersItems = value; }
+            set { m_importDeclareParametersItems = value; }
         }
 
         public Framework.ITaskItem[] SimpleSetParameterItems
         {
             get { return m_simpleSetParamterItems; }
-            set { this.m_simpleSetParamterItems = value; }
+            set { m_simpleSetParamterItems = value; }
         }
 
         public Framework.ITaskItem[] ImportSetParametersItems
         {
             get { return m_importSetParametersItems; }
-            set { this.m_importSetParametersItems = value; }
+            set { m_importSetParametersItems = value; }
         }
 
         public Framework.ITaskItem[] SetParameterItems
         {
             get { return m_setParamterItems; }
-            set { this.m_setParamterItems = value; }
+            set { m_setParamterItems = value; }
         }
 
         public bool EnableMSDeployBackup { get; set; }
@@ -847,35 +847,35 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             }
             catch (System.Exception exception)
             {
-                this.Log.LogErrorFromException(exception);
+                Log.LogErrorFromException(exception);
                 return false; // failed the task
             }
 
             string errorMessage = null;
-            if (!MsDeploy.Utility.CheckMSDeploymentVersion(this.Log, out errorMessage))
+            if (!MsDeploy.Utility.CheckMSDeploymentVersion(Log, out errorMessage))
                 return false;
 
             VSMSDeployObject src = null;
             VSMSDeployObject dest = null;
 
-            if (this.Source == null || this.Source.GetLength(0) != 1)
+            if (Source == null || Source.GetLength(0) != 1)
             {
-                this.Log.LogError("Source must be 1 item");
+                Log.LogError("Source must be 1 item");
                 return false;
             }
             else
             {
-                src = VSMSDeployObjectFactory.CreateVSMSDeployObject(this.Source[0]);
+                src = VSMSDeployObjectFactory.CreateVSMSDeployObject(Source[0]);
             }
 
-            if (this.Destination == null || this.Destination.GetLength(0) != 1)
+            if (Destination == null || Destination.GetLength(0) != 1)
             {
-                this.Log.LogError("Destination must be 1 item");
+                Log.LogError("Destination must be 1 item");
                 return false;
             }
             else
             {
-                dest = VSMSDeployObjectFactory.CreateVSMSDeployObject(this.Destination[0]);
+                dest = VSMSDeployObjectFactory.CreateVSMSDeployObject(Destination[0]);
                 VSHostObject hostObj = new VSHostObject(HostObject as System.Collections.Generic.IEnumerable<Framework.ITaskItem>);
                 string username, password;
                 if (hostObj.ExtractCredentials(out username, out password))
@@ -886,21 +886,21 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             }
 
             //$Todo, Should we split the Disable Link to two set of setting, one for source, one for destination
-            src.DisableLinks = this.DisableLink;
-            dest.DisableLinks = this.DisableLink;
-            src.EnableLinks = this.EnableLink;
-            dest.EnableLinks = this.EnableLink;
-            if (this.RetryAttempts >= 0)
+            src.DisableLinks = DisableLink;
+            dest.DisableLinks = DisableLink;
+            src.EnableLinks = EnableLink;
+            dest.EnableLinks = EnableLink;
+            if (RetryAttempts >= 0)
             {
-                src.RetryAttempts = this.RetryAttempts;
-                dest.RetryAttempts = this.RetryAttempts;
+                src.RetryAttempts = RetryAttempts;
+                dest.RetryAttempts = RetryAttempts;
             }
-            if (this.RetryInterval >= 0)
+            if (RetryInterval >= 0)
             {
-                src.RetryInterval = this.RetryInterval;
-                dest.RetryInterval = this.RetryInterval;
+                src.RetryInterval = RetryInterval;
+                dest.RetryInterval = RetryInterval;
             }
-            dest.UserAgent = this.UserAgent;
+            dest.UserAgent = UserAgent;
 
             SetupPublishRelatedProperties(ref dest);
 
@@ -1132,9 +1132,9 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             switch (lowerName)
             {
                 case "msdeployversionstotry":
-                    return this.MSDeployVersionsToTry;
+                    return MSDeployVersionsToTry;
                 case "highimportanceeventtypes":
-                    return this.HighImportanceEventTypes;
+                    return HighImportanceEventTypes;
                 default:
                     break;
             }

--- a/src/WebSdk/Publish/Tasks/Tasks/Xdt/TransformXml.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/Xdt/TransformXml.cs
@@ -60,7 +60,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
             {
                 if (string.IsNullOrEmpty(_transformRootPath))
                 {
-                    return this.SourceRootPath;
+                    return SourceRootPath;
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
When looking over some CLI code, I kept noticing `this`. Since `this` doesn't do anything, I removed `this`. In some codebases, `this` can help differentiate between 2 different members. Here, I did not find a situation that requires `this`. Since `this` appears grey in VS, let's just remove `this`.