### PR TITLE
Reduce test timeout to speed up timeouts.

### DIFF
--- a/src/Tests/UnitTests.proj
+++ b/src/Tests/UnitTests.proj
@@ -8,7 +8,7 @@
 
     <EnableAzurePipelinesReporter Condition="'$(BUILD_BUILDNUMBER)' != ''">true</EnableAzurePipelinesReporter>
 
-    <XUnitWorkItemTimeout>2:00:00</XUnitWorkItemTimeout>
+    <XUnitWorkItemTimeout>45:00</XUnitWorkItemTimeout>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/UnitTests.proj
+++ b/src/Tests/UnitTests.proj
@@ -8,7 +8,7 @@
 
     <EnableAzurePipelinesReporter Condition="'$(BUILD_BUILDNUMBER)' != ''">true</EnableAzurePipelinesReporter>
 
-    <XUnitWorkItemTimeout>45:00</XUnitWorkItemTimeout>
+    <XUnitWorkItemTimeout>00:45:00</XUnitWorkItemTimeout>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This will affect ~.2% of test work items

From some queries, in the past 30d we ran 1031819 test work items in Helix. Of those, 1695 took longer than 45 minutes. Most of those were 45-60 minutes but it is probably almost as fast to timeout and retry than to let it keep going in many of those cases.