### PR TITLE
Log SDK Culture mismatch message at Low importance to unblock SDK migration

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -161,7 +161,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var invalidContextWarnings = engine.Warnings.Where(msg => msg.Code == "NETSDK1188");
             invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
 
-            var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1188");
+            var invalidContextMessages = engine.Messages;
             invalidContextMessages.Should().HaveCount(shouldHaveWarnings ? 0 : 1);
 
         }
@@ -184,7 +184,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var invalidContextWarnings = engine.Warnings.Where(msg => msg.Code == "NETSDK1187");
             invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
 
-            var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1187");
+            var invalidContextMessages = engine.Messages;
             invalidContextMessages.Should().HaveCount(shouldHaveWarnings ? 0 : 1);
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -21,12 +21,12 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             byte[] oldHash;
             try
             {
-                 oldHash = task.HashSettings();
+                oldHash = task.HashSettings();
             }
             catch (ArgumentNullException)
             {
                 Assert.True(
-                    false, 
+                    false,
                     "HashSettings is likely not correctly handling null value of one or more optional task parameters");
 
                 throw; // unreachable
@@ -161,7 +161,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var invalidContextWarnings = engine.Warnings.Where(msg => msg.Code == "NETSDK1188");
             invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
 
-            var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1187" && msg.Importance == MessageImportance.Low);
+            var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1188" && msg.Importance == MessageImportance.Low);
             invalidContextMessages.Should().HaveCount(shouldHaveWarnings ? 0 : 1);
 
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -161,7 +161,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var invalidContextWarnings = engine.Warnings.Where(msg => msg.Code == "NETSDK1188");
             invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
 
-            var invalidContextMessages = engine.Messages;
+            var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1187" && msg.Importance == MessageImportance.Low);
             invalidContextMessages.Should().HaveCount(shouldHaveWarnings ? 0 : 1);
 
         }
@@ -184,7 +184,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var invalidContextWarnings = engine.Warnings.Where(msg => msg.Code == "NETSDK1187");
             invalidContextWarnings.Should().HaveCount(shouldHaveWarnings ? 1 : 0);
 
-            var invalidContextMessages = engine.Messages;
+            var invalidContextMessages = engine.Messages.Where(msg => msg.Code == "NETSDK1187" && msg.Importance == MessageImportance.Low);
             invalidContextMessages.Should().HaveCount(shouldHaveWarnings ? 0 : 1);
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1564,7 +1564,8 @@ namespace Microsoft.NET.Build.Tasks
                                 }
                                 else
                                 {
-                                    _task.Log.LogMessage(Strings.PackageContainsIncorrectlyCasedLocale, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale);
+                                    var formatStringWithoutCode = Strings.PackageContainsIncorrectlyCasedLocale.Substring(Strings.PackageContainsIncorrectlyCasedLocale.IndexOf(' '));
+                                    _task.Log.LogMessage(formatStringWithoutCode, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale);
                                 }
                             }
                             locale = normalizedLocale;
@@ -1575,9 +1576,11 @@ namespace Microsoft.NET.Build.Tasks
                             if (tfm.Version.Major >= 7)
                             {
                                 _task.Log.LogWarning(Strings.PackageContainsUnknownLocale, package.Name, package.Version.ToNormalizedString(), cnf.InvalidCultureName);
-                            } else
+                            }
+                            else
                             {
-                                _task.Log.LogMessage(Strings.PackageContainsUnknownLocale, package.Name, package.Version.ToNormalizedString(), cnf.InvalidCultureName);
+                                var formatStringWithoutCode = Strings.PackageContainsUnknownLocale.Substring(Strings.PackageContainsIncorrectlyCasedLocale.IndexOf(' '));
+                                _task.Log.LogMessage(formatStringWithoutCode, package.Name, package.Version.ToNormalizedString(), cnf.InvalidCultureName);
                             }
 
                             // We could potentially strip this unknown locale at this point, but we do not.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1564,8 +1564,10 @@ namespace Microsoft.NET.Build.Tasks
                                 }
                                 else
                                 {
-                                    var formatStringWithoutCode = Strings.PackageContainsIncorrectlyCasedLocale.Substring(Strings.PackageContainsIncorrectlyCasedLocale.IndexOf(' '));
-                                    _task.Log.LogMessage(formatStringWithoutCode, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale);
+                                    // We emit low-priority messages here because some clients may interpret normal or higher messages
+                                    // as warnings when they have codes, locations, etc.
+                                    // Roslyn does similar for IDE-only analysis messages.
+                                    _task.Log.LogMessage(MessageImportance.Low, Strings.PackageContainsIncorrectlyCasedLocale, package.Name, package.Version.ToNormalizedString(), locale, normalizedLocale);
                                 }
                             }
                             locale = normalizedLocale;
@@ -1579,8 +1581,10 @@ namespace Microsoft.NET.Build.Tasks
                             }
                             else
                             {
-                                var formatStringWithoutCode = Strings.PackageContainsUnknownLocale.Substring(Strings.PackageContainsIncorrectlyCasedLocale.IndexOf(' '));
-                                _task.Log.LogMessage(formatStringWithoutCode, package.Name, package.Version.ToNormalizedString(), cnf.InvalidCultureName);
+                                // We emit low-priority messages here because some clients may interpret normal or higher messages
+                                // as warnings when they have codes, locations, etc.
+                                // Roslyn does similar for IDE-only analysis messages.
+                                _task.Log.LogMessage(MessageImportance.Low, Strings.PackageContainsUnknownLocale, package.Name, package.Version.ToNormalizedString(), cnf.InvalidCultureName);
                             }
 
                             // We could potentially strip this unknown locale at this point, but we do not.


### PR DESCRIPTION
When previewing Substrate's upgrade to .NET 8 SDK @rainersigwald found that even Messages that _look_ like MSBuild Warnings or Errors would get flagged by Substrate's build as Errors. Unfortunately, since Messages are not controllable/suppressible with NoWarn in the way that Warnings and Errors are, this led to an unavoidable build break on update. While we are investigating a proper fix for this build tooling's behavior, we can also be a bit defensive in the SDK and emit the message as a Low importance, which causes this tooling to not flag it. Roslyn does similar for some IDe diagnostics.

## Customer Impact

Customers that are inspecting Message lines for text that looks like/behaves like an MSBuild diagnostic will detect and raise an un-suppressible error.

## Testing

Automated tests updated and passing

## Risk

**Low** - this is just changing the Importance of an emitted message, not the logic of when that message is fired.
