### PR TITLE
Fix xunit failures in NuGetPackageInstallerTests.cs

### DIFF
--- a/src/Tests/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         }
 
         [Fact]
-        public void GivenNoPackageSourceMappingItShouldError()
+        public async Task GivenNoPackageSourceMappingItShouldError()
         {
             string getTestLocalFeedPath = GetTestLocalFeedPath();
             string relativePath = Path.GetRelativePath(Environment.CurrentDirectory, getTestLocalFeedPath);
@@ -179,16 +179,16 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             var patterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(dictionary);
             var mockPackageSourceMapping = new PackageSourceMapping(patterns);
 
-            Action a = () => _toolInstaller.DownloadPackageAsync(
+            Func<Task> a = () => _toolInstaller.DownloadPackageAsync(
                 TestPackageId,
                 new NuGetVersion(TestPackageVersion),
                 new PackageSourceLocation(sourceFeedOverrides: new[] { relativePath }),
-                packageSourceMapping: mockPackageSourceMapping).GetAwaiter().GetResult();
-            a.Should().Throw<NuGetPackageInstallerException>().And.Message.Should().Contain(string.Format(Cli.NuGetPackageDownloader.LocalizableStrings.FailedToFindSourceUnderPackageSourceMapping, TestPackageId));
+                packageSourceMapping: mockPackageSourceMapping);
+            (await a.Should().ThrowAsync<NuGetPackageInstallerException>()).And.Message.Should().Contain(string.Format(Cli.NuGetPackageDownloader.LocalizableStrings.FailedToFindSourceUnderPackageSourceMapping, TestPackageId));
         }
 
         [Fact]
-        public void GivenPackageSourceMappingFeedNotFoundItShouldError()
+        public async Task GivenPackageSourceMappingFeedNotFoundItShouldError()
         {
             string getTestLocalFeedPath = GetTestLocalFeedPath();
             string relativePath = Path.GetRelativePath(Environment.CurrentDirectory, getTestLocalFeedPath);
@@ -200,12 +200,12 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             var patterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(dictionary);
             var mockPackageSourceMapping = new PackageSourceMapping(patterns);
 
-            Action a = () => _toolInstaller.DownloadPackageAsync(
+            Func<Task> a = () => _toolInstaller.DownloadPackageAsync(
                 TestPackageId,
                 new NuGetVersion(TestPackageVersion),
                 new PackageSourceLocation(sourceFeedOverrides: new[] { relativePath }),
-                packageSourceMapping: mockPackageSourceMapping).GetAwaiter().GetResult();
-            a.Should().Throw<NuGetPackageInstallerException>().And.Message.Should().Contain(string.Format(Cli.NuGetPackageDownloader.LocalizableStrings.FailedToMapSourceUnderPackageSourceMapping, TestPackageId));
+                packageSourceMapping: mockPackageSourceMapping);
+            (await a.Should().ThrowAsync<NuGetPackageInstallerException>()).And.Message.Should().Contain(string.Format(Cli.NuGetPackageDownloader.LocalizableStrings.FailedToMapSourceUnderPackageSourceMapping, TestPackageId));
         }
 
         [Fact]


### PR DESCRIPTION
Moved the test fixes out from https://github.com/dotnet/sdk/pull/36041 to unblock the failing CI.