### PR TITLE
IDE0017 "Object initialization can be simplified" cleanup

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/PollingFileWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/PollingFileWatcher.cs
@@ -31,9 +31,11 @@ namespace Microsoft.DotNet.Watcher.Internal
             _watchedDirectory = new DirectoryInfo(watchedDirectory);
             BasePath = _watchedDirectory.FullName;
 
-            _pollingThread = new Thread(new ThreadStart(PollingLoop));
-            _pollingThread.IsBackground = true;
-            _pollingThread.Name = nameof(PollingFileWatcher);
+            _pollingThread = new Thread(new ThreadStart(PollingLoop))
+            {
+                IsBackground = true,
+                Name = nameof(PollingFileWatcher)
+            };
 
             CreateKnownFilesSnapshot();
 

--- a/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -105,9 +105,11 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
 
         public static SlnFile Read(string file)
         {
-            SlnFile slnFile = new SlnFile();
-            slnFile.FullPath = Path.GetFullPath(file);
-            slnFile._format = FileUtil.GetTextFormatInfo(file);
+            SlnFile slnFile = new SlnFile
+            {
+                FullPath = Path.GetFullPath(file),
+                _format = FileUtil.GetTextFormatInfo(file)
+            };
 
             using (var sr = new StreamReader(new FileStream(file, FileMode.Open, FileAccess.Read)))
             {
@@ -429,8 +431,10 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             {
                 if (_properties == null)
                 {
-                    _properties = new SlnPropertySet();
-                    _properties.ParentSection = this;
+                    _properties = new SlnPropertySet
+                    {
+                        ParentSection = this
+                    };
                     if (_sectionLines != null)
                     {
                         foreach (var line in _sectionLines)
@@ -1066,8 +1070,11 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             var sec = this.FirstOrDefault(s => s.Id == id);
             if (sec == null)
             {
-                sec = new SlnSection { Id = id };
-                sec.SectionType = sectionType;
+                sec = new SlnSection
+                {
+                    Id = id,
+                    SectionType = sectionType
+                };
                 Add(sec);
             }
             return sec;

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessStartInfoExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessStartInfoExtensions.cs
@@ -39,10 +39,9 @@ namespace Microsoft.DotNet.Cli.Utils
 
             var process = new Process
             {
-                StartInfo = startInfo
+                StartInfo = startInfo,
+                EnableRaisingEvents = true
             };
-
-            process.EnableRaisingEvents = true;
 
             using (var reaper = new ProcessReaper(process))
             {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -103,9 +103,9 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 AllowScriptsOption = new CliOption<AllowRunScripts>("--allow-scripts")
                 {
                     Description = SymbolStrings.TemplateCommand_Option_AllowScripts,
-                    Arity = new ArgumentArity(1, 1)
+                    Arity = new ArgumentArity(1, 1),
+                    DefaultValueFactory = (_) => AllowRunScripts.Prompt
                 };
-                AllowScriptsOption.DefaultValueFactory = (_) => AllowRunScripts.Prompt;
                 Options.Add(AllowScriptsOption);
             }
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateResult.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateResult.cs
@@ -39,10 +39,12 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         internal static TemplateResult FromParseResult(TemplateCommand templateCommand, ParseResult parseResult)
         {
-            TemplateResult result = new TemplateResult(templateCommand, parseResult);
-            result.IsLanguageMatch = templateCommand.LanguageOption == null || !parseResult.HasErrorFor(templateCommand.LanguageOption, out _);
-            result.IsTypeMatch = templateCommand.TypeOption == null || !parseResult.HasErrorFor(templateCommand.TypeOption, out _);
-            result.IsBaselineMatch = templateCommand.BaselineOption == null || !parseResult.HasErrorFor(templateCommand.BaselineOption, out _);
+            TemplateResult result = new TemplateResult(templateCommand, parseResult)
+            {
+                IsLanguageMatch = templateCommand.LanguageOption == null || !parseResult.HasErrorFor(templateCommand.LanguageOption, out _),
+                IsTypeMatch = templateCommand.TypeOption == null || !parseResult.HasErrorFor(templateCommand.TypeOption, out _),
+                IsBaselineMatch = templateCommand.BaselineOption == null || !parseResult.HasErrorFor(templateCommand.BaselineOption, out _)
+            };
 
             if (templateCommand.LanguageOption != null && result.IsTemplateMatch)
             {

--- a/src/Cli/dotnet/Telemetry/Telemetry.cs
+++ b/src/Cli/dotnet/Telemetry/Telemetry.cs
@@ -136,8 +136,10 @@ namespace Microsoft.DotNet.Cli.Telemetry
         {
             try
             {
-                var persistenceChannel = new PersistenceChannel.PersistenceChannel(sendersCount: _senderCount);
-                persistenceChannel.SendingInterval = TimeSpan.FromMilliseconds(1);
+                var persistenceChannel = new PersistenceChannel.PersistenceChannel(sendersCount: _senderCount)
+                {
+                    SendingInterval = TimeSpan.FromMilliseconds(1)
+                };
 
                 var config = TelemetryConfiguration.CreateDefault();
                 config.TelemetryChannel = persistenceChannel;

--- a/src/Cli/dotnet/ToolManifest/ToolManifestEditor.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestEditor.cs
@@ -165,8 +165,10 @@ namespace Microsoft.DotNet.ToolManifest
 
                         foreach (var toolJson in tools.EnumerateObject())
                         {
-                            var serializableLocalToolSinglePackage = new SerializableLocalToolSinglePackage();
-                            serializableLocalToolSinglePackage.PackageId = toolJson.Name;
+                            var serializableLocalToolSinglePackage = new SerializableLocalToolSinglePackage
+                            {
+                                PackageId = toolJson.Name
+                            };
                             if (toolJson.Value.TryGetStringValue(JsonPropertyVersion, out var versionJson))
                             {
                                 serializableLocalToolSinglePackage.Version = versionJson;

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -21,10 +21,11 @@ namespace Microsoft.DotNet.Cli
 
         private static CliCommand ConstructCommand()
         {
-            var command = new DocumentedCommand("nuget", DocsLink);
-
-            // some subcommands are not defined here and just forwarded to NuGet app
-            command.TreatUnmatchedTokensAsErrors = false;
+            var command = new DocumentedCommand("nuget", DocsLink)
+            {
+                // some subcommands are not defined here and just forwarded to NuGet app
+                TreatUnmatchedTokensAsErrors = false
+            };
 
             command.Options.Add(new CliOption<bool>("--version"));
             command.Options.Add(new CliOption<string>("--verbosity", "-v"));
@@ -167,8 +168,10 @@ namespace Microsoft.DotNet.Cli
             };
 
             CliCommand CertificateCommand() {
-                CliOption<string> algorithm = new("--algorithm");
-                algorithm.DefaultValueFactory = (_argResult) => "SHA256";
+                CliOption<string> algorithm = new("--algorithm")
+                {
+                    DefaultValueFactory = (_argResult) => "SHA256"
+                };
                 algorithm.AcceptOnlyFromAmong("SHA256", "SHA384", "SHA512");
 
                 return new CliCommand("certificate") {

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
@@ -15,8 +15,10 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 
         public LaunchSettingsApplyResult TryGetLaunchSettings(string? launchProfileName, JsonElement model)
         {
-            var config = new ProjectLaunchSettingsModel();
-            config.LaunchProfileName = launchProfileName;
+            var config = new ProjectLaunchSettingsModel
+            {
+                LaunchProfileName = launchProfileName
+            };
 
             foreach (var property in model.EnumerateObject())
             {

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -159,8 +159,10 @@ namespace Microsoft.DotNet.Cli
 
         private static CliCommand ConstructCommand()
         {
-            DocumentedCommand command = new("test", DocsLink, LocalizableStrings.AppFullName);
-            command.TreatUnmatchedTokensAsErrors = false;
+            DocumentedCommand command = new("test", DocsLink, LocalizableStrings.AppFullName)
+            {
+                TreatUnmatchedTokensAsErrors = false
+            };
 
             // We are on purpose not capturing the solution, project or directory here. We want to pass it to the
             // MSBuild command so we are letting it flow.

--- a/src/Cli/dotnet/commands/dotnet-vstest/VSTestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-vstest/VSTestCommandParser.cs
@@ -19,9 +19,10 @@ namespace Microsoft.DotNet.Cli
 
         private static CliCommand ConstructCommand()
         {
-            DocumentedCommand command = new("vstest", DocsLink);
-
-            command.TreatUnmatchedTokensAsErrors = false;
+            DocumentedCommand command = new("vstest", DocsLink)
+            {
+                TreatUnmatchedTokensAsErrors = false
+            };
 
             command.Options.Add(CommonOptions.TestPlatformOption);
             command.Options.Add(CommonOptions.TestFrameworkOption);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadResolverFactory.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadResolverFactory.cs
@@ -35,9 +35,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         public static CreationResult Create(CreationParameters parameters)
         {
-            var result = new CreationResult();
-
-            result.InstalledSdkVersion = new ReleaseVersion(parameters.VersionForTesting ?? Product.Version);
+            var result = new CreationResult
+            {
+                InstalledSdkVersion = new ReleaseVersion(parameters.VersionForTesting ?? Product.Version)
+            };
 
             bool manifestsNeedValidation;
             if (string.IsNullOrEmpty(parameters.SdkVersionFromOption))

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -130,16 +130,17 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             DirectoryPath? offlineCache = null)
         {
 
-            var transaction = new CliTransaction();
-
-            transaction.RollbackStarted = () =>
+            var transaction = new CliTransaction
             {
-                Reporter.WriteLine(LocalizableStrings.RollingBackInstall);
-            };
-            // Don't hide the original error if roll back fails, but do log the rollback failure
-            transaction.RollbackFailed = ex =>
-            {
-                Reporter.WriteLine(string.Format(LocalizableStrings.RollBackFailedMessage, ex.Message));
+                RollbackStarted = () =>
+                {
+                    Reporter.WriteLine(LocalizableStrings.RollingBackInstall);
+                },
+                // Don't hide the original error if roll back fails, but do log the rollback failure
+                RollbackFailed = ex =>
+                {
+                    Reporter.WriteLine(string.Format(LocalizableStrings.RollBackFailedMessage, ex.Message));
+                }
             };
 
             transaction.Run(

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -78,10 +78,12 @@ internal sealed class DockerCli : ILocalRegistry
         string commandPath = await FindFullCommandPath(cancellationToken);
 
         // call `docker load` and get it ready to receive input
-        ProcessStartInfo loadInfo = new(commandPath, $"load");
-        loadInfo.RedirectStandardInput = true;
-        loadInfo.RedirectStandardOutput = true;
-        loadInfo.RedirectStandardError = true;
+        ProcessStartInfo loadInfo = new(commandPath, $"load")
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
 
         using Process? loadProcess = Process.Start(loadInfo);
 

--- a/src/StaticWebAssetsSdk/Tasks/ReferencedProjectConfiguration.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ReferencedProjectConfiguration.cs
@@ -97,17 +97,18 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
             internal static ReferencedProjectConfiguration FromTaskItem(ITaskItem arg)
             {
-                var result = new ReferencedProjectConfiguration();
-
-                result.Identity = arg.GetMetadata("FullPath");
-                result.Version = int.Parse(arg.GetMetadata(nameof(Version)), CultureInfo.InvariantCulture);
-                result.Source = arg.GetMetadata(nameof(Source));
-                result.GetBuildAssetsTargets = arg.GetMetadata(nameof(GetBuildAssetsTargets));
-                result.AdditionalBuildProperties = arg.GetMetadata(nameof(AdditionalBuildProperties));
-                result.AdditionalBuildPropertiesToRemove = arg.GetMetadata(nameof(AdditionalBuildPropertiesToRemove));
-                result.GetPublishAssetsTargets = arg.GetMetadata(nameof(GetPublishAssetsTargets));
-                result.AdditionalPublishProperties = arg.GetMetadata(nameof(AdditionalPublishProperties));
-                result.AdditionalPublishPropertiesToRemove = arg.GetMetadata(nameof(AdditionalPublishPropertiesToRemove));
+                var result = new ReferencedProjectConfiguration
+                {
+                    Identity = arg.GetMetadata("FullPath"),
+                    Version = int.Parse(arg.GetMetadata(nameof(Version)), CultureInfo.InvariantCulture),
+                    Source = arg.GetMetadata(nameof(Source)),
+                    GetBuildAssetsTargets = arg.GetMetadata(nameof(GetBuildAssetsTargets)),
+                    AdditionalBuildProperties = arg.GetMetadata(nameof(AdditionalBuildProperties)),
+                    AdditionalBuildPropertiesToRemove = arg.GetMetadata(nameof(AdditionalBuildPropertiesToRemove)),
+                    GetPublishAssetsTargets = arg.GetMetadata(nameof(GetPublishAssetsTargets)),
+                    AdditionalPublishProperties = arg.GetMetadata(nameof(AdditionalPublishProperties)),
+                    AdditionalPublishPropertiesToRemove = arg.GetMetadata(nameof(AdditionalPublishPropertiesToRemove))
+                };
 
                 return result;
             }

--- a/src/StaticWebAssetsSdk/Tasks/StaticWebAssetsDiscoveryPattern.cs
+++ b/src/StaticWebAssetsSdk/Tasks/StaticWebAssetsDiscoveryPattern.cs
@@ -65,13 +65,14 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         internal static StaticWebAssetsDiscoveryPattern FromTaskItem(ITaskItem pattern)
         {
-            var result = new StaticWebAssetsDiscoveryPattern();
-
-            result.Name = pattern.ItemSpec;
-            result.Source = pattern.GetMetadata(nameof(Source));
-            result.BasePath = pattern.GetMetadata(nameof(BasePath));
-            result.ContentRoot = pattern.GetMetadata(nameof(ContentRoot));
-            result.Pattern = pattern.GetMetadata(nameof(Pattern));
+            var result = new StaticWebAssetsDiscoveryPattern
+            {
+                Name = pattern.ItemSpec,
+                Source = pattern.GetMetadata(nameof(Source)),
+                BasePath = pattern.GetMetadata(nameof(BasePath)),
+                ContentRoot = pattern.GetMetadata(nameof(ContentRoot)),
+                Pattern = pattern.GetMetadata(nameof(Pattern))
+            };
 
             return result;
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GetPublishItemsOutputGroupOutputsTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GetPublishItemsOutputGroupOutputsTests.cs
@@ -31,12 +31,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [WindowsOnlyFact]
         public void It_can_expand_OutputPath()
         {
-            var task = new GetPublishItemsOutputGroupOutputs();
-
-            task.PublishDir = @"bin\Debug\net5.0\publish\";
-            task.ResolvedFileToPublish = new[]
+            var task = new GetPublishItemsOutputGroupOutputs
+            {
+                PublishDir = @"bin\Debug\net5.0\publish\",
+                ResolvedFileToPublish = new[]
             {
                 _apphost, _dll, _dll
+            }
             };
 
             task.Execute().Should().BeTrue();

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GetPublishItemsOutputGroupOutputsTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GetPublishItemsOutputGroupOutputsTests.cs
@@ -35,9 +35,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 PublishDir = @"bin\Debug\net5.0\publish\",
                 ResolvedFileToPublish = new[]
-            {
-                _apphost, _dll, _dll
-            }
+                {
+                    _apphost, _dll, _dll
+                }
             };
 
             task.Execute().Should().BeTrue();

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
@@ -85,8 +85,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
                 using (JsonTextWriter writer = new JsonTextWriter(File.CreateText($"result-{baselineFileName}.deps.json")))
                 {
-                    JsonSerializer serializer = new JsonSerializer();
-                    serializer.Formatting = Formatting.Indented;
+                    JsonSerializer serializer = new JsonSerializer
+                    {
+                        Formatting = Formatting.Indented
+                    };
                     serializer.Serialize(writer, result);
                 }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProduceContentsAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProduceContentsAssetsTask.cs
@@ -24,8 +24,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             // mock preprocessor
-            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false);
-            assetPreprocessor.MockReadContent = inputText;
+            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false)
+            {
+                MockReadContent = inputText
+            };
 
             // input items
             var contentPreprocessorValues = GetPreprocessorValueItems(preprocessorValues);
@@ -73,8 +75,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             // mock preprocessor
-            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false);
-            assetPreprocessor.MockReadContent = inputText;
+            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false)
+            {
+                MockReadContent = inputText
+            };
 
             // input items
             var contentPreprocessorValues = GetPreprocessorValueItems(preprocessorValues);
@@ -127,8 +131,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             // mock preprocessor
-            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false);
-            assetPreprocessor.MockReadContent = inputText;
+            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false)
+            {
+                MockReadContent = inputText
+            };
 
             // input items
             var contentPreprocessorValues = GetPreprocessorValueItems(preprocessorValues);
@@ -204,8 +210,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             // mock preprocessor
-            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false);
-            assetPreprocessor.MockReadContent = inputText;
+            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false)
+            {
+                MockReadContent = inputText
+            };
 
             // input items
             var contentPreprocessorValues = GetPreprocessorValueItems(preprocessorValues);
@@ -280,8 +288,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             // mock preprocessor
-            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false);
-            assetPreprocessor.MockReadContent = inputText;
+            var assetPreprocessor = new MockContentAssetPreprocessor((s) => false)
+            {
+                MockReadContent = inputText
+            };
 
             // input items
             var contentPreprocessorValues = GetPreprocessorValueItems(preprocessorValues);

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
@@ -140,16 +140,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         private ResolveTargetingPackAssets InitializeTask(string mockPackageDirectory, IBuildEngine buildEngine)
         {
-            var task = new ResolveTargetingPackAssets()
+            var task = new ResolveTargetingPackAssets
             {
                 BuildEngine = buildEngine,
+                FrameworkReferences = DefaultFrameworkReferences(),
+
+                ResolvedTargetingPacks = DefaultTargetingPacks(mockPackageDirectory),
+
+                ProjectLanguage = "C#"
             };
-
-            task.FrameworkReferences = DefaultFrameworkReferences();
-
-            task.ResolvedTargetingPacks = DefaultTargetingPacks(mockPackageDirectory);
-
-            task.ProjectLanguage = "C#";
 
             return task;
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
@@ -144,9 +144,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 BuildEngine = buildEngine,
                 FrameworkReferences = DefaultFrameworkReferences(),
-
                 ResolvedTargetingPacks = DefaultTargetingPacks(mockPackageDirectory),
-
                 ProjectLanguage = "C#"
             };
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
@@ -60,18 +60,20 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     { MetadataKeys.Version, "1.2.3" }
                 });
 
-            var task = new CollectSDKReferencesDesignTime();
-            task.SdkReferences = new[] {
+            var task = new CollectSDKReferencesDesignTime
+            {
+                SdkReferences = new[] {
                 sdkReference1,
                 sdkReference2
-            };
-            task.PackageReferences = new ITaskItem[] {
+            },
+                PackageReferences = new ITaskItem[] {
                 packageReference1,
                 packageReference2,
                 packageReference3,
                 defaultImplicitPackage1
+            },
+                DefaultImplicitPackages = "DefaultImplicitPackage1;SomeOtherImplicitPackage"
             };
-            task.DefaultImplicitPackages = "DefaultImplicitPackage1;SomeOtherImplicitPackage";
 
             // Act
             var result = task.Execute();

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
@@ -62,16 +62,18 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var task = new CollectSDKReferencesDesignTime
             {
-                SdkReferences = new[] {
-                sdkReference1,
-                sdkReference2
-            },
-                PackageReferences = new ITaskItem[] {
-                packageReference1,
-                packageReference2,
-                packageReference3,
-                defaultImplicitPackage1
-            },
+                SdkReferences = new[]
+                {
+                    sdkReference1,
+                    sdkReference2
+                },
+                PackageReferences = new ITaskItem[]
+                {
+                    packageReference1,
+                    packageReference2,
+                    packageReference3,
+                    defaultImplicitPackage1
+                },
                 DefaultImplicitPackages = "DefaultImplicitPackage1;SomeOtherImplicitPackage"
             };
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -43,17 +43,17 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void It_resolves_FrameworkReferences()
         {
-            var task = new ProcessFrameworkReferences();
-
-            task.EnableTargetingPackDownload = true;
-            task.TargetFrameworkIdentifier = ".NETCoreApp";
-            task.TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion;
-            task.FrameworkReferences = new[]
+            var task = new ProcessFrameworkReferences
+            {
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
+                FrameworkReferences = new[]
             {
                 new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
-            };
+            },
 
-            task.KnownFrameworkReferences = new[]
+                KnownFrameworkReferences = new[]
             {
                 new MockTaskItem("Microsoft.AspNetCore.App",
                     new Dictionary<string, string>()
@@ -65,6 +65,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         {"TargetingPackName", "Microsoft.AspNetCore.App"},
                         {"TargetingPackVersion", "1.9.0"}
                     })
+            }
             };
 
             task.Execute().Should().BeTrue();
@@ -79,19 +80,19 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void Given_targetPlatform_and_targetPlatform_version_It_resolves_FrameworkReferences_()
         {
-            var task = new ProcessFrameworkReferences();
-
-            task.EnableTargetingPackDownload = true;
-            task.TargetFrameworkIdentifier = ".NETCoreApp";
-            task.TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion;
-            task.TargetPlatformIdentifier = "Windows";
-            task.TargetPlatformVersion = "10.0.18362";
-            task.FrameworkReferences = new[]
+            var task = new ProcessFrameworkReferences
+            {
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
+                TargetPlatformIdentifier = "Windows",
+                TargetPlatformVersion = "10.0.18362",
+                FrameworkReferences = new[]
             {
                 new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
-            };
+            },
 
-            task.KnownFrameworkReferences = new[]
+                KnownFrameworkReferences = new[]
             {
                 new MockTaskItem("Microsoft.AspNetCore.App",
                     new Dictionary<string, string>()
@@ -103,6 +104,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         {"TargetingPackName", "Microsoft.AspNetCore.App"},
                         {"TargetingPackVersion", "1.9.0"}
                     })
+            }
             };
 
             task.Execute().Should().BeTrue();
@@ -117,16 +119,16 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void It_does_not_resolve_FrameworkReferences_if_targetframework_doesnt_match()
         {
-            var task = new ProcessFrameworkReferences();
-
-            task.TargetFrameworkIdentifier = ".NETCoreApp";
-            task.TargetFrameworkVersion = "2.0";
-            task.FrameworkReferences = new[]
+            var task = new ProcessFrameworkReferences
+            {
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "2.0",
+                FrameworkReferences = new[]
             {
                 new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
-            };
+            },
 
-            task.KnownFrameworkReferences = new[]
+                KnownFrameworkReferences = new[]
             {
                 new MockTaskItem("Microsoft.AspNetCore.App",
                     new Dictionary<string, string>()
@@ -138,6 +140,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         {"TargetingPackName", "Microsoft.AspNetCore.App"},
                         {"TargetingPackVersion", "1.9.0"}
                     })
+            }
             };
 
             task.Execute().Should().BeTrue();

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -49,23 +49,22 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetFrameworkIdentifier = ".NETCoreApp",
                 TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
                 FrameworkReferences = new[]
-            {
-                new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
-            },
-
+                {
+                    new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
+                },
                 KnownFrameworkReferences = new[]
-            {
-                new MockTaskItem("Microsoft.AspNetCore.App",
-                    new Dictionary<string, string>()
-                    {
-                        {"TargetFramework", ToolsetInfo.CurrentTargetFramework},
-                        {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
-                        {"DefaultRuntimeFrameworkVersion", "1.9.5"},
-                        {"LatestRuntimeFrameworkVersion", "1.9.6"},
-                        {"TargetingPackName", "Microsoft.AspNetCore.App"},
-                        {"TargetingPackVersion", "1.9.0"}
-                    })
-            }
+                {
+                    new MockTaskItem("Microsoft.AspNetCore.App",
+                        new Dictionary<string, string>()
+                        {
+                            {"TargetFramework", ToolsetInfo.CurrentTargetFramework},
+                            {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
+                            {"DefaultRuntimeFrameworkVersion", "1.9.5"},
+                            {"LatestRuntimeFrameworkVersion", "1.9.6"},
+                            {"TargetingPackName", "Microsoft.AspNetCore.App"},
+                            {"TargetingPackVersion", "1.9.0"}
+                        })
+                }
             };
 
             task.Execute().Should().BeTrue();
@@ -88,23 +87,22 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetPlatformIdentifier = "Windows",
                 TargetPlatformVersion = "10.0.18362",
                 FrameworkReferences = new[]
-            {
-                new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
-            },
-
+                {
+                    new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
+                },
                 KnownFrameworkReferences = new[]
-            {
-                new MockTaskItem("Microsoft.AspNetCore.App",
-                    new Dictionary<string, string>()
-                    {
-                        {"TargetFramework", ToolsetInfo.CurrentTargetFramework},
-                        {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
-                        {"DefaultRuntimeFrameworkVersion", "1.9.5"},
-                        {"LatestRuntimeFrameworkVersion", "1.9.6"},
-                        {"TargetingPackName", "Microsoft.AspNetCore.App"},
-                        {"TargetingPackVersion", "1.9.0"}
-                    })
-            }
+                {
+                    new MockTaskItem("Microsoft.AspNetCore.App",
+                        new Dictionary<string, string>()
+                        {
+                            {"TargetFramework", ToolsetInfo.CurrentTargetFramework},
+                            {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
+                            {"DefaultRuntimeFrameworkVersion", "1.9.5"},
+                            {"LatestRuntimeFrameworkVersion", "1.9.6"},
+                            {"TargetingPackName", "Microsoft.AspNetCore.App"},
+                            {"TargetingPackVersion", "1.9.0"}
+                        })
+                }
             };
 
             task.Execute().Should().BeTrue();
@@ -124,23 +122,22 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetFrameworkIdentifier = ".NETCoreApp",
                 TargetFrameworkVersion = "2.0",
                 FrameworkReferences = new[]
-            {
-                new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
-            },
-
+                {
+                    new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
+                },
                 KnownFrameworkReferences = new[]
-            {
-                new MockTaskItem("Microsoft.AspNetCore.App",
-                    new Dictionary<string, string>()
-                    {
-                        {"TargetFramework", "netcoreapp3.0"},
-                        {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
-                        {"DefaultRuntimeFrameworkVersion", "1.9.5"},
-                        {"LatestRuntimeFrameworkVersion", "1.9.6"},
-                        {"TargetingPackName", "Microsoft.AspNetCore.App"},
-                        {"TargetingPackVersion", "1.9.0"}
-                    })
-            }
+                {
+                    new MockTaskItem("Microsoft.AspNetCore.App",
+                        new Dictionary<string, string>()
+                        {
+                            {"TargetFramework", "netcoreapp3.0"},
+                            {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
+                            {"DefaultRuntimeFrameworkVersion", "1.9.5"},
+                            {"LatestRuntimeFrameworkVersion", "1.9.6"},
+                            {"TargetingPackName", "Microsoft.AspNetCore.App"},
+                            {"TargetingPackVersion", "1.9.0"}
+                        })
+                }
             };
 
             task.Execute().Should().BeTrue();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -152,8 +152,10 @@ namespace Microsoft.NET.Build.Tasks
             bool isFrameworkDependent,
             IList<LockFileItem> packageFolders)
         {
-            RuntimeConfig config = new RuntimeConfig();
-            config.RuntimeOptions = new RuntimeOptions();
+            RuntimeConfig config = new RuntimeConfig
+            {
+                RuntimeOptions = new RuntimeOptions()
+            };
 
             AddFrameworks(
                 config.RuntimeOptions,
@@ -192,9 +194,11 @@ namespace Microsoft.NET.Build.Tasks
                     //  If there are no RuntimeFrameworks (which would be set in the ProcessFrameworkReferences task based
                     //  on FrameworkReference items), then use package resolved from MicrosoftNETPlatformLibrary for
                     //  the runtimeconfig
-                    RuntimeConfigFramework framework = new RuntimeConfigFramework();
-                    framework.Name = lockFilePlatformLibrary.Name;
-                    framework.Version = lockFilePlatformLibrary.Version.ToNormalizedString();
+                    RuntimeConfigFramework framework = new RuntimeConfigFramework
+                    {
+                        Name = lockFilePlatformLibrary.Name,
+                        Version = lockFilePlatformLibrary.Version.ToNormalizedString()
+                    };
 
                     frameworks.Add(framework);
                 }
@@ -224,9 +228,11 @@ namespace Microsoft.NET.Build.Tasks
                         continue;
                     }
 
-                    RuntimeConfigFramework framework = new RuntimeConfigFramework();
-                    framework.Name = platformLibrary.Name;
-                    framework.Version = platformLibrary.Version;
+                    RuntimeConfigFramework framework = new RuntimeConfigFramework
+                    {
+                        Name = platformLibrary.Name,
+                        Version = platformLibrary.Version
+                    };
 
                     frameworks.Add(framework);
                 }
@@ -325,8 +331,10 @@ namespace Microsoft.NET.Build.Tasks
 
         private void WriteDevRuntimeConfig(IList<LockFileItem> packageFolders)
         {
-            RuntimeConfig devConfig = new RuntimeConfig();
-            devConfig.RuntimeOptions = new RuntimeOptions();
+            RuntimeConfig devConfig = new RuntimeConfig
+            {
+                RuntimeOptions = new RuntimeOptions()
+            };
 
             AddAdditionalProbingPaths(devConfig.RuntimeOptions, packageFolders);
 
@@ -373,10 +381,12 @@ namespace Microsoft.NET.Build.Tasks
 
         private static void WriteToJsonFile(string fileName, object value)
         {
-            JsonSerializer serializer = new JsonSerializer();
-            serializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
-            serializer.Formatting = Formatting.Indented;
-            serializer.DefaultValueHandling = DefaultValueHandling.Ignore;
+            JsonSerializer serializer = new JsonSerializer
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Formatting = Formatting.Indented,
+                DefaultValueHandling = DefaultValueHandling.Ignore
+            };
 
             using (JsonTextWriter writer = new JsonTextWriter(new StreamWriter(File.Create(fileName))))
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -212,8 +212,10 @@ namespace Microsoft.NET.Build.Tasks
 
                 // This TaskItem corresponds to the output R2R image. It is equivalent to the input TaskItem, only the ItemSpec for it points to the new path
                 // for the newly created R2R image
-                TaskItem r2rFileToPublish = new TaskItem(file);
-                r2rFileToPublish.ItemSpec = outputR2RImage;
+                TaskItem r2rFileToPublish = new TaskItem(file)
+                {
+                    ItemSpec = outputR2RImage
+                };
                 r2rFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                 r2rFilesPublishList.Add(r2rFileToPublish);
 
@@ -227,8 +229,10 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         // This TaskItem is the R2R->R2RPDB entry, for a R2R image that was just created, and for which we need to create native PDBs. This will be used as
                         // an input to the ReadyToRunCompiler task
-                        TaskItem pdbCompilationEntry = new TaskItem(file);
-                        pdbCompilationEntry.ItemSpec = outputR2RImage;
+                        TaskItem pdbCompilationEntry = new TaskItem(file)
+                        {
+                            ItemSpec = outputR2RImage
+                        };
                         pdbCompilationEntry.SetMetadata(MetadataKeys.OutputPDBImage, outputPDBImage);
                         pdbCompilationEntry.SetMetadata(MetadataKeys.CreatePDBCommand, crossgen1CreatePDBCommand);
                         symbolsCompilationList.Add(pdbCompilationEntry);
@@ -236,8 +240,10 @@ namespace Microsoft.NET.Build.Tasks
 
                     // This TaskItem corresponds to the output PDB image. It is equivalent to the input TaskItem, only the ItemSpec for it points to the new path
                     // for the newly created PDB image.
-                    TaskItem r2rSymbolsFileToPublish = new TaskItem(file);
-                    r2rSymbolsFileToPublish.ItemSpec = outputPDBImage;
+                    TaskItem r2rSymbolsFileToPublish = new TaskItem(file)
+                    {
+                        ItemSpec = outputPDBImage
+                    };
                     r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.RelativePath, outputPDBImageRelativePath);
                     r2rSymbolsFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                     if (!IncludeSymbolsInSingleFile)
@@ -257,8 +263,10 @@ namespace Microsoft.NET.Build.Tasks
                 compositeR2RImageRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, "r2r" + Path.GetExtension(compositeR2RImageRelativePath));
                 var compositeR2RImage = Path.Combine(OutputPath, compositeR2RImageRelativePath);
 
-                TaskItem r2rCompilationEntry = new TaskItem(MainAssembly);
-                r2rCompilationEntry.ItemSpec = r2rCompositeInputList[0].ItemSpec;
+                TaskItem r2rCompilationEntry = new TaskItem(MainAssembly)
+                {
+                    ItemSpec = r2rCompositeInputList[0].ItemSpec
+                };
                 r2rCompilationEntry.SetMetadata(MetadataKeys.OutputR2RImage, compositeR2RImage);
                 r2rCompilationEntry.SetMetadata(MetadataKeys.CreateCompositeImage, "true");
                 r2rCompilationEntry.RemoveMetadata(MetadataKeys.OriginalItemSpec);
@@ -288,8 +296,10 @@ namespace Microsoft.NET.Build.Tasks
                         r2rCompilationEntry.SetMetadata(MetadataKeys.OutputPDBImage, compositePDBImage);
 
                         // Publish composite PDB file
-                        TaskItem r2rSymbolsFileToPublish = new TaskItem(MainAssembly);
-                        r2rSymbolsFileToPublish.ItemSpec = compositePDBImage;
+                        TaskItem r2rSymbolsFileToPublish = new TaskItem(MainAssembly)
+                        {
+                            ItemSpec = compositePDBImage
+                        };
                         r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.RelativePath, compositePDBRelativePath);
                         r2rSymbolsFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                         if (!IncludeSymbolsInSingleFile)
@@ -304,8 +314,10 @@ namespace Microsoft.NET.Build.Tasks
                 imageCompilationList.Add(r2rCompilationEntry);
 
                 // Publish it
-                TaskItem compositeR2RFileToPublish = new TaskItem(MainAssembly);
-                compositeR2RFileToPublish.ItemSpec = compositeR2RImage;
+                TaskItem compositeR2RFileToPublish = new TaskItem(MainAssembly)
+                {
+                    ItemSpec = compositeR2RImage
+                };
                 compositeR2RFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                 compositeR2RFileToPublish.SetMetadata(MetadataKeys.RelativePath, compositeR2RImageRelativePath);
                 r2rFilesPublishList.Add(compositeR2RFileToPublish);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
@@ -21,9 +21,11 @@ namespace Microsoft.NET.Build.Tasks
 
         public static RuntimePackAssetInfo FromItem(ITaskItem item)
         {
-            var assetInfo = new RuntimePackAssetInfo();
-            assetInfo.SourcePath = item.ItemSpec;
-            assetInfo.DestinationSubPath = item.GetMetadata(MetadataKeys.DestinationSubPath);
+            var assetInfo = new RuntimePackAssetInfo
+            {
+                SourcePath = item.ItemSpec,
+                DestinationSubPath = item.GetMetadata(MetadataKeys.DestinationSubPath)
+            };
 
             string assetTypeString = item.GetMetadata(MetadataKeys.AssetType);
             if (assetTypeString.Equals("runtime", StringComparison.OrdinalIgnoreCase))

--- a/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/BlockingMemoryStreamTests.cs
+++ b/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/BlockingMemoryStreamTests.cs
@@ -83,9 +83,10 @@ namespace Microsoft.DotNet.Cli.Utils
                     Assert.Equal(3, buffer[2]);
 
                     readerThreadSuccessful = true;
-                });
-
-                readerThread.IsBackground = true;
+                })
+                {
+                    IsBackground = true
+                };
                 readerThread.Start();
 
                 // ensure the thread is executing

--- a/src/Tests/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
@@ -308,10 +308,9 @@ namespace Microsoft.NET.Build.Tests
         {
             var testProject = new TestProject("App")
             {
-                IsExe = true
+                IsExe = true,
+                UseArtifactsOutput = true
             };
-
-            testProject.UseArtifactsOutput = true;
 
             var testAsset = _testAssetsManager.CreateTestProjects(new[] { testProject }, callingMethod: callingMethod);
 

--- a/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
@@ -41,8 +41,10 @@ namespace Microsoft.NET.Build.Tests
 
             var projectDirectory = Path.Combine(testAsset.TestRoot, relativeProjectPath);
 
-            var command = new MSBuildCommand(Log, "ResolveAssemblyReferencesDesignTime", projectDirectory);
-            command.WorkingDirectory = projectDirectory;
+            var command = new MSBuildCommand(Log, "ResolveAssemblyReferencesDesignTime", projectDirectory)
+            {
+                WorkingDirectory = projectDirectory
+            };
             var result = command.Execute(args);
 
             result.Should().Pass();
@@ -109,8 +111,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
-            var getValuesCommand = new GetValuesCommand(testAsset, "_PackageDependenciesDesignTime", GetValuesCommand.ValueType.Item);
-            getValuesCommand.DependsOnTargets = "ResolvePackageDependenciesDesignTime";
+            var getValuesCommand = new GetValuesCommand(testAsset, "_PackageDependenciesDesignTime", GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "ResolvePackageDependenciesDesignTime"
+            };
 
             getValuesCommand.Execute()
                 .Should()
@@ -154,10 +158,12 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Fail();
 
-            var getValuesCommand = new GetValuesCommand(testAsset, "_PackageDependenciesDesignTime", GetValuesCommand.ValueType.Item);
-            getValuesCommand.ShouldRestore = false;
-            getValuesCommand.DependsOnTargets = "ResolvePackageDependenciesDesignTime";
-            getValuesCommand.MetadataNames = new List<string>() { "DiagnosticLevel" };
+            var getValuesCommand = new GetValuesCommand(testAsset, "_PackageDependenciesDesignTime", GetValuesCommand.ValueType.Item)
+            {
+                ShouldRestore = false,
+                DependsOnTargets = "ResolvePackageDependenciesDesignTime",
+                MetadataNames = new List<string>() { "DiagnosticLevel" }
+            };
 
             getValuesCommand
                 .WithWorkingDirectory(testAsset.TestRoot)
@@ -206,8 +212,10 @@ namespace Microsoft.NET.Build.Tests
 
             string projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);
 
-            var buildCommand = new MSBuildCommand(Log, null, projectFolder);
-            buildCommand.WorkingDirectory = projectFolder;
+            var buildCommand = new MSBuildCommand(Log, null, projectFolder)
+            {
+                WorkingDirectory = projectFolder
+            };
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -842,8 +842,10 @@ namespace FrameworkReferenceTest
             };
 
             var getValuesCommand = new GetValuesCommand(Log, projectFolder, testProject.TargetFrameworks,
-                "ResolvedFrameworkReference", GetValuesCommand.ValueType.Item);
-            getValuesCommand.DependsOnTargets = "ResolveFrameworkReferences";
+                "ResolvedFrameworkReference", GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "ResolveFrameworkReferences"
+            };
             getValuesCommand.MetadataNames.AddRange(expectedMetadata);
 
             getValuesCommand.Execute().Should().Pass();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
@@ -107,9 +107,10 @@ namespace Microsoft.NET.Build.Tests
                 testDirectory,
                 tfm,
                 itemName,
-                GetValuesCommand.ValueType.Item);
-
-            command.DependsOnTargets = "";
+                GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = ""
+            };
             command.Execute().Should().Pass();
 
             return command.GetValues();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
