### PR TITLE
IDE0049 "Name can be simplified" cleanup

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.Watcher.Internal
                         // events.
                         //
                         // See the remarks here: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit#System_Diagnostics_Process_WaitForExit_System_Int32_
-                        if (!_process.WaitForExit(Int32.MaxValue))
+                        if (!_process.WaitForExit(int.MaxValue))
                         {
                             throw new TimeoutException();
                         }

--- a/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -504,7 +504,7 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             }
             throw new InvalidSolutionFormatException(
                 curLineNum,
-                String.Format(LocalizableStrings.InvalidSectionTypeError, s));
+                string.Format(LocalizableStrings.InvalidSectionTypeError, s));
         }
 
         private string FromSectionType(bool isProjectSection, SlnSectionType type)

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/NativeMethods.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/NativeMethods.cs
@@ -23,26 +23,26 @@ namespace Microsoft.DotNet.Cli.Utils
             [StructLayout(LayoutKind.Sequential)]
             internal struct JobObjectBasicLimitInformation
             {
-                public Int64 PerProcessUserTimeLimit;
-                public Int64 PerJobUserTimeLimit;
+                public long PerProcessUserTimeLimit;
+                public long PerJobUserTimeLimit;
                 public JobObjectLimitFlags LimitFlags;
                 public UIntPtr MinimumWorkingSetSize;
                 public UIntPtr MaximumWorkingSetSize;
-                public UInt32 ActiveProcessLimit;
+                public uint ActiveProcessLimit;
                 public UIntPtr Affinity;
-                public UInt32 PriorityClass;
-                public UInt32 SchedulingClass;
+                public uint PriorityClass;
+                public uint SchedulingClass;
             }
 
             [StructLayout(LayoutKind.Sequential)]
             internal struct IoCounters
             {
-                public UInt64 ReadOperationCount;
-                public UInt64 WriteOperationCount;
-                public UInt64 OtherOperationCount;
-                public UInt64 ReadTransferCount;
-                public UInt64 WriteTransferCount;
-                public UInt64 OtherTransferCount;
+                public ulong ReadOperationCount;
+                public ulong WriteOperationCount;
+                public ulong OtherOperationCount;
+                public ulong ReadTransferCount;
+                public ulong WriteTransferCount;
+                public ulong OtherTransferCount;
             }
 
             [StructLayout(LayoutKind.Sequential)]
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Cli.Utils
             internal static extern SafeWaitHandle CreateJobObjectW(IntPtr lpJobAttributes, string lpName);
 
             [DllImport("kernel32.dll", SetLastError = true)]
-            internal static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoClass jobObjectInformationClass, IntPtr lpJobObjectInformation, UInt32 cbJobObjectInformationLength);
+            internal static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoClass jobObjectInformationClass, IntPtr lpJobObjectInformation, uint cbJobObjectInformationLength);
 
             [DllImport("kernel32.dll", SetLastError = true)]
             internal static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/RuntimeEnvironment.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/RuntimeEnvironment.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Cli.Utils
             // This is same as sysctl kern.version
             // FreeBSD 11.0-RELEASE-p1 FreeBSD 11.0-RELEASE-p1 #0 r306420: Thu Sep 29 01:43:23 UTC 2016     root@releng2.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC
             // What we want is major release as minor releases should be compatible.
-            String version = RuntimeInformation.OSDescription;
+            string version = RuntimeInformation.OSDescription;
             try
             {
                 // second token up to first dot

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private static bool ForceUniversalEncodingOptInEnabled()
         {
-            return String.Equals(Environment.GetEnvironmentVariable("DOTNET_CLI_FORCE_UTF8_ENCODING"), "true", StringComparison.OrdinalIgnoreCase);
+            return string.Equals(Environment.GetEnvironmentVariable("DOTNET_CLI_FORCE_UTF8_ENCODING"), "true", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Installer.Windows
             }
         }
 
-        private void ServerExited(Object sender, EventArgs e)
+        private void ServerExited(object sender, EventArgs e)
         {
             _log?.LogMessage($"Elevated command instance has exited.");
         }

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Cli
             // Setup
             Debug.Assert(_propertyToCheck == MSBuildPropertyNames.PUBLISH_RELEASE || _propertyToCheck == MSBuildPropertyNames.PACK_RELEASE, "Only PackRelease or PublishRelease are currently expected.");
             var nothing = Enumerable.Empty<string>();
-            if (String.Equals(Environment.GetEnvironmentVariable(EnvironmentVariableNames.DISABLE_PUBLISH_AND_PACK_RELEASE), "true", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(Environment.GetEnvironmentVariable(EnvironmentVariableNames.DISABLE_PUBLISH_AND_PACK_RELEASE), "true", StringComparison.OrdinalIgnoreCase))
             {
                 return nothing;
             }
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.Cli
             HashSet<string> configValues = new HashSet<string>();
             object projectDataLock = new object();
 
-            if (String.Equals(Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_LAZY_PUBLISH_AND_PACK_RELEASE_FOR_SOLUTIONS), "true", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_LAZY_PUBLISH_AND_PACK_RELEASE_FOR_SOLUTIONS), "true", StringComparison.OrdinalIgnoreCase))
             {
                 // Evaluate only one project for speed if this environment variable is used. Will break more customers if enabled (adding 8.0 project to SLN with other project TFMs with no Publish or PackRelease.)
                 return GetSingleProjectFromSolution(sln, globalProps);
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Cli
                 // 1) This error should not be thrown in VS because it is part of the SDK CLI code
                 // 2) If PublishRelease or PackRelease is disabled via opt out, or Configuration is specified, we won't get to this code, so we won't error
                 // 3) This code only gets hit if we are in a solution publish setting, so we don't need to worry about it failing other publish scenarios
-                throw new GracefulException(Strings.SolutionProjectConfigurationsConflict, _propertyToCheck, String.Join("\n", (configuredProjects).Select(x => x.FullPath)));
+                throw new GracefulException(Strings.SolutionProjectConfigurationsConflict, _propertyToCheck, string.Join("\n", (configuredProjects).Select(x => x.FullPath)));
             }
             return configuredProjects.FirstOrDefault();
         }

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.Tools.Common
                 return projectKey;
             }
 
-            var keyWithoutWhitespace = String.Concat(solutionKey.Where(c => !Char.IsWhiteSpace(c)));
+            var keyWithoutWhitespace = string.Concat(solutionKey.Where(c => !char.IsWhiteSpace(c)));
             if (projectKeys.TryGetValue(keyWithoutWhitespace, out projectKey))
             {
                 return projectKey;

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                         if (caseInsensitiveProfileMatches.Count() > 1)
                         {
                             throw new GracefulException(LocalizableStrings.DuplicateCaseInsensitiveLaunchProfileNames,
-                                String.Join(",\n", caseInsensitiveProfileMatches.Select(p => $"\t{p.Name}").ToArray()));
+                                string.Join(",\n", caseInsensitiveProfileMatches.Select(p => $"\t{p.Name}").ToArray()));
                         }
                         else if (!caseInsensitiveProfileMatches.Any())
                         {

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Tools.Run
                         //NOTE: MSBuild variables are not expanded like they are in VS
                         targetCommand.EnvironmentVariable(entry.Key, value);
                     }
-                    if (String.IsNullOrEmpty(targetCommand.CommandArgs) && launchSettings.CommandLineArgs != null)
+                    if (string.IsNullOrEmpty(targetCommand.CommandArgs) && launchSettings.CommandLineArgs != null)
                     {
                         targetCommand.SetCommandArgs(launchSettings.CommandLineArgs);
                     }

--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.Tools.Test
                 result.OptionValuesToBeForwarded(TestCommandParser.GetCommand()) // all msbuild-recognized tokens
                     .Concat(unMatchedNonSettingsArgs); // all tokens that the test-parser doesn't explicitly track (minus the settings tokens)
 
-            VSTestTrace.SafeWriteTrace(() => $"MSBuild args from forwarded options: {String.Join(", ", parsedArgs)}");
+            VSTestTrace.SafeWriteTrace(() => $"MSBuild args from forwarded options: {string.Join(", ", parsedArgs)}");
             msbuildArgs.AddRange(parsedArgs);
 
             if (settings.Any())

