### PR TITLE
Update RID parsing's `LastIndexOf` call to use invariant culture

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -262,9 +262,9 @@ namespace Microsoft.DotNet.Cli
             return currentRuntimeIdentifiers[0]; // First rid is the most specific (ex win-x64)
         }
 
-        private static string GetOsFromRid(string rid) => rid.Substring(0, rid.LastIndexOf("-"));
+        private static string GetOsFromRid(string rid) => rid.Substring(0, rid.LastIndexOf("-", StringComparison.InvariantCulture));
 
-        private static string GetArchFromRid(string rid) => rid.Substring(rid.LastIndexOf("-") + 1, rid.Length - rid.LastIndexOf("-") - 1);
+        private static string GetArchFromRid(string rid) => rid.Substring(rid.LastIndexOf("-", StringComparison.InvariantCulture) + 1, rid.Length - rid.LastIndexOf("-", StringComparison.InvariantCulture) - 1);
 
         private static IEnumerable<string> ForwardSelfContainedOptions(bool isSelfContained, ParseResult parseResult)
         {

--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -80,9 +80,9 @@ namespace Microsoft.DotNet.Cli
                 command.Options.Add(option);
             }
         }
-        private static string GetOsFromRid(string rid) => rid.Substring(0, rid.LastIndexOf("-"));
-        private static string GetArchFromRid(string rid) => rid.Substring(rid.LastIndexOf("-") + 1, rid.Length - rid.LastIndexOf("-") - 1);
-        public static string RestoreRuntimeArgFunc(IEnumerable<string> rids) 
+        private static string GetOsFromRid(string rid) => rid.Substring(0, rid.LastIndexOf("-", StringComparison.InvariantCulture));
+        private static string GetArchFromRid(string rid) => rid.Substring(rid.LastIndexOf("-", StringComparison.InvariantCulture) + 1, rid.Length - rid.LastIndexOf("-", StringComparison.InvariantCulture) - 1);
+        public static string RestoreRuntimeArgFunc(IEnumerable<string> rids)
         {
             List<string> convertedRids = new();
             foreach (string rid in rids)

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     var expectedArch = RuntimeInformation.ProcessArchitecture.Equals(Architecture.Arm64) ? "arm64" : Environment.Is64BitOperatingSystem ? "x64" : "x86";
                     command.GetArgumentsToMSBuild()
                         .Should()
-                        .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch} -property:SelfContained=false");
+                        .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch}");
                 });
             }
             finally { CultureInfo.CurrentCulture = currentCultureBefore; }
@@ -192,7 +192,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     }
                     command.GetArgumentsToMSBuild()
                         .Should()
-                        .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier={expectedOs}-arch -property:SelfContained=false");
+                        .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier={expectedOs}-arch");
                 });
             }
             finally { CultureInfo.CurrentCulture = currentCultureBefore;}

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools;
 using BuildCommand = Microsoft.DotNet.Tools.Build.BuildCommand;
@@ -147,6 +148,54 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     .Should()
                     .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-x64 -property:SelfContained=false");
             });
+        }
+
+        [Fact]
+        public void ArchOptionIsResolvedFromRidUnderDifferentCulture()
+        {
+            CultureInfo currentCultureBefore = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("th");
+                CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+                {
+                    var msbuildPath = "<msbuildpath>";
+                    var command = BuildCommand.FromArgs(new string[] { "--os", "os" }, msbuildPath);
+                    var expectedArch = RuntimeInformation.ProcessArchitecture.Equals(Architecture.Arm64) ? "arm64" : Environment.Is64BitOperatingSystem ? "x64" : "x86";
+                    command.GetArgumentsToMSBuild()
+                        .Should()
+                        .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier=os-{expectedArch} -property:SelfContained=false");
+                });
+            }
+            finally { CultureInfo.CurrentCulture = currentCultureBefore; }
+        }
+
+        [Fact]
+        public void OsOptionIsResolvedFromRidUnderDifferentCulture()
+        {
+            CultureInfo currentCultureBefore = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("th");
+                CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+                {
+                    var msbuildPath = "<msbuildpath>";
+                    var command = BuildCommand.FromArgs(new string[] { "--arch", "arch" }, msbuildPath);
+                    var expectedOs = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win" :
+                        RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux" :
+                        RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx" :
+                        null;
+                    if (expectedOs == null)
+                    {
+                        // Not a supported OS for running test
+                        return;
+                    }
+                    command.GetArgumentsToMSBuild()
+                        .Should()
+                        .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier={expectedOs}-arch -property:SelfContained=false");
+                });
+            }
+            finally { CultureInfo.CurrentCulture = currentCultureBefore;}
         }
     }
 }


### PR DESCRIPTION
Per #34347, update RID parsing's `LastIndexOf` call to use invariant culture