@@ -103,8 +103,10 @@ namespace Microsoft.NET.Build.Tests
                             new XElement(ns + "RuntimeIdentifiers", secondFrameworkRids)));
                 });
 
-            var command = new GetValuesCommand(Log, testAsset.TestRoot, "", valueName: "RuntimeIdentifiers");
-            command.DependsOnTargets = "GetAllRuntimeIdentifiers";
+            var command = new GetValuesCommand(Log, testAsset.TestRoot, "", valueName: "RuntimeIdentifiers")
+            {
+                DependsOnTargets = "GetAllRuntimeIdentifiers"
+            };
             command.ExecuteWithoutRestore().Should().Pass();
             command.GetValues().Should().BeEquivalentTo(expectedCombination.Split(';'));
         }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -283,10 +283,11 @@ namespace Microsoft.NET.Build.Tests
             var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
 
             var getValuesCommand = new GetValuesCommand(Log, libraryProjectDirectory,
-                "netstandard1.5", "DefineConstants");
-
-            getValuesCommand.ShouldCompile = true;
-            getValuesCommand.Configuration = configuration;
+                "netstandard1.5", "DefineConstants")
+            {
+                ShouldCompile = true,
+                Configuration = configuration
+            };
 
             getValuesCommand
                 .Execute("/p:Configuration=" + configuration)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
