### PR TITLE
ComputeDotnetBaseImageTag: handle rtm and servicing channels.

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageTag.cs
@@ -85,37 +85,25 @@ public sealed class ComputeDotnetBaseImageTag : Microsoft.Build.Utilities.Task
     }
 
      private string? DetermineLabelBasedOnChannel(int major, int minor, string[] releaseLabels) {
-      // this would be a switch, but we have to support net47x where Range and Index aren't available
-        if (releaseLabels.Length == 0)
+        var channel = releaseLabels.Length > 0 ? releaseLabels[0] : null;
+        switch (channel)
         {
-            return $"{major}.{minor}";
-        }
-        else
-        {
-            var channel = releaseLabels[0];
-            if (channel == "rc" || channel == "preview")
-            {
+            case null or "rtm" or "servicing":
+                return $"{major}.{minor}";
+            case "rc" or "preview":
                 if (releaseLabels.Length > 1)
                 {
                     // Per the dotnet-docker team, the major.minor preview tag format is a fluke and the major.minor.0 form
                     // should be used for all previews going forward.
                     return $"{major}.{minor}.0-{channel}.{releaseLabels[1]}";
                 }
-                else
-                {
-                    Log.LogError(Resources.Strings.InvalidSdkPrereleaseVersion, channel);
-                    return null;
-                }
-            }
-            else if (channel == "alpha" || channel == "dev" || channel == "ci")
-            {
-                return $"{major}.{minor}-preview";
-            }
-            else
-            {
                 Log.LogError(Resources.Strings.InvalidSdkPrereleaseVersion, channel);
                 return null;
-            }
-        }
+            case "alpha" or "dev" or "ci":
+                return $"{major}.{minor}-preview";
+            default:
+                Log.LogError(Resources.Strings.InvalidSdkPrereleaseVersion, channel);
+                return null;
+        };
      }
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -164,6 +164,8 @@ public class TargetsTests
     [InlineData("6.0.100-preview.1", "v6.0", "6.0")]
     [InlineData("8.0.100-dev", "v8.0", "8.0-preview")]
     [InlineData("8.0.100-ci", "v8.0", "8.0-preview")]
+    [InlineData("8.0.100-rtm.23502.3", "v8.0", "8.0")]
+    [InlineData("8.0.100-servicing.23502.3", "v8.0", "8.0")]
     [InlineData("8.0.100-alpha.12345", "v8.0", "8.0-preview")]
     [InlineData("9.0.100-alpha.12345", "v9.0", "9.0-preview")]
     [Theory]


### PR DESCRIPTION
## Description

The SDK Version is used as part of computing what the proper tag for the MS Dotnet Docker images (dotnet/runtime-deps, dotnet/runtime, dotnet/aspnet) should be used for a given project. The SDK version is SemVer format, but has special meaning for the first 'prerelease segment', but our original algorithm didn't take into account the meaning of two stages of SDK versioning:

* `rtm`
* `servicing`

that aren't readily visible to external users.  This PR updates our tag calculates to recognize the special segments and treat them as stable versions for purposes of detecting the tag.

## Customer Impact

Users that test or create containers using rtm or servicing-versioned SDK versions would get an error about an unknown SDK version. There is a workaround - the user can eject entirely from 'base image inference' and explicitly set a base image. This defeats a lot of the value of the SDK Container Publish, though.

## Regression

**No** - this gap has been in the base image selection code since it was added, the reason we didn't see this for .NET 7 is because the container publish wasn't integrated into the SDK until 7.0.300 - well after SDK versioning was stablized.

## Risk

**Low** - this is a very simple change that includes automated tests.

Fixes https://github.com/dotnet/sdk/issues/35647