--- a/src/Cli/dotnet/commands/dotnet-tool/uninstall/ToolUninstallCommandLowLevelErrorConverter.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/uninstall/ToolUninstallCommandLowLevelErrorConverter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Tools.Tool.Uninstall
             {
                 userFacingMessages = new[]
                 {
-                    String.Format(
+                    string.Format(
                         CommonLocalizableStrings.FailedToUninstallToolPackage,
                         packageId,
                         ex.Message),

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -283,7 +283,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     {
                         Log?.LogMessage($"ProductCode mismatch! Cached package: {msi.ProductCode}, pack record: {record.ProductCode}.");
                         string logFile = GetMsiLogName(record, InstallAction.Uninstall);
-                        uint error = ExecuteWithProgress(String.Format(LocalizableStrings.MsiProgressUninstall, id), () => UninstallMsi(record.ProductCode, logFile));
+                        uint error = ExecuteWithProgress(string.Format(LocalizableStrings.MsiProgressUninstall, id), () => UninstallMsi(record.ProductCode, logFile));
                         ExitOnError(error, $"Failed to uninstall {msi.MsiPath}.");
                     }
                     else
@@ -586,7 +586,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     string packageDataPath = Path.Combine(extractionPath, "data");
                     if (!Cache.TryGetMsiPathFromPackageData(packageDataPath, out string msiPath, out _))
                     {
-                        throw new FileNotFoundException(String.Format(LocalizableStrings.ManifestMsiNotFoundInNuGetPackage, extractionPath));
+                        throw new FileNotFoundException(string.Format(LocalizableStrings.ManifestMsiNotFoundInNuGetPackage, extractionPath));
                     }
                     string msiExtractionPath = Path.Combine(extractionPath, "msi");
 
@@ -604,7 +604,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         if (result != Error.SUCCESS)
                         {
                             Log?.LogMessage($"ExtractManifestAsync: Admin install failed: {result}");
-                            throw new GracefulException(String.Format(LocalizableStrings.FailedToExtractMsi, msiPath));
+                            throw new GracefulException(string.Format(LocalizableStrings.FailedToExtractMsi, msiPath));
                         }
                     }
 
@@ -619,7 +619,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
                     if (manifestFolder == null)
                     {
-                        throw new GracefulException(String.Format(LocalizableStrings.ExpectedSingleManifest, nupkgPath));
+                        throw new GracefulException(string.Format(LocalizableStrings.ExpectedSingleManifest, nupkgPath));
                     }
 
                     FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(manifestFolder, targetPath));
@@ -930,17 +930,17 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 case InstallAction.MinorUpdate:
                 case InstallAction.Install:
                 case InstallAction.MajorUpgrade:
-                    error = ExecuteWithProgress(String.Format(LocalizableStrings.MsiProgressInstall, name), () => InstallMsi(msi.MsiPath, logFile));
+                    error = ExecuteWithProgress(string.Format(LocalizableStrings.MsiProgressInstall, name), () => InstallMsi(msi.MsiPath, logFile));
                     ExitOnError(error, $"Failed to install {msi.Payload}.");
                     break;
 
                 case InstallAction.Repair:
-                    error = ExecuteWithProgress(String.Format(LocalizableStrings.MsiProgressRepair, name), () => RepairMsi(msi.ProductCode, logFile));
+                    error = ExecuteWithProgress(string.Format(LocalizableStrings.MsiProgressRepair, name), () => RepairMsi(msi.ProductCode, logFile));
                     ExitOnError(error, $"Failed to repair {msi.Payload}.");
                     break;
 
                 case InstallAction.Uninstall:
-                    error = ExecuteWithProgress(String.Format(LocalizableStrings.MsiProgressUninstall, name), () => UninstallMsi(msi.ProductCode, logFile));
+                    error = ExecuteWithProgress(string.Format(LocalizableStrings.MsiProgressUninstall, name), () => UninstallMsi(msi.ProductCode, logFile));
                     ExitOnError(error, $"Failed to remove {msi.Payload}.");
                     break;
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             if ((ParentProcess == null) || (ParentProcess.StartTime > CurrentProcess.StartTime) ||
                 !string.Equals(ParentProcess.MainModule.FileName, Environment.ProcessPath, StringComparison.OrdinalIgnoreCase))
             {
-                throw new SecurityException(String.Format(LocalizableStrings.NoTrustWithParentPID, ParentProcess?.Id));
+                throw new SecurityException(string.Format(LocalizableStrings.NoTrustWithParentPID, ParentProcess?.Id));
             }
 
             // Configure pipe DACLs

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -470,7 +470,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         private static string GetAdvertisingWorkloadsFilePath(string userProfileDir, SdkFeatureBand featureBand) => Path.Combine(userProfileDir, $".workloadAdvertisingUpdates{featureBand}");
 
-        private async Task<String> GetOnlinePackagePath(SdkFeatureBand sdkFeatureBand, ManifestId manifestId, bool includePreviews)
+        private async Task<string> GetOnlinePackagePath(SdkFeatureBand sdkFeatureBand, ManifestId manifestId, bool includePreviews)
         {
             string packagePath = await _nugetPackageDownloader.DownloadPackageAsync(
                 _workloadManifestInstaller.GetManifestPackageId(manifestId, sdkFeatureBand),

--- a/src/Containers/Microsoft.NET.Build.Containers/BaseImageNotFoundException.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BaseImageNotFoundException.cs
@@ -6,5 +6,5 @@ namespace Microsoft.NET.Build.Containers;
 public sealed class BaseImageNotFoundException : Exception
 {
     internal BaseImageNotFoundException(string specifiedRuntimeIdentifier, string repositoryName, string reference, IEnumerable<string> supportedRuntimeIdentifiers)
-            : base($"The RuntimeIdentifier '{specifiedRuntimeIdentifier}' is not supported by {repositoryName}:{reference}. The supported RuntimeIdentifiers are {String.Join(",", supportedRuntimeIdentifiers)}") { }
+            : base($"The RuntimeIdentifier '{specifiedRuntimeIdentifier}' is not supported by {repositoryName}:{reference}. The supported RuntimeIdentifiers are {string.Join(",", supportedRuntimeIdentifiers)}") { }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -50,7 +50,7 @@ public static class ContainerHelpers
     {
         var portNo = 0;
         error = null;
-        if (String.IsNullOrEmpty(portNumber))
+        if (string.IsNullOrEmpty(portNumber))
         {
             error = ParsePortError.MissingPortNumber;
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -98,7 +98,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             return !Log.HasLoggedErrors;
         }
 
-        SafeLog(Strings.ContainerBuilder_StartBuildingImage, Repository, String.Join(",", ImageTags), sourceImageReference);
+        SafeLog(Strings.ContainerBuilder_StartBuildingImage, Repository, string.Join(",", ImageTags), sourceImageReference);
 
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows);
         imageBuilder.AddLayer(newLayer);

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
@@ -82,13 +82,13 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
     public override bool Execute()
     {
         string[] validTags;
-        if (!String.IsNullOrEmpty(ContainerImageTag) && ContainerImageTags.Length >= 1)
+        if (!string.IsNullOrEmpty(ContainerImageTag) && ContainerImageTags.Length >= 1)
         {
             Log.LogErrorWithCodeFromResources(nameof(Strings.AmbiguousTags), nameof(ContainerImageTag), nameof(ContainerImageTags));
             return !Log.HasLoggedErrors;
         }
 
-        if (!String.IsNullOrEmpty(ContainerImageTag))
+        if (!string.IsNullOrEmpty(ContainerImageTag))
         {
             if (ContainerHelpers.IsValidImageTag(ContainerImageTag))
             {
@@ -105,7 +105,7 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
             validTags = valids;
             if (invalids.Any())
             {
-                Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidTags), nameof(ContainerImageTags), String.Join(",", invalids));
+                Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidTags), nameof(ContainerImageTags), string.Join(",", invalids));
                 return !Log.HasLoggedErrors;
             }
         }
@@ -114,7 +114,7 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
             validTags = Array.Empty<string>();
         }
 
-        if (!String.IsNullOrEmpty(ContainerRegistry) && !ContainerHelpers.IsValidRegistry(ContainerRegistry))
+        if (!string.IsNullOrEmpty(ContainerRegistry) && !ContainerHelpers.IsValidRegistry(ContainerRegistry))
         {
             Log.LogErrorWithCodeFromResources(nameof(Strings.CouldntRecognizeRegistry), ContainerRegistry);
             return !Log.HasLoggedErrors;
@@ -173,7 +173,7 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
             Log.LogMessage(MessageImportance.Low, "Image: {0}", ParsedContainerImage);
             Log.LogMessage(MessageImportance.Low, "Tag: {0}", ParsedContainerTag);
             Log.LogMessage(MessageImportance.Low, "Image Name: {0}", NewContainerRepository);
-            Log.LogMessage(MessageImportance.Low, "Image Tags: {0}", String.Join(", ", NewContainerTags));
+            Log.LogMessage(MessageImportance.Low, "Image Tags: {0}", string.Join(", ", NewContainerTags));
         }
 
         return !Log.HasLoggedErrors;

--- a/src/RazorSdk/Tool/ServerProtocol/NativeMethods.cs
+++ b/src/RazorSdk/Tool/ServerProtocol/NativeMethods.cs
@@ -6,20 +6,20 @@ namespace Microsoft.NET.Sdk.Razor.Tool
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct STARTUPINFO
     {
-        internal Int32 cb;
+        internal int cb;
         internal string lpReserved;
         internal string lpDesktop;
         internal string lpTitle;
-        internal Int32 dwX;
-        internal Int32 dwY;
-        internal Int32 dwXSize;
-        internal Int32 dwYSize;
-        internal Int32 dwXCountChars;
-        internal Int32 dwYCountChars;
-        internal Int32 dwFillAttribute;
-        internal Int32 dwFlags;
-        internal Int16 wShowWindow;
-        internal Int16 cbReserved2;
+        internal int dwX;
+        internal int dwY;
+        internal int dwXSize;
+        internal int dwYSize;
+        internal int dwXCountChars;
+        internal int dwYCountChars;
+        internal int dwFillAttribute;
+        internal int dwFlags;
+        internal short wShowWindow;
+        internal short cbReserved2;
         internal IntPtr lpReserved2;
         internal IntPtr hStdInput;
         internal IntPtr hStdOutput;
@@ -47,7 +47,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
 
         internal const uint NORMAL_PRIORITY_CLASS = 0x0020;
         internal const uint CREATE_NO_WINDOW = 0x08000000;
-        internal const Int32 STARTF_USESTDHANDLES = 0x00000100;
+        internal const int STARTF_USESTDHANDLES = 0x00000100;
         internal const int ERROR_SUCCESS = 0;
 
         #endregion

--- a/src/Resolvers/Microsoft.DotNet.SdkResolver/NETCoreSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.SdkResolver/NETCoreSdkResolver.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.DotNetSdkResolver
                             continue;
                         }
 
-                        if (minimumSdkMajorVersion != 0 && Int32.TryParse(netcoreSdkVersion.Split('.')[0], out int sdkMajorVersion) && sdkMajorVersion < minimumSdkMajorVersion)
+                        if (minimumSdkMajorVersion != 0 && int.TryParse(netcoreSdkVersion.Split('.')[0], out int sdkMajorVersion) && sdkMajorVersion < minimumSdkMajorVersion)
                         {
                             continue;
                         }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
@@ -42,7 +42,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     string manifestVersionString = parts[0];
                     if (!FXVersion.TryParse(manifestVersionString, out FXVersion version))
                     {
-                        throw new FormatException(String.Format(Strings.InvalidVersionForWorkload, manifest.Key, manifestVersionString));
+                        throw new FormatException(string.Format(Strings.InvalidVersionForWorkload, manifest.Key, manifestVersionString));
                     }
 
                     manifestVersion = new ManifestVersion(parts[0]);

--- a/src/Tasks/Common/ConflictResolution/ConflictItem.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictItem.cs
@@ -69,7 +69,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                 {
                     _assemblyVersion = null;
 
-                    var assemblyVersionString = OriginalItem?.GetMetadata(nameof(AssemblyVersion)) ?? String.Empty;
+                    var assemblyVersionString = OriginalItem?.GetMetadata(nameof(AssemblyVersion)) ?? string.Empty;
 
                     if (assemblyVersionString.Length != 0)
                     {
@@ -116,7 +116,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
             {
                 if (_fileName == null)
                 {
-                    _fileName = OriginalItem == null ? String.Empty : Path.GetFileName(OriginalItem.ItemSpec);
+                    _fileName = OriginalItem == null ? string.Empty : Path.GetFileName(OriginalItem.ItemSpec);
                 }
                 return _fileName;
             }
@@ -133,7 +133,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                 {
                     _fileVersion = null;
 
-                    var fileVersionString = OriginalItem?.GetMetadata(nameof(FileVersion)) ?? String.Empty;
+                    var fileVersionString = OriginalItem?.GetMetadata(nameof(FileVersion)) ?? string.Empty;
 
                     if (fileVersionString.Length != 0)
                     {
@@ -190,7 +190,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                 {
                     _packageVersion = null;
 
-                    var packageVersionString = OriginalItem?.GetMetadata(nameof(MetadataNames.NuGetPackageVersion)) ?? String.Empty;
+                    var packageVersionString = OriginalItem?.GetMetadata(nameof(MetadataNames.NuGetPackageVersion)) ?? string.Empty;
 
                     if (packageVersionString.Length != 0)
                     {
@@ -212,7 +212,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
             {
                 if (_sourcePath == null)
                 {
-                    _sourcePath = ItemUtilities.GetSourcePath(OriginalItem) ?? String.Empty;
+                    _sourcePath = ItemUtilities.GetSourcePath(OriginalItem) ?? string.Empty;
                 }
 
                 return _sourcePath.Length == 0 ? null : _sourcePath;

--- a/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
             {
                 var itemKey = getItemKey(conflictItem);
 
-                if (String.IsNullOrEmpty(itemKey))
+                if (string.IsNullOrEmpty(itemKey))
                 {
                     continue;
                 }

--- a/src/Tasks/Common/ItemUtilities.cs
+++ b/src/Tasks/Common/ItemUtilities.cs
@@ -50,7 +50,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             var aliases = item.GetMetadata(MetadataNames.Aliases);
 
-            if (!String.IsNullOrEmpty(aliases))
+            if (!string.IsNullOrEmpty(aliases))
             {
                 // skip compile-time conflict detection for aliased assemblies.
                 // An alias is the way to avoid a conflict
@@ -68,7 +68,7 @@ namespace Microsoft.NET.Build.Tasks
             // RAR to handle or not as it sees fit.
             var sourcePath = GetSourcePath(item);
 
-            if (String.IsNullOrEmpty(sourcePath))
+            if (string.IsNullOrEmpty(sourcePath))
             {
                 return null;
             }
@@ -112,7 +112,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             var sourcePath = item.GetMetadata(MetadataNames.HintPath)?.Trim();
 
-            if (String.IsNullOrWhiteSpace(sourcePath))
+            if (string.IsNullOrWhiteSpace(sourcePath))
             {
                 // assume item-spec points to the file.
                 // this won't work if it comes from a targeting pack or SDK, but
@@ -133,7 +133,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 var value = item.GetMetadata(metadata)?.Trim();
 
-                if (!String.IsNullOrWhiteSpace(value))
+                if (!string.IsNullOrWhiteSpace(value))
                 {
                     // normalize path
                     return value.Replace('\\', '/');

--- a/src/Tasks/Common/MSBuildUtilities.cs
+++ b/src/Tasks/Common/MSBuildUtilities.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Build.Tasks
         /// <returns>Boolean true or false, corresponding to the string.</returns>
         internal static bool ConvertStringToBool(string parameterValue, bool defaultValue = false)
         {
-            if (String.IsNullOrEmpty(parameterValue))
+            if (string.IsNullOrEmpty(parameterValue))
             {
                 return defaultValue;
             }
@@ -48,12 +48,12 @@ namespace Microsoft.NET.Build.Tasks
         /// </summary>
         private static bool ValidBooleanTrue(string parameterValue)
         {
-            return ((String.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
+            return ((string.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
         }
 
         /// <summary>
@@ -62,12 +62,12 @@ namespace Microsoft.NET.Build.Tasks
         /// </summary>
         private static bool ValidBooleanFalse(string parameterValue)
         {
-            return ((String.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
+            return ((string.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/GetDependsOnNETStandard.net46.cs
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/GetDependsOnNETStandard.net46.cs
@@ -48,8 +48,8 @@ namespace Microsoft.NET.Build.Tasks
                 var assemblyImport = (IMetaDataAssemblyImport)metadataDispenser.OpenScope(filePathAbsolute, 0, s_importerGuid);
 
                 var asmRefEnum = IntPtr.Zero;
-                var asmRefTokens = new UInt32[16];
-                UInt32 fetched;
+                var asmRefTokens = new uint[16];
+                uint fetched;
 
                 var assemblyMD = new ASSEMBLYMETADATA()
                 {
@@ -77,7 +77,7 @@ namespace Microsoft.NET.Build.Tasks
                         {
                             // Determine the length of the string to contain the name first.
                             IntPtr hashDataPtr, pubKeyPtr;
-                            UInt32 hashDataLength, pubKeyBytes, asmNameLength, flags;
+                            uint hashDataLength, pubKeyBytes, asmNameLength, flags;
                             assemblyImport.GetAssemblyRefProps(
                                 asmRefTokens[i],
                                 out pubKeyPtr,
@@ -163,13 +163,13 @@ namespace Microsoft.NET.Build.Tasks
         internal interface IMetaDataDispenser
         {
             [return: MarshalAs(UnmanagedType.Interface)]
-            object DefineScope([In] ref Guid rclsid, [In] UInt32 dwCreateFlags, [In] ref Guid riid);
+            object DefineScope([In] ref Guid rclsid, [In] uint dwCreateFlags, [In] ref Guid riid);
 
             [return: MarshalAs(UnmanagedType.Interface)]
-            object OpenScope([In][MarshalAs(UnmanagedType.LPWStr)]  string szScope, [In] UInt32 dwOpenFlags, [In] ref Guid riid);
+            object OpenScope([In][MarshalAs(UnmanagedType.LPWStr)]  string szScope, [In] uint dwOpenFlags, [In] ref Guid riid);
 
             [return: MarshalAs(UnmanagedType.Interface)]
-            object OpenScopeOnMemory([In] IntPtr pData, [In] UInt32 cbData, [In] UInt32 dwOpenFlags, [In] ref Guid riid);
+            object OpenScopeOnMemory([In] IntPtr pData, [In] uint cbData, [In] uint dwOpenFlags, [In] ref Guid riid);
         }
         
         [ComImport]
@@ -177,16 +177,16 @@ namespace Microsoft.NET.Build.Tasks
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         internal interface IMetaDataAssemblyImport
         {
-            void GetAssemblyProps(UInt32 mdAsm, out IntPtr pPublicKeyPtr, out UInt32 ucbPublicKeyPtr, out UInt32 uHashAlg, StringBuilder strName, UInt32 cchNameIn, out UInt32 cchNameRequired, IntPtr amdInfo, out UInt32 dwFlags);
-            void GetAssemblyRefProps(UInt32 mdAsmRef, out IntPtr ppbPublicKeyOrToken, out UInt32 pcbPublicKeyOrToken, StringBuilder strName, UInt32 cchNameIn, out UInt32 pchNameOut, ref ASSEMBLYMETADATA amdInfo, out IntPtr ppbHashValue, out UInt32 pcbHashValue, out UInt32 pdwAssemblyRefFlags);
-            void GetFileProps([In] UInt32 mdFile, StringBuilder strName, UInt32 cchName, out UInt32 cchNameRequired, out IntPtr bHashData, out UInt32 cchHashBytes, out UInt32 dwFileFlags);
+            void GetAssemblyProps(uint mdAsm, out IntPtr pPublicKeyPtr, out uint ucbPublicKeyPtr, out uint uHashAlg, StringBuilder strName, uint cchNameIn, out uint cchNameRequired, IntPtr amdInfo, out uint dwFlags);
+            void GetAssemblyRefProps(uint mdAsmRef, out IntPtr ppbPublicKeyOrToken, out uint pcbPublicKeyOrToken, StringBuilder strName, uint cchNameIn, out uint pchNameOut, ref ASSEMBLYMETADATA amdInfo, out IntPtr ppbHashValue, out uint pcbHashValue, out uint pdwAssemblyRefFlags);
+            void GetFileProps([In] uint mdFile, StringBuilder strName, uint cchName, out uint cchNameRequired, out IntPtr bHashData, out uint cchHashBytes, out uint dwFileFlags);
             void GetExportedTypeProps();
             void GetManifestResourceProps();
-            void EnumAssemblyRefs([In, Out] ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray), Out] UInt32[] asmRefs, System.UInt32 asmRefCount, out System.UInt32 iFetched);
-            void EnumFiles([In, Out] ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray), Out] UInt32[] fileRefs, System.UInt32 fileRefCount, out System.UInt32 iFetched);
+            void EnumAssemblyRefs([In, Out] ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray), Out] uint[] asmRefs, uint asmRefCount, out uint iFetched);
+            void EnumFiles([In, Out] ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray), Out] uint[] fileRefs, uint fileRefCount, out uint iFetched);
             void EnumExportedTypes();
             void EnumManifestResources();
-            void GetAssemblyFromScope(out UInt32 mdAsm);
+            void GetAssemblyFromScope(out uint mdAsm);
             void FindExportedTypeByName();
             void FindManifestResourceByName();
             // PreserveSig because this method is an exception that 
@@ -216,16 +216,16 @@ namespace Microsoft.NET.Build.Tasks
         [StructLayout(LayoutKind.Sequential)]
         internal struct ASSEMBLYMETADATA
         {
-            public UInt16 usMajorVersion;
-            public UInt16 usMinorVersion;
-            public UInt16 usBuildNumber;
-            public UInt16 usRevisionNumber;
+            public ushort usMajorVersion;
+            public ushort usMinorVersion;
+            public ushort usBuildNumber;
+            public ushort usRevisionNumber;
             public IntPtr rpLocale;
-            public UInt32 cchLocale;
+            public uint cchLocale;
             public IntPtr rpProcessors;
-            public UInt32 cProcessors;
+            public uint cProcessors;
             public IntPtr rOses;
-            public UInt32 cOses;
+            public uint cOses;
         }
 
         #endregion

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAssetsFileResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAssetsFileResolver.cs
@@ -189,7 +189,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             string sourcedir = Path.GetDirectoryName(sourcepath);
             string destinationSubDirPath = preserveStoreLayout ? sourcedir.Substring(packageRoot.Length) : destinationSubDirectory;
 
-            if (!String.IsNullOrEmpty(destinationSubDirPath) && !destinationSubDirPath.EndsWith(Path.DirectorySeparatorChar))
+            if (!string.IsNullOrEmpty(destinationSubDirPath) && !destinationSubDirPath.EndsWith(Path.DirectorySeparatorChar))
             {
                 destinationSubDirPath += Path.DirectorySeparatorChar;
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AllowEmptyTelemetry.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Build.Tasks
         public AllowEmptyTelemetry()
         {
             EventData = Array.Empty<ITaskItem>();
-            EventName = String.Empty;
+            EventName = string.Empty;
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Tasks
                     {
                         value = HashWithNormalizedCasing(value);
                     }
-                    if (String.IsNullOrEmpty(value))
+                    if (string.IsNullOrEmpty(value))
                     {
                         properties[key] = "null";
                     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CollectSDKReferencesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CollectSDKReferencesDesignTime.cs
@@ -74,7 +74,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 else
                 {
-                    Boolean.TryParse(isImplicitlyDefinedString, out isImplicitlyDefined);
+                    bool.TryParse(isImplicitlyDefinedString, out isImplicitlyDefined);
                 }
 
                 if (isImplicitlyDefined)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -99,7 +99,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 // If the platform library is not Microsoft.NETCore.App, treat it as an implicit dependency.
                 // This makes it so Microsoft.AspNet.* 2.x platforms also exclude Microsoft.NETCore.App files.
-                if (PlatformLibrary.Name.Length > 0 && !String.Equals(PlatformLibrary.Name, NetCorePlatformLibrary, StringComparison.OrdinalIgnoreCase))
+                if (PlatformLibrary.Name.Length > 0 && !string.Equals(PlatformLibrary.Name, NetCorePlatformLibrary, StringComparison.OrdinalIgnoreCase))
                 {
                     var library = _lockFileTarget.GetLibrary(NetCorePlatformLibrary);
                     if (library != null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1813,7 +1813,7 @@ namespace Microsoft.NET.Build.Tasks
 
                         // If the platform library is not Microsoft.NETCore.App, treat it as an implicit dependency.
                         // This makes it so Microsoft.AspNet.* 2.x platforms also exclude Microsoft.NETCore.App files.
-                        if (!String.Equals(platformLibrary.Name, NetCorePlatformLibrary, StringComparison.OrdinalIgnoreCase))
+                        if (!string.Equals(platformLibrary.Name, NetCorePlatformLibrary, StringComparison.OrdinalIgnoreCase))
                         {
                             var library = _runtimeTarget.GetLibrary(NetCorePlatformLibrary);
                             if (library != null)

--- a/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/src/Tests/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 msbuildAdditionalSdkResolverFolder = "";
             }
 
-            var scheduler = new AssemblyScheduler(methodLimit: !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("TestFullMSBuild")) ? 32 : 16);
+            var scheduler = new AssemblyScheduler(methodLimit: !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TestFullMSBuild")) ? 32 : 16);
             var assemblyPartitionInfos = scheduler.Schedule(targetPath, netFramework: netFramework);
 
             var partitionedWorkItem = new List<ITaskItem>();
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 string command = $"{driver} exec {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml {assemblyPartitionInfo.ClassListArgumentString} {arguments}";
                 if (netFramework)
                 {
-                    var testFilter = String.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
+                    var testFilter = string.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
                     command = $"{driver} test {assemblyName} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} {(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .\\ --logger trx {testFilter}";
                 }
 

--- a/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
+++ b/src/Tests/HelixTasks/TarGzFileCreateFromDirectory.cs
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
         private string GetExcludes()
         {
-            var excludes = String.Empty;
+            var excludes = string.Empty;
 
             if (ExcludePatterns != null)
             {

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -27,7 +27,7 @@ public class EndToEndTests : IDisposable
         var (normalizedName, warning, error) = ContainerHelpers.NormalizeRepository(callerMemberName);
         if (error is (var format, var args))
         {
-            throw new ArgumentException(String.Format(Strings.ResourceManager.GetString(format)!, args));
+            throw new ArgumentException(string.Format(Strings.ResourceManager.GetString(format)!, args));
         }
 
         return normalizedName!; // non-null if error is null

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -19,7 +19,7 @@ public class TargetsTests
         var (project, _, d) = ProjectInitializer.InitProject(new()
         {
             [selfContainedPropertyName] = selfContainedPropertyValue.ToString()
-        }, projectName: $"{nameof(CanDeferEntrypoint)}_{selfContainedPropertyName}_{selfContainedPropertyValue}_{String.Join("_", entrypointArgs)}");
+        }, projectName: $"{nameof(CanDeferEntrypoint)}_{selfContainedPropertyName}_{selfContainedPropertyValue}_{string.Join("_", entrypointArgs)}");
         using var _ = d;
         Assert.True(project.Build(ComputeContainerConfig));
         var computedEntrypointArgs = project.GetItems(ContainerEntrypoint).Select(i => i.EvaluatedInclude).ToArray();
@@ -59,7 +59,7 @@ public class TargetsTests
         }, projectName: $"{nameof(CanNormalizeInputContainerNames)}_{projectName}_{expectedContainerImageName}_{shouldPass}");
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        instance.Build(new[] { ComputeContainerConfig }, new[] { logger }, null, out var outputs).Should().Be(shouldPass, String.Join(Environment.NewLine, logger.AllMessages));
+        instance.Build(new[] { ComputeContainerConfig }, new[] { logger }, null, out var outputs).Should().Be(shouldPass, string.Join(Environment.NewLine, logger.AllMessages));
         Assert.Equal(expectedContainerImageName, instance.GetPropertyValue(ContainerRepository));
     }
 
@@ -80,7 +80,7 @@ public class TargetsTests
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
         instance.Build(new[] { "_ContainerVerifySDKVersion" }, new[] { logger }, null, out var outputs).Should().Be(isAllowed);
-        var derivedIsAllowed = Boolean.Parse(project.GetProperty("_IsSDKContainerAllowedVersion").EvaluatedValue);
+        var derivedIsAllowed = bool.Parse(project.GetProperty("_IsSDKContainerAllowedVersion").EvaluatedValue);
         if (isAllowed)
         {
             logger.Errors.Should().HaveCount(0, "an error should not have been created");
@@ -133,7 +133,7 @@ public class TargetsTests
         }, projectName: $"{nameof(ShouldNotIncludeSourceControlLabelsUnlessUserOptsIn)}_{includeSourceControl}");
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        instance.Build(new[] { ComputeContainerConfig }, new[] { logger }, null, out var outputs).Should().BeTrue("Build should have succeeded but failed due to {0}", String.Join("\n", logger.AllMessages));
+        instance.Build(new[] { ComputeContainerConfig }, new[] { logger }, null, out var outputs).Should().BeTrue("Build should have succeeded but failed due to {0}", string.Join("\n", logger.AllMessages));
         var labels = instance.GetItems(ContainerLabel);
         if (includeSourceControl)
         {
@@ -179,7 +179,7 @@ public class TargetsTests
         }, projectName: $"{nameof(CanComputeTagsForSupportedSDKVersions)}_{sdkVersion}_{tfm}_{expectedTag}");
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        instance.Build(new[] { "_ComputeContainerBaseImageTag" }, new[] { logger }, null, out var outputs).Should().BeTrue(String.Join(Environment.NewLine, logger.Errors));
+        instance.Build(new[] { "_ComputeContainerBaseImageTag" }, new[] { logger }, null, out var outputs).Should().BeTrue(string.Join(Environment.NewLine, logger.Errors));
         var computedTag = instance.GetProperty("_ContainerBaseImageTag").EvaluatedValue;
         computedTag.Should().Be(expectedTag);
     }
@@ -202,7 +202,7 @@ public class TargetsTests
         }, projectName: $"{nameof(CanComputeContainerUser)}_{tfm}_{rid}_{expectedUser}");
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        instance.Build(new[] { ComputeContainerConfig }, new[] { logger }, null, out var outputs).Should().BeTrue(String.Join(Environment.NewLine, logger.Errors));
+        instance.Build(new[] { ComputeContainerConfig }, new[] { logger }, null, out var outputs).Should().BeTrue(string.Join(Environment.NewLine, logger.Errors));
         var computedTag = instance.GetProperty("ContainerUser")?.EvaluatedValue;
         computedTag.Should().Be(expectedUser);
     }
@@ -221,7 +221,7 @@ public class TargetsTests
         }, projectName: $"{nameof(WindowsUsersGetLinuxContainers)}_{sdkPortableRid}_{expectedRid}");
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        instance.Build(new[] { ComputeContainerConfig }, null, null, out var outputs).Should().BeTrue(String.Join(Environment.NewLine, logger.Errors));
+        instance.Build(new[] { ComputeContainerConfig }, null, null, out var outputs).Should().BeTrue(string.Join(Environment.NewLine, logger.Errors));
         var computedRid = instance.GetProperty(KnownStrings.Properties.ContainerRuntimeIdentifier)?.EvaluatedValue;
         computedRid.Should().Be(expectedRid);
     }
@@ -243,7 +243,7 @@ public class TargetsTests
         }, projectName: $"{nameof(CanTakeContainerBaseFamilyIntoAccount)}_{sdkVersion}_{tfmMajMin}_{containerFamily}_{expectedTag}");
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        instance.Build(new[] { _ComputeContainerBaseImageTag }, null, null, out var outputs).Should().BeTrue(String.Join(Environment.NewLine, logger.Errors));
+        instance.Build(new[] { _ComputeContainerBaseImageTag }, null, null, out var outputs).Should().BeTrue(string.Join(Environment.NewLine, logger.Errors));
         var computedBaseImageTag = instance.GetProperty(KnownStrings.Properties._ContainerBaseImageTag)?.EvaluatedValue;
         computedBaseImageTag.Should().Be(expectedTag);
     }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
@@ -106,7 +106,7 @@ namespace Microsoft.NET.Build.Tests
                 $"libuv{FileConstants.DynamicLibSuffix}"
             };
 
-            outputDirectory.Should().OnlyHaveFiles(expectedFiles.Where(x => !String.IsNullOrEmpty(x)).ToList());
+            outputDirectory.Should().OnlyHaveFiles(expectedFiles.Where(x => !string.IsNullOrEmpty(x)).ToList());
 
             new DotnetCommand(Log, Path.Combine(outputDirectory.FullName, "App.dll"))
                 .Execute()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -94,7 +94,7 @@ namespace Microsoft.NET.Publish.Tests
                 targetFramework: TargetFramework,
                 runtimeIdentifier: runtimeIdentifier).FullName;
             byte[] fileContent = File.ReadAllBytes(Path.Combine(outputDirectory, TestProjectName + ".exe"));
-            UInt32 peHeaderOffset = BitConverter.ToUInt32(fileContent, PEHeaderPointerOffset);
+            uint peHeaderOffset = BitConverter.ToUInt32(fileContent, PEHeaderPointerOffset);
             BitConverter
                 .ToUInt16(fileContent, (int)(peHeaderOffset + SubsystemOffset))
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToTestAMultitargetedSolutionWithPublishReleaseOrPackRelease.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToTestAMultitargetedSolutionWithPublishReleaseOrPackRelease.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NET.Publish.Tests
             List<TestProject> testProjects = new List<TestProject>();
             var testProject = new TestProject("TestProject")
             {
-                TargetFrameworks = String.Join(";", exeProjTfms),
+                TargetFrameworks = string.Join(";", exeProjTfms),
                 IsExe = true
             };
             testProject.RecordProperties("Configuration", "Optimize", PReleaseProperty);
@@ -52,7 +52,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var libraryProject = new TestProject("LibraryProject")
             {
-                TargetFrameworks = String.Join(";", libraryProjTfms),
+                TargetFrameworks = string.Join(";", libraryProjTfms),
                 IsExe = false
             };
             libraryProject.RecordProperties("Configuration", "Optimize", PReleaseProperty);
@@ -271,7 +271,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdErrContaining(String.Format(Strings.SolutionProjectConfigurationsConflict, PublishRelease, "")); ;
+                .HaveStdErrContaining(string.Format(Strings.SolutionProjectConfigurationsConflict, PublishRelease, "")); ;
         }
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishDepsFilePathTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishDepsFilePathTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NET.Publish.Tests
             var targetFramework = testProject.TargetFrameworks;
             var publishDepsFilePath = GetPropertyValue(projectPath, targetFramework, "PublishDepsFilePath");
 
-            String.IsNullOrEmpty(publishDepsFilePath).Should().BeTrue();
+            string.IsNullOrEmpty(publishDepsFilePath).Should().BeTrue();
         }
 
         string GetPropertyValue(string projectPath, string targetFramework, string property)

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
@@ -739,7 +739,7 @@ public class TestReference
         private void BuildWasmMinimalAndValidateBootConfig((string name, string value)[] properties, Action<BootJsonData> validateBootConfig)
         {
             var testAppName = "BlazorWasmMinimal";
-            var testInstance = CreateAspNetSdkTestAsset(testAppName, identifier: String.Join("-", properties.Select(p => p.name + p.value ?? "null")));
+            var testInstance = CreateAspNetSdkTestAsset(testAppName, identifier: string.Join("-", properties.Select(p => p.name + p.value ?? "null")));
 
             foreach (var property in properties)
             {

--- a/src/Tests/Microsoft.NET.TestFramework/Assertions/StringAssertionsExtensions.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Assertions/StringAssertionsExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.TestFramework.Assertions
         public static AndConstraint<StringAssertions> BeVisuallyEquivalentTo(this StringAssertions assertions, string expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(String.Compare(NormalizeLineEndings(assertions.Subject), NormalizeLineEndings(expected), CultureInfo.CurrentCulture, CompareOptions.IgnoreSymbols) == 0)
+                .ForCondition(string.Compare(NormalizeLineEndings(assertions.Subject), NormalizeLineEndings(expected), CultureInfo.CurrentCulture, CompareOptions.IgnoreSymbols) == 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith($"String \"{assertions.Subject}\" is not visually equivalent to expected string \"{expected}\".");
 

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -278,7 +278,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
             if (SelfContained != "")
             {
-                propertyGroup.Add(new XElement(ns + "SelfContained", String.Equals(SelfContained, "true", StringComparison.OrdinalIgnoreCase) ? "true" : "false"));
+                propertyGroup.Add(new XElement(ns + "SelfContained", string.Equals(SelfContained, "true", StringComparison.OrdinalIgnoreCase) ? "true" : "false"));
             }
 
             if (ReferencedProjects.Any())
@@ -497,7 +497,7 @@ namespace {safeThisName}
                 if (colonIndex > 0)
                 {
                     string propertyName = line.Substring(0, colonIndex);
-                    string propertyValue = line.Length == colonIndex + 1 ? String.Empty : line.Substring(colonIndex + 2);
+                    string propertyValue = line.Length == colonIndex + 1 ? string.Empty : line.Substring(colonIndex + 2);
                     propertyValues[propertyName] = propertyValue;
                 }
             }

--- a/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NET.TestFramework
     {
         public string TestAssetsRoot { get; private set; }
 
-        private List<String> TestDestinationDirectories { get; } = new List<string>();
+        private List<string> TestDestinationDirectories { get; } = new List<string>();
 
         protected ITestOutputHelper Log { get; }
 

--- a/src/Tests/Microsoft.NET.TestFramework/TestPackageReference.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestPackageReference.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NET.TestFramework
         public bool UpdatePackageReference { get; private set; }
         public bool NuGetPackageExists()
         {
-            return File.Exists(Path.Combine(NupkgPath, String.Concat(ID + "." + Version + ".nupkg")));
+            return File.Exists(Path.Combine(NupkgPath, string.Concat(ID + "." + Version + ".nupkg")));
         }
     }
 }

--- a/src/Tests/Microsoft.Win32.Msi.Manual.Tests/Program.cs
+++ b/src/Tests/Microsoft.Win32.Msi.Manual.Tests/Program.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Win32.Msi.Manual.Tests
             Console.SetCursorPosition(0, top);
         }
 
-        void OnActionData(Object sender, ActionDataEventArgs e)
+        void OnActionData(object sender, ActionDataEventArgs e)
         {
             if (ActionDataEnabled)
             {
@@ -115,7 +115,7 @@ namespace Microsoft.Win32.Msi.Manual.Tests
             e.Result = DialogResult.IDOK;
         }
 
-        void OnActionStart(Object send, ActionStartEventArgs e)
+        void OnActionStart(object send, ActionStartEventArgs e)
         {
             if (ActionDataEnabled)
             {
@@ -134,7 +134,7 @@ namespace Microsoft.Win32.Msi.Manual.Tests
             e.Result = DialogResult.IDOK;
         }
 
-        void OnProgress(Object send, ProgressEventArgs e)
+        void OnProgress(object send, ProgressEventArgs e)
         {
             e.Result = DialogResult.IDOK;
 

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsVbProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsVbProj.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .WithWorkingDirectory(testInstance.Path)
                 .Execute("--launch-profile", "first");
 
-            string expectedError = String.Format(LocalizableStrings.DuplicateCaseInsensitiveLaunchProfileNames, "\tfirst," + (OperatingSystem.IsWindows() ? "\r" : "") + "\n\tFIRST");
+            string expectedError = string.Format(LocalizableStrings.DuplicateCaseInsensitiveLaunchProfileNames, "\tfirst," + (OperatingSystem.IsWindows() ? "\r" : "") + "\n\tFIRST");
             runResult
                 .Should()
                 .Fail()
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(String.Format(LocalizableStrings.LaunchProfileDoesNotExist, invalidLaunchProfileName));
+                .HaveStdErrContaining(string.Format(LocalizableStrings.LaunchProfileDoesNotExist, invalidLaunchProfileName));
         }
 
         [Theory]

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -241,7 +241,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                        .Execute("--logger", "trx", "--results-directory", trxLoggerDirectory);
 
             // Verify
-            String[] trxFiles = Directory.GetFiles(trxLoggerDirectory, "*.trx");
+            string[] trxFiles = Directory.GetFiles(trxLoggerDirectory, "*.trx");
             Assert.Single(trxFiles);
             result.StdOut.Should().Contain(trxFiles[0]);
 

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdErrContaining(String.Format(Workloads.Workload.Install.LocalizableStrings.WorkloadNotRecognized, "fake"));
+                .HaveStdErrContaining(string.Format(Workloads.Workload.Install.LocalizableStrings.WorkloadNotRecognized, "fake"));
         }
 
         [Fact(Skip = "https://github.com/dotnet/sdk/issues/26624")]
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdErrContaining(String.Format(Workloads.Workload.Install.LocalizableStrings.CannotCombineSkipManifestAndRollback, "skip-manifest-update", "from-rollback-file", "skip-manifest-update", "from-rollback-file"));
+                .HaveStdErrContaining(string.Format(Workloads.Workload.Install.LocalizableStrings.CannotCombineSkipManifestAndRollback, "skip-manifest-update", "from-rollback-file", "skip-manifest-update", "from-rollback-file"));
         }
 
 
@@ -328,7 +328,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             var exceptionThrown = Assert.Throws<GracefulException>(() => new WorkloadInstallCommand(parseResult, reporter: _reporter, workloadResolver: workloadResolver, workloadInstaller: installer,
                 nugetPackageDownloader: nugetDownloader, workloadManifestUpdater: manifestUpdater, userProfileDir: testDirectory, dotnetDir: dotnetRoot, version: "6.0.100", installedFeatureBand: "6.0.100"));
-            exceptionThrown.Message.Should().Be(String.Format(Workloads.Workload.Install.LocalizableStrings.WorkloadNotSupportedOnPlatform, mockWorkloadId));
+            exceptionThrown.Message.Should().Be(string.Format(Workloads.Workload.Install.LocalizableStrings.WorkloadNotSupportedOnPlatform, mockWorkloadId));
         }
 
         [Theory]
@@ -583,7 +583,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             installManager.InstallWorkloads(new List<WorkloadId>(), false); // Don't actually do any installs, just update manifests
 
             string.Join(" ", _reporter.Lines).Should().Contain(Workloads.Workload.Install.LocalizableStrings.CheckForUpdatedWorkloadManifests);
-            string.Join(" ", _reporter.Lines).Should().Contain(String.Format(Workloads.Workload.Install.LocalizableStrings.CheckForUpdatedWorkloadManifests, "mock-manifest"));
+            string.Join(" ", _reporter.Lines).Should().Contain(string.Format(Workloads.Workload.Install.LocalizableStrings.CheckForUpdatedWorkloadManifests, "mock-manifest"));
         }
 
         private string AppendForUserLocal(string identifier, bool userLocal)

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -271,7 +271,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             // check that update did not fail
             _reporter.Lines.Should().NotContain(l => l.ToLowerInvariant().Contains("fail"));
-            _reporter.Lines.Should().NotContain(String.Format(Workloads.Workload.Install.LocalizableStrings.AdManifestPackageDoesNotExist, testManifestName));
+            _reporter.Lines.Should().NotContain(string.Format(Workloads.Workload.Install.LocalizableStrings.AdManifestPackageDoesNotExist, testManifestName));
 
         }
 
@@ -339,7 +339,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             //  Assert
             _reporter.Lines.Should().NotContain(l => l.ToLowerInvariant().Contains("fail"));
-            _reporter.Lines.Should().Contain(String.Format(Workloads.Workload.Install.LocalizableStrings.AdManifestPackageDoesNotExist, testManifestName));
+            _reporter.Lines.Should().Contain(string.Format(Workloads.Workload.Install.LocalizableStrings.AdManifestPackageDoesNotExist, testManifestName));
         }
 
         [Theory]
@@ -405,7 +405,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             Directory.GetFiles(adManifestDir).Should().BeEmpty();
 
             _reporter.Lines.Should().NotContain(l => l.ToLowerInvariant().Contains("fail"));
-            _reporter.Lines.Should().Contain(String.Format(Workloads.Workload.Install.LocalizableStrings.AdManifestPackageDoesNotExist, testManifestName));
+            _reporter.Lines.Should().Contain(string.Format(Workloads.Workload.Install.LocalizableStrings.AdManifestPackageDoesNotExist, testManifestName));
         }
 
         [Fact]