@@ -146,10 +146,11 @@ namespace Microsoft.NET.Build.Tests
             var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
 
             var getValuesCommand = new GetValuesCommand(Log, libraryProjectDirectory,
-                "netstandard1.6", "DefineConstants");
-
-            getValuesCommand.ShouldCompile = true;
-            getValuesCommand.Configuration = configuration;
+                "netstandard1.6", "DefineConstants")
+            {
+                ShouldCompile = true,
+                Configuration = configuration
+            };
 
             getValuesCommand
                 .Execute("/p:Configuration=" + configuration)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSSupportedVersion.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSSupportedVersion.cs
@@ -15,8 +15,10 @@ namespace Microsoft.NET.Build.Tests
             TestProject testProject = SetUpProject();
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()
@@ -38,8 +40,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()
@@ -60,8 +64,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()
@@ -77,8 +83,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()
@@ -95,8 +103,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()
@@ -112,8 +122,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()
@@ -149,8 +161,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()
@@ -166,8 +180,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()
@@ -193,8 +209,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()
@@ -240,8 +258,10 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var runCommand = new DotnetCommand(Log, "run");
-            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            var runCommand = new DotnetCommand(Log, "run")
+            {
+                WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name)
+            };
             runCommand.Execute()
                 .Should()
                 .Pass()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithVB.cs
