### PR TITLE
Replace explicit richCodeNavigationEnvironment in .vsts-ci-richnav.yml

### DIFF
--- a/.vsts-ci-richnav.yml
+++ b/.vsts-ci-richnav.yml
@@ -23,7 +23,6 @@ stages:
         name: Windows_NT_FullFramework
         enableRichCodeNavigation: true
         richCodeNavigationLanguage: 'csharp'
-        richCodeNavigationEnvironment: 'production'
         pool:
             name: $(DncEngPublicBuildPool)
             demands: ImageOverride -equals windows.vs2019.amd64.open   


### PR DESCRIPTION
This is managed by the arcade defaults, we should be using the "internal" environment as requested by the RichNav team.