### PR TITLE
Containers: reuse HTTP connections more.

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobOperations.cs
@@ -31,7 +31,7 @@ internal class DefaultBlobOperations : IBlobOperations
     public async Task<bool> ExistsAsync(string repositoryName, string digest, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        HttpResponseMessage response = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Head, new Uri(_baseUri, $"/v2/{repositoryName}/blobs/{digest}")), cancellationToken).ConfigureAwait(false);
+        using HttpResponseMessage response = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Head, new Uri(_baseUri, $"/v2/{repositoryName}/blobs/{digest}")), cancellationToken).ConfigureAwait(false);
         return response.StatusCode switch
         {
             HttpStatusCode.OK => true,

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobUploadOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobUploadOperations.cs
@@ -108,7 +108,7 @@ internal class DefaultBlobUploadOperations : IBlobUploadOperations
         _logger.LogTrace("Uploading {0} bytes of content at {1}", content.Headers.ContentLength, uploadUri);
 
         HttpRequestMessage patchMessage = GetPatchHttpRequest(uploadUri, content);
-        HttpResponseMessage patchResponse = await _client.SendAsync(patchMessage, cancellationToken).ConfigureAwait(false);
+        using HttpResponseMessage patchResponse = await _client.SendAsync(patchMessage, cancellationToken).ConfigureAwait(false);
 
         _logger.LogTrace("Received status code '{0}' from upload.", patchResponse.StatusCode);
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
@@ -30,10 +30,7 @@ internal class DefaultRegistryAPI : IRegistryAPI
 
     private static HttpClient CreateClient(string registryName, Uri baseUri, ILogger logger, bool isAmazonECRRegistry = false)
     {
-        var innerHandler = new SocketsHttpHandler()
-        {
-            PooledConnectionLifetime = TimeSpan.FromMilliseconds(10 /* total guess */)
-        };
+        var innerHandler = new SocketsHttpHandler();
 
         // Ignore certificate for https localhost repository.
         if (baseUri.Host == "localhost" && baseUri.Scheme == "https")

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -105,7 +105,7 @@ internal sealed class Registry
     public async Task<ImageBuilder> GetImageManifestAsync(string repositoryName, string reference, string runtimeIdentifier, string runtimeIdentifierGraphPath, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        HttpResponseMessage initialManifestResponse = await _registryAPI.Manifest.GetAsync(repositoryName, reference, cancellationToken).ConfigureAwait(false);
+        using HttpResponseMessage initialManifestResponse = await _registryAPI.Manifest.GetAsync(repositoryName, reference, cancellationToken).ConfigureAwait(false);
 
         return initialManifestResponse.Content.Headers.ContentType?.MediaType switch
         {
@@ -157,7 +157,7 @@ internal sealed class Registry
             throw new BaseImageNotFoundException(runtimeIdentifier, repositoryName, reference, ridManifestDict.Keys);
         }
         PlatformSpecificManifest matchingManifest = ridManifestDict[bestManifestRid];
-        HttpResponseMessage manifestResponse = await _registryAPI.Manifest.GetAsync(repositoryName, matchingManifest.digest, cancellationToken).ConfigureAwait(false);
+        using HttpResponseMessage manifestResponse = await _registryAPI.Manifest.GetAsync(repositoryName, matchingManifest.digest, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
## Description

Closes https://github.com/dotnet/sdk/issues/35753

This removes the artificially-short Pool Lifetime used by the HttpClientHandler that the SDK Container publishing tooling uses to communicate with remote container registries.
This short lifetime was something we put in very early on in the lifetime of the code, and likely was part of a mitigation around our incorrect authentication handling in earlier versions.

## Customer Impact

This short lifetime lead to many connections getting used instead of fewer connections being re-used. Some registries may have configurations that rely on some connection-local state (like sticky sessions) and using more connections that required can impact those flows. In addition, reusing connections improves performance, because negotiating new connections takes non-trivial amounts of time.

## Regression

**No** - we've had this code since our early versions.

## Risk

**Low** - while this does change the configuration of the HttpClientHandler used for all registry communication, testing against our set of supported live registries shows no regression in behaviors, and manual testing confirms this.