### PR TITLE
Enable users to install unlisted version of tool if specify the exact match of the version of the tool

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/INuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/INuGetPackageDownloader.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             NuGetVersion packageVersion = null,
             PackageSourceLocation packageSourceLocation = null,
             bool includePreview = false,
+            bool includeUnlisted = false,
             DirectoryPath? downloadFolder = null,
             PackageSourceMapping packageSourceMapping = null);
 

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -527,9 +527,9 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             VersionRange versionRange,
              PackageSourceLocation packageSourceLocation = null)
         {
-            if(!string.IsNullOrEmpty(versionRange.OriginalString))
+            if(versionRange.MinVersion != null && versionRange.MaxVersion != null && versionRange.MinVersion == versionRange.MaxVersion)
             {
-                return NuGetVersion.Parse(versionRange.OriginalString);
+                return NuGetVersion.Parse(versionRange.MinVersion.ToString());
             }
 
             CancellationToken cancellationToken = CancellationToken.None;

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -529,7 +529,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
         {
             if(versionRange.MinVersion != null && versionRange.MaxVersion != null && versionRange.MinVersion == versionRange.MaxVersion)
             {
-                return NuGetVersion.Parse(versionRange.MinVersion.ToString());
+                return versionRange.MinVersion;
             }
 
             CancellationToken cancellationToken = CancellationToken.None;

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -79,13 +79,14 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             NuGetVersion packageVersion = null,
             PackageSourceLocation packageSourceLocation = null,
             bool includePreview = false,
+            bool includeUnlisted = false,
             DirectoryPath? downloadFolder = null,
             PackageSourceMapping packageSourceMapping = null)
         {
             CancellationToken cancellationToken = CancellationToken.None;
 
             (var source, var resolvedPackageVersion) = await GetPackageSourceAndVersion(packageId, packageVersion,
-                packageSourceLocation, includePreview, packageSourceMapping).ConfigureAwait(false);
+                packageSourceLocation, includePreview, includeUnlisted, packageSourceMapping).ConfigureAwait(false);
 
             FindPackageByIdResource resource = null;
             SourceRepository repository = GetSourceRepository(source);
@@ -220,6 +221,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
              NuGetVersion packageVersion = null,
              PackageSourceLocation packageSourceLocation = null,
              bool includePreview = false,
+             bool includeUnlisted = false,
              PackageSourceMapping packageSourceMapping = null)
         {
             CancellationToken cancellationToken = CancellationToken.None;
@@ -239,7 +241,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                 packageVersion = new NuGetVersion(packageVersion);
                 (source, packageMetadata) =
                     await GetPackageMetadataAsync(packageId.ToString(), packageVersion, packagesSources,
-                        cancellationToken).ConfigureAwait(false);
+                        cancellationToken, includeUnlisted).ConfigureAwait(false);
             }
 
             packageVersion = packageMetadata.Identity.Version;
@@ -421,14 +423,14 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             {
                 foundPackagesBySource = packageSources.Select(source => GetPackageMetadataAsync(source,
                     packageIdentifier,
-                    true, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult()).ToArray();
+                    true, false, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult()).ToArray();
             }
             else
             {
                 foundPackagesBySource =
                     await Task.WhenAll(
                             packageSources.Select(source => GetPackageMetadataAsync(source, packageIdentifier,
-                                true, cancellationToken)))
+                                true, false, cancellationToken)))
                         .ConfigureAwait(false);
             }
 
@@ -475,14 +477,14 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             {
                 foundPackagesBySource = packageSources.Select(source => GetPackageMetadataAsync(source,
                     packageIdentifier,
-                    true, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult()).ToArray();
+                    true, false, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult()).ToArray();
             }
             else
             {
                 foundPackagesBySource =
                     await Task.WhenAll(
                             packageSources.Select(source => GetPackageMetadataAsync(source, packageIdentifier,
-                                true, cancellationToken)))
+                                true, false, cancellationToken)))
                         .ConfigureAwait(false);
             }
 
