### PR TITLE
Fix concurrent tool restore and version range error

### DIFF
--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -26,6 +26,7 @@ using NuGet.Repositories;
 using NuGet.RuntimeModel;
 using NuGet.Versioning;
 using NuGet.Configuration;
+using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.DotNet.Cli.ToolPackage
 {
@@ -85,8 +86,12 @@ namespace Microsoft.DotNet.Cli.ToolPackage
                     {
                         nugetLogger = new NuGetConsoleLogger();
                     }
-                    var versionString = versionRange?.OriginalString ?? "*";
-                    versionRange = VersionRange.Parse(versionString);
+
+                    if (versionRange == null)
+                    {
+                        var versionString = "*";
+                        versionRange = VersionRange.Parse(versionString);
+                    }
 
                     var toolDownloadDir = isGlobalTool ? _globalToolStageDir : _localToolDownloadDir;
                     var assetFileDirectory = isGlobalTool ? _globalToolStageDir : _localToolAssetDir;

--- a/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
 
             ToolRestoreResult[] toolRestoreResults =
                 packagesFromManifest
-                    .AsParallel()
+                    .AsEnumerable()
                     .Select(package => InstallPackages(package, configFile))
                     .ToArray();
 

--- a/src/Tests/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
@@ -18,14 +18,18 @@ using NuGet.Frameworks;
 using NuGet.Versioning;
 using LocalizableStrings = Microsoft.DotNet.Tools.Tool.Restore.LocalizableStrings;
 using Parser = Microsoft.DotNet.Cli.Parser;
+using Microsoft.DotNet.Cli.ToolPackage;
+using System.Reflection;
+using System.Text.Json;
 
 namespace Microsoft.DotNet.Tests.Commands.Tool
 {
-    public class ToolRestoreCommandTests
+    public class ToolRestoreCommandTests: SdkTest
     {
         private readonly IFileSystem _fileSystem;
         private readonly IToolPackageStore _toolPackageStore;
         private readonly ToolPackageDownloaderMock _toolPackageDownloaderMock;
+        private readonly ToolPackageDownloader _toolPackageDownloader;
         private readonly ParseResult _parseResult;
         private readonly BufferedReporter _reporter;
         private readonly string _temporaryDirectory;
@@ -47,7 +51,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
         private int _installCalledCount = 0;
 
-        public ToolRestoreCommandTests()
+        public ToolRestoreCommandTests(ITestOutputHelper log): base(log)
         {
             _packageVersionA = NuGetVersion.Parse("1.0.4");
             _packageVersionWithCommandNameCollisionWithA = NuGetVersion.Parse("1.0.9");
@@ -61,6 +65,8 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             ToolPackageStoreMock toolPackageStoreMock =
                 new ToolPackageStoreMock(new DirectoryPath(_pathToPlacePackages), _fileSystem);
             _toolPackageStore = toolPackageStoreMock;
+
+            _toolPackageDownloader = new ToolPackageDownloader(toolPackageStoreMock);
 
             _toolPackageDownloaderMock = new ToolPackageDownloaderMock(
                 _toolPackageStore,
@@ -300,6 +306,63 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     l.Contains(
                         string.Format(LocalizableStrings.CommandsMismatch,
                             "\"different-command-nameA\" \"different-command-nameB\"", _packageIdA, "\"a\"")));
+        }
+
+        private class CacheRow
+        {
+            public string Version { get; set; }
+            public string TargetFramework { get; set; }
+            public string RuntimeIdentifier { get; set; }
+            public string Name { get; set; }
+            public string Runner { get; set; }
+            public string PathToExecutable { get; set; }
+        }
+
+        [Fact]
+        public void ItRestoresCorrectToolVersion()
+        {
+            var testDir = _testAssetsManager.CreateTestDirectory().Path;
+
+            string configContents = """
+                {
+                  "version": 1,
+                  "isRoot": true,
+                  "tools": {
+                    "dotnet-ef": {
+                      "version": "8.0.0-rc.1.23419.6",
+                      "commands": [
+                        "dotnet-ef"
+                      ]
+                    }
+                  }
+                }
+                """;
+
+            File.WriteAllText(Path.Combine(testDir, "dotnet-tools.json"), configContents);
+
+            string CliHome = Path.Combine(testDir, ".home");
+            Directory.CreateDirectory(CliHome);
+
+            var toolRestoreCommand = new DotnetCommand(Log, "tool", "restore")
+                .WithEnvironmentVariable("DOTNET_CLI_HOME", CliHome)
+                .WithEnvironmentVariable("DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK", "true")
+                .WithWorkingDirectory(testDir);
+
+            toolRestoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var cacheFilePath = Path.Combine(CliHome, ".dotnet", "toolResolverCache", "1", "dotnet-ef");
+
+            string json = File.ReadAllText(cacheFilePath);
+
+            var rows = JsonSerializer.Deserialize<List<CacheRow>>(json);
+
+            rows.Count.Should().Be(1);
+
+            rows[0].Name.Should().Be("dotnet-ef");
+            rows[0].Version.Should().Be("8.0.0-rc.1.23419.6");
         }
 
         [Fact]


### PR DESCRIPTION

**Customer Impact**

In .NET 8 we made a breaking change that changes the current .NET tool installation mechanism from restore a local temporary project to downloading the .NET tool from NuGet. This change was introduced because this previous mechanism has number of side effects, often show up as flaky restore errors because MSBuild concepts like Directory.Build.props, or other heirarchical notions, pollute the restore. 

The change, however, affect the behavior in tool restore. For one, the change in tool install affect the parallel tool restore as it might read multiple too info into the same config file. For another, the change of getting tool's version tries to read from a property `.originalString` that might not exist. 

The intended way to fix this is to make the parallel tool restore sequential, and to get rid of reading the `.originalString` property. To make the tool restore sequential, instead of using `AsParallel()` in the code, the updated code uses `AsEnumerate()` to reduce the chance of error. For version, this pull request adds a condition to check if the `versionRange` passed in is null and set it to a default value. 
Both changes are validated by tests.

**Testing**
Existing unit tests passed without changes. New tested are added to validate tool restore returns the correct version, and tool restore is able to restore multiple tools. The new testing scenarios pass with changes in the pull request. 

**Risk**
Low. This change resolves some errors caused by breaking change by add conditions to set the `versionRange` and make parallel tool restore sequential, without adding complexity to the behavior. 

Current unit tests passed without changes, and new tests are added to validate the change. Even though making parallel tool restore sequential might reduce the speed of tool restore, this is a validate approach because it reduces the risk of issues from concurrent restoration.

**Original description**
Referred to [Add known issue for .NET tool restore in .NET 8 RC2 ](https://github.com/dotnet/core/pull/8799/commits/86917f474fcadfe909443f29a87e4d3284e7a7f5 )