### PR TITLE
[wasm] Move PublishTrimmed=true from pack to SDK

### DIFF
--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/VanillaWasmTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/VanillaWasmTests.cs
@@ -27,17 +27,6 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json")).Should().Exist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.webassembly.js")).Should().NotExist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "dotnet.native.wasm")).Should().Exist();
-
-            new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "System.Xml.XPath.wasm")).Should().Exist();
-
-            var publish = new PublishCommand(testInstance);
-            publish.Execute()
-                .Should()
-                .Pass();
-                
-            var publishOutputDirectory = Path.Combine(testInstance.Path, "bin", "Release", targetFramework);
-
-            new FileInfo(Path.Combine(publishOutputDirectory, "wwwroot", "_framework", "System.Xml.XPath.wasm")).Should().NotExist();
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/VanillaWasmTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/VanillaWasmTests.cs
@@ -27,6 +27,17 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json")).Should().Exist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.webassembly.js")).Should().NotExist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "dotnet.native.wasm")).Should().Exist();
+
+            new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "System.Xml.XPath.wasm")).Should().Exist();
+
+            var publish = new PublishCommand(testInstance);
+            publish.Execute()
+                .Should()
+                .Pass();
+                
+            var publishOutputDirectory = Path.Combine(testInstance.Path, "bin", "Release", targetFramework);
+
+            new FileInfo(Path.Combine(publishOutputDirectory, "wwwroot", "_framework", "System.Xml.XPath.wasm")).Should().NotExist();
         }
     }
 }

--- a/src/WasmSdk/Sdk/Sdk.props
+++ b/src/WasmSdk/Sdk/Sdk.props
@@ -18,6 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UseMonoRuntime>true</UseMonoRuntime>
     
     <SelfContained>true</SelfContained>
+    <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">true</PublishTrimmed>
 
     <_WasmSdkImportsMicrosoftNETSdkPublish Condition="'$(UsingMicrosoftNETSdkPublish)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkPublish>
     <_WasmSdkImportsMicrosoftNETSdkStaticWebAssets Condition="'$(UsingMicrosoftNETSdkStaticWebAssets)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkStaticWebAssets>


### PR DESCRIPTION
- PublishTrimmed must be set early enough so that `ProcessFrameworkReferences` knows it should include a reference to package `Microsoft.NET.ILLink.Tasks`
- Runtime PR is https://github.com/dotnet/runtime/pull/93456
- It needs to be backported to .NET 8.0

Fixes https://github.com/dotnet/runtime/issues/93400