### PR TITLE
Upgrade MSBuildLocator ref from 1.6.1 to 1.6.10

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -334,9 +334,9 @@
       <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23468.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23471.2">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>e9d6489787a5ea5400a31dfa34aa6ad6b590de9b</Sha>
+      <Sha>6dbf3aaa0fc9664df86462f5c70b99800934fccd</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23463.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -167,7 +167,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Manually updated">
     <!-- Dependencies from https://github.com/microsoft/MSBuildLocator -->
-    <MicrosoftBuildLocatorPackageVersion>1.6.1</MicrosoftBuildLocatorPackageVersion>
+    <MicrosoftBuildLocatorPackageVersion>1.6.10</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerPinnedVersionPackageVersion>4.0.1</MicrosoftCodeAnalysisCSharpAnalyzerPinnedVersionPackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
This was missed as part of the set of changes to respond to the upgrade of Microsoft.Build.Locator to 1.6.10 in source-build: https://github.com/dotnet/source-build-externals/pull/214

This is needed to allow source-build to work. Without it, it causes a version conflict between 1.6.1 and 1.6.10:

```
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277: Found conflicts between different versions of "Microsoft.Build.Locator" that could not be resolved. [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277: There was a conflict between "Microsoft.Build.Locator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd" and "Microsoft.Build.Locator, Version=1.6.10.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd". [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:     "Microsoft.Build.Locator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd" was chosen because it was primary and "Microsoft.Build.Locator, Version=1.6.10.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd" was not. [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:     References which depend on "Microsoft.Build.Locator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd" [/vmr/src/sdk/artifacts/source-build/self/package-cache/microsoft.build.locator/1.6.1/lib/net6.0/Microsoft.Build.Locator.dll]. [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:         /vmr/src/sdk/artifacts/source-build/self/package-cache/microsoft.build.locator/1.6.1/lib/net6.0/Microsoft.Build.Locator.dll [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:           Project file item includes which caused reference "/vmr/src/sdk/artifacts/source-build/self/package-cache/microsoft.build.locator/1.6.1/lib/net6.0/Microsoft.Build.Locator.dll". [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:             /vmr/src/sdk/artifacts/source-build/self/package-cache/microsoft.build.locator/1.6.1/lib/net6.0/Microsoft.Build.Locator.dll [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:     References which depend on "Microsoft.Build.Locator, Version=1.6.10.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd" []. [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:         /vmr/src/sdk/artifacts/source-build/self/package-cache/microsoft.codeanalysis.workspaces.msbuild/4.8.0-3.23471.10/lib/net8.0/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:           Project file item includes which caused reference "/vmr/src/sdk/artifacts/source-build/self/package-cache/microsoft.codeanalysis.workspaces.msbuild/4.8.0-3.23471.10/lib/net8.0/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll". [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:             /vmr/src/sdk/artifacts/source-build/self/package-cache/microsoft.codeanalysis.workspaces.msbuild/4.8.0-3.23471.10/lib/net8.0/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
    /vmr/.dotnet/sdk/8.0.100-rc.1.23455.8/Microsoft.Common.CurrentVersion.targets(2364,5): error MSB3277:             /vmr/src/sdk/artifacts/source-build/self/package-cache/microsoft.codeanalysis.workspaces.msbuild/4.8.0-3.23471.10/lib/net8.0/Microsoft.CodeAnalysis.Workspaces.MSBuild.dll [/vmr/src/sdk/artifacts/source-build/self/src/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj]
```