@@ -157,10 +157,11 @@ namespace Microsoft.NET.Build.Tests
             var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
 
             var getValuesCommand = new GetValuesCommand(Log, libraryProjectDirectory,
-                "netstandard1.5", "FinalDefineConstants");
-
-            getValuesCommand.ShouldCompile = true;
-            getValuesCommand.Configuration = configuration;
+                "netstandard1.5", "FinalDefineConstants")
+            {
+                ShouldCompile = true,
+                Configuration = configuration
+            };
 
             getValuesCommand
                 .Execute("/p:Configuration=" + configuration)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -160,10 +160,12 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var getValuesCommand = new GetValuesCommand(testAsset, "RuntimePack", GetValuesCommand.ValueType.Item);
-            getValuesCommand.MetadataNames = new List<string>() { "NuGetPackageId", "NuGetPackageVersion" };
-            getValuesCommand.DependsOnTargets = "ProcessFrameworkReferences";
-            getValuesCommand.ShouldRestore = false;
+            var getValuesCommand = new GetValuesCommand(testAsset, "RuntimePack", GetValuesCommand.ValueType.Item)
+            {
+                MetadataNames = new List<string>() { "NuGetPackageId", "NuGetPackageVersion" },
+                DependsOnTargets = "ProcessFrameworkReferences",
+                ShouldRestore = false
+            };
 
             getValuesCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -455,9 +455,11 @@ namespace Microsoft.NET.Build.Tests
 
         private string GetReferencedWindowsSdkVersion(TestAsset testAsset)
         {
-            var getValueCommand = new GetValuesCommand(testAsset, "PackageDownload", GetValuesCommand.ValueType.Item);
-            getValueCommand.ShouldRestore = false;
-            getValueCommand.DependsOnTargets = "_CheckForInvalidConfigurationAndPlatform;CollectPackageDownloads";
+            var getValueCommand = new GetValuesCommand(testAsset, "PackageDownload", GetValuesCommand.ValueType.Item)
+            {
+                ShouldRestore = false,
+                DependsOnTargets = "_CheckForInvalidConfigurationAndPlatform;CollectPackageDownloads"
+            };
             getValueCommand.MetadataNames.Add("Version");
             getValueCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -182,8 +182,10 @@ namespace Microsoft.NET.Build.Tests
             var buildCommand = new BuildCommand(parentAsset);
             buildCommand.Execute().Should().Pass();
 
-            var getValuesCommand = new GetValuesCommand(Log, Path.Combine(parentAsset.Path, parentProject.Name), tfm, "ResultOutput");
-            getValuesCommand.DependsOnTargets = "Build";
+            var getValuesCommand = new GetValuesCommand(Log, Path.Combine(parentAsset.Path, parentProject.Name), tfm, "ResultOutput")
+            {
+                DependsOnTargets = "Build"
+            };
             getValuesCommand.Execute().Should().Pass();
 
             var valuesResult = getValuesCommand.GetValuesWithMetadata().Select(pair => Path.GetFullPath(pair.value));

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
@@ -67,8 +67,10 @@ namespace Microsoft.NET.Build.Tests
                 projectFolder,
                 targetFramework,
                 "Reference",
-                GetValuesCommand.ValueType.Item);
-            getReferenceCommand.DependsOnTargets = "Build";
+                GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "Build"
+            };
             var result = getReferenceCommand.Execute("/v:detailed").Should().Pass();
             if (expectConflicts)
             {
@@ -86,8 +88,10 @@ namespace Microsoft.NET.Build.Tests
                 projectFolder,
                 targetFramework,
                 "ReferenceCopyLocalPaths",
-                GetValuesCommand.ValueType.Item);
-            getReferenceCopyLocalPathsCommand.DependsOnTargets = "Build";
+                GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "Build"
+            };
             getReferenceCopyLocalPathsCommand.Execute().Should().Pass();
 
             referenceCopyLocalPaths = getReferenceCopyLocalPathsCommand.GetValues();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -239,9 +239,10 @@ namespace Microsoft.NET.Build.Tests
                 var getValuesCommand = new GetValuesCommand(testAsset,
                     valueName: "Analyzer",
                     GetValuesCommand.ValueType.Item,
-                    targetFramework);
-
-                getValuesCommand.DependsOnTargets = "ResolveLockFileAnalyzers";
+                    targetFramework)
+                {
+                    DependsOnTargets = "ResolveLockFileAnalyzers"
+                };
 
                 getValuesCommand.Execute("-p:TargetFramework=" + targetFramework).Should().Pass();
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenTransitiveFrameworkReferencesAreDisabled.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenTransitiveFrameworkReferencesAreDisabled.cs
@@ -150,14 +150,13 @@ namespace Microsoft.NET.Build.Tests
 
             referencedProject.FrameworkReferences.Add("Microsoft.AspNetCore.App");
 