--- a/src/WebSdk/Publish/Tasks/Kudu/KuduConnect.cs
+++ b/src/WebSdk/Publish/Tasks/Kudu/KuduConnect.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
             {
                 lock (_syncObject)
                 {
-                    string authInfo = String.Format("{0}:{1}", _connectionInfo.UserName, _connectionInfo.Password);
+                    string authInfo = string.Format("{0}:{1}", _connectionInfo.UserName, _connectionInfo.Password);
                     return Convert.ToBase64String(Encoding.UTF8.GetBytes(authInfo));
                 }
             }

--- a/src/WebSdk/Publish/Tasks/Kudu/KuduVfsDeploy.cs
+++ b/src/WebSdk/Publish/Tasks/Kudu/KuduVfsDeploy.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
         {
             get
             {
-                return String.Format(ConnectionInfo.DestinationUrl, ConnectionInfo.SiteName, "vfs/site/wwwroot/");
+                return string.Format(ConnectionInfo.DestinationUrl, ConnectionInfo.SiteName, "vfs/site/wwwroot/");
             }
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
             return System.Threading.Tasks.Task.Run(
                 async () =>
                 {
-                    string relPath = file.Replace(sourcePath, String.Empty);
+                    string relPath = file.Replace(sourcePath, string.Empty);
                     string relUrl = relPath.Replace(Path.DirectorySeparatorChar, '/');
                     string apiUrl = DestinationUrl + relUrl;
 
@@ -74,14 +74,14 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
                                     {
                                         lock (_syncObject)
                                         {
-                                            _logger.LogMessage(Microsoft.Build.Framework.MessageImportance.High, String.Format(Resources.KUDUDEPLOY_AddingFileFailed, ConnectionInfo.SiteName + "/" + relUrl, response.ReasonPhrase));
+                                            _logger.LogMessage(Microsoft.Build.Framework.MessageImportance.High, string.Format(Resources.KUDUDEPLOY_AddingFileFailed, ConnectionInfo.SiteName + "/" + relUrl, response.ReasonPhrase));
                                         }
                                     }
                                     else
                                     {
                                         lock (_syncObject)
                                         {
-                                            _logger.LogMessage(Microsoft.Build.Framework.MessageImportance.High, String.Format(Resources.KUDUDEPLOY_AddingFile, ConnectionInfo.SiteName + "/" + relUrl));
+                                            _logger.LogMessage(Microsoft.Build.Framework.MessageImportance.High, string.Format(Resources.KUDUDEPLOY_AddingFile, ConnectionInfo.SiteName + "/" + relUrl));
                                         }
                                     }
                                 }

--- a/src/WebSdk/Publish/Tasks/Kudu/KuduZipDeploy.cs
+++ b/src/WebSdk/Publish/Tasks/Kudu/KuduZipDeploy.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
         {
             get
             {
-                return String.Format(ConnectionInfo.DestinationUrl, ConnectionInfo.SiteName, "zip/site/wwwroot/");
+                return string.Format(ConnectionInfo.DestinationUrl, ConnectionInfo.SiteName, "zip/site/wwwroot/");
             }
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
             if (!File.Exists(zipFileFullPath))
             {
                 // If the source file directory does not exist quit early.
-                _logger.LogError(String.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, Resources.KUDUDEPLOY_DeployOutputPathEmpty));
+                _logger.LogError(string.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, Resources.KUDUDEPLOY_DeployOutputPathEmpty));
                 return false;
             }
 
@@ -41,7 +41,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
 
         private async System.Threading.Tasks.Task<bool> PostZipAsync(string zipFilePath)
         {
-            if (String.IsNullOrEmpty(zipFilePath))
+            if (string.IsNullOrEmpty(zipFilePath))
             {
                 return false;
             }
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
                         {
                             if (!response.IsSuccessStatusCode)
                             {
-                                _logger.LogError(String.Format(Resources.KUDUDEPLOY_PublishZipFailedReason, ConnectionInfo.SiteName, response.ReasonPhrase));
+                                _logger.LogError(string.Format(Resources.KUDUDEPLOY_PublishZipFailedReason, ConnectionInfo.SiteName, response.ReasonPhrase));
                                 return false;
                             }
                         }

--- a/src/WebSdk/Publish/Tasks/Tasks/Kudu/KuduDeploy.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/Kudu/KuduDeploy.cs
@@ -73,14 +73,14 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
 
         public override bool Execute()
         {
-            if (String.IsNullOrEmpty(PublishIntermediateOutputPath))
+            if (string.IsNullOrEmpty(PublishIntermediateOutputPath))
             {
                 Log.LogError(Resources.KUDUDEPLOY_DeployOutputPathEmpty);
                 return false;
             }
 
             KuduConnectionInfo connectionInfo = GetConnectionInfo();
-            if (String.IsNullOrEmpty(connectionInfo.UserName) || String.IsNullOrEmpty(connectionInfo.Password) || String.IsNullOrEmpty(connectionInfo.DestinationUrl))
+            if (string.IsNullOrEmpty(connectionInfo.UserName) || string.IsNullOrEmpty(connectionInfo.Password) || string.IsNullOrEmpty(connectionInfo.DestinationUrl))
             {
                 Log.LogError(Resources.KUDUDEPLOY_ConnectionInfoMissing);
                 return false;
@@ -118,12 +118,12 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
                 success = deployTask.Wait(TimeoutMilliseconds);
                 if (!success)
                 {
-                    Log.LogError(String.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, Resources.KUDUDEPLOY_OperationTimeout));
+                    Log.LogError(string.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, Resources.KUDUDEPLOY_OperationTimeout));
                 }
             }
             catch (AggregateException ae)
             {
-                Log.LogError(String.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, ae.Flatten().Message));
+                Log.LogError(string.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, ae.Flatten().Message));
                 success = false;
             }
 
