### PR TITLE
Fix: Emit attribute type defines when excluded

### DIFF
--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -277,7 +277,7 @@ namespace Microsoft.DotNet.GenAPI
 
         private SyntaxNode GenerateForwardedTypeAssemblyAttributes(IAssemblySymbol assembly, SyntaxNode compilationUnit)
         {
-            foreach (INamedTypeSymbol symbol in assembly.GetForwardedTypes().Where(_attributeDataSymbolFilter.Include))
+            foreach (INamedTypeSymbol symbol in assembly.GetForwardedTypes().Where(_symbolFilter.Include))
             {
                 if (symbol.TypeKind != TypeKind.Error)
                 {

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -258,7 +258,7 @@ namespace Microsoft.DotNet.GenAPI
                     SyntaxFactory.AttributeArgument(SyntaxFactory.IdentifierName($"\"{assembly.Identity.Version}\"")))
                     .WithTrailingTrivia(SyntaxFactory.LineFeed));
             }
-                
+
             // [assembly: System.Runtime.CompilerServices.ReferenceAssembly]
             if (attributes.All(attribute => attribute.AttributeClass?.ToDisplayString() != typeof(ReferenceAssemblyAttribute).FullName))
             {

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.GenAPI
         ///   "non-empty" means either unmanaged types like ints and enums, or reference types that are not the root.
         /// - A struct containing generic fields cannot have struct layout cycles.
         /// </summary>
-        public static IEnumerable<SyntaxNode> SynthesizeDummyFields(this INamedTypeSymbol namedType, ISymbolFilter symbolFilter, ISymbolFilter? attributeDataSymbolFilter)
+        public static IEnumerable<SyntaxNode> SynthesizeDummyFields(this INamedTypeSymbol namedType, ISymbolFilter symbolFilter, ISymbolFilter attributeDataSymbolFilter)
         {
             // Collect all excluded fields
             IEnumerable<IFieldSymbol> excludedFields = namedType.GetMembers()
@@ -126,8 +126,7 @@ namespace Microsoft.DotNet.GenAPI
                 foreach (IFieldSymbol genericField in genericTypedFields)
                 {
                     ImmutableArray<AttributeData> genericFieldAttributes = genericField.GetAttributes()
-                        .ExcludeWithFilter(attributeDataSymbolFilter)
-                        .ExcludeNonVisibleOutsideOfAssembly(symbolFilter);
+                        .ExcludeNonVisibleOutsideOfAssembly(attributeDataSymbolFilter);
 
                     yield return CreateDummyField(genericField.Type.ToDisplayString(),
                         NormalizeIdentifier(genericField.Name),

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -125,12 +125,9 @@ namespace Microsoft.DotNet.GenAPI
                 // Add a dummy field for each generic excluded field
                 foreach (IFieldSymbol genericField in genericTypedFields)
                 {
-                    ImmutableArray<AttributeData> genericFieldAttributes = genericField.GetAttributes()
-                        .ExcludeNonVisibleOutsideOfAssembly(attributeDataSymbolFilter);
-
                     yield return CreateDummyField(genericField.Type.ToDisplayString(),
                         NormalizeIdentifier(genericField.Name),
-                        FromAttributeData(genericFieldAttributes),
+                        FromAttributeData(genericField.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(attributeDataSymbolFilter)),
                         namedType.IsReadOnly);
                 }
 

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxNodeExtensions.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxNodeExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editing;
@@ -17,14 +16,9 @@ namespace Microsoft.DotNet.GenAPI
         public static SyntaxNode AddMemberAttributes(this SyntaxNode node,
             SyntaxGenerator syntaxGenerator,
             ISymbol member,
-            ISymbolFilter symbolFilter,
-            ISymbolFilter? attributeDataSymbolFilter)
+            ISymbolFilter attributeDataSymbolFilter)
         {
-            ImmutableArray<AttributeData> memberAttributes = member.GetAttributes()
-                .ExcludeWithFilter(attributeDataSymbolFilter)
-                .ExcludeNonVisibleOutsideOfAssembly(symbolFilter);
-
-            foreach (AttributeData attribute in memberAttributes)
+            foreach (AttributeData attribute in member.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(attributeDataSymbolFilter))
             {
                 // The C# compiler emits the DefaultMemberAttribute on any type containing an indexer.
                 // In C# it is an error to manually attribute a type with the DefaultMemberAttribute if the type also declares an indexer.

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AttributeDataExtensions.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AttributeDataExtensions.cs
@@ -12,6 +12,16 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
     /// </summary>
     public static class AttributeDataExtensions
     {
+        // Determines if an AttributeData object is visible outside of the containing assembly.
+        // By default also verifies the visibility of the attribute's arguments.
+        private static bool IsVisibleOutsideOfAssembly(this AttributeData attributeData,
+            ISymbolFilter symbolFilter,
+            bool excludeWithTypeArgumentsNotVisibleOutsideOfAssembly = true) =>
+            attributeData.AttributeClass != null &&
+            symbolFilter.Include(attributeData.AttributeClass) &&
+            (!excludeWithTypeArgumentsNotVisibleOutsideOfAssembly ||
+             !HasTypeArgumentsNotVisibleOutsideOfAssembly(attributeData, symbolFilter));
+
         /// <summary>
         /// Excludes <see cref="AttributeData"/> that is not visible outside of an assembly.
         /// </summary>
@@ -28,15 +38,5 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
                 .Any(typedConstant => typedConstant.Kind == TypedConstantKind.Type
                     && typedConstant.Value is INamedTypeSymbol namedTypeSymbol
                     && !symbolFilter.Include(namedTypeSymbol));
-
-        // Determines if an AttributeData object is visible outside of the containing assembly.
-        // By default also verifies the visibility of the attribute's arguments.
-        private static bool IsVisibleOutsideOfAssembly(this AttributeData attributeData,
-            ISymbolFilter symbolFilter,
-            bool excludeWithTypeArgumentsNotVisibleOutsideOfAssembly = true) =>
-            attributeData.AttributeClass != null &&
-            symbolFilter.Include(attributeData.AttributeClass) &&
-            (!excludeWithTypeArgumentsNotVisibleOutsideOfAssembly ||
-             !HasTypeArgumentsNotVisibleOutsideOfAssembly(attributeData, symbolFilter));
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AttributeDataExtensions.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AttributeDataExtensions.cs
@@ -20,20 +20,6 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
             bool excludeWithTypeArgumentsNotVisibleOutsideOfAssembly = true) =>
             attributes.Where(attribute => attribute.IsVisibleOutsideOfAssembly(symbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly)).ToImmutableArray();
 
-        /// <summary>
-        /// Excludes <see cref="AttributeData"/> based on a passed in filter.
-        /// </summary>
-        /// <returns></returns>
-        public static ImmutableArray<AttributeData> ExcludeWithFilter(this ImmutableArray<AttributeData> attributes, ISymbolFilter? symbolFilter)
-        {
-            if (symbolFilter is null)
-                return attributes;
-
-            return attributes
-                .Where(attributeData => attributeData.AttributeClass is not null && symbolFilter.Include(attributeData.AttributeClass))
-                .ToImmutableArray();
-        }
-
         // Checks if an AttributeData has INamedTypeSymbol arguments that point to a type that
         // isn't visible outside of the containing assembly.
         private static bool HasTypeArgumentsNotVisibleOutsideOfAssembly(this AttributeData attributeData, ISymbolFilter symbolFilter) =>

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="..\Microsoft.DotNet.ApiSymbolExtensions.Tests\SymbolFactory.cs" />
+    <Compile Include="..\Microsoft.DotNet.ApiSymbolExtensions.Tests\TempDirectory.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests/TempDirectory.cs
+++ b/src/Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests/TempDirectory.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.ApiCompatibility.Tests
+namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
 {
     public class TempDirectory : IDisposable
     {

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="..\Microsoft.DotNet.ApiSymbolExtensions.Tests\SymbolFactory.cs" />
+    <Compile Include="..\Microsoft.DotNet.ApiSymbolExtensions.Tests\TempDirectory.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes half of https://github.com/dotnet/sdk/issues/33388 Regressed as part of .NET 8 Preview 2: https://github.com/dotnet/sdk/commit/137a4ac17a10b10b661e956fc1e56e280c4fd5c8

When attributes are configured to be excluded from GenAPI, the attribute definitions themselves were also incorrectly excluded, not just their usage on members.

Added a test to verify this behavior. I tested the changes locally and @MichaelSimons is verifying this in SBRP as well.