-            var testProject = new TestProject()
+            var testProject = new TestProject
             {
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
-                SelfContained = "true"
+                SelfContained = "true",
+                RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid()
             };
-
-            testProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid();
             testProject.AdditionalProperties["DisableTransitiveFrameworkReferenceDownloads"] = "True";
             testProject.AdditionalProperties["RestorePackagesPath"] = nugetPackagesFolder;
 

--- a/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -61,8 +61,10 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var getValuesCommand = new GetValuesCommand(testAsset, "SuggestedWorkload", GetValuesCommand.ValueType.Item);
-            getValuesCommand.DependsOnTargets = "GetSuggestedWorkloads";
+            var getValuesCommand = new GetValuesCommand(testAsset, "SuggestedWorkload", GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "GetSuggestedWorkloads"
+            };
             getValuesCommand.MetadataNames.Add("VisualStudioComponentId");
             getValuesCommand.MetadataNames.Add("VisualStudioComponentIds");
             getValuesCommand.ShouldRestore = false;
@@ -242,9 +244,11 @@ namespace Microsoft.NET.Build.Tests
                 .CreateTestProject(mainProject);
 
             var getValuesCommand =
-                new GetValuesCommand(testAsset, "_ResolvedSuggestedWorkload", GetValuesCommand.ValueType.Item);
-            getValuesCommand.DependsOnTargets = "_GetRequiredWorkloads";
-            getValuesCommand.ShouldRestore = false;
+                new GetValuesCommand(testAsset, "_ResolvedSuggestedWorkload", GetValuesCommand.ValueType.Item)
+                {
+                    DependsOnTargets = "_GetRequiredWorkloads",
+                    ShouldRestore = false
+                };
 
             getValuesCommand.Execute("/p:SkipResolvePackageAssets=true")
                 .Should()
