### PR TITLE
Add .gitignore to exclude files generated by test

### DIFF
--- a/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/.gitignore
+++ b/src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/.gitignore
@@ -1,0 +1,1 @@
+*.received.txt

--- a/src/Tests/dotnet-new.Tests/Approvals/.gitignore
+++ b/src/Tests/dotnet-new.Tests/Approvals/.gitignore
@@ -1,0 +1,2 @@
+*.received/**
+*.received.txt


### PR DESCRIPTION
When I run `build.cmd -test` according to [Developer Guide](/dotnet/sdk/tree/main/documentation/project-docs/developer-guide.md), git reports a lot of changes, which makes it hard to identify real changes made by human.

![image](https://github.com/dotnet/sdk/assets/30565051/050720d9-677a-437e-b0e8-acbc3fa18d60)

These files are generated in the following directories:

`src/Tests/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals`
`src/Tests/dotnet-new.Tests/Approvals`

Therefore, I raised this pull request to exclude those auto-generated files.