### PR TITLE
Fix: Validate attribute type defines when excluded

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
@@ -27,17 +27,11 @@ namespace Microsoft.DotNet.ApiCompat
             _compatibilityLogger = new Lazy<ISuppressibleLog>(() => logFactory(SuppressionEngine));
             _apiCompatRunner = new Lazy<IApiCompatRunner>(() =>
             {
-                CompositeSymbolFilter compositeSymbolFilter = new CompositeSymbolFilter()
-                    .Add(new AccessibilitySymbolFilter(respectInternals));
-
-                if (excludeAttributesFiles != null)
-                {
-                    compositeSymbolFilter.Add(new DocIdSymbolFilter(excludeAttributesFiles));
-                }
-
                 SymbolEqualityComparer symbolEqualityComparer = new();
-                ApiComparerSettings apiComparerSettings = new(compositeSymbolFilter,
+                ApiComparerSettings apiComparerSettings = new(
+                    new AccessibilitySymbolFilter(respectInternals),
                     symbolEqualityComparer,
+                    excludeAttributesFiles != null ? new DocIdSymbolFilter(excludeAttributesFiles) : null,
                     new AttributeDataEqualityComparer(symbolEqualityComparer,
                         new TypedConstantEqualityComparer(symbolEqualityComparer)),
                     respectInternals);

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparerSettings.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparerSettings.cs
@@ -21,6 +21,9 @@ namespace Microsoft.DotNet.ApiCompatibility
         public IEqualityComparer<ISymbol> SymbolEqualityComparer { get; set; }
 
         /// <inheritdoc />
+        public ISymbolFilter? AttributeDataSymbolFilter { get; set; }
+
+        /// <inheritdoc />
         public IEqualityComparer<AttributeData> AttributeDataEqualityComparer { get; set; }
 
         /// <inheritdoc />
@@ -34,6 +37,7 @@ namespace Microsoft.DotNet.ApiCompatibility
 
         public ApiComparerSettings(ISymbolFilter? symbolFilter = null,
             IEqualityComparer<ISymbol>? symbolEqualityComparer = null,
+            ISymbolFilter? attributeDataSymbolFilter = null,
             IEqualityComparer<AttributeData>? attributeDataEqualityComparer = null,
             bool includeInternalSymbols = false,
             bool strictMode = false,
@@ -41,6 +45,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         {
             SymbolFilter = symbolFilter ?? new AccessibilitySymbolFilter(includeInternalSymbols);
             SymbolEqualityComparer = symbolEqualityComparer ?? new Comparing.SymbolEqualityComparer();
+            AttributeDataSymbolFilter = attributeDataSymbolFilter;
             AttributeDataEqualityComparer = attributeDataEqualityComparer ?? new AttributeDataEqualityComparer(SymbolEqualityComparer, new TypedConstantEqualityComparer(SymbolEqualityComparer));
             IncludeInternalSymbols = includeInternalSymbols;
             StrictMode = strictMode;

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparerSettings.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparerSettings.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         public IEqualityComparer<ISymbol> SymbolEqualityComparer { get; set; }
 
         /// <inheritdoc />
-        public ISymbolFilter? AttributeDataSymbolFilter { get; set; }
+        public ISymbolFilter AttributeDataSymbolFilter { get; set; }
 
         /// <inheritdoc />
         public IEqualityComparer<AttributeData> AttributeDataEqualityComparer { get; set; }
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         {
             SymbolFilter = symbolFilter ?? new AccessibilitySymbolFilter(includeInternalSymbols);
             SymbolEqualityComparer = symbolEqualityComparer ?? new Comparing.SymbolEqualityComparer();
-            AttributeDataSymbolFilter = attributeDataSymbolFilter;
+            AttributeDataSymbolFilter = attributeDataSymbolFilter ?? new CompositeSymbolFilter();
             AttributeDataEqualityComparer = attributeDataEqualityComparer ?? new AttributeDataEqualityComparer(SymbolEqualityComparer, new TypedConstantEqualityComparer(SymbolEqualityComparer));
             IncludeInternalSymbols = includeInternalSymbols;
             StrictMode = strictMode;

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -75,15 +75,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             IList<CompatDifference> differences)
         {
             // Filter out attributes that should be excluded based on the settings.
-            if (_settings.AttributeDataSymbolFilter is not null)
-            {
-                left = left.Where(attributeData => attributeData.AttributeClass is not null && _settings.AttributeDataSymbolFilter.Include(attributeData.AttributeClass)).ToImmutableArray();
-                right = right.Where(attributeData => attributeData.AttributeClass is not null && _settings.AttributeDataSymbolFilter.Include(attributeData.AttributeClass)).ToImmutableArray();
-            }
-
-            // See discussion in https://github.com/dotnet/sdk/pull/27774. ApiCompat intentionally considers non excluded attribute arguments.
-            left = left.ExcludeNonVisibleOutsideOfAssembly(_settings.SymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);
-            right = right.ExcludeNonVisibleOutsideOfAssembly(_settings.SymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);
+            // ApiCompat intentionally considers non excluded attribute arguments. See discussion in https://github.com/dotnet/sdk/pull/27774.
+            left = left.ExcludeNonVisibleOutsideOfAssembly(_settings.AttributeDataSymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);
+            right = right.ExcludeNonVisibleOutsideOfAssembly(_settings.AttributeDataSymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);
 
             // No attributes, nothing to do. Exit early.
             if (left.Length == 0 && right.Length == 0)

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -74,6 +74,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             ImmutableArray<AttributeData> right,
             IList<CompatDifference> differences)
         {
+            // Filter out attributes that should be excluded based on the settings.
+            if (_settings.AttributeDataSymbolFilter is not null)
+            {
+                left = left.Where(attributeData => attributeData.AttributeClass is not null && _settings.AttributeDataSymbolFilter.Include(attributeData.AttributeClass)).ToImmutableArray();
+                right = right.Where(attributeData => attributeData.AttributeClass is not null && _settings.AttributeDataSymbolFilter.Include(attributeData.AttributeClass)).ToImmutableArray();
+            }
+
             // See discussion in https://github.com/dotnet/sdk/pull/27774. ApiCompat intentionally considers non excluded attribute arguments.
             left = left.ExcludeNonVisibleOutsideOfAssembly(_settings.SymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);
             right = right.ExcludeNonVisibleOutsideOfAssembly(_settings.SymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
@@ -22,6 +22,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         IEqualityComparer<ISymbol> SymbolEqualityComparer { get; }
 
         /// <summary>
+        /// The attribute data symbol filter.
+        /// </summary>
+        ISymbolFilter? AttributeDataSymbolFilter { get; }
+
+        /// <summary>
         /// The attribute data equality comparer.
         /// </summary>
         IEqualityComparer<AttributeData> AttributeDataEqualityComparer { get; }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         /// <summary>
         /// The attribute data symbol filter.
         /// </summary>
-        ISymbolFilter? AttributeDataSymbolFilter { get; }
+        ISymbolFilter AttributeDataSymbolFilter { get; }
 
         /// <summary>
         /// The attribute data equality comparer.

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         IEqualityComparer<ISymbol> SymbolEqualityComparer { get; }
 
         /// <summary>
-        /// The attribute data symbol filter.
+        /// The attribute data symbol filter. This filter is responsible for all filtering of the application of attributes, including visibility.
         /// </summary>
         ISymbolFilter AttributeDataSymbolFilter { get; }
 

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -26,8 +26,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
          * - Member
          */
 
-        private static ISymbolFilter GetAccessibilityAndAttributeSymbolFiltersAsComposite(params string[] excludeAttributeFiles) =>
-            new CompositeSymbolFilter().Add(new AccessibilitySymbolFilter(false)).Add(new DocIdSymbolFilter(excludeAttributeFiles));
+        private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
 
         public static TheoryData<string, string, CompatDifference[]> TypesCases => new()
         {
@@ -1327,11 +1326,10 @@ new CompatDifference[] {
             using TempDirectory root = new();
             string filePath = Path.Combine(root.DirPath, "exclusions.txt");
             File.Create(filePath).Dispose();
-            TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
-            differ.Settings.SymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = new DocIdSymbolFilter(new string[] { filePath });
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1345,11 +1343,10 @@ new CompatDifference[] {
             using TempDirectory root = new();
             string filePath = Path.Combine(root.DirPath, "exclusions.txt");
             File.Create(filePath).Dispose();
-            TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: true));
-            differ.Settings.SymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = new DocIdSymbolFilter(new string[] { filePath });
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1362,7 +1359,6 @@ new CompatDifference[] {
             using TempDirectory root = new();
             string filePath = Path.Combine(root.DirPath, "exclusions.txt");
             File.WriteAllText(filePath, "T:System.SerializableAttribute");
-            TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
             string leftSyntax = @"
 namespace CompatTests
 {
@@ -1399,11 +1395,66 @@ namespace CompatTests
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
-            differ.Settings.SymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = new DocIdSymbolFilter(new string[] { filePath });
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
             Assert.Empty(actual);
+        }
+
+        [Fact]
+        public void AttributesExcludedButMembersValidated()
+        {
+            using TempDirectory root = new();
+            string filePath = Path.Combine(root.DirPath, "exclusions.txt");
+            File.WriteAllText(filePath, "T:CompatTests.FooAttribute");
+            TestRuleFactory ruleFactory = new(
+                (settings, context) => new AttributesMustMatch(settings, context),
+                (settings, context) => new MembersMustExist(settings, context));
+            string leftSyntax = @"
+namespace CompatTests
+{
+  using System;
+  
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+
+  [Foo(""S"", A = true, B = 3)]
+  public class First {}
+}
+";
+            string rightSyntax = @"
+namespace CompatTests
+{
+  using System;
+  
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+    public string X;
+  }
+
+  [Foo(""T"", A = false, B = 4)]
+  public class First {}
+}
+";
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new(ruleFactory, new ApiComparerSettings(strictMode: true));
+            differ.Settings.AttributeDataSymbolFilter = new DocIdSymbolFilter(new string[] { filePath });
+
+            IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right).ToArray();
+
+            Assert.Equal(new[]
+            {
+                CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.FooAttribute.X"),
+            }, actual);
         }
     }
 }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -28,6 +28,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
 
+        private static ISymbolFilter GetAccessibilityAndAttributeSymbolFiltersAsComposite(params string[] excludeAttributeFiles) =>
+            new CompositeSymbolFilter().Add(new AccessibilitySymbolFilter(false)).Add(new DocIdSymbolFilter(excludeAttributeFiles));
+
         public static TheoryData<string, string, CompatDifference[]> TypesCases => new()
         {
             // No change to type's attributes
@@ -1329,7 +1332,7 @@ new CompatDifference[] {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
-            differ.Settings.AttributeDataSymbolFilter = new DocIdSymbolFilter(new string[] { filePath });
+            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1346,7 +1349,7 @@ new CompatDifference[] {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: true));
-            differ.Settings.AttributeDataSymbolFilter = new DocIdSymbolFilter(new string[] { filePath });
+            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1395,7 +1398,7 @@ namespace CompatTests
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
-            differ.Settings.AttributeDataSymbolFilter = new DocIdSymbolFilter(new string[] { filePath });
+            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1447,7 +1450,7 @@ namespace CompatTests
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(ruleFactory, new ApiComparerSettings(strictMode: true));
-            differ.Settings.AttributeDataSymbolFilter = new DocIdSymbolFilter(new string[] { filePath });
+            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right).ToArray();
 


### PR DESCRIPTION
Fixes half of https://github.com/dotnet/sdk/issues/33388
Regressed as part of .NET 8 Preview 2: https://github.com/dotnet/sdk/commit/137a4ac17a10b10b661e956fc1e56e280c4fd5c8

When attributes are configured to be excluded from APICompat compatibility validation, the attribute definitions themselves were also incorrectly excluded, not just their usage on members.

This fixes that by storing the attribute exclusion filter in a separate field in the rule settings.

Added a test that excercises that behavior.