### PR TITLE
[release/8.0.1xx] Fix CodeAnalysis version used by APICompat assemblies

### DIFF
--- a/src/ApiCompat/Directory.Build.props
+++ b/src/ApiCompat/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <DirectoryPackagesPropsPath>$(MSBuildThisFileDirectory)Directory.Packages.props</DirectoryPackagesPropsPath>
+  </PropertyGroup>
+
+  <Import Project="..\..\Directory.Build.props" />
+
+</Project>

--- a/src/ApiCompat/Directory.Packages.props
+++ b/src/ApiCompat/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <Import Project="..\..\Directory.Packages.props" />
+
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+    <!-- We pin the code analysis version when not in source build as we need to support running on older
+         SDKs when the OOB package is used. -->
+    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
@@ -9,6 +9,7 @@
 
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- This package doesn't contain any lib or ref assemblies because it's a tooling package.-->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
@@ -31,46 +32,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- ExcludeAssets="Runtime" is being set to avoid adding package references and dependencies of package and project references into the package. -->
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
-    <ProjectReference Include="..\Microsoft.DotNet.GenAPI\Microsoft.DotNet.GenAPI.csproj" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-    <!-- We carry NuGet as part of the package in case the package is used with an older SDKs or with full framework MSBuild. -->
-    <PackageReference Include="NuGet.Frameworks" />
-    <PackageReference Include="NuGet.Packaging" />
-    <PackageReference Include="NuGet.Protocol" />
+    <ProjectReference Include="..\Microsoft.DotNet.GenAPI\Microsoft.DotNet.GenAPI.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="**\*.props;**\*.targets" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
     <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!--
-      Update all PackageReference and ProjectReference Items to have
-      PrivateAssets="All" and default Publish to true.
-      This removes the dependency nodes from the generated nuspec and
-      forces the publish output to contain the dlls.
-     -->
-    <PackageReference Update="@(PackageReference)">
-      <PrivateAssets>All</PrivateAssets>
-      <Publish Condition="'%(PackageReference.Publish)' == ''">true</Publish>
-      <ExcludeAssets Condition="'%(PackageReference.Publish)' == 'false'">runtime</ExcludeAssets>
-    </PackageReference>
-    <ProjectReference Update="@(ProjectReference)">
-      <PrivateAssets>All</PrivateAssets>
-      <Publish Condition="'%(ProjectReference.Publish)' == ''">true</Publish>
-    </ProjectReference>
-
-    <!--
-      Update all Reference items to have Pack="false"
-      This removes the frameworkDependency nodes from the generated nuspec
-    -->
-    <Reference Update="@(Reference)">
-      <Pack>false</Pack>
-    </Reference>
   </ItemGroup>
 
   <Target Name="_AddBuildOutputToPackageCore" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Directory.Build.props
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+
+  <!-- Re-use APICompat's build props file which defines the correct CodeAnalysis version. -->
+  <Import Project="..\ApiCompat\Directory.Build.props" />
+
+</Project>

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net8.0;net472</TargetFrameworks>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <MicrosoftCodeAnalysisMinimumVersion>4.0.1</MicrosoftCodeAnalysisMinimumVersion>
   </PropertyGroup>
 
   <!-- Exclude files that depend on Microsoft.Build.Framework and Microsoft.Build.Utilities.Core. These will be included by users of this package. -->
@@ -16,12 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" ExcludeAssets="Runtime" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <!-- We pin the code analysis version when not in source build as we need to support running on older
-    SDKs when the OOB package is used. -->
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(MicrosoftCodeAnalysisMinimumVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/sdk/commit/1952283a0e08ea44046088c70ff699afeb5dba11
Manual (simplified) backport of https://github.com/dotnet/sdk/commit/f3143488131043ba6788f72044b7b28bbcc462dd

### Description

The Microsoft.CodeAnalysis version used by
- Microsoft.DotNet.ApiCompatibility and
- Microsoft.DotNet.ApiCompat.Task

was determined by the CPM's transitive pinning feature (4.8.0) instead of the version that is governed by Microsoft.DotNet.ApiSymbolExtensions (4.0.1).

Because of that, the "Microsoft.DotNet.ApiCompat.Task" package wasn't working anymore on .NET 6 and .NET 7 SDKs.

### Customer Impact

Customers can again use the Microsoft.DotNet.ApiCompat.Task nuget package on a .NET 6 or .NET 7 SDK.

### Testing
Manually tested by building the packages and observing the assembly references in the assemblies.

### Risk
Low. The change is isolated and the assembly references are now correct.