### PR TITLE
[release/8.0.1xx] Define a default set of hot reload capabilities for Blazor WebAssembly

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -100,8 +100,6 @@ setTimeout(async function () {
     try {
       applyUpdateCapabilities = window.Blazor._internal.getApplyUpdateCapabilities();
     } catch (error) {
-      console.warn(error);
-
       const message = error.message || '<unknown error>'
       let messageAndStack = error.stack || message
       if (!messageAndStack.includes(message))

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -13,8 +13,13 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     internal sealed class BlazorWebAssemblyDeltaApplier : SingleProcessDeltaApplier
     {
+        private const string DefaultCapabilities60 = "Baseline";
+        private const string DefaultCapabilities70 = "Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes";
+        private const string DefaultCapabilities80 = "Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes AddInstanceFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod UpdateParameters GenericAddFieldToExistingType";
+
         private static Task<ImmutableArray<string>>? s_cachedCapabilties;
         private readonly IReporter _reporter;
+        private Version? _targetFrameworkVersion;
         private int _sequenceId;
 
         public BlazorWebAssemblyDeltaApplier(IReporter reporter)
@@ -30,6 +35,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             // Configure the app for EnC
             context.ProcessSpec.EnvironmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
+
+            _targetFrameworkVersion = context.FileSet?.Project?.TargetFrameworkVersion;
         }
 
         public override Task<ImmutableArray<string>> GetApplyUpdateCapabilitiesAsync(DotNetWatchContext context, CancellationToken cancellationToken)
@@ -59,12 +66,24 @@ namespace Microsoft.DotNet.Watcher.Tools
                     }
 
                     var capabilities = Encoding.UTF8.GetString(buffer.AsSpan(0, response.Value.Count));
+                    var shouldFallBackToDefaultCapabilities = false;
 
                     // error while fetching capabilities from WASM:
                     if (capabilities.StartsWith("!"))
                     {
-                        _reporter.Error($"Exception while reading WASM runtime capabilities: {capabilities[1..]}");
-                        return ImmutableArray<string>.Empty;
+                        _reporter.Warn($"Exception while reading WASM runtime capabilities: {capabilities[1..]}");
+                        shouldFallBackToDefaultCapabilities = true;
+                    }
+                    else if (capabilities.Length == 0)
+                    {
+                        _reporter.Warn($"Unable to read WASM runtime capabilities");
+                        shouldFallBackToDefaultCapabilities = true;
+                    }
+
+                    if (shouldFallBackToDefaultCapabilities)
+                    {
+                        capabilities = GetDefaultCapabilities(_targetFrameworkVersion);
+                        _reporter.Verbose($"Falling back to default WASM capabilities: '{capabilities}'");
                     }
 
                     // Capabilities are expressed a space-separated string.
@@ -76,6 +95,15 @@ namespace Microsoft.DotNet.Watcher.Tools
                     ArrayPool<byte>.Shared.Return(buffer);
                 }
             }
+
+            static string GetDefaultCapabilities(Version? targetFrameworkVersion)
+                => targetFrameworkVersion?.Major switch
+                {
+                    >= 8 => DefaultCapabilities80,
+                    >= 7 => DefaultCapabilities70,
+                    >= 6 => DefaultCapabilities60,
+                    _ => string.Empty,
+                };
         }
 
         public override async Task<ApplyStatus> Apply(DotNetWatchContext context, ImmutableArray<WatchHotReloadService.Update> updates, CancellationToken cancellationToken)

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -71,12 +71,12 @@ namespace Microsoft.DotNet.Watcher.Tools
                     // error while fetching capabilities from WASM:
                     if (capabilities.StartsWith("!"))
                     {
-                        _reporter.Warn($"Exception while reading WASM runtime capabilities: {capabilities[1..]}");
+                        _reporter.Verbose($"Exception while reading WASM runtime capabilities: {capabilities[1..]}");
                         shouldFallBackToDefaultCapabilities = true;
                     }
                     else if (capabilities.Length == 0)
                     {
-                        _reporter.Warn($"Unable to read WASM runtime capabilities");
+                        _reporter.Verbose($"Unable to read WASM runtime capabilities");
                         shouldFallBackToDefaultCapabilities = true;
                     }
 


### PR DESCRIPTION
## [release/8.0.1xx] Define a default set of hot reload capabilities for Blazor WebAssembly

Fixes an issue preventing `dotnet watch` from working when a Blazor Web app is configured to use WebAssembly interactivity.

## Description

If a `dotnet watch` hot reload session attempts to initialize and read WebAssembly hot reload capabilities before the WebAssembly .NET runtime starts, hot reload breaks for the entirety of the session. This bug is almost inevitable in Blazor Web scenarios, since Blazor WebAssembly initialization gets deferred until the first interactive WebAssembly component appears on the page.

This PR addresses the issue by defining a set of default WASM hot reload capabilities to use if the WebAssembly runtime is not available by the time the hot reload session initializes.

Fixes https://github.com/dotnet/aspnetcore/issues/50765

## Customer Impact

Most customers developing a "Full stack Blazor"-style app with WebAssembly interactivity enabled will have a completely broken hot reload experience without this fix.

## Regression?

- [ ] Yes
- [X] No

This bug only appears in "Full stack Blazor" apps, which are new in .NET 8.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix is fairly straightforward and is isolated to the development experience (app functionality is not affected).

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A