### PR TITLE
Containers: support using OCI base images.

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -94,7 +94,7 @@ public static class ContainerBuilder
         logger.LogInformation(Strings.ContainerBuilder_StartBuildingImage, imageName, string.Join(",", imageName), sourceImageReference);
         cancellationToken.ThrowIfCancellationRequested();
 
-        Layer newLayer = Layer.FromDirectory(publishDirectory.FullName, workingDir, imageBuilder.IsWindows);
+        Layer newLayer = Layer.FromDirectory(publishDirectory.FullName, workingDir, imageBuilder.IsWindows, imageBuilder.ManifestMediaType);
         imageBuilder.AddLayer(newLayer);
         imageBuilder.SetWorkingDirectory(workingDir);
 

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -26,6 +26,11 @@ internal sealed class ImageBuilder
 
     public ImageConfig BaseImageConfig => _baseImageConfig;
 
+    /// <summary>
+    /// MediaType of the output manifest.
+    /// </summary>
+    public string ManifestMediaType => _manifest.MediaType; // output the same media type as the base image manifest.
+
     internal ImageBuilder(ManifestV2 manifest, ImageConfig baseImageConfig, ILogger logger)
     {
         _manifest = manifest;

--- a/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
@@ -6,6 +6,7 @@ using System.Formats.Tar;
 using System.IO.Compression;
 using System.Security.Cryptography;
 using System.IO.Enumeration;
+using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers;
 
@@ -49,7 +50,7 @@ internal class Layer
         return new(ContentStore.PathForDescriptor(descriptor), descriptor);
     }
 
-    public static Layer FromDirectory(string directory, string containerPath, bool isWindowsLayer)
+    public static Layer FromDirectory(string directory, string containerPath, bool isWindowsLayer, string manifestMediaType)
     {
         long fileSize;
         Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
@@ -186,9 +187,17 @@ internal class Layer
         string contentHash = Convert.ToHexString(hash).ToLowerInvariant();
         string uncompressedContentHash = Convert.ToHexString(uncompressedHash).ToLowerInvariant();
 
+        string layerMediaType = manifestMediaType switch
+        {
+             // TODO: configurable? gzip always?
+            SchemaTypes.DockerManifestV2 => "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            SchemaTypes.OciManifestV1 => "application/vnd.oci.image.layer.v1.tar+gzip",
+            _ => throw new ArgumentException(Resource.FormatString(nameof(Strings.UnrecognizedMediaType), manifestMediaType))
+        };
+
         Descriptor descriptor = new()
         {
-            MediaType = "application/vnd.docker.image.rootfs.diff.tar.gzip", // TODO: configurable? gzip always?
+            MediaType = layerMediaType,
             Size = fileSize,
             Digest = $"sha256:{contentHash}",
             UncompressedDigest = $"sha256:{uncompressedContentHash}",

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
@@ -42,7 +42,7 @@ internal class DefaultManifestOperations : IManifestOperations
     {
         string jsonString = JsonSerializer.SerializeToNode(manifest)?.ToJsonString() ?? "";
         HttpContent manifestUploadContent = new StringContent(jsonString);
-        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(SchemaTypes.DockerManifestV2);
+        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(manifest.MediaType);
 
         HttpResponseMessage putResponse = await _client.PutAsync(new Uri(_baseUri, $"/v2/{repositoryName}/manifests/{reference}"), manifestUploadContent, cancellationToken).ConfigureAwait(false);
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -100,7 +100,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         SafeLog(Strings.ContainerBuilder_StartBuildingImage, Repository, String.Join(",", ImageTags), sourceImageReference);
 
-        Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows);
+        Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows, imageBuilder.ManifestMediaType);
         imageBuilder.AddLayer(newLayer);
         imageBuilder.SetWorkingDirectory(WorkingDirectory);
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -57,7 +57,7 @@ public class EndToEndTests : IDisposable
 
         Assert.NotNull(imageBuilder);
 
-        Layer l = Layer.FromDirectory(publishDirectory, "/app", false);
+        Layer l = Layer.FromDirectory(publishDirectory, "/app", false, imageBuilder.ManifestMediaType);
 
         imageBuilder.AddLayer(l);
 
@@ -103,7 +103,7 @@ public class EndToEndTests : IDisposable
             cancellationToken: default).ConfigureAwait(false);
         Assert.NotNull(imageBuilder);
 
