### PR TITLE
[release/8.0.1xx] GenAPI - Emit attribute type defines when excluded

### DIFF
--- a/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -27,6 +27,7 @@ namespace Microsoft.DotNet.GenAPI
         private readonly ILog _logger;
         private readonly TextWriter _textWriter;
         private readonly ISymbolFilter _symbolFilter;
+        private readonly ISymbolFilter _attributeDataSymbolFilter;
         private readonly string? _exceptionMessage;
         private readonly bool _includeAssemblyAttributes;
         private readonly AdhocWorkspace _adhocWorkspace;
@@ -35,6 +36,7 @@ namespace Microsoft.DotNet.GenAPI
 
         public CSharpFileBuilder(ILog logger,
             ISymbolFilter symbolFilter,
+            ISymbolFilter attributeDataSymbolFilter,
             TextWriter textWriter,
             string? exceptionMessage,
             bool includeAssemblyAttributes,
@@ -43,6 +45,7 @@ namespace Microsoft.DotNet.GenAPI
             _logger = logger;
             _textWriter = textWriter;
             _symbolFilter = symbolFilter;
+            _attributeDataSymbolFilter = attributeDataSymbolFilter;
             _exceptionMessage = exceptionMessage;
             _includeAssemblyAttributes = includeAssemblyAttributes;
             _adhocWorkspace = new AdhocWorkspace();
@@ -107,8 +110,9 @@ namespace Microsoft.DotNet.GenAPI
 
             foreach (INamedTypeSymbol typeMember in typeMembers.Order())
             {
-                SyntaxNode typeDeclaration = _syntaxGenerator.DeclarationExt(typeMember, _symbolFilter)
-                    .AddMemberAttributes(_syntaxGenerator, _symbolFilter, typeMember);
+                SyntaxNode typeDeclaration = _syntaxGenerator
+                    .DeclarationExt(typeMember, _symbolFilter)
+                    .AddMemberAttributes(_syntaxGenerator, typeMember, _attributeDataSymbolFilter);
 
                 typeDeclaration = Visit(typeDeclaration, typeMember);
 
@@ -171,7 +175,7 @@ namespace Microsoft.DotNet.GenAPI
             // If it's a value type
             if (namedType.TypeKind == TypeKind.Struct)
             {
-                namedTypeNode = _syntaxGenerator.AddMembers(namedTypeNode, namedType.SynthesizeDummyFields(_symbolFilter));
+                namedTypeNode = _syntaxGenerator.AddMembers(namedTypeNode, namedType.SynthesizeDummyFields(_symbolFilter, _attributeDataSymbolFilter));
             }
 
             namedTypeNode = _syntaxGenerator.AddMembers(namedTypeNode, namedType.TryGetInternalDefaultConstructor(_symbolFilter));
@@ -203,8 +207,9 @@ namespace Microsoft.DotNet.GenAPI
                     continue;
                 }
 
-                SyntaxNode memberDeclaration = _syntaxGenerator.DeclarationExt(member, _symbolFilter)
-                    .AddMemberAttributes(_syntaxGenerator, _symbolFilter, member);
+                SyntaxNode memberDeclaration = _syntaxGenerator
+                    .DeclarationExt(member, _symbolFilter)
+                    .AddMemberAttributes(_syntaxGenerator, member, _attributeDataSymbolFilter);
 
                 if (member is INamedTypeSymbol nestedTypeSymbol)
                 {
@@ -235,7 +240,7 @@ namespace Microsoft.DotNet.GenAPI
         private SyntaxNode GenerateAssemblyAttributes(IAssemblySymbol assembly, SyntaxNode compilationUnit)
         {
             // When assembly references aren't available, assembly attributes with foreign types won't be resolved.
-            ImmutableArray<AttributeData> attributes = assembly.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(_symbolFilter);
+            ImmutableArray<AttributeData> attributes = assembly.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(_attributeDataSymbolFilter);
 
             // Emit assembly attributes from the IAssemblySymbol
             List<SyntaxNode> attributeSyntaxNodes = attributes

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/INamedTypeSymbolExtension.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.GenAPI
         ///   "non-empty" means either unmanaged types like ints and enums, or reference types that are not the root.
         /// - A struct containing generic fields cannot have struct layout cycles.
         /// </summary>
-        public static IEnumerable<SyntaxNode> SynthesizeDummyFields(this INamedTypeSymbol namedType, ISymbolFilter symbolFilter)
+        public static IEnumerable<SyntaxNode> SynthesizeDummyFields(this INamedTypeSymbol namedType, ISymbolFilter symbolFilter, ISymbolFilter attributeDataSymbolFilter)
         {
             // Collect all excluded fields
             IEnumerable<IFieldSymbol> excludedFields = namedType.GetMembers()
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.GenAPI
                 {
                     yield return CreateDummyField(genericField.Type.ToDisplayString(),
                         NormalizeIdentifier(genericField.Name),
-                        FromAttributeData(genericField.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(symbolFilter)),
+                        FromAttributeData(genericField.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(attributeDataSymbolFilter)),
                         namedType.IsReadOnly);
                 }
 
@@ -204,7 +204,7 @@ namespace Microsoft.DotNet.GenAPI
             // records with a record constructor don't require a default constructor
             if (namedType.IsRecord && namedType.TryGetRecordConstructor(out _))
             {
-                yield break;                
+                yield break;
             }
 
             // Nothing to do if type already exposes constructor, or has an excluded implicit constructor (since it would match visibility)

--- a/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxNodeExtensions.cs
+++ b/src/GenAPI/Microsoft.DotNet.GenAPI/SyntaxNodeExtensions.cs
@@ -15,10 +15,10 @@ namespace Microsoft.DotNet.GenAPI
 
         public static SyntaxNode AddMemberAttributes(this SyntaxNode node,
             SyntaxGenerator syntaxGenerator,
-            ISymbolFilter symbolFilter,
-            ISymbol member)
+            ISymbol member,
+            ISymbolFilter attributeDataSymbolFilter)
         {
-            foreach (AttributeData attribute in member.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(symbolFilter))
+            foreach (AttributeData attribute in member.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(attributeDataSymbolFilter))
             {
                 // The C# compiler emits the DefaultMemberAttribute on any type containing an indexer.
                 // In C# it is an error to manually attribute a type with the DefaultMemberAttribute if the type also declares an indexer.
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.GenAPI
 
                 node = syntaxGenerator.AddAttributes(node, syntaxGenerator.Attribute(attribute));
             }
+
             return node;
         }
     }

--- a/src/Microsoft.DotNet.ApiSymbolExtensions/AttributeDataExtensions.cs
+++ b/src/Microsoft.DotNet.ApiSymbolExtensions/AttributeDataExtensions.cs
@@ -12,11 +12,9 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
     /// </summary>
     public static class AttributeDataExtensions
     {
-        /// <summary>
-        /// Determines if an <see cref="AttributeData"/> object is visible outside of the containing assembly.
-        /// By default also verifies the visibility of the attribute's arguments.
-        /// </summary>
-        public static bool IsVisibleOutsideOfAssembly(this AttributeData attributeData,
+        // Determines if an AttributeData object is visible outside of the containing assembly.
+        // By default also verifies the visibility of the attribute's arguments.
+        private static bool IsVisibleOutsideOfAssembly(this AttributeData attributeData,
             ISymbolFilter symbolFilter,
             bool excludeWithTypeArgumentsNotVisibleOutsideOfAssembly = true) =>
             attributeData.AttributeClass != null &&
@@ -32,10 +30,9 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
             bool excludeWithTypeArgumentsNotVisibleOutsideOfAssembly = true) =>
             attributes.Where(attribute => attribute.IsVisibleOutsideOfAssembly(symbolFilter, excludeWithTypeArgumentsNotVisibleOutsideOfAssembly)).ToImmutableArray();
 
-        /// <summary>
-        /// Checks if an <see cref="AttributeData"/> has <see cref="INamedTypeSymbol"/> arguments that point to a <see cref="Type"/> that isn't visible outside of the containing assembly.
-        /// </summary>
-        public static bool HasTypeArgumentsNotVisibleOutsideOfAssembly(this AttributeData attributeData, ISymbolFilter symbolFilter) =>
+        // Checks if an AttributeData has INamedTypeSymbol arguments that point to a type that
+        // isn't visible outside of the containing assembly.
+        private static bool HasTypeArgumentsNotVisibleOutsideOfAssembly(this AttributeData attributeData, ISymbolFilter symbolFilter) =>
             attributeData.NamedArguments.Select(namedArgument => namedArgument.Value)
                 .Concat(attributeData.ConstructorArguments)
                 .Any(typedConstant => typedConstant.Kind == TypedConstantKind.Type

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="..\Microsoft.DotNet.ApiSymbolExtensions.Tests\SymbolFactory.cs" />
+    <Compile Include="..\Microsoft.DotNet.ApiSymbolExtensions.Tests\TempDirectory.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests/TempDirectory.cs
+++ b/src/Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests/TempDirectory.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.ApiCompatibility.Tests
+namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
 {
     public class TempDirectory : IDisposable
     {

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -30,19 +30,39 @@ namespace Microsoft.DotNet.GenAPI.Tests
             bool includeEffectivelyPrivateSymbols = true,
             bool includeExplicitInterfaceImplementationSymbols = true,
             bool allowUnsafe = false,
-            [CallerMemberName]string assemblyName = "")
+            string excludedAttributeFile = null,
+            [CallerMemberName] string assemblyName = "")
         {
             StringWriter stringWriter = new();
 
-            CompositeSymbolFilter compositeFilter = new CompositeSymbolFilter()
+            // Configure symbol filters
+            AccessibilitySymbolFilter accessibilitySymbolFilter = new(
+                includeInternalSymbols,
+                includeEffectivelyPrivateSymbols,
+                includeExplicitInterfaceImplementationSymbols);
+
+            CompositeSymbolFilter symbolFilter = new CompositeSymbolFilter()
                 .Add(new ImplicitSymbolFilter())
-                .Add(new AccessibilitySymbolFilter(includeInternalSymbols,
-                    includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols));
-            IAssemblySymbolWriter csharpFileBuilder = new CSharpFileBuilder(new ConsoleLog(MessageImportance.Low),
-                compositeFilter, stringWriter, null, false, MetadataReferences);
+                .Add(accessibilitySymbolFilter);
+
+            CompositeSymbolFilter attributeDataSymbolFilter = new();
+            if (excludedAttributeFile is not null)
+            {
+                attributeDataSymbolFilter.Add(new DocIdSymbolFilter(new string[] { excludedAttributeFile }));
+            }
+            attributeDataSymbolFilter.Add(accessibilitySymbolFilter);
+
+            IAssemblySymbolWriter csharpFileBuilder = new CSharpFileBuilder(
+                new ConsoleLog(MessageImportance.Low),
+                symbolFilter,
+                attributeDataSymbolFilter,
+                stringWriter,
+                null,
+                false,
+                MetadataReferences);
 
             using Stream assemblyStream = SymbolFactory.EmitAssemblyStreamFromSyntax(original, enableNullable: true, allowUnsafe: allowUnsafe, assemblyName: assemblyName);
-            AssemblySymbolLoader assemblySymbolLoader = new AssemblySymbolLoader(resolveAssemblyReferences: true, includeInternalSymbols: includeInternalSymbols);
+            AssemblySymbolLoader assemblySymbolLoader = new(resolveAssemblyReferences: true, includeInternalSymbols: includeInternalSymbols);
             assemblySymbolLoader.AddReferenceSearchPaths(typeof(object).Assembly!.Location!);
             assemblySymbolLoader.AddReferenceSearchPaths(typeof(DynamicAttribute).Assembly!.Location!);
             IAssemblySymbol assemblySymbol = assemblySymbolLoader.LoadAssembly(assemblyName, assemblyStream);
@@ -2734,6 +2754,51 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     """,
                 expected: expected,
                 includeInternalSymbols: includeInternalSymbols);
+        }
+
+        [Fact]
+        public void TestAttributesExcludedWithFilter()
+        {
+            using TempDirectory root = new();
+            string filePath = Path.Combine(root.DirPath, "exclusions.txt");
+            File.WriteAllText(filePath, "T:A.AnyTestAttribute");
+
+            RunTest(original: """
+                    namespace A
+                    {
+                        public partial class AnyTestAttribute : System.Attribute
+                        {
+                            public AnyTestAttribute(System.Type xType)
+                            {
+                                XType = xType;
+                            }
+
+                            public System.Type XType { get; set; }
+                        }
+
+                        [AnyTest(typeof(string))]
+                        [System.Obsolete]
+                        public class PublicClass { }
+                    }
+                    """,
+                expected: """
+                    namespace A
+                    {
+                        public partial class AnyTestAttribute : System.Attribute
+                        {
+                            public AnyTestAttribute(System.Type xType) { }
+
+                            public System.Type XType { get { throw null; } set { } }
+                        }
+
+                        [System.Obsolete]
+                        public partial class PublicClass
+                        {
+                        }
+                    }
+                    """,
+                includeInternalSymbols: false,
+                excludedAttributeFile: filePath);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
+++ b/src/Tests/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="..\Microsoft.DotNet.ApiSymbolExtensions.Tests\SymbolFactory.cs" />
+    <Compile Include="..\Microsoft.DotNet.ApiSymbolExtensions.Tests\TempDirectory.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/sdk/pull/36279
Regression from .NET 8 Preview 2: https://github.com/dotnet/sdk/commit/137a4ac17a10b10b661e956fc1e56e280c4fd5c8

## Customer Impact
_GenAPI is a global tool / MSBuild task that scans an assembly's public API and generates a C# file out of that information_

This roslyn based GenAPI tooling is currently only used by our source build partners and **isn't publicly shipping**. Our partners let us know that when using the opt-in "attribute exclusion" feature, type definitions of those attributes are missing from the generated compiled source file. This fixes the regression introduced during the .NET 8 development lifecycle.

## Testing
Unit test added and compatibility checks performed locally in various repositories (dotnet/source-build-reference-packages).

## Risk
Low - The fix is isolated, well tested, the feature is opt-in and the overall tool isn't publicly shipping (yet).