### PR TITLE
[release/8.0.1xx] Adjust trim/aot warning messages (#35186)

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -930,7 +930,7 @@ You may need to build the project on another operating system or architecture, o
     <comment>{StrBegin="NETSDK1209: "}</comment>
   </data>
   <data name="IsAotCompatibleUnsupported" xml:space="preserve">
-    <value>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+    <value>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</value>
     <comment>{StrBegin="NETSDK1210: "}</comment>
   </data>
@@ -940,7 +940,7 @@ You may need to build the project on another operating system or architecture, o
     <comment>{StrBegin="NETSDK1211: "}</comment>
   </data>
   <data name="IsTrimmableUnsupported" xml:space="preserve">
-    <value>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+    <value>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</value>
     <comment>{StrBegin="NETSDK1212: "}</comment>
   </data>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible se pro cílovou architekturu nepodporuje. Zvažte vícenásobné cílení na podporovanou architekturu, abyste umožnili analýzu kompilace předem, a nastavte IsAotCompatible pouze pro podporované architektury. Příklad:
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible se pro cílovou architekturu nepodporuje. Zvažte vícenásobné cílení na podporovanou architekturu, abyste umožnili analýzu kompilace předem, a nastavte IsAotCompatible pouze pro podporované architektury. Příklad:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable se pro cílovou architekturu nepodporuje. Zvažte vícenásobné cílení na podporovanou architekturu, která umožňuje oříznutí, a nastavte IsTrimmable pouze pro podporované architektury. Příklad:
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable se pro cílovou architekturu nepodporuje. Zvažte vícenásobné cílení na podporovanou architekturu, která umožňuje oříznutí, a nastavte IsTrimmable pouze pro podporované architektury. Příklad:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible wird für das Zielframework nicht unterstützt. Erwägen Sie die Festlegung mehrerer Zielversionen auf ein unterstütztes Framework, um eine Vorabkompilierungsanalyse zu ermöglichen, und legen Sie IsAotCompatible nur für die unterstützten Frameworks fest. Beispiel: 
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible wird für das Zielframework nicht unterstützt. Erwägen Sie die Festlegung mehrerer Zielversionen auf ein unterstütztes Framework, um eine Vorabkompilierungsanalyse zu ermöglichen, und legen Sie IsAotCompatible nur für die unterstützten Frameworks fest. Beispiel: 
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable wird für das Zielframework nicht unterstützt. Erwägen Sie die Festlegung mehrerer Zielversionen auf ein unterstütztes Framework, um das Kürzen zu aktivieren, und legen Sie IsTrimmable nur für die unterstützten Frameworks fest. Beispiel: 
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable wird für das Zielframework nicht unterstützt. Erwägen Sie die Festlegung mehrerer Zielversionen auf ein unterstütztes Framework, um das Kürzen zu aktivieren, und legen Sie IsTrimmable nur für die unterstützten Frameworks fest. Beispiel: 
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible no se admite para la plataforma de destino. Considere la posibilidad de usar varios destinos en un marco compatible para habilitar el análisis de compilación con antelación y establezca IsAotCompatible solo para los marcos admitidos. Por ejemplo:
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible no se admite para la plataforma de destino. Considere la posibilidad de usar varios destinos en un marco compatible para habilitar el análisis de compilación con antelación y establezca IsAotCompatible solo para los marcos admitidos. Por ejemplo:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable no se admite para la plataforma de destino. Considere la posibilidad de usar varios destinos en un marco compatible para habilitar el recorte y establezca IsTrimmable solo para los marcos admitidos. Por ejemplo:
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable no se admite para la plataforma de destino. Considere la posibilidad de usar varios destinos en un marco compatible para habilitar el recorte y establezca IsTrimmable solo para los marcos admitidos. Por ejemplo:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible n'est pas pris en charge pour le framework cible. Envisagez le multi-ciblage vers un framework pris en charge pour permettre une analyse de compilation en amont, et définissez IsAotCompatible uniquement pour les frameworks pris en charge. Par exemple : 
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible n'est pas pris en charge pour le framework cible. Envisagez le multi-ciblage vers un framework pris en charge pour permettre une analyse de compilation en amont, et définissez IsAotCompatible uniquement pour les frameworks pris en charge. Par exemple : 
 &lt;IsAotCompatible Condition="$([MSBuild] ::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable n'est pas pris en charge pour le framework cible. Envisagez le multi-ciblage vers un framework pris en charge pour activer le découpage, et définissez IsTrimmable uniquement pour les frameworks pris en charge. Par exemple : 
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable n'est pas pris en charge pour le framework cible. Envisagez le multi-ciblage vers un framework pris en charge pour activer le découpage, et définissez IsTrimmable uniquement pour les frameworks pris en charge. Par exemple : 
 &lt;IsTrimmable Condition="$([MSBuild] ::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible non è supportato per il framework di destinazione. Provare a usare più destinazioni in un framework supportato per abilitare l'analisi di compilazione in anticipo e impostare IsAotCompatible solo per i framework supportati. Ad esempio:
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible non è supportato per il framework di destinazione. Provare a usare più destinazioni in un framework supportato per abilitare l'analisi di compilazione in anticipo e impostare IsAotCompatible solo per i framework supportati. Ad esempio:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable non è supportato per il framework di destinazione. Provare a usare più destinazioni in un framework supportato per abilitare la limitazione e impostare IsTrimmable solo per i framework supportati. Per esempio:
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable non è supportato per il framework di destinazione. Provare a usare più destinazioni in un framework supportato per abilitare la limitazione e impostare IsTrimmable solo per i framework supportati. Per esempio:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible はターゲット フレームワークではサポートされていません。Ahead of Time コンパイル分析を有効にするには、サポートされているフレームワークに対するマルチターゲットを検討し、サポートされているフレームワークに限り IsAotCompatible を設定してください。例：
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible はターゲット フレームワークではサポートされていません。Ahead of Time コンパイル分析を有効にするには、サポートされているフレームワークに対するマルチターゲットを検討し、サポートされているフレームワークに限り IsAotCompatible を設定してください。例：
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable はターゲット フレームワークではサポートされていません。トリミングを有効にするには、サポートされているフレームワークに対するマルチターゲットを検討し、サポートされているフレームワークに限り IsTrimmable を設定してください。例：
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable はターゲット フレームワークではサポートされていません。トリミングを有効にするには、サポートされているフレームワークに対するマルチターゲットを検討し、サポートされているフレームワークに限り IsTrimmable を設定してください。例：
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible은 대상 프레임워크에 대해 지원되지 않습니다. 지원되는 프레임워크에 다중 대상을 지정하여 AOT(Ahead-of-time) 컴파일 분석을 사용하도록 설정하고 지원되는 프레임워크에 대해서만 IsAotCompatible을 설정하세요. 예:
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible은 대상 프레임워크에 대해 지원되지 않습니다. 지원되는 프레임워크에 다중 대상을 지정하여 AOT(Ahead-of-time) 컴파일 분석을 사용하도록 설정하고 지원되는 프레임워크에 대해서만 IsAotCompatible을 설정하세요. 예:
 true &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable은 대상 프레임워크에 대해 지원되지 않습니다. 지원되는 프레임워크에 다중 대상을 지정하여 트리밍을 사용하도록 설정하고 지원되는 프레임워크에 대해서만 IsTrimmable을 설정하세요. 예:
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable은 대상 프레임워크에 대해 지원되지 않습니다. 지원되는 프레임워크에 다중 대상을 지정하여 트리밍을 사용하도록 설정하고 지원되는 프레임워크에 대해서만 IsTrimmable을 설정하세요. 예:
 true &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: Element IsAotCompatible nie jest obsługiwany dla platformy docelowej. Rozważ zastosowanie wielu elementów docelowych do obsługiwanej platformy, aby umożliwić analizę kompilacji z wyprzedzeniem, i ustaw wartość IsAotCompatible tylko dla obsługiwanych platform. Na przykład:
+        <target state="needs-review-translation">NETSDK1210: Element IsAotCompatible nie jest obsługiwany dla platformy docelowej. Rozważ zastosowanie wielu elementów docelowych do obsługiwanej platformy, aby umożliwić analizę kompilacji z wyprzedzeniem, i ustaw wartość IsAotCompatible tylko dla obsługiwanych platform. Na przykład:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: Element IsTrimmable nie jest obsługiwany dla platformy docelowej. Rozważ zastosowanie wielu elementów docelowych do obsługiwanej platformy, aby włączyć przycinanie, i ustaw właściwość IsTrimmable tylko dla obsługiwanych platform. Na przykład:
+        <target state="needs-review-translation">NETSDK1212: Element IsTrimmable nie jest obsługiwany dla platformy docelowej. Rozważ zastosowanie wielu elementów docelowych do obsługiwanej platformy, aby włączyć przycinanie, i ustaw właściwość IsTrimmable tylko dla obsługiwanych platform. Na przykład:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible não é compatível com a estrutura de destino. Considere o direcionamento múltiplo para uma estrutura com suporte para permitir a análise de compilação antecipada e defina IsAotCompatible apenas para as estruturas com suporte. Por exemplo:
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible não é compatível com a estrutura de destino. Considere o direcionamento múltiplo para uma estrutura com suporte para permitir a análise de compilação antecipada e defina IsAotCompatible apenas para as estruturas com suporte. Por exemplo:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;verdadeiro&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable não é compatível com a estrutura de destino. Considere o direcionamento múltiplo para uma estrutura com suporte para habilitar o corte e defina IsTrimmable somente para as estruturas com suporte. Por exemplo:
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable não é compatível com a estrutura de destino. Considere o direcionamento múltiplo para uma estrutura com suporte para habilitar o corte e defina IsTrimmable somente para as estruturas com suporte. Por exemplo:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;verdadeiro&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible не поддерживается целевой платформой. Рассмотрите возможность использовать несколько целевых версий для поддерживаемой платформы, чтобы включить анализ AOT-компиляции, и настройте IsAotCompatible только для поддерживаемых платформ. Например:
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible не поддерживается целевой платформой. Рассмотрите возможность использовать несколько целевых версий для поддерживаемой платформы, чтобы включить анализ AOT-компиляции, и настройте IsAotCompatible только для поддерживаемых платформ. Например:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable не поддерживается целевой платформой. Рассмотрите возможность использовать несколько целевых версий для поддерживаемой платформы, чтобы включить обрезку, и настройте IsTrimmable только для поддерживаемых платформ. Например:
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable не поддерживается целевой платформой. Рассмотрите возможность использовать несколько целевых версий для поддерживаемой платформы, чтобы включить обрезку, и настройте IsTrimmable только для поддерживаемых платформ. Например:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: IsAotCompatible hedef altyapı için desteklenmiyor. Önceden derleme analizini etkinleştirmek için desteklenen bir altyapıya çoklu hedefleme uygulayabilirsiniz ve IsAotCompatible'ı yalnızca desteklenen altyapılar için ayarlayabilirsiniz. Örneğin:
+        <target state="needs-review-translation">NETSDK1210: IsAotCompatible hedef altyapı için desteklenmiyor. Önceden derleme analizini etkinleştirmek için desteklenen bir altyapıya çoklu hedefleme uygulayabilirsiniz ve IsAotCompatible'ı yalnızca desteklenen altyapılar için ayarlayabilirsiniz. Örneğin:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: IsTrimmable hedef altyapı için desteklenmiyor. Kırpmayı etkinleştirmek için desteklenen bir altyapıya çoklu hedefleme uygulayabilirsiniz ve IsTrimmable'ı yalnızca desteklenen altyapılar için ayarlayabilirisiniz. Örneğin:
+        <target state="needs-review-translation">NETSDK1212: IsTrimmable hedef altyapı için desteklenmiyor. Kırpmayı etkinleştirmek için desteklenen bir altyapıya çoklu hedefleme uygulayabilirsiniz ve IsTrimmable'ı yalnızca desteklenen altyapılar için ayarlayabilirisiniz. Örneğin:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: 目标框架不支持 IsAotCompatible。请考虑对受支持的框架进行多目标设定来启用提前编译分析，并且仅为受支持的框架设置 IsAotCompatible。例如:
+        <target state="needs-review-translation">NETSDK1210: 目标框架不支持 IsAotCompatible。请考虑对受支持的框架进行多目标设定来启用提前编译分析，并且仅为受支持的框架设置 IsAotCompatible。例如:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: 目标框架不支持 IsTrimmable。请考虑对受支持的框架进行多目标设定以启用剪裁，并且仅为受支持的框架设置 IsTrimmable。例如:
+        <target state="needs-review-translation">NETSDK1212: 目标框架不支持 IsTrimmable。请考虑对受支持的框架进行多目标设定以启用剪裁，并且仅为受支持的框架设置 IsTrimmable。例如:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -570,16 +570,16 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1170: "}</note>
       </trans-unit>
       <trans-unit id="IsAotCompatibleUnsupported">
-        <source>NETSDK1210: IsAotCompatible is not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
+        <source>NETSDK1210: IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</source>
-        <target state="translated">NETSDK1210: 目標架構不支援 IsAotCompatible。考慮對支援的架構設定多重目標，以啟用提前編譯分析，並僅針對支援的架構設定 IsAotCompatible。例如:
+        <target state="needs-review-translation">NETSDK1210: 目標架構不支援 IsAotCompatible。考慮對支援的架構設定多重目標，以啟用提前編譯分析，並僅針對支援的架構設定 IsAotCompatible。例如:
 &lt;IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))"&gt;true&lt;/IsAotCompatible&gt;</target>
         <note>{StrBegin="NETSDK1210: "}</note>
       </trans-unit>
       <trans-unit id="IsTrimmableUnsupported">