-        Layer l = Layer.FromDirectory(publishDirectory, "/app", false);
+        Layer l = Layer.FromDirectory(publishDirectory, "/app", false, imageBuilder.ManifestMediaType);
 
         imageBuilder.AddLayer(l);
 
@@ -144,7 +144,7 @@ public class EndToEndTests : IDisposable
             cancellationToken: default).ConfigureAwait(false);
         Assert.NotNull(imageBuilder);
 
-        Layer l = Layer.FromDirectory(publishDirectory, "/app", false);
+        Layer l = Layer.FromDirectory(publishDirectory, "/app", false, imageBuilder.ManifestMediaType);
 
         imageBuilder.AddLayer(l);
 
@@ -456,7 +456,7 @@ public class EndToEndTests : IDisposable
             cancellationToken: default).ConfigureAwait(false);
         Assert.NotNull(imageBuilder);
 
-        Layer l = Layer.FromDirectory(publishDirectory, isWin ? "C:\\app" : "/app", isWin);
+        Layer l = Layer.FromDirectory(publishDirectory, isWin ? "C:\\app" : "/app", isWin, imageBuilder.ManifestMediaType);
 
         imageBuilder.AddLayer(l);
         imageBuilder.SetWorkingDirectory(workingDir);

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/LayerEndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/LayerEndToEndTests.cs
@@ -29,7 +29,7 @@ public sealed class LayerEndToEndTests : IDisposable
 
         File.WriteAllText(testFilePath, testString);
 
-        Layer l = Layer.FromDirectory(directory: folder.Path, containerPath: "/app", false);
+        Layer l = Layer.FromDirectory(directory: folder.Path, containerPath: "/app", false, SchemaTypes.DockerManifestV2);
 
         Console.WriteLine(l.Descriptor);
 
@@ -54,7 +54,7 @@ public sealed class LayerEndToEndTests : IDisposable
 
         File.WriteAllText(testFilePath, testString);
 
-        Layer l = Layer.FromDirectory(directory: folder.Path, containerPath: "C:\\app", true);
+        Layer l = Layer.FromDirectory(directory: folder.Path, containerPath: "C:\\app", true, SchemaTypes.DockerManifestV2);
 
         var allEntries = LoadAllTarEntries(l.BackingFile);
         Assert.True(allEntries.TryGetValue("Files", out var filesEntry) && filesEntry.EntryType == TarEntryType.Directory, "Missing Files directory entry");


### PR DESCRIPTION
## Description

The SDK Container tools throw an error when using a base image with the `OCI` manifest format instead of the `Docker` media type format, because we assume that the final generated image will be the `Docker` format. This is not a good assumption, and many registries fail to accept our containers as a result. The fix is to ensure that the media type format of the base image is used for the image we generate.

This **does not** impact the Microsoft-authored .NET images, but many registries can provide OCI manifest formats and so users that use custom base images may encounter this.

## Regression

**No** - we didn't support this use case at all until we recently gained the ability to read OCI manifest formats

## Risk

**Low** - testing has established that this change doesn't regress the existing scenarios around the out-of-the-box capabilities, and also established that previously-failing use cases light up with this fix.

## Testing

* In-repo automated tests verify previous use cases
* [Github actions container pushes](https://github.com/baronfel/sdk-container-demo/actions/runs/6263424893/job/17007797080) covering the new scenario are passing
* Reporting contributor verifies the fix works on their setup

Fixes https://github.com/dotnet/sdk/issues/35608.