### PR TITLE
Fix pending reboot check

### DIFF
--- a/src/Cli/dotnet/Installer/Windows/WindowsUtils.cs
+++ b/src/Cli/dotnet/Installer/Windows/WindowsUtils.cs
@@ -64,8 +64,10 @@ namespace Microsoft.DotNet.Installer.Windows
             using RegistryKey sessionKey = localMachineKey?.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\Session Manager");
 
             string[] pendingFileRenameOperations = (string[])sessionKey?.GetValue("PendingFileRenameOperations") ?? new string[0];
+            // Destination files for pending renames start with !\??\, whereas the source does not have the leading "!".
+            bool hasPendingFileRenames = pendingFileRenameOperations.Any(s => !string.IsNullOrWhiteSpace(s) && s.StartsWith(@"!\??\"));
 
-            return (auKey != null || cbsKey != null || pendingFileRenameOperations.Length > 0);
+            return (auKey != null || cbsKey != null || hasPendingFileRenames);
         }
     }
 }


### PR DESCRIPTION
## Description

Previously, the SDK checked for the existence of pending file rename operations. However, we should be checking for any remaining destination files that have not been renamed. Destination files start with a special prefix `!\??\` which differs from the source name that starts with `\??\`

Fixes #28993