@@ -144,12 +144,12 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
                 success = zipTask.Wait(TimeoutMilliseconds);
                 if (!success)
                 {
-                    Log.LogError(String.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, Resources.KUDUDEPLOY_OperationTimeout));
+                    Log.LogError(string.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, Resources.KUDUDEPLOY_OperationTimeout));
                 }
             }
             catch (AggregateException ae)
             {
-                Log.LogError(String.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, ae.Flatten().Message));
+                Log.LogError(string.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, ae.Flatten().Message));
                 success = false;
             }
 
@@ -162,8 +162,8 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
         internal string CreateZipFile(string sourcePath)
         {
             // Zip the files from PublishOutput path.
-            string zipFileFullPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), String.Format("Publish{0}.zip", new Random().Next(Int32.MaxValue)));
-            Log.LogMessage(Microsoft.Build.Framework.MessageImportance.High, String.Format(Resources.KUDUDEPLOY_CopyingToTempLocation, zipFileFullPath));
+            string zipFileFullPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), string.Format("Publish{0}.zip", new Random().Next(int.MaxValue)));
+            Log.LogMessage(Microsoft.Build.Framework.MessageImportance.High, string.Format(Resources.KUDUDEPLOY_CopyingToTempLocation, zipFileFullPath));
 
             try
             {
@@ -171,7 +171,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Kudu
             }
             catch (Exception e)
             {
-                Log.LogError(String.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, e.Message));
+                Log.LogError(string.Format(Resources.KUDUDEPLOY_AzurePublishErrorReason, e.Message));
                 // If we are unable to zip the file, then we fail.
                 return null;
             }

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/GetPassword.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/GetPassword.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             return GetClearTextPassword(encryptedData);
         }
 
