### PR TITLE
Declare dependencies for two Extensions.Logging packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,8 +34,8 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftNETCoreAppRefPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingPackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftNETCoreAppRefPackageVersion)"/>
     <PackageVersion Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -386,6 +386,16 @@
       <SourceBuild RepoName="symreader" ManagedOnly="true" />
     </Dependency>
     <!-- Dependency required for flowing correct package version in source-build, using PVP flow. -->
+    <Dependency Name="Microsoft.Extensions.Logging" Version="8.0.0-rtm.23476.15">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>0933e300f0c0647a15a0433f1a3b07bcab9882f4</Sha>
+    </Dependency>
+    <!-- Dependency required for flowing correct package version in source-build, using PVP flow. -->
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rtm.23476.15">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>0933e300f0c0647a15a0433f1a3b07bcab9882f4</Sha>
+    </Dependency>
+    <!-- Dependency required for flowing correct package version in source-build, using PVP flow. -->
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="8.0.0-rtm.23476.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>0933e300f0c0647a15a0433f1a3b07bcab9882f4</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,11 +58,11 @@
     <MicrosoftNETHostModelVersion>8.0.0-rtm.23476.15</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>8.0.0-rtm.23476.15</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
+    <MicrosoftExtensionsLoggingVersion>8.0.0-rtm.23476.15</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.0-rtm.23476.15</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>8.0.0-rtm.23476.15</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftNETILLinkTasksPackageVersion>8.0.0-rtm.23476.15</MicrosoftNETILLinkTasksPackageVersion>
     <SystemServiceProcessServiceControllerVersion>8.0.0-rtm.23476.15</SystemServiceProcessServiceControllerVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>$(MicrosoftExtensionsLoggingConsoleVersion)</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>$(MicrosoftExtensionsLoggingConsoleVersion)</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->


### PR DESCRIPTION
There can be circumstances for source-build where the referenced version of the runtime by the sdk is a different version than is actually built. This can happen when the same commit has multiple versions associated with it.

This can cause the build of the sdk in the VMR to get an error similar to the following:

```
   /vmr/src/sdk/artifacts/source-build/self/src/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj : error NU1102: Unable to find package Microsoft.Extensions.Logging with version (>= 8.0.0-rc.2.23476.7) [/vmr/src/sdk/artifacts/source-build/self/src/source-build.slnf]
    /vmr/src/sdk/artifacts/source-build/self/src/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj : error NU1102:   - Found 4 version(s) in previously-source-built [ Nearest version: 8.0.0-rc.1.23419.4 ] [/vmr/src/sdk/artifacts/source-build/self/src/source-build.slnf]
    /vmr/src/sdk/artifacts/source-build/self/src/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj : error NU1102:   - Found 3 version(s) in reference-packages [ Nearest version: 7.0.0 ] [/vmr/src/sdk/artifacts/source-build/self/src/source-build.slnf]
    /vmr/src/sdk/artifacts/source-build/self/src/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj : error NU1102:   - Found 1 version(s) in source-built [ Nearest version: 8.0.0-rc.2.23475.17 ] [/vmr/src/sdk/artifacts/source-build/self/src/source-build.slnf]
```

This is because there is no declared dependency for `Microsoft.Extensions.Logging` and `Microsoft.Extensions.Logging.Abstractions`. Version.props defines those versions to be derived from the version of `Microsoft.Extensions.Logging.Console`. But those properties get defined before source-build's override of `MicrosoftExtensionsLoggingConsoleVersion`.

To fix this, I've declared those two packages as explicit dependencies and updated the associated properties to have the actual version values instead of deriving it. Also removed the `Package` portion of the property name which is not needed and keeps things consistent with the existing `MicrosoftExtensionsLoggingConsoleVersion` property.