-        <source>NETSDK1212: IsTrimmable is not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
+        <source>NETSDK1212: IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</source>
-        <target state="translated">NETSDK1212: 目標架構不支援 IsTrimmable。考慮對支援的架構設定多重目標，以啟用修剪，並僅針對支援的架構設定 IsTrimmable。例如:
+        <target state="needs-review-translation">NETSDK1212: 目標架構不支援 IsTrimmable。考慮對支援的架構設定多重目標，以啟用修剪，並僅針對支援的架構設定 IsTrimmable。例如:
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -439,16 +439,10 @@ namespace Microsoft.NET.Build.Tasks
                         // items that bypass the error above.
                         Log.LogError(Strings.AotUnsupportedTargetFramework);
                     } else if (IsAotCompatible || EnableAotAnalyzer) {
-                        // Technically this is reachable by setting EnableAotAnalyzer without IsAotCompatible,
-                        // but the recommended way to enable AOT analysis is to set IsAotCompatible,
-                        // so the warning points to the common case.
                         Log.LogWarning(Strings.IsAotCompatibleUnsupported);
                     } else if (PublishTrimmed) {
                         Log.LogError(Strings.PublishTrimmedRequiresVersion30);
                     } else if (IsTrimmable || EnableTrimAnalyzer) {
-                        // Technically this is reachable by setting EnableTrimAnalyzer without IsTrimmable,
-                        // but the recommended way to enable trim analysis is to set IsTrimmable,
-                        // so the warning points to the common case.
                         Log.LogWarning(Strings.IsTrimmableUnsupported);
                     } else if (EnableSingleFileAnalyzer) {
                         // There's no IsSingleFileCompatible setting. EnableSingleFileAnalyzer is the


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/35186.

For completeness, these messages should mention all of the properties that can be set to produce the warning, even those that aren't the recommended way to enable trim/aot compatibility.For completeness, these messages should mention all of the properties that can be set to produce the warning, even those that aren't the recommended way to enable trim/aot compatibility.


## Customer Impact
The previous warning message was confusing - it pointed to IsTrimmable when the warning was really caused by EnableTrimAnalyzer. Customers who set EnableTrimAnalyzer for an unsupported TFM will hit this warning.
The dotnet test team hit this, and customers are likely to hit it too.

## Testing

Passed existing unit tests without any behavior changes. Only change is to the wording of the message.

## Risk

Low. This is just a change to the wording of the warning message. However, note that the translated messages will need updating.
