### PR TITLE
Pass failure message reported from from getApplyUpdateCapabilities in WASM to dotnet watch

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -101,7 +101,8 @@ setTimeout(async function () {
       applyUpdateCapabilities = window.Blazor._internal.getApplyUpdateCapabilities();
     } catch (error) {
       console.warn(error);
-      applyUpdateCapabilities = sendErrorToClient ? '!' + error.stack : '';
+
+      applyUpdateCapabilities = sendErrorToClient ? (error.stack || error.message || '<unknown error>') : '';
     }
     connection.send(applyUpdateCapabilities);
   }

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -47,7 +47,8 @@ setTimeout(async function () {
         'BlazorHotReloadDeltav1': () => applyBlazorDeltas(payload.sharedSecret, payload.deltas, false),
         'BlazorHotReloadDeltav2': () => applyBlazorDeltas(payload.sharedSecret, payload.deltas, true),
         'HotReloadDiagnosticsv1': () => displayDiagnostics(payload.diagnostics),
-        'BlazorRequestApplyUpdateCapabilities': getBlazorWasmApplyUpdateCapabilities,
+        'BlazorRequestApplyUpdateCapabilities': () => getBlazorWasmApplyUpdateCapabilities(false),
+        'BlazorRequestApplyUpdateCapabilities2': () => getBlazorWasmApplyUpdateCapabilities(true),
         'AspNetCoreHotReloadApplied': () => aspnetCoreHotReloadApplied()
       };
 
@@ -94,13 +95,15 @@ setTimeout(async function () {
       .forEach(e => updateCssElement(e));
   }
 
-  function getBlazorWasmApplyUpdateCapabilities() {
+  function getBlazorWasmApplyUpdateCapabilities(sendErrorToClient) {
     let applyUpdateCapabilities;
     try {
       applyUpdateCapabilities = window.Blazor._internal.getApplyUpdateCapabilities();
     } catch (error) {
       console.warn(error);
-      applyUpdateCapabilities = '!' + error.stack;
+      if (sendErrorToClient) {
+        applyUpdateCapabilities = '!' + error.stack;
+      }
     }
     connection.send(applyUpdateCapabilities);
   }

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -101,9 +101,7 @@ setTimeout(async function () {
       applyUpdateCapabilities = window.Blazor._internal.getApplyUpdateCapabilities();
     } catch (error) {
       console.warn(error);
-      if (sendErrorToClient) {
-        applyUpdateCapabilities = '!' + error.stack;
-      }
+      applyUpdateCapabilities = sendErrorToClient ? '!' + error.stack : '';
     }
     connection.send(applyUpdateCapabilities);
   }

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -106,7 +106,7 @@ setTimeout(async function () {
       let messageAndStack = error.stack || message
       if (!messageAndStack.includes(message))
       {
-         messageAndStack = messageAndStack + "\n" + message;
+         messageAndStack = message + "\n" + messageAndStack;
       }
 
       applyUpdateCapabilities = sendErrorToClient ? "!" + messageAndStack : '';

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -98,8 +98,9 @@ setTimeout(async function () {
     let applyUpdateCapabilities;
     try {
       applyUpdateCapabilities = window.Blazor._internal.getApplyUpdateCapabilities();
-    } catch {
-      applyUpdateCapabilities = '';
+    } catch (error) {
+      console.warn(error);
+      applyUpdateCapabilities = '!' + error.stack;
     }
     connection.send(applyUpdateCapabilities);
   }

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -102,7 +102,14 @@ setTimeout(async function () {
     } catch (error) {
       console.warn(error);
 
-      applyUpdateCapabilities = sendErrorToClient ? (error.stack || error.message || '<unknown error>') : '';
+      const message = error.message || '<unknown error>'
+      let messageAndStack = error.stack || message
+      if (!messageAndStack.includes(message))
+      {
+         messageAndStack = messageAndStack + "\n" + message;
+      }
+
+      applyUpdateCapabilities = sendErrorToClient ? "!" + messageAndStack : '';
     }
     connection.send(applyUpdateCapabilities);
   }

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         private readonly struct BlazorRequestApplyUpdateCapabilities
         {
-            public string Type => "BlazorRequestApplyUpdateCapabilities";
+            public string Type => "BlazorRequestApplyUpdateCapabilities2";
         }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -60,6 +60,13 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                     var capabilities = Encoding.UTF8.GetString(buffer.AsSpan(0, response.Value.Count));
 
+                    // error while fetching capabilities from WASM:
+                    if (capabilities.StartsWith("!"))
+                    {
+                        _reporter.Error($"Exception while reading WASM runtime capabilities: {capabilities[1..]}");
+                        return ImmutableArray<string>.Empty;
+                    }
+
                     // Capabilities are expressed a space-separated string.
                     // e.g. https://github.com/dotnet/runtime/blob/14343bdc281102bf6fffa1ecdd920221d46761bc/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs#L87
                     return capabilities.Split(' ').ToImmutableArray();


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

Updates browser script handler that implements Hot Reload to report errors that might occur when detecting runtime capabilities back to the `dotnet watch` tool instead of swallowing them.

## Customer Impact

Makes it easier for the customer to diagnose and report issues such as https://github.com/dotnet/aspnetcore/issues/50765.
Without this change dotnet watch does not apply changes to the WASM client when an error occurs in the client without indicating a reason.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Added a new version of the RPC message (keeping the previous one unchanged) that reports the capabilities to minimize risk.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
