### PR TITLE
Disable IDE0200 "Lambda expression can be removed" warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -274,6 +274,8 @@ dotnet_diagnostic.IDE0043.severity = warning
 dotnet_diagnostic.IDE0062.severity = warning
 # ConvertTypeOfToNameOf
 dotnet_diagnostic.IDE0082.severity = warning
+# Remove unnecessary lambda expression
+dotnet_diagnostic.IDE0200.severity = none
 # Remove redundant nullable directive
 dotnet_diagnostic.IDE0240.severity = warning
 


### PR DESCRIPTION
## Summary
After a discussion in the [PR for cleaning up IDE0200](https://github.com/dotnet/sdk/pull/35678), the conclusion was to, instead, simply disable the warning. Now, VS will no longer show greyed out bits for lambda simplification.