### PR TITLE
[release/8.0.1xx] APICompat - Validate attribute type defines when excluded

### DIFF
--- a/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
@@ -27,17 +27,22 @@ namespace Microsoft.DotNet.ApiCompat
             _compatibilityLogger = new Lazy<ISuppressableLog>(() => logFactory(SuppressionEngine));
             _apiCompatRunner = new Lazy<IApiCompatRunner>(() =>
             {
-                CompositeSymbolFilter compositeSymbolFilter = new CompositeSymbolFilter()
-                    .Add(new AccessibilitySymbolFilter(respectInternals));
+                AccessibilitySymbolFilter accessibilitySymbolFilter = new(respectInternals);
+                SymbolEqualityComparer symbolEqualityComparer = new();
 
-                if (excludeAttributesFiles != null)
+                // The attribute data symbol filter is a composite that contains both the accessibility
+                // symbol filter and the doc id symbol filter.
+                CompositeSymbolFilter attributeDataSymbolFilter = new CompositeSymbolFilter()
+                    .Add(accessibilitySymbolFilter);
+                if (excludeAttributesFiles is not null)
                 {
-                    compositeSymbolFilter.Add(new DocIdSymbolFilter(excludeAttributesFiles));
+                    attributeDataSymbolFilter.Add(new DocIdSymbolFilter(excludeAttributesFiles));
                 }
 
-                SymbolEqualityComparer symbolEqualityComparer = new();
-                ApiComparerSettings apiComparerSettings = new(compositeSymbolFilter,
+                ApiComparerSettings apiComparerSettings = new(
+                    accessibilitySymbolFilter,
                     symbolEqualityComparer,
+                    attributeDataSymbolFilter,
                     new AttributeDataEqualityComparer(symbolEqualityComparer,
                         new TypedConstantEqualityComparer(symbolEqualityComparer)),
                     respectInternals);

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparerSettings.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiComparerSettings.cs
@@ -21,6 +21,9 @@ namespace Microsoft.DotNet.ApiCompatibility
         public IEqualityComparer<ISymbol> SymbolEqualityComparer { get; set; }
 
         /// <inheritdoc />
+        public ISymbolFilter AttributeDataSymbolFilter { get; set; }
+
+        /// <inheritdoc />
         public IEqualityComparer<AttributeData> AttributeDataEqualityComparer { get; set; }
 
         /// <inheritdoc />
@@ -34,6 +37,7 @@ namespace Microsoft.DotNet.ApiCompatibility
 
         public ApiComparerSettings(ISymbolFilter? symbolFilter = null,
             IEqualityComparer<ISymbol>? symbolEqualityComparer = null,
+            ISymbolFilter? attributeDataSymbolFilter = null,
             IEqualityComparer<AttributeData>? attributeDataEqualityComparer = null,
             bool includeInternalSymbols = false,
             bool strictMode = false,
@@ -41,6 +45,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         {
             SymbolFilter = symbolFilter ?? new AccessibilitySymbolFilter(includeInternalSymbols);
             SymbolEqualityComparer = symbolEqualityComparer ?? new Comparing.SymbolEqualityComparer();
+            AttributeDataSymbolFilter = attributeDataSymbolFilter ?? new CompositeSymbolFilter();
             AttributeDataEqualityComparer = attributeDataEqualityComparer ?? new AttributeDataEqualityComparer(SymbolEqualityComparer, new TypedConstantEqualityComparer(SymbolEqualityComparer));
             IncludeInternalSymbols = includeInternalSymbols;
             StrictMode = strictMode;

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -74,9 +74,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             ImmutableArray<AttributeData> right,
             IList<CompatDifference> differences)
         {
-            // See discussion in https://github.com/dotnet/sdk/pull/27774. ApiCompat intentionally considers non excluded attribute arguments.
-            left = left.ExcludeNonVisibleOutsideOfAssembly(_settings.SymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);
-            right = right.ExcludeNonVisibleOutsideOfAssembly(_settings.SymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);
+            // Filter out attributes that should be excluded based on the settings.
+            // ApiCompat intentionally considers non excluded attribute arguments. See discussion in https://github.com/dotnet/sdk/pull/27774.
+            left = left.ExcludeNonVisibleOutsideOfAssembly(_settings.AttributeDataSymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);
+            right = right.ExcludeNonVisibleOutsideOfAssembly(_settings.AttributeDataSymbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly: false);
 
             // No attributes, nothing to do. Exit early.
             if (left.Length == 0 && right.Length == 0)

--- a/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
+++ b/src/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
@@ -22,6 +22,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         IEqualityComparer<ISymbol> SymbolEqualityComparer { get; }
 
         /// <summary>
+        /// The attribute data symbol filter. This filter is responsible for all filtering of the application of attributes, including visibility.
+        /// </summary>
+        ISymbolFilter AttributeDataSymbolFilter { get; }
+
+        /// <summary>
         /// The attribute data equality comparer.
         /// </summary>
         IEqualityComparer<AttributeData> AttributeDataEqualityComparer { get; }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -26,6 +26,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
          * - Member
          */
 
+        private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
+
         private static ISymbolFilter GetAccessibilityAndAttributeSymbolFiltersAsComposite(params string[] excludeAttributeFiles) =>
             new CompositeSymbolFilter().Add(new AccessibilitySymbolFilter(false)).Add(new DocIdSymbolFilter(excludeAttributeFiles));
 
@@ -1327,11 +1329,10 @@ new CompatDifference[] {
             using TempDirectory root = new();
             string filePath = Path.Combine(root.DirPath, "exclusions.txt");
             File.Create(filePath).Dispose();
-            TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
-            differ.Settings.SymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1345,11 +1346,10 @@ new CompatDifference[] {
             using TempDirectory root = new();
             string filePath = Path.Combine(root.DirPath, "exclusions.txt");
             File.Create(filePath).Dispose();
-            TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: true));
-            differ.Settings.SymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1362,7 +1362,6 @@ new CompatDifference[] {
             using TempDirectory root = new();
             string filePath = Path.Combine(root.DirPath, "exclusions.txt");
             File.WriteAllText(filePath, "T:System.SerializableAttribute");
-            TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
             string leftSyntax = @"
 namespace CompatTests
 {
@@ -1399,11 +1398,64 @@ namespace CompatTests
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
-            differ.Settings.SymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
             Assert.Empty(actual);
+        }
+
+        [Fact]
+        public void AttributesExcludedButMembersValidated()
+        {
+            using TempDirectory root = new();
+            string filePath = Path.Combine(root.DirPath, "exclusions.txt");
+            File.WriteAllText(filePath, "T:CompatTests.FooAttribute");
+            TestRuleFactory ruleFactory = new(
+                (settings, context) => new AttributesMustMatch(settings, context),
+                (settings, context) => new MembersMustExist(settings, context));
+            string leftSyntax = @"
+namespace CompatTests
+{
+  using System;
+  
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+  }
+  [Foo(""S"", A = true, B = 3)]
+  public class First {}
+}
+";
+            string rightSyntax = @"
+namespace CompatTests
+{
+  using System;
+  
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+    public bool A;
+    public int B;
+    public string X;
+  }
+  [Foo(""T"", A = false, B = 4)]
+  public class First {}
+}
+";
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new(ruleFactory, new ApiComparerSettings(strictMode: true));
+            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+
+            IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right).ToArray();
+
+            Assert.Equal(new[]
+            {
+                CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.FooAttribute.X"),
+            }, actual);
         }
     }
 }


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/sdk/pull/36272
Regression from .NET 8 Preview 2: https://github.com/dotnet/sdk/commit/137a4ac17a10b10b661e956fc1e56e280c4fd5c8

## Customer Impact
Customers who use APICompat / PackageValidation to perform API compatibility checks and use the "exclude attributes" opt-in feature, expect attribute types defined in the assembly in question to be validated. Unfortunately, because of an architectural decision this behavior regressed during .NET 8 Preview 2. This fix restores that expectation.

## Testing
Unit test added and compatibility checks performed locally in various repositories (dotnet/runtime).

## Risk
Low - The fix is isolated, well tested and the feature is opt-in.