### PR TITLE
SDK resolver perf: Optimize EnvironmentProvider.SearchPaths

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -33,17 +33,12 @@ namespace Microsoft.DotNet.NativeWrapper
         {
             get
             {
-                if (_searchPaths == null)
-                {
-                    var searchPaths =
-                        _getEnvironmentVariable(Constants.PATH)
-                        .Split(new char[] { Path.PathSeparator }, options: StringSplitOptions.RemoveEmptyEntries)
-                        .Select(p => p.Trim('"'))
-                        .Where(p => p.IndexOfAny(s_invalidPathChars) == -1)
-                        .ToList();
-
-                    _searchPaths = searchPaths;
-                }
+                _searchPaths ??=
+                    _getEnvironmentVariable(Constants.PATH)
+                    .Split(new char[] { Path.PathSeparator }, options: StringSplitOptions.RemoveEmptyEntries)
+                    .Select(p => p.Trim('"'))
+                    .Where(p => p.IndexOfAny(s_invalidPathChars) == -1)
+                    .ToList();
 
                 return _searchPaths;
             }
@@ -53,7 +48,8 @@ namespace Microsoft.DotNet.NativeWrapper
         {
             var commandNameWithExtension = commandName + Constants.ExeSuffix;
             var commandPath = SearchPaths
-                .FirstOrDefault(p => File.Exists(Path.Combine(p, commandNameWithExtension)));
+                .Select(p => Path.Combine(p, commandNameWithExtension))
+                .FirstOrDefault(File.Exists);
 
             return commandPath;
         }


### PR DESCRIPTION
The current code has multiple issues.
- It calls `Path.GetInvalidPathChars()` in a loop, which means unnecessary allocations.
- It uses an inherently quadratic `.Any(c => p.Contains(c)` instead of `IndexOfAny`.
- It caches the paths in `_searchPaths` but still performs some filtering every time `GetCommandPath` is called.

All this costs us 120 ms of CPU when evaluating the OrchardCore solution (~10% of SDK resolution and ~1% of evaluation overall).

![image](https://github.com/dotnet/sdk/assets/12206368/071bcf0b-c2c1-45f2-b67d-6e89693e9acf)