@@ -525,6 +527,11 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             VersionRange versionRange,
              PackageSourceLocation packageSourceLocation = null)
         {
+            if(!string.IsNullOrEmpty(versionRange.OriginalString))
+            {
+                return NuGetVersion.Parse(versionRange.OriginalString);
+            }
+
             CancellationToken cancellationToken = CancellationToken.None;
             IPackageSearchMetadata packageMetadata;
 
@@ -539,7 +546,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
         }
 
         private async Task<(PackageSource, IPackageSearchMetadata)> GetPackageMetadataAsync(string packageIdentifier,
-            NuGetVersion packageVersion, IEnumerable<PackageSource> sources, CancellationToken cancellationToken)
+            NuGetVersion packageVersion, IEnumerable<PackageSource> sources, CancellationToken cancellationToken, bool includeUnlisted = false)
         {
             if (string.IsNullOrWhiteSpace(packageIdentifier))
             {
@@ -555,7 +562,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                 CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             List<Task<(PackageSource source, IEnumerable<IPackageSearchMetadata> foundPackages)>> tasks = sources
                 .Select(source =>
-                    GetPackageMetadataAsync(source, packageIdentifier, true, linkedCts.Token)).ToList();
+                    GetPackageMetadataAsync(source, packageIdentifier, true, includeUnlisted, linkedCts.Token)).ToList();
 
             bool TryGetPackageMetadata(
                 (PackageSource source, IEnumerable<IPackageSearchMetadata> foundPackages) sourceAndFoundPackages,
@@ -621,7 +628,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
         }
 
         private async Task<(PackageSource source, IEnumerable<IPackageSearchMetadata> foundPackages)>
-            GetPackageMetadataAsync(PackageSource source, string packageIdentifier, bool includePrerelease = false,
+            GetPackageMetadataAsync(PackageSource source, string packageIdentifier, bool includePrerelease = false, bool includeUnlisted = false,
                 CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(packageIdentifier))
@@ -643,7 +650,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                 foundPackages = await resource.GetMetadataAsync(
                     packageIdentifier,
                     includePrerelease,
-                    false,
+                    includeUnlisted,
                     _cacheSettings,
                     _verboseLogger,
                     cancellationToken).ConfigureAwait(false);

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -93,6 +93,12 @@ namespace Microsoft.DotNet.Cli.ToolPackage
                     var nugetPackageDownloader = new NuGetPackageDownloader.NuGetPackageDownloader(toolDownloadDir, verboseLogger: nugetLogger, isNuGetTool: true);
 
                     var packageSourceLocation = new PackageSourceLocation(packageLocation.NugetConfig, packageLocation.RootConfigDirectory, null, packageLocation.AdditionalFeeds);
+
+                    bool givenSpecificVersion = false;
+                    if (!string.IsNullOrEmpty(versionRange.OriginalString))
+                    {
+                        givenSpecificVersion = true;
+                    }
                     NuGetVersion packageVersion = nugetPackageDownloader.GetBestPackageVersionAsync(packageId, versionRange, packageSourceLocation).GetAwaiter().GetResult();
 
                     rollbackDirectory = isGlobalTool ? toolDownloadDir.Value: Path.Combine(toolDownloadDir.Value, packageId.ToString(), packageVersion.ToString());
@@ -116,7 +122,7 @@ namespace Microsoft.DotNet.Cli.ToolPackage
 
                     if (package == null)
                     {
-                        DownloadAndExtractPackage(packageLocation, packageId, nugetPackageDownloader, toolDownloadDir.Value, _toolPackageStore, packageVersion, packageSourceLocation).GetAwaiter().GetResult();
+                        DownloadAndExtractPackage(packageLocation, packageId, nugetPackageDownloader, toolDownloadDir.Value, _toolPackageStore, packageVersion, packageSourceLocation, givenSpecificVersion).GetAwaiter().GetResult();
                     }
                     else if(isGlobalTool)
                     {
@@ -236,10 +242,11 @@ namespace Microsoft.DotNet.Cli.ToolPackage
             string packagesRootPath,
             IToolPackageStore toolPackageStore,
             NuGetVersion packageVersion,
-            PackageSourceLocation packageSourceLocation
+            PackageSourceLocation packageSourceLocation,
+            bool includeUnlisted = false
             )
         {
-            var packagePath = await nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation).ConfigureAwait(false);
+            var packagePath = await nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation, includeUnlisted: includeUnlisted).ConfigureAwait(false);
 
             // look for package on disk and read the version
             NuGetVersion version;

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.Cli.ToolPackage
                     var packageSourceLocation = new PackageSourceLocation(packageLocation.NugetConfig, packageLocation.RootConfigDirectory, null, packageLocation.AdditionalFeeds);
 
                     bool givenSpecificVersion = false;
-                    if (!string.IsNullOrEmpty(versionRange.OriginalString))
+                    if (versionRange.MinVersion != null && versionRange.MaxVersion != null && versionRange.MinVersion == versionRange.MaxVersion)
                     {
                         givenSpecificVersion = true;
                     }
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Cli.ToolPackage
 
                     if (package == null)
                     {
-                        DownloadAndExtractPackage(packageLocation, packageId, nugetPackageDownloader, toolDownloadDir.Value, _toolPackageStore, packageVersion, packageSourceLocation, givenSpecificVersion).GetAwaiter().GetResult();
+                        DownloadAndExtractPackage(packageLocation, packageId, nugetPackageDownloader, toolDownloadDir.Value, _toolPackageStore, packageVersion, packageSourceLocation, includeUnlisted: givenSpecificVersion).GetAwaiter().GetResult();
                     }
                     else if(isGlobalTool)
                     {

--- a/src/Tests/dotnet-workload-install.Tests/FailingNuGetPackageInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/FailingNuGetPackageInstaller.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
         public Task<string> DownloadPackageAsync(PackageId packageId, NuGetVersion packageVersion,
             PackageSourceLocation packageSourceLocation = null,
             bool includePreview = false,
+            bool includeUnlisted = false,
             DirectoryPath? downloadFolder = null,
             PackageSourceMapping packageSourceMapping = null)
         {

--- a/src/Tests/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             NuGetVersion packageVersion = null,
             PackageSourceLocation packageSourceLocation = null,
             bool includePreview = false,
+            bool includeUnlisted = false,
             DirectoryPath? downloadFolder = null,
             PackageSourceMapping packageSourceMapping = null)
         {

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -352,11 +352,11 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     PackageVersion).Green());
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/sdk/pull/36021")]
         public void WhenRunWithValidUnlistedVersionRangeItShouldSucceed()
         {
             const string nugetSourcePath = "https://api.nuget.org/v3/index.json";
-            ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {UnlistedPackageId} --version 0.5.0 --add-source {nugetSourcePath}");
+            ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {UnlistedPackageId} --version [0.5.0] --add-source {nugetSourcePath}");
 
             var toolInstallGlobalOrToolPathCommand = new ToolInstallGlobalOrToolPathCommand(
                 result,

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -352,11 +352,10 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     PackageVersion).Green());
         }
 
