### PR TITLE
Avoid running new APIs under older TFMs

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -290,8 +290,11 @@ setTimeout(async function () {
 
       webSocket.addEventListener('open', onOpen);
       webSocket.addEventListener('close', onClose);
-      webSocket.addEventListener('close', () => window.Blazor?.removeEventListener('enhancedload', notifyHotReloadApplied));
-      window.Blazor?.addEventListener('enhancedload', notifyHotReloadApplied);
+      if (window.Blazor?.removeEventListener && window.Blazor?.addEventListener)
+      {
+        webSocket.addEventListener('close', () => window.Blazor?.removeEventListener('enhancedload', notifyHotReloadApplied));
+        window.Blazor?.addEventListener('enhancedload', notifyHotReloadApplied);
+      }
     });
   }
 }, 500);


### PR DESCRIPTION
## Description

This PR resolves a regression that was introduced in 8.0 RC 2 wherein running a Blazor application with hot reload enabled would cause the app to fail to launch if the application was targeting a non-`net8.0` TFM.

## Customer Impact

This regression has a high impact to users as there are no viable workarounds for users using the new SDK for apps that are targeting an older TFM.

## Regression?

- [X] Yes
- [ ] No

This PR fixes a regression from the 7.0 and 8.0 RC 1 SDKs.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Code delta is small and reduces the likelihood of unavailable APIs being called on incompatible runtimes.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A