### PR TITLE
Don't add implicit package references when downloads have been disabled.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -808,7 +808,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             // Packs with RID-agnostic build packages that contain MSBuild targets.
-            if (toolPackType is not ToolPackType.Crossgen2)
+            if (toolPackType is not ToolPackType.Crossgen2 && EnableRuntimePackDownload)
             {
                 var buildPackageName = knownPack.ItemSpec;
                 var buildPackage = new TaskItem(buildPackageName);
@@ -821,7 +821,8 @@ namespace Microsoft.NET.Build.Tasks
             // The version comparison doesn't consider prerelease labels, so 8.0.0-foo will be considered equal to 8.0.0 and
             // will not get the extra analyzer package reference.
             if (toolPackType is ToolPackType.ILLink &&
-                new VersionComparer(VersionComparison.Version).Compare(NuGetVersion.Parse(packVersion), new NuGetVersion(8, 0, 0)) < 0)
+                new VersionComparer(VersionComparison.Version).Compare(NuGetVersion.Parse(packVersion), new NuGetVersion(8, 0, 0)) < 0 &&
+                EnableRuntimePackDownload)
             {
                 var analyzerPackage = new TaskItem("Microsoft.NET.ILLink.Analyzers");
                 analyzerPackage.SetMetadata(MetadataKeys.Version, packVersion);


### PR DESCRIPTION
This change ensures that all of the packages that we might bootstrap in dotnet/runtime are not added as downloads (the same treatment every other package resolved here gets).