-        // [Fact(Skip = "https://github.com/dotnet/sdk/pull/36021")]
         [Fact]
         public void WhenRunWithValidUnlistedVersionRangeItShouldSucceed()
         {
-            /*const string nugetSourcePath = "https://api.nuget.org/v3/index.json";
+            const string nugetSourcePath = "https://api.nuget.org/v3/index.json";
             var testDir = _testAssetsManager.CreateTestDirectory().Path;
 
             var toolInstallGlobalOrToolPathCommand = new DotnetCommand(Log, "tool", "install", "-g", UnlistedPackageId, "--version", "[0.5.0]", "--add-source", nugetSourcePath)
@@ -367,8 +366,12 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             // Uninstall the unlisted package
             var toolUninstallCommand = new DotnetCommand(Log, "tool", "uninstall", "-g", UnlistedPackageId);
-            toolUninstallCommand.Execute().Should().Pass();*/
+            toolUninstallCommand.Execute().Should().Pass();
+        }
 
+        [Fact]
+        public void WhenRunWithoutValidVersionUnlistedToolItShouldThrow()
+        {
             const string nugetSourcePath = "https://api.nuget.org/v3/index.json";
             var testDir = _testAssetsManager.CreateTestDirectory().Path;
 
@@ -377,28 +380,6 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 .WithWorkingDirectory(testDir);
 
             toolInstallGlobalOrToolPathCommand.Execute().Should().Fail();
-        }
-
-        [Fact]
-        public void WhenRunWithoutValidVersionUnlistedToolItShouldThrow()
-        {
-            const string nugetSourcePath = "https://api.nuget.org/v3/index.json";
-            ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {UnlistedPackageId} --add-source {nugetSourcePath}");
-
-            var toolInstallGlobalOrToolPathCommand = new ToolInstallGlobalOrToolPathCommand(
-                result,
-                _createToolPackageStoresAndDownloader,
-                _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
-                _reporter);
-
-            Action action = () => toolInstallGlobalOrToolPathCommand.Execute();
-
-            action
-                .Should().Throw<GracefulException>()
-                .And.Message.Should().Contain(
-                    LocalizableStrings.ToolInstallationRestoreFailed +
-                    Environment.NewLine + string.Format(LocalizableStrings.ToolInstallationFailedWithRestoreGuidance, UnlistedPackageId));
         }
 
         [Fact]

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         private const string PackageId = "global.tool.console.demo";
         private const string PackageVersion = "1.0.4";
         private const string ToolCommandName = "SimulatorCommand";
