### PR TITLE
Add escape hatch for publishing with SelfContained=true, but no RuntimeIdentifier.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -209,7 +209,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
 
     <!-- The following RID errors are asserts, and we don't expect them to ever occur. The error message is added as a safeguard.-->
-    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
+    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(AllowSelfContainedWithoutRuntimeIdentifier)' != 'true'"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="SelfContained"/>
 


### PR DESCRIPTION
This is identical to issue #33414 (allow PublishAot=true without RuntimeIdentifier), except for the SelfContained property instead of the PublishAot property.

This adds an escape hatch for a sanity check when trying to publish with SelfContained=true, but without a RuntimeIdentifier, because the check is not valid when building universal apps for macOS and Mac Catalyst (the netX-macos and netX-maccatalyst target frameworks).

When building such an app, the project file will set RuntimeIdentifiers (plural):

    <TargetFramework>net8.0-macos</TargetFramework>
    <RuntimeIdentifiers>osx-x64;osx-arm</RuntimeIdentifiers>

and then during the build, the macOS SDK will run two inner builds, with RuntimeIdentifiers unset, and RuntimeIdentifier set to each of the rids (and at the end merge the result into a single app).

The problem is that the outer build, where RuntimeIdentifiers is set, but RuntimeIdentifier isn't, triggers the sanity check if the developer sets SelfContained=true, and that fails the build.

Note that SelfContained defaults to true if PublishTrimmed=true, which means that just setting PublishTrimmed=true also triggers the sanity check.

Ref: https://github.com/xamarin/xamarin-macios/issues/19142