### PR TITLE
SDK resolver perf: Don't check current process for dotnet.exe on .NET Framework

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -67,10 +67,15 @@ namespace Microsoft.DotNet.NativeWrapper
                 return environmentOverride;
             }
 
-            string dotnetExe = _getCurrentProcessPath();
+            string dotnetExe;
+#if NETCOREAPP
+            // The dotnet executable is loading only the .NET version of this code so there is no point checking
+            // the current process path on .NET Framework. We are expected to find dotnet on PATH.
+            dotnetExe = _getCurrentProcessPath();
 
             if (string.IsNullOrEmpty(dotnetExe) || !Path.GetFileNameWithoutExtension(dotnetExe)
                     .Equals(Constants.DotNet, StringComparison.InvariantCultureIgnoreCase))
+#endif
             {
                 string dotnetExeFromPath = GetCommandPath(Constants.DotNet);
                 
@@ -87,6 +92,13 @@ namespace Microsoft.DotNet.NativeWrapper
                 } else {
                     log?.Invoke($"GetDotnetExeDirectory: dotnet command path not found.  Using current process");
                     log?.Invoke($"GetDotnetExeDirectory: Path variable: {_getEnvironmentVariable(Constants.PATH)}");
+
+#if !NETCOREAPP
+                    // If we failed to find dotnet on PATH, we revert to the old behavior of returning the current process
+                    // path. This is really an error state but we're keeping the contract of always returning a non-empty
+                    // path for backward compatibility.
+                    dotnetExe = _getCurrentProcessPath();
+#endif
                 }
             }
 


### PR DESCRIPTION
When evaluating projects in Visual Studio, more than half of the CPU spent in SDK resolution is in `EnvironmentProvider.GetCurrentProcessPath()`. Making this call in the .NET Framework version of the resolver does not make sense as there is no Framework `dotnet.exe`. This PRs reorders the checks so that `EnvironmentProvider.GetCurrentProcessPath()` does not run except for failure cases, which speeds up evaluation of the OrchardCore solution by ~18%.

The Framework `Process.MainModule` getter is slow. In this trace the total CPU spent in evaluation was 9459 ms.

![image](https://github.com/dotnet/sdk/assets/12206368/8a907dcb-acf2-4e70-ba35-f0eecc44c584)