@@ -290,9 +294,11 @@ namespace Microsoft.NET.Build.Tests
                 .CreateTestProject(mainProject, identifier: mainTfm + "_" + referencingTfm);
 
             var getValuesCommand =
-                new GetValuesCommand(testAsset, "_ResolvedSuggestedWorkload", GetValuesCommand.ValueType.Item);
-            getValuesCommand.DependsOnTargets = "_GetRequiredWorkloads";
-            getValuesCommand.ShouldRestore = false;
+                new GetValuesCommand(testAsset, "_ResolvedSuggestedWorkload", GetValuesCommand.ValueType.Item)
+                {
+                    DependsOnTargets = "_GetRequiredWorkloads",
+                    ShouldRestore = false
+                };
 
             getValuesCommand.Execute("/p:SkipResolvePackageAssets=true")
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -156,8 +156,10 @@ namespace Microsoft.NET.Publish.Tests
                 .CopyTestAsset("TargetManifests", "multifile")
                 .WithSource();
 
-            var storeCommand = new ComposeStoreCommand(Log, simpleDependenciesAsset.TestRoot, "NewtonsoftFilterProfile.xml");
-            storeCommand.WorkingDirectory = simpleDependenciesAsset.Path;
+            var storeCommand = new ComposeStoreCommand(Log, simpleDependenciesAsset.TestRoot, "NewtonsoftFilterProfile.xml")
+            {
+                WorkingDirectory = simpleDependenciesAsset.Path
+            };
 
             var OutputFolder = Path.Combine(simpleDependenciesAsset.TestRoot, "o");
             var WorkingDir = Path.Combine(simpleDependenciesAsset.TestRoot, "w");

