### PR TITLE
Workload commands: JSON only output adjustments

### DIFF
--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -82,12 +82,14 @@ namespace Microsoft.DotNet.Workloads.Workload
             _workloadManifestUpdaterFromConstructor = workloadManifestUpdater;
         }
 
-        protected async Task<List<WorkloadDownload>> GetDownloads(IEnumerable<WorkloadId> workloadIds, bool skipManifestUpdate, bool includePreview, string downloadFolder = null)
+        protected async Task<List<WorkloadDownload>> GetDownloads(IEnumerable<WorkloadId> workloadIds, bool skipManifestUpdate, bool includePreview, string downloadFolder = null,
+            IReporter reporter = null, INuGetPackageDownloader packageDownloader = null)
         {
+            reporter ??= Reporter;
+            packageDownloader ??= PackageDownloader;
+
             List<WorkloadDownload> ret = new();
-
             DirectoryPath? tempPath = null;
-
             try
             {
                 if (!skipManifestUpdate)
@@ -109,7 +111,7 @@ namespace Microsoft.DotNet.Workloads.Workload
 
                     if (!manifestDownloads.Any())
                     {
-                        Reporter.WriteLine(Strings.SkippingManifestUpdate);
+                        reporter.WriteLine(Strings.SkippingManifestUpdate);
                     }
 
                     foreach (var download in manifestDownloads)
@@ -117,8 +119,8 @@ namespace Microsoft.DotNet.Workloads.Workload
                         //  Add package to the list of downloads
                         ret.Add(download);
 
-                        //  Download package                        
-                        var downloadedPackagePath = await PackageDownloader.DownloadPackageAsync(new PackageId(download.NuGetPackageId), new NuGetVersion(download.NuGetPackageVersion),
+                        //  Download package
+                        var downloadedPackagePath = await packageDownloader.DownloadPackageAsync(new PackageId(download.NuGetPackageId), new NuGetVersion(download.NuGetPackageVersion),
                             _packageSourceLocation, downloadFolder: folderForManifestDownloads);
 
                         //  Extract manifest from package
@@ -140,9 +142,9 @@ namespace Microsoft.DotNet.Workloads.Workload
                     DirectoryPath downloadFolderDirectoryPath = new DirectoryPath(downloadFolder);
                     foreach (var packDownload in packDownloads)
                     {
-                        Reporter.WriteLine(string.Format(Install.LocalizableStrings.DownloadingPackToCacheMessage, packDownload.NuGetPackageId, packDownload.NuGetPackageVersion, downloadFolder));
+                        reporter.WriteLine(string.Format(Install.LocalizableStrings.DownloadingPackToCacheMessage, packDownload.NuGetPackageId, packDownload.NuGetPackageVersion, downloadFolder));
 
-                        await PackageDownloader.DownloadPackageAsync(new PackageId(packDownload.NuGetPackageId), new NuGetVersion(packDownload.NuGetPackageVersion),
+                        await packageDownloader.DownloadPackageAsync(new PackageId(packDownload.NuGetPackageId), new NuGetVersion(packDownload.NuGetPackageVersion),
                             _packageSourceLocation, downloadFolder: downloadFolderDirectoryPath);
                     }
                 }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
@@ -71,6 +71,8 @@ namespace Microsoft.DotNet.Workloads.Workload
             get;
         }
 
+        protected bool IsPackageDownloaderProvided { get; }
+
         /// <summary>
         /// Initializes a new <see cref="WorkloadCommandBase"/> instance.
         /// </summary>
@@ -107,7 +109,8 @@ namespace Microsoft.DotNet.Workloads.Workload
 
             TempPackagesDirectory = new DirectoryPath(Path.Combine(TempDirectoryPath, "dotnet-sdk-advertising-temp"));
 
-            PackageDownloader = nugetPackageDownloader ?? new NuGetPackageDownloader(TempPackagesDirectory,
+            IsPackageDownloaderProvided = nugetPackageDownloader != null;
+            PackageDownloader = IsPackageDownloaderProvided ? nugetPackageDownloader : new NuGetPackageDownloader(TempPackagesDirectory,
                 filePermissionSetter: null,
                 new FirstPartyNuGetPackageSigningVerifier(),
                 nugetLogger,

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
@@ -111,6 +111,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                 filePermissionSetter: null,
                 new FirstPartyNuGetPackageSigningVerifier(),
                 nugetLogger,
+                Reporter,
                 restoreActionConfig: RestoreActionConfiguration,
                 verifySignatures: VerifySignatures);
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NullReporter.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NullReporter.cs
@@ -14,5 +14,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         public void WriteLine() { }
 
         public void WriteLine(string format, params object?[] args) => WriteLine(string.Format(format, args));
+
+        public static NullReporter Instance { get; } = new NullReporter();
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             bool usedRollback = !string.IsNullOrWhiteSpace(_fromRollbackDefinition);
             if (_printDownloadLinkOnly)
             {
-                var packageDownloader = new NuGetPackageDownloader(
+                var packageDownloader = IsPackageDownloaderProvided ? PackageDownloader : new NuGetPackageDownloader(
                     TempPackagesDirectory,
                     filePermissionSetter: null,
                     new FirstPartyNuGetPackageSigningVerifier(),

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             }
             else if (_printDownloadLinkOnly)
             {
-                var packageDownloader = new NuGetPackageDownloader(
+                var packageDownloader = IsPackageDownloaderProvided ? PackageDownloader : new NuGetPackageDownloader(
                     TempPackagesDirectory,
                     filePermissionSetter: null,
                     new FirstPartyNuGetPackageSigningVerifier(),

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -308,7 +308,6 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             installManager.Execute();
 
-            _reporter.Lines.Should().Contain("==allPackageLinksJsonOutputStart==");
             string.Join(" ", _reporter.Lines).Should().Contain("http://mock-url/xamarin.android.sdk.8.4.7.nupkg");
             string.Join(" ", _reporter.Lines).Should().Contain("http://mock-url/mock-manifest-package.1.0.5.nupkg");
         }

--- a/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -250,7 +250,6 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
 
             command.Execute();
 
-            _reporter.Lines.Should().Contain("==allPackageLinksJsonOutputStart==");
             string.Join(" ", _reporter.Lines).Should().Contain("http://mock-url/xamarin.android.templates.1.0.3.nupkg", "New pack urls should be included in output");
             string.Join(" ", _reporter.Lines).Should().Contain("http://mock-url/xamarin.android.framework.8.4.0.nupkg", "Urls for packs with updated versions should be included in output");
             string.Join(" ", _reporter.Lines).Should().NotContain("xamarin.android.sdk", "Urls for packs with the same version should not be included in output");
@@ -327,7 +326,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
 
 
             updateCommand.Execute();
-            _reporter.Lines.Count().Should().Be(3);
+            _reporter.Lines.Count().Should().Be(1);
             string.Join("", _reporter.Lines).Should().Contain("samplemanifest");
         }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/22887

> [!NOTE]
> This PR is a breaking change. 
> I do plan to also work on [this issue](https://github.com/dotnet/sdk/issues/22882) which would be good to lump together in the same breaking change doc.

## Summary
There were a couple of primary changes:
- Removed the Start/End boundary lines from the JSON only workload commands
- Only have the JSON being written (no logging messages) for the JSON only workload commands

Commands adjusted:
- `dotnet workload list --machine-readable`
- `dotnet workload install --print-download-link-only`
- `dotnet workload update --print-download-link-only`
- `dotnet workload update --print-rollback`

## Details
The first change (boundary lines) was very simple and just involved removing a couple of `WriteLine` outputs for each command. Then, adjusting tests accordingly.

The second change was a bit more involved. We use a `Reporter` to write out to the console. Think of it as just an output stream. Right now, these commands are designed to:
- Pass an instance of `Reporter` down through the workload command hierarchy.
- If one is not provided, the default `Reporter.Output` will be used.
- The `Reporter` property can only be set via this constructor hierarchy.

For the commands in question, we need to:
- Use the configured `Reporter` to write the JSON appropriately
- Every other usage of `Reporter` beyond writing the JSON is replaced with `NullReporter.Instance`

To do this was a bit tricky. I had to add the ability to pass a `Reporter` to several methods that utilized it. But there was something else that also needed adjusted. The `PackageDownloader` is also created deep in the hierarchy using the `Reporter` from the constructor. Since I actually want to utilize the `Reporter` being passed in to write the JSON, I can't just force the `Reporter` property to be `NullReporter`.

So, I ended up creating a new instance of `NuGetPackageDownloader` for this situation. It also allowed me to use a `NullLogger` which applies to the NuGet messages. For unit testing, I had to add `IsPackageDownloaderProvided` to indicate that a `PackageDownloader` was passed through the constructor hierarchy. Then, I use that `PackageDownloader` instead of creating a new one.