-        public static string GetClearTextPassword(Byte[] encryptedData)
+        public static string GetClearTextPassword(byte[] encryptedData)
         {
             if (encryptedData == null)
             {
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             try
             {
 #pragma warning disable CA1416 // This functionality is only expected to work in Windows.
-                Byte[] uncrypted = System.Security.Cryptography.ProtectedData.Unprotect(encryptedData, null, System.Security.Cryptography.DataProtectionScope.CurrentUser);
+                byte[] uncrypted = System.Security.Cryptography.ProtectedData.Unprotect(encryptedData, null, System.Security.Cryptography.DataProtectionScope.CurrentUser);
 #pragma warning restore CA1416 // This functionality is only expected to work in Windows.
                 plainPWD = Encoding.Unicode.GetString(uncrypted);
             }

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/VsMsdeploy.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/VsMsdeploy.cs
@@ -450,7 +450,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
 
 
         // Utility function to log all public instance property to CustomerBuildEventArgs 
-        private static void AddAllPropertiesToCustomBuildWithPropertyEventArgs(CustomBuildWithPropertiesEventArgs cbpEventArg, System.Object obj)
+        private static void AddAllPropertiesToCustomBuildWithPropertyEventArgs(CustomBuildWithPropertiesEventArgs cbpEventArg, object obj)
         {
 #if NET472
             if (obj != null)

--- a/src/WebSdk/Publish/Tasks/Tasks/ValidateParameter.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/ValidateParameter.cs
@@ -16,9 +16,9 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
 
         public override bool Execute()
         {
-            if (String.IsNullOrEmpty(ParameterValue))
+            if (string.IsNullOrEmpty(ParameterValue))
             {
-                Log.LogError(String.Format(CultureInfo.CurrentCulture, Resources.ValidateParameter_ArgumentNullError, ParameterName));
+                Log.LogError(string.Format(CultureInfo.CurrentCulture, Resources.ValidateParameter_ArgumentNullError, ParameterName));
                 return false;
             }
 

--- a/src/WebSdk/Publish/Tasks/Tasks/Xdt/TaskTransformationLogger.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/Xdt/TaskTransformationLogger.cs
@@ -37,7 +37,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
             {
                 if (indentString == null)
                 {
-                    indentString = String.Empty;
+                    indentString = string.Empty;
                     for (int i = 0; i < indentLevel; i++)
                     {
                         indentString += indentStringPiece;
@@ -86,7 +86,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
                     break;
             }
 
-            loggingHelper.LogMessage(importance, String.Concat(IndentString, message), messageArgs);
+            loggingHelper.LogMessage(importance, string.Concat(IndentString, message), messageArgs);
         }
 
         void IXmlTransformationLogger.LogWarning(string message, params object[] messageArgs)
@@ -161,7 +161,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
                 {
                     sb.AppendFormat("{0} : {1}", exIterator.GetType().Name, exIterator.Message);
                     sb.AppendLine();
-                    if (!String.IsNullOrEmpty(exIterator.StackTrace))
+                    if (!string.IsNullOrEmpty(exIterator.StackTrace))
                     {
                         sb.Append(exIterator.StackTrace);
                     }

--- a/src/WebSdk/Publish/Tasks/Tasks/Xdt/TransformXml.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/Xdt/TransformXml.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
         private bool stackTrace = false;
 
         [Required]
-        public String Source
+        public string Source
         {
             get
             {
@@ -42,7 +42,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
 
 
         [Required]
-        public String Transform
+        public string Transform
         {
             get
             {
@@ -72,7 +72,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
 
 
         [Required]
-        public String Destination
+        public string Destination
         {
             get
             {

--- a/src/WebSdk/Publish/Tasks/WebConfigTransform.cs
+++ b/src/WebSdk/Publish/Tasks/WebConfigTransform.cs
@@ -117,7 +117,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
                 // if the app path is already there in the web.config, don't do anything.
                 if (string.Equals(appPath, (string)argumentsAttribute, StringComparison.OrdinalIgnoreCase))
                 {
-                    appPath = String.Empty;
+                    appPath = string.Empty;
                 }
                 attributes.Insert(processPathIndex + 1,
                     new XAttribute("arguments", (appPath + " " + (string)argumentsAttribute).Trim()));


### PR DESCRIPTION
## Summary
I've been noticing a lot of random greyed out code in the codebase. So, I'm going through and using tooling to apply fixes for what the analyzers are detecting. Here, I ran the fix for [Use language keywords instead of framework type names for type references (IDE0049)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049). These types of automated changes are non-functional changes. Just purely code cleanup.