+        private readonly string UnlistedPackageId = "Elemental.SysInfoTool";
 
         public ToolInstallGlobalOrToolPathCommandTests()
         {
@@ -331,6 +332,31 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         public void WhenRunWithValidVersionRangeItShouldSucceed()
         {
             ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {PackageId} --version [1.0,2.0]");
+
+            var toolInstallGlobalOrToolPathCommand = new ToolInstallGlobalOrToolPathCommand(
+                result,
+                _createToolPackageStoresAndDownloader,
+                _createShellShimRepository,
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
+                _reporter);
+
+            toolInstallGlobalOrToolPathCommand.Execute().Should().Be(0);
+
+            _reporter
+                .Lines
+                .Should()
+                .Equal(string.Format(
+                    LocalizableStrings.InstallationSucceeded,
+                    ToolCommandName,
+                    PackageId,
+                    PackageVersion).Green());
+        }
+
+        [Fact]
+        public void WhenRunWithValidUnlistedVersionRangeItShouldSucceed()
+        {
+            const string nugetSourcePath = "https://api.nuget.org/v3/index.json";
+            ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {UnlistedPackageId} --version 0.5.0 --add-source {nugetSourcePath}");
 
             var toolInstallGlobalOrToolPathCommand = new ToolInstallGlobalOrToolPathCommand(
                 result,


### PR DESCRIPTION
**Customer Impact**

In .NET 8 we made a breaking change that changes the current .NET tool installation mechanism from restore a local temporary project to downloading the .NET tool from NuGet. This change was introduced because this previous mechanism has number of side effects, often show up as flaky restore errors because MSBuild concepts like Directory.Build.props, or other heirarchical notions, pollute the restore. 

The change, however, disable users from installing unlisted tools. Previously, users were able to install unlisted tools per fix in #28951. However, since the mechanism of tool installation are changed, the unlisted tools' downloading are disabled by default. For users, installing unlisted tools are a useful method because it provides clarity and simplicity for those who write tools independently or do not share the tools to the public. 

The intended way to fix this is to provide a feature to allow users to install the unlisted version but only if the user specify the exact match, i.e. `[version]`. (referred to [NuGet package version reference](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning)). To add this feature, an unlisted parameter is passed to the NuGet API if a exact version is detected. Changes are validated by tests.

**Testing**
Existing unit tests passed without changes. New tested are added to validate an unlisted tool can be installed with exact version match, and failed to be installed without the version match. The new testing scenarios pass with changes in the pull request. 

**Risk**
Low. This change adds a feature that was missed from breaking change without adding complexity to the behavior. 

**Original description**
Referred to [some deprecated global tools get NuGetPackageNotFoundException when installing](https://github.com/dotnet/sdk/issues/35566)