### PR TITLE
Update APICompat & GenAPI CodeAnalysis versions

### DIFF
--- a/src/ApiCompat/Directory.Build.props
+++ b/src/ApiCompat/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+
+  <Import Project="..\Compatibility\Directory.Build.props" />
+
+</Project>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -2,11 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
-    <Nullable>enable</Nullable>
-    <StrongNameKeyId>Open</StrongNameKeyId>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -49,7 +44,6 @@
     <None Include="**\*.props;**\*.targets" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
     <None Include="..\..\Tasks\Microsoft.NET.Build.Tasks\targets\Microsoft.NET.ApiCompat.Common.targets" Pack="true" Link="build/Microsoft.NET.ApiCompat.Common.targets" PackagePath="build/%(Filename)%(Extension)" />
     <None Include="..\..\Tasks\Microsoft.NET.Build.Tasks\targets\Microsoft.NET.ApiCompat.ValidatePackage.targets" Pack="true" Link="build/Microsoft.NET.ApiCompat.ValidatePackage.targets" PackagePath="build/%(Filename)%(Extension)" />
-    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
   </ItemGroup>
 
   <Target Name="_AddBuildOutputToPackageCore" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
-    <StrongNameKeyId>Open</StrongNameKeyId>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
     <PackAsTool>true</PackAsTool>
@@ -23,10 +20,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <ProjectReference Include="..\Microsoft.DotNet.PackageValidation\Microsoft.DotNet.PackageValidation.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
   </ItemGroup>
 
   <!-- Move code analysis assemblies into a sub directory so that they can be conditionally resolved. -->

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
@@ -2,12 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
     <PackAsTool>true</PackAsTool>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
-    <StrongNameKeyId>Open</StrongNameKeyId>
-    <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- We need to compare ISymbols in a special way (by name) and roslyn symbol comparers take more heuristics into consideration.-->
     <NoWarn>$(NoWarn);RS1024</NoWarn>
   </PropertyGroup>

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
-    <StrongNameKeyId>Open</StrongNameKeyId>
-    <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Directory.Build.props
+++ b/src/Compatibility/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>
+
+  <PropertyGroup>
+    <DirectoryPackagesPropsPath>$(MSBuildThisFileDirectory)Directory.Packages.props</DirectoryPackagesPropsPath>
+  </PropertyGroup>
+
+  <Import Project="..\..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
+  </ItemGroup>
+
+</Project>

--- a/src/Compatibility/Directory.Packages.props
+++ b/src/Compatibility/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <Import Project="..\..\Directory.Packages.props" />
+
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true' and '$(SkipMicrosoftCodeAnalysisCSharpPinning)' != 'true'">
+    <!-- We pin the code analysis version when not in source build as we need to support running on older
+         SDKs when the OOB package is used. -->
+    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/GenAPI/Directory.Build.props
+++ b/src/GenAPI/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <Import Project="..\Compatibility\Directory.Build.props" />
+
+  <PropertyGroup>
+    <SkipMicrosoftCodeAnalysisCSharpPinning>true</SkipMicrosoftCodeAnalysisCSharpPinning>
+  </PropertyGroup>
+
+</Project>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
@@ -2,13 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
-    <StrongNameKeyId>Open</StrongNameKeyId>
-    <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- This package doesn't contain any lib or ref assemblies because it's a tooling package.-->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
@@ -31,46 +27,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- ExcludeAssets="Runtime" is being set to avoid adding package references and dependencies of package and project references into the package. -->
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
-    <ProjectReference Include="..\Microsoft.DotNet.GenAPI\Microsoft.DotNet.GenAPI.csproj" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-    <!-- We carry NuGet as part of the package in case the package is used with an older SDKs or with full framework MSBuild. -->
-    <PackageReference Include="NuGet.Frameworks" />
-    <PackageReference Include="NuGet.Packaging" />
-    <PackageReference Include="NuGet.Protocol" />
+    <ProjectReference Include="..\Microsoft.DotNet.GenAPI\Microsoft.DotNet.GenAPI.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="**\*.props;**\*.targets" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
-    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!--
-      Update all PackageReference and ProjectReference Items to have
-      PrivateAssets="All" and default Publish to true.
-      This removes the dependency nodes from the generated nuspec and
-      forces the publish output to contain the dlls.
-     -->
-    <PackageReference Update="@(PackageReference)">
-      <PrivateAssets>All</PrivateAssets>
-      <Publish Condition="'%(PackageReference.Publish)' == ''">true</Publish>
-      <ExcludeAssets Condition="'%(PackageReference.Publish)' == 'false'">runtime</ExcludeAssets>
-    </PackageReference>
-    <ProjectReference Update="@(ProjectReference)">
-      <PrivateAssets>All</PrivateAssets>
-      <Publish Condition="'%(ProjectReference.Publish)' == ''">true</Publish>
-    </ProjectReference>
-
-    <!--
-      Update all Reference items to have Pack="false"
-      This removes the frameworkDependency nodes from the generated nuspec
-    -->
-    <Reference Update="@(Reference)">
-      <Pack>false</Pack>
-    </Reference>
   </ItemGroup>
 
   <Target Name="_AddBuildOutputToPackageCore" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Microsoft.DotNet.GenAPI.Tool.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Tool/Microsoft.DotNet.GenAPI.Tool.csproj
@@ -2,12 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
-    <StrongNameKeyId>Open</StrongNameKeyId>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>genapi</ToolCommandName>
@@ -17,10 +12,6 @@
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
     <ProjectReference Include="..\Microsoft.DotNet.GenAPI\Microsoft.DotNet.GenAPI.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
   </ItemGroup>
 
 </Project>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
@@ -2,10 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
-    <Nullable>enable</Nullable>
-    <StrongNameKeyId>Open</StrongNameKeyId>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Directory.Build.props
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+
+  <Import Project="..\Compatibility\Directory.Build.props" />
+
+</Project>

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
-    <Nullable>enable</Nullable>
-    <StrongNameKeyId>Open</StrongNameKeyId>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- Exclude files that depend on Microsoft.Build.Framework and Microsoft.Build.Utilities.Core. These will be included by users of this package. -->
@@ -14,12 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" ExcludeAssets="Runtime" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <!-- We pin the code analysis version when not in source build as we need to support running on older
-    SDKs when the OOB package is used. -->
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
@@ -3,10 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MicrosoftCodeAnalysisMinimumVersion>4.0.1</MicrosoftCodeAnalysisMinimumVersion>
   </PropertyGroup>
 
   <!-- Exclude files that depend on Microsoft.Build.Framework and Microsoft.Build.Utilities.Core. These will be included by users of this package. -->
@@ -21,7 +19,7 @@
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <!-- We pin the code analysis version when not in source build as we need to support running on older
     SDKs when the OOB package is used. -->
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(MicrosoftCodeAnalysisMinimumVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,4 +29,5 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/35468

According to https://learn.microsoft.com/en-us/visualstudio/productinfo/vs-servicing and https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022, 4.4.0 is the minimum supported version at the time the 9.0 packages ship.

This needs to be backported into release/8.0.1xx as well as the CPM change already affected those.