### PR TITLE
Including RuntimePackAsset in DesignerRuntimeImplementationProjectOutputGroup

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -127,20 +127,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_DesignerShadowCopy Include="@(ReferenceCopyLocalPaths)" />
 
-      <!--
-        For .NET Core, we do not include NuGet package assets,
-        irrespective of self-contained / copy-local settings. Designer
-        will load these from the NuGet cache or shared framework always.
-      -->
+      <!-- For .NET Core, we do not include NuGet package assets, as the designer will load these from the NuGet cache. -->
       <_DesignerShadowCopy
         Remove="@(_ResolvedCopyLocalBuildAssets)"
         Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
         />
 
-      <!-- Include runtimepack assets -->
+      <!-- For .NET Core runtime pack assets, we do not include them regardless of whether the app is
+              self-contained, as they will be loaded from the shared framework.  However, for runtime pack
+              assets where RuntimePackAlwaysCopyLocal is true, there is no shared framework, so we still
+              include those.  -->
       <_DesignerShadowCopy
-        Include="@(RuntimePackAsset->WithMetadataValue('RuntimePackAlwaysCopyLocal', 'true'))"
-        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+        Remove="@(RuntimePackAsset)"
+        Condition="'%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' != 'true'"
         />
 
       <DesignerRuntimeImplementationProjectOutputGroupOutput

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -128,12 +128,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_DesignerShadowCopy Include="@(ReferenceCopyLocalPaths)" />
 
       <!--
-        For .NET Core, we do not include NuGet package assets or runtime pack
-        assets, irrespective of self-contained / copy-local settings. Designer
+        For .NET Core, we do not include NuGet package assets,
+        irrespective of self-contained / copy-local settings. Designer
         will load these from the NuGet cache or shared framework always.
       -->
       <_DesignerShadowCopy
-        Remove="@(_ResolvedCopyLocalBuildAssets);@(RuntimePackAsset)"
+        Remove="@(_ResolvedCopyLocalBuildAssets)"
+        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+        />
+
+      <!-- Include runtimepack assets -->
+      <_DesignerShadowCopy
+        Include="@(RuntimePackAsset)"
         Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
         />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -139,7 +139,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <!-- Include runtimepack assets -->
       <_DesignerShadowCopy
-        Include="@(RuntimePackAsset)"
+        Include="@(RuntimePackAsset->WithMetadataValue('RuntimePackAlwaysCopyLocal', 'true'))"
         Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
         />
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
@@ -20,7 +20,8 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net7.0-windows10.0.17763")]
         public void It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup(string targetFramework)
         {
-            if (targetFramework == "net5.0-windows" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if ((targetFramework == "net5.0-windows" || targetFramework == "net7.0-windows10.0.17763")
+                && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // net5.0-windows is windows only scenario
                 return;

--- a/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
@@ -14,7 +14,6 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData("net46", "true")]
         [InlineData("net46", "false")]
         [InlineData("netcoreapp3.0", "true")]
         [InlineData("netcoreapp3.0", "false")]

--- a/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
@@ -14,11 +14,15 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData("net46")]
-        [InlineData("netcoreapp3.0")]
-        [InlineData("net5.0-windows")]
-        [InlineData("net7.0-windows10.0.17763")]
-        public void It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup(string targetFramework)
+        [InlineData("net46", "true")]
+        [InlineData("net46", "false")]
+        [InlineData("netcoreapp3.0", "true")]
+        [InlineData("netcoreapp3.0", "false")]
+        [InlineData("net5.0-windows", "true")]
+        [InlineData("net5.0-windows", "false")]
+        [InlineData("net7.0-windows10.0.17763", "true")]
+        [InlineData("net7.0-windows10.0.17763", "false")]
+        public void It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup(string targetFramework, string isSelfContained)
         {
             if ((targetFramework == "net5.0-windows" || targetFramework == "net7.0-windows10.0.17763")
                 && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -39,7 +43,8 @@ namespace Microsoft.NET.Build.Tests
                 IsExe = true,
                 TargetFrameworks = targetFramework,
                 PackageReferences = { new TestPackageReference("NewtonSoft.Json", ToolsetInfo.GetNewtonsoftJsonPackageVersion()) },
-                ReferencedProjects = { projectRef }
+                ReferencedProjects = { projectRef },
+                SelfContained = isSelfContained
             };
 
             var asset = _testAssetsManager

--- a/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
@@ -17,6 +17,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net46")]
         [InlineData("netcoreapp3.0")]
         [InlineData("net5.0-windows")]
+        [InlineData("net7.0-windows10.0.17763")]
         public void It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup(string targetFramework)
         {
             if (targetFramework == "net5.0-windows" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -91,6 +92,7 @@ namespace Microsoft.NET.Build.Tests
             {
                 case "netcoreapp3.0":
                 case "net5.0-windows":
+                case "net7.0-windows10.0.17763":
                     var depsFileLibraries = GetRuntimeLibraryFileNames(depsFile);
                     depsFileLibraries.Should().BeEquivalentTo(new[] { "Newtonsoft.Json.dll" });
 
@@ -101,13 +103,21 @@ namespace Microsoft.NET.Build.Tests
                     options["tfm"].Value<string>().Should().Be(targetFramework.Split('-')[0]);
                     options["additionalProbingPaths"].Value<JArray>().Should().NotBeEmpty();
 
-                    otherFiles.Should().BeEquivalentTo(new[] { "ReferencedProject.dll", "ReferencedProject.pdb" });
+                    if (targetFramework == "net7.0-windows10.0.17763")
+                    {
+                        otherFiles.Should().BeEquivalentTo(["ReferencedProject.dll", "ReferencedProject.pdb", "Microsoft.Windows.SDK.NET.dll", "WinRT.Runtime.dll"]);
+                    }
+                    else
+                    {
+                        otherFiles.Should().BeEquivalentTo(["ReferencedProject.dll", "ReferencedProject.pdb"]);
+                    }
+
                     break;
 
                 case "net46":
                     depsFile.Should().BeNull();
                     runtimeConfig.Should().BeNull();
-                    otherFiles.Should().BeEquivalentTo(new[] { "Newtonsoft.Json.dll", "ReferencedProject.dll", "ReferencedProject.pdb" });
+                    otherFiles.Should().BeEquivalentTo(["Newtonsoft.Json.dll", "ReferencedProject.dll", "ReferencedProject.pdb"]);
                     break;
             }
         }


### PR DESCRIPTION
`RuntimePackAsset` paths are not available in SDK and they are required by WinForms .NET designer.