### PR TITLE
Skip workload integrity check on Linux and non-sudo

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -166,9 +166,12 @@ namespace Microsoft.DotNet.Cli
                     bool telemetryOptout = environmentProvider.GetEnvironmentVariableAsBool(EnvironmentVariableNames.TELEMETRY_OPTOUT, defaultValue: CompileOptions.TelemetryOptOutDefault);
                     bool addGlobalToolsToPath = environmentProvider.GetEnvironmentVariableAsBool(EnvironmentVariableNames.DOTNET_ADD_GLOBAL_TOOLS_TO_PATH, defaultValue: true);
                     bool nologo = environmentProvider.GetEnvironmentVariableAsBool(EnvironmentVariableNames.DOTNET_NOLOGO, defaultValue: false);
-                    bool skipWorkloadIntegrityCheck = environmentProvider.GetEnvironmentVariableAsBool(EnvironmentVariableNames.DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK,
-                        // Default the workload integrity check skip to true if the command is being ran in CI. Otherwise, false.
-                        defaultValue: new CIEnvironmentDetectorForTelemetry().IsCIEnvironment());
+
+                    // Default the workload integrity check skip to true if the command is being ran in CI,
+                    // or the command is on Linux and not running as sudo since sudo is required for updating the workload manifests.
+                    bool skipWicDefault = new CIEnvironmentDetectorForTelemetry().IsCIEnvironment() ||
+                        (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !SudoEnvironmentDirectoryOverride.IsRunningUnderSudo());
+                    bool skipWorkloadIntegrityCheck = environmentProvider.GetEnvironmentVariableAsBool(EnvironmentVariableNames.DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK, defaultValue: skipWicDefault);
 
                     ReportDotnetHomeUsage(environmentProvider);
 

--- a/src/Cli/dotnet/SudoEnvironmentDirectoryOverride.cs
+++ b/src/Cli/dotnet/SudoEnvironmentDirectoryOverride.cs
@@ -14,18 +14,9 @@ namespace Microsoft.DotNet.Cli
     public static class SudoEnvironmentDirectoryOverride
     {
         /// <summary>
-        /// Not for security use. Detect if command is running under sudo
-        /// via if SUDO_UID being set.
+        /// Not for security use. Detect if command is running under sudo via if SUDO_UID being set.
         /// </summary>
-        public static bool IsRunningUnderSudo()
-        {
-            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SUDO_UID")))
-            {
-                return true;
-            }
-
-            return false;
-        }
+        public static bool IsRunningUnderSudo() => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SUDO_UID"));
 
         public static void OverrideEnvironmentVariableToTmp(ParseResult parseResult)
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/35128

## Summary
For Linux, it seems that `sudo` is required to update workload manifests. Therefore, the workload integrity check will fail if the first-run command is not `sudo` on Linux. I've added a condition when setting the default `skipWorkloadIntegrityCheck` to account for this scenario so the check will be skipped appropriately. Also, minor cleanup in the `IsRunningUnderSudo` method (for simplification purposes).