### PR TITLE
Also exempt RuntimeIdentifiers Fixes #35575

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -54,7 +54,8 @@ Copyright (c) .NET Foundation. All rights reserved.
    -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and
                             '$(HasRuntimeOutput)' == 'true' and
-                            $([MSBuild]::IsOSPlatform(`Windows`))and
+                            $([MSBuild]::IsOSPlatform(`Windows`)) and
+                            '$(RuntimeIdentifiers)' == '' and
                             '$(RuntimeIdentifier)' == ''">
     <_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(PlatformTarget)' == 'x64'">win7-x64</RuntimeIdentifier>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -55,11 +55,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and
                             '$(HasRuntimeOutput)' == 'true' and
                             $([MSBuild]::IsOSPlatform(`Windows`)) and
-                            '$(RuntimeIdentifiers)' == '' and
                             '$(RuntimeIdentifier)' == ''">
     <_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(PlatformTarget)' == 'x64'">win7-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(PlatformTarget)' == 'x86' or '$(PlatformTarget)' == ''">win7-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(PlatformTarget)' == 'x64' and $([MSBuild]::AreFeaturesEnabled('17.10'))">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="('$(PlatformTarget)' == 'x86' or '$(PlatformTarget)' == '') and $([MSBuild]::AreFeaturesEnabled('17.10'))">win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <!-- Breaking change in .NET 8: Some publish properties used to imply SelfContained or require it at the time of this PR to work. We decided to infer SelfContained still in these situations. -->


### PR DESCRIPTION
Fixes #35575

A project should not specify both RuntimeIdentifiers and RuntimeIdentifier. This check should include that acknowledgement even if RuntimeIdentifiers is barely supported.
 
I tried making a simple console app with some of the properties ladipro described, and I could confirm that though there were many places that used the rids I passed in and many other places that used the rids I passed in plus a "default" rid, there were also a few places (even with a very simple app!) that used just the rid it incorrectly inferred.