### PR TITLE
Add ProjectCapability for Native AOT properties.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1278,6 +1278,20 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="CrossPlatformExecutable" />
   </ItemGroup>
 
+  <!-- Native AOT compilation -->
+  <ItemGroup>
+    <ProjectCapability Include="NativeAOTProperties" Condition="'$(ShowNativeAOTProperties)' == 'true'"/>
+  </ItemGroup>
+
+  <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for WPF and WinForms projects -->
+  <PropertyGroup>
+    <ShowNativeAOTProperties Condition="'$(UseWPF)' != 'true'
+                             and '$(UseWindowsForms)' != 'true'
+                             and '$(ShowNativeAOTProperties)' == ''
+                             and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                             and $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '8.0'))">true</ShowNativeAOTProperties>
+  </PropertyGroup>
+
   <!-- Reference Manager capabilities -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ProjectCapability Remove="ReferenceManagerAssemblies" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1279,18 +1279,18 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!-- Native AOT compilation -->
-  <ItemGroup>
-    <ProjectCapability Include="NativeAOTProperties" Condition="'$(ShowNativeAOTProperties)' == 'true'"/>
-  </ItemGroup>
-
   <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for WPF and WinForms projects -->
   <PropertyGroup>
-    <ShowNativeAOTProperties Condition="'$(UseWPF)' != 'true'
+    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
+                             and '$(UseWPF)' != 'true'
                              and '$(UseWindowsForms)' != 'true'
-                             and '$(ShowNativeAOTProperties)' == ''
                              and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                              and $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '8.0'))">true</ShowNativeAOTProperties>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(ShowNativeAOTProperties)' == 'true'">
+    <ProjectCapability Include="NativeAOTProperties"/>
+  </ItemGroup>
 
   <!-- Reference Manager capabilities -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1280,16 +1280,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Native AOT compilation -->
   <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for WPF and WinForms projects -->
-  <PropertyGroup>
-    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
-                             and '$(UseWPF)' != 'true'
-                             and '$(UseWindowsForms)' != 'true'
-                             and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                             and $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '8.0'))">true</ShowNativeAOTProperties>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(ShowNativeAOTProperties)' == 'true'">
-    <ProjectCapability Include="NativeAOTProperties"/>
+  <ItemGroup Condition="'$(UseWPF)' != 'true'
+             and '$(UseWindowsForms)' != 'true'
+             and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+             and $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '8.0'))">
+    <ProjectCapability Include="NativeAOT"/>
   </ItemGroup>
 
   <!-- Reference Manager capabilities -->

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -20,7 +20,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ServerGarbageCollection Condition="'$(ServerGarbageCollection)' == ''">true</ServerGarbageCollection>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == '' and '$(IsPackable)' == 'false'">true</WarnOnPackingNonPackableProject>
-    <ShowNativeAOTProperties>false</ShowNativeAOTProperties>
   </PropertyGroup>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props"

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -20,6 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ServerGarbageCollection Condition="'$(ServerGarbageCollection)' == ''">true</ServerGarbageCollection>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == '' and '$(IsPackable)' == 'false'">true</WarnOnPackingNonPackableProject>
+    <ShowNativeAOTProperties>false</ShowNativeAOTProperties>
   </PropertyGroup>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props"


### PR DESCRIPTION
The `NativeAOT` capability is being used in project system to control the visibility of the Native AOT properties introduced recently to .NET 8. The idea is that, in general, we want to set this capability to true so that we show these properties for projects targeting .NET 8 or higher. 

The exceptions at the moment would be class libraries, WPF and WinForms projects, which are filtered using the property condition. Other project types, like MAUI and Web projects, can disable this capability by removing the `ProjectCapability` in their props file: `<ProjectCapability Remove="NativeAOT"/>`. 

This PR was created in lieu of https://github.com/dotnet/sdk/pull/34485 to be considered for the release branch 8.0.1xx.

Fixes [AB#1831643](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1831643)