### PR TITLE
[release/8.0.1xx] [wasm] Move PublishTrimmed=true from pack to SDK

### DIFF
--- a/src/WasmSdk/Sdk/Sdk.props
+++ b/src/WasmSdk/Sdk/Sdk.props
@@ -20,6 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UseMonoRuntime>true</UseMonoRuntime>
     
     <SelfContained>true</SelfContained>
+    <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">true</PublishTrimmed>
 
     <_WasmSdkImportsMicrosoftNETSdkPublish Condition="'$(UsingMicrosoftNETSdkPublish)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkPublish>
     <_WasmSdkImportsMicrosoftNETSdkStaticWebAssets Condition="'$(UsingMicrosoftNETSdkStaticWebAssets)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkStaticWebAssets>


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/36094

### Customer Impact

Fix trimming of WebAssembly apps created from wasmbrowser template. Without the change apps are incorrectly not trimmed by default.

 
### Testing

Manually


### Risk

Low