--- a/src/Tests/Microsoft.NET.Restore.Tests/RestoreWithOlderNuGet.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/RestoreWithOlderNuGet.cs
@@ -21,8 +21,10 @@ namespace Microsoft.NET.Restore.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var restoreCommand = new NuGetExeRestoreCommand(Log, testAsset.Path, testProject.Name);
-            restoreCommand.NuGetExeVersion = "5.7.0";
+            var restoreCommand = new NuGetExeRestoreCommand(Log, testAsset.Path, testProject.Name)
+            {
+                NuGetExeVersion = "5.7.0"
+            };
             restoreCommand
                 //  Workaround for CI machines where MSBuild workload resolver isn't enabled by default
                 .WithEnvironmentVariable("MSBuildEnableWorkloadResolver", "false")

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ApplyCssScopesTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ApplyCssScopesTest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         public void ApplyAllCssScopes_FailsWhenTheScopedCss_DoesNotMatchTheRazorComponent()
         {
             // Arrange
-            var taskInstance = new ApplyCssScopes()
+            var taskInstance = new ApplyCssScopes
             {
                 RazorComponents = new[]
                 {
@@ -143,10 +143,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                     new TaskItem("TestFiles/Pages/Index.razor.css", new Dictionary<string, string> { ["CssScope"] = "index-scope" }),
                     new TaskItem("TestFiles/Pages/Counter.razor.css", new Dictionary<string, string> { ["CssScope"] = "counter-scope" }),
                     new TaskItem("TestFiles/Pages/Profile.razor.css", new Dictionary<string, string> { ["CssScope"] = "profile-scope" }),
-                }
+                },
+                BuildEngine = Mock.Of<IBuildEngine>()
             };
-
-            taskInstance.BuildEngine = Mock.Of<IBuildEngine>();
 
             // Act
             var result = taskInstance.Execute();
@@ -159,7 +158,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         public void ApplyAllCssScopes_FailsWhenTheScopedCss_DoesNotMatchTheRazorView()
         {
             // Arrange
-            var taskInstance = new ApplyCssScopes()
+            var taskInstance = new ApplyCssScopes
             {
                 RazorGenerate = new[]
                 {
@@ -172,10 +171,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                     new TaskItem("TestFiles/Pages/Index.cshtml.css", new Dictionary<string, string> { ["CssScope"] = "index-scope" }),
                     new TaskItem("TestFiles/Pages/Counter.cshtml.css", new Dictionary<string, string> { ["CssScope"] = "counter-scope" }),
                     new TaskItem("TestFiles/Pages/Profile.cshtml.css", new Dictionary<string, string> { ["CssScope"] = "profile-scope" }),
-                }
+                },
+                BuildEngine = Mock.Of<IBuildEngine>()
             };
-
-            taskInstance.BuildEngine = Mock.Of<IBuildEngine>();
 
             // Act
             var result = taskInstance.Execute();
@@ -246,7 +244,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         public void ApplyAllCssScopes_FailsWhenMultipleScopedCssFiles_MatchTheSameRazorComponent()
         {
             // Arrange
-            var taskInstance = new ApplyCssScopes()
+            var taskInstance = new ApplyCssScopes
             {
                 RazorComponents = new[]
                 {
@@ -263,10 +261,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                         ["CssScope"] = "conflict-scope",
                         ["RazorComponent"] = "TestFiles/Pages/Index.razor"
                     }),
-                }
+                },
+                BuildEngine = Mock.Of<IBuildEngine>()
             };
-
-            taskInstance.BuildEngine = Mock.Of<IBuildEngine>();
 
             // Act
             var result = taskInstance.Execute();
@@ -279,7 +276,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         public void ApplyAllCssScopes_FailsWhenMultipleScopedCssFiles_MatchTheSameRazorView()
         {
             // Arrange
-            var taskInstance = new ApplyCssScopes()
+            var taskInstance = new ApplyCssScopes
             {
                 RazorGenerate = new[]
                 {
@@ -296,10 +293,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                         ["CssScope"] = "conflict-scope",
                         ["View"] = "TestFiles/Pages/Index.cshtml"
                     }),
-                }
+                },
+                BuildEngine = Mock.Of<IBuildEngine>()
             };
-
-            taskInstance.BuildEngine = Mock.Of<IBuildEngine>();
 
             // Act
             var result = taskInstance.Execute();
@@ -351,7 +347,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         public void ApplyAllCssScopes_ScopedCssComponentsDontMatchWithScopedCssViewStylesAndViceversa()
         {
             // Arrange
-            var taskInstance = new ApplyCssScopes()
+            var taskInstance = new ApplyCssScopes
             {
                 RazorComponents = new[]
                 {
@@ -369,10 +365,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                     new TaskItem("TestFiles/Pages/_Host.razor.css", new Dictionary<string, string> { ["CssScope"] = "_host-scope" }),
                     new TaskItem("TestFiles/Pages/Index.cshtml.css", new Dictionary<string, string> { ["CssScope"] = "index-scope" }),
                     new TaskItem("TestFiles/Pages/Counter.cshtml.css", new Dictionary<string, string> { ["CssScope"] = "counter-scope" }),
-                }
+                },
+                BuildEngine = Mock.Of<IBuildEngine>()
             };
