### PR TITLE
Skip getting Windows GUI bit on non-Windows in AppHostShellShimMaker

### DIFF
--- a/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
+++ b/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
@@ -40,14 +40,14 @@ namespace Microsoft.DotNet.ShellShim
             string entryPointFullPath = Path.GetFullPath(entryPoint.Value);
             var appBinaryFilePath = Path.GetRelativePath(Path.GetDirectoryName(appHostDestinationFilePath), entryPointFullPath);
 
-
             if (ResourceUpdater.IsSupportedOS())
             {
-                var windowsGraphicalUserInterfaceBit = PEUtils.GetWindowsGraphicalUserInterfaceBit(entryPointFullPath);
+                bool windowsGraphicalUserInterface = OperatingSystem.IsWindows()
+                    && PEUtils.GetWindowsGraphicalUserInterfaceBit(entryPointFullPath) == WindowsGUISubsystem;
                 HostWriter.CreateAppHost(appHostSourceFilePath: appHostSourcePath,
                                          appHostDestinationFilePath: appHostDestinationFilePath,
                                          appBinaryFilePath: appBinaryFilePath,
-                                         windowsGraphicalUserInterface: (windowsGraphicalUserInterfaceBit == WindowsGUISubsystem) && OperatingSystem.IsWindows(),
+                                         windowsGraphicalUserInterface: windowsGraphicalUserInterface,
                                          assemblyToCopyResourcesFrom: entryPointFullPath,
                                          enableMacOSCodeSign: OperatingSystem.IsMacOS());
             }


### PR DESCRIPTION
`AppHostShellShimMaker` had an implicit assumption that `ResourceUpdater.IsSupportedOS()` was tied to Windows. That is no longer the case as of RC1, resulting in `PEUtils.GetWindowsGraphicalUserInterfaceBit` being unnecessarily called on non-Windows when creating a shim.

See https://github.com/dotnet/runtime/issues/92344.
This doesn't address the underlying issue around the function not properly handling endianness, but it brings back the previous behaviour where the problematic function isn't called when not needed.

cc @agocke @dotnet/domestic-cat 

### Customer Impact

When installing a tool on a non-Windows platform, we are unnecessarily trying to get the Windows subsystem bit for a PE image. This exposed a pre-existing issue where the function called did not properly handle endianness and resulted in a failure to install the tool on non-little-endian systems. This was a regression in RC1. See https://github.com/dotnet/runtime/issues/92344.

### Testing
Manual.

### Risk
Low. This switches the order of a check such that we only try to get the Windows subsystem bit on Windows (instead of always getting it and only using it on Windows).