### PR TITLE
Update GivenThatWeWantToPublishAFrameworkDependentApp.cs to fix chars…

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
@@ -112,7 +112,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdOutContaining(Strings.FrameworkDependentAppHostRequiresVersion21.Replace("“", "\"").Replace("”", "\""));
+                .HaveStdOutContaining(Strings.FrameworkDependentAppHostRequiresVersion21.Replace("\u0093", "\"").Replace("\u0094", "\""));
         }
     }
 }


### PR DESCRIPTION
…et error.

This pull request addresses Issue #33819 .

When I run `build.cmd` on Windows 11 in Chinese environment, I reproduced the above issue. Then I tried to open the source file in Visual Studio, and there was a popup window which is shown below.

![图片](https://github.com/dotnet/sdk/assets/30565051/21a7b2dd-b016-475a-930a-e16230e233a3)

And I found that there are two special characters in Line 115, which causes the issue. (The special characters are replaced with `?` below.)

```text
.HaveStdOutContaining(Strings.FrameworkDependentAppHostRequiresVersion21.Replace("?", "\"").Replace("?", "\""));
```

Then I opened the binary editor and found the code of the two special characters, one of which is `93` and another is `94`.

![图片](https://github.com/dotnet/sdk/assets/30565051/0cea8901-e90c-4870-b4c0-dc465e7930a1)

I think we had better use unicode escape sequences instead of placing the special characters in souce code. Therefore, I raised this pull request. This pull request just replaces the two special characters with `\u0093` and `\u0094`.