-
-            taskInstance.BuildEngine = Mock.Of<IBuildEngine>();
 
             // Act
             var result = taskInstance.Execute();

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestTest.cs
@@ -315,16 +315,18 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             string additionalBuildProperties = ";",
             string additionalBuildPropertiesToRemove = ";WebPublishProfileFile")
         {
-            var result = new StaticWebAssetsManifest.ReferencedProjectConfiguration();
-            result.Identity = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), $"{source}.csproj"));
-            result.Version = version;
-            result.Source = source;
-            result.GetPublishAssetsTargets = publishTargets;
-            result.AdditionalPublishProperties = additionalPublishProperties;
-            result.AdditionalPublishPropertiesToRemove = additionalPublishPropertiesToRemove;
-            result.GetBuildAssetsTargets = buildTargets;
-            result.AdditionalBuildProperties = additionalBuildProperties;
-            result.AdditionalBuildPropertiesToRemove = additionalBuildPropertiesToRemove;
+            var result = new StaticWebAssetsManifest.ReferencedProjectConfiguration
+            {
+                Identity = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), $"{source}.csproj")),
+                Version = version,
+                Source = source,
+                GetPublishAssetsTargets = publishTargets,
+                AdditionalPublishProperties = additionalPublishProperties,
+                AdditionalPublishPropertiesToRemove = additionalPublishPropertiesToRemove,
+                GetBuildAssetsTargets = buildTargets,
+                AdditionalBuildProperties = additionalBuildProperties,
+                AdditionalBuildPropertiesToRemove = additionalBuildPropertiesToRemove
+            };
 
             return result;
         }

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadPackGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadPackGroupTests.cs
@@ -184,10 +184,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader.Tests
 
         WorkloadPackGroupJson ConvertGroupToJson(WorkloadPackGroup group)
         {
-            var groupJson = new WorkloadPackGroupJson();
-
-            groupJson.GroupPackageId = group.Workload.Id + ".Packs";
-            groupJson.GroupPackageVersion = group.WorkloadManifestVersion;
+            var groupJson = new WorkloadPackGroupJson
+            {
+                GroupPackageId = group.Workload.Id + ".Packs",
+                GroupPackageVersion = group.WorkloadManifestVersion
+            };
 
             foreach (var pack in group.Packs)
             {

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/SdkCommandSpec.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/SdkCommandSpec.cs
@@ -36,10 +36,12 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public ProcessStartInfo ToProcessStartInfo(bool doNotEscapeArguments = false)
         {
-            var ret = new ProcessStartInfo();
-            ret.FileName = FileName;
-            ret.Arguments = doNotEscapeArguments ? string.Join(" ", Arguments) : EscapeArgs();
-            ret.UseShellExecute = false;
+            var ret = new ProcessStartInfo
+            {
+                FileName = FileName,
+                Arguments = doNotEscapeArguments ? string.Join(" ", Arguments) : EscapeArgs(),
+                UseShellExecute = false
+            };
             foreach (var kvp in Environment)
             {
                 ret.Environment[kvp.Key] = kvp.Value;

--- a/src/Tests/Microsoft.NET.TestFramework/TestCommandLine.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestCommandLine.cs
@@ -37,8 +37,10 @@ namespace Microsoft.NET.TestFramework
 
         public static TestCommandLine Parse(string[] args)
         {
-            TestCommandLine ret = new TestCommandLine();
-            ret.RemainingArgs = new List<string>();
+            TestCommandLine ret = new TestCommandLine
+            {
+                RemainingArgs = new List<string>()
+            };
             Stack<string> argStack = new Stack<string>(args.Reverse());
 
             while (argStack.Any())
@@ -210,9 +212,10 @@ namespace Microsoft.NET.TestFramework
 
             public static TestList Parse(XElement element)
             {
-                TestList group = new TestList();
-
-                group.Name = element.Attribute("Name")?.Value;
+                TestList group = new TestList
+                {
+                    Name = element.Attribute("Name")?.Value
+                };
 
                 foreach (var item in element.Elements())
                 {

--- a/src/Tests/Microsoft.NET.TestFramework/TestDirectory.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestDirectory.cs
@@ -31,8 +31,10 @@ namespace Microsoft.NET.TestFramework
                 try
                 {
                     //  Clear read-only flags on anything in the directory
-                    var dirInfo = new DirectoryInfo(path);
-                    dirInfo.Attributes = FileAttributes.Normal;
+                    var dirInfo = new DirectoryInfo(path)
+                    {
+                        Attributes = FileAttributes.Normal
+                    };
                     foreach (var info in dirInfo.GetFileSystemInfos("*", SearchOption.AllDirectories))
                     {
                         info.Attributes = FileAttributes.Normal;

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -88,9 +88,10 @@ namespace Microsoft.NET.TestFramework
             {
                 FullFrameworkMSBuildPath = null;
                 var logger = new StringTestLogger();
-                var command = new DotnetCommand(logger, "--version");
-
-                command.WorkingDirectory = TestContext.Current.TestExecutionDirectory;
+                var command = new DotnetCommand(logger, "--version")
+                {
+                    WorkingDirectory = TestContext.Current.TestExecutionDirectory
+                };
 
                 var result = command.Execute();
 
@@ -110,9 +111,10 @@ namespace Microsoft.NET.TestFramework
         private void InitMSBuildVersion()
         {
             var logger = new StringTestLogger();
-            var command = new MSBuildVersionCommand(logger);
-
-            command.WorkingDirectory = TestContext.Current.TestExecutionDirectory;
+            var command = new MSBuildVersionCommand(logger)
+            {
+                WorkingDirectory = TestContext.Current.TestExecutionDirectory
+            };
 
             var result = command.Execute();
 

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -186,8 +186,10 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                     manifestId => (manifestId.ToString(), Path.Combine(testDir, "dotnet", "sdk-manifests", currentFeatureBand, manifestId.ToString(), "WorkloadManifest.json"), currentFeatureBand)))
                 .ToArray();
 
-            var workloadManifestProvider = new MockManifestProvider(manifestInfo);
-            workloadManifestProvider.SdkFeatureBand = new SdkFeatureBand(currentFeatureBand);
+            var workloadManifestProvider = new MockManifestProvider(manifestInfo)
+            {
+                SdkFeatureBand = new SdkFeatureBand(currentFeatureBand)
+            };
             var nugetDownloader = new MockNuGetPackageDownloader(dotnetRoot);
             var workloadResolver = WorkloadResolver.CreateForTests(workloadManifestProvider, dotnetRoot);
             var installationRepo = new MockInstallationRecordRepository();

--- a/src/WebSdk/Publish/Tasks/MsDeploy/CommonUtility.cs
+++ b/src/WebSdk/Publish/Tasks/MsDeploy/CommonUtility.cs
@@ -462,8 +462,10 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         public static void SaveDocument(Xml.XmlDocument document, string outputFileName, System.Text.Encoding encode)
         {
 #if NET472
-            Xml.XmlTextWriter textWriter = new Xml.XmlTextWriter(outputFileName, encode);
-            textWriter.Formatting = System.Xml.Formatting.Indented;
+            Xml.XmlTextWriter textWriter = new Xml.XmlTextWriter(outputFileName, encode)
+            {
+                Formatting = System.Xml.Formatting.Indented
+            };
             document.Save(textWriter);
             textWriter.Close();
 #else

--- a/src/WebSdk/Publish/Tasks/Tasks/GenerateEFSQLScripts.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/GenerateEFSQLScripts.cs
@@ -99,9 +99,11 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
                     Log.LogMessage(MessageImportance.High, string.Format("Executing command: {0} {1}", psi.FileName, psi.Arguments));
                 }
 
-                proc = new Process();
-                proc.StartInfo = psi;
-                proc.EnableRaisingEvents = true;
+                proc = new Process
+                {
+                    StartInfo = psi,
+                    EnableRaisingEvents = true
+                };
                 proc.OutputDataReceived += Proc_OutputDataReceived;
                 proc.ErrorDataReceived += Proc_ErrorDataReceived;
                 proc.Exited += Proc_Exited;

--- a/src/WebSdk/Publish/Tasks/Tasks/Kudu/KuduDeploy.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/Kudu/KuduDeploy.cs
@@ -61,12 +61,14 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
 
         internal KuduConnectionInfo GetConnectionInfo()
         {
-            KuduConnectionInfo connectionInfo = new KuduConnectionInfo();
-            connectionInfo.DestinationUrl = PublishUrl;
+            KuduConnectionInfo connectionInfo = new KuduConnectionInfo
+            {
+                DestinationUrl = PublishUrl,
 
-            connectionInfo.UserName = UserName;
-            connectionInfo.Password = Password;
-            connectionInfo.SiteName = PublishSiteName;
+                UserName = UserName,
+                Password = Password,
+                SiteName = PublishSiteName
+            };
 
             return connectionInfo;
         }

--- a/src/WebSdk/Publish/Tasks/Tasks/Kudu/KuduDeploy.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/Kudu/KuduDeploy.cs
@@ -64,7 +64,6 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
             KuduConnectionInfo connectionInfo = new KuduConnectionInfo
             {
                 DestinationUrl = PublishUrl,
-
                 UserName = UserName,
                 Password = Password,
                 SiteName = PublishSiteName

--- a/src/WebSdk/Publish/Tasks/Tasks/Xdt/TransformXml.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/Xdt/TransformXml.cs
@@ -202,9 +202,10 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
         {
             try
             {
-                XmlTransformableDocument document = new XmlTransformableDocument();
-
-                document.PreserveWhitespace = true;
+                XmlTransformableDocument document = new XmlTransformableDocument
+                {
+                    PreserveWhitespace = true
+                };
                 document.Load(sourceFile);
 
                 return document;


### PR DESCRIPTION
## Summary
I've been noticing a lot of random squiggles in the codebase. So, I'm going through and using tooling to apply fixes for what the analyzers are detecting. Here, I ran the fix for [Use object initializers (IDE0017)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0017). These types of automated changes are non-functional changes. Just purely code cleanup.