### PR TITLE
Revert skipped tests due to VS 17.8-p3

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateGlobalUsings_BlazorWasm.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateGlobalUsings_BlazorWasm.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.Build.Tests
     {
         public GivenThatWeWantToGenerateGlobalUsings_BlazorWasm(ITestOutputHelper log) : base(log) { }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [RequiresMSBuildVersionFact("17.0.0.32901")]
         public void It_generates_blazorwasm_usings_and_builds_successfully()
         {
             var tfm = ToolsetInfo.CurrentTargetFramework;

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateGlobalUsings_WebApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateGlobalUsings_WebApp.cs
@@ -8,7 +8,7 @@ namespace Microsoft.NET.Build.Tests
 
         public GivenThatWeWantToGenerateGlobalUsings_WebApp(ITestOutputHelper log) : base(log) { }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [RequiresMSBuildVersionFact("17.0.0.32901")]
         public void It_generates_web_implicit_usings_and_builds_successfully()
         {
             var tfm = ToolsetInfo.CurrentTargetFramework;

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [InlineData("WebApp", false)]
         [InlineData("WebApp", true)]
         [InlineData("WebApp", null)]
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Build.Tests
             VerifyInterceptorsFeatureProperties(asset, isEnabled, "Microsoft.AspNetCore.Http.Generated");
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [InlineData("WebApp", false)]
         [InlineData("WebApp", true)]
         [InlineData("WebApp", null)]
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Build.Tests
             VerifyInterceptorsFeatureProperties(asset, isEnabled, "Microsoft.Extensions.Configuration.Binder.SourceGeneration");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void It_enables_requestdelegategenerator_and_configbindinggenerator_for_PublishAot()
         {
             var asset = _testAssetsManager
@@ -70,7 +70,7 @@ namespace Microsoft.NET.Build.Tests
             VerifyInterceptorsFeatureProperties(asset, expectEnabled: true, "Microsoft.AspNetCore.Http.Generated", "Microsoft.Extensions.Configuration.Binder.SourceGeneration");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void It_enables_requestdelegategenerator_and_configbindinggenerator_for_PublishTrimmed()
         {
             var asset = _testAssetsManager

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -1020,7 +1020,7 @@ public static class Program
             }
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [InlineData("invalidProfile", true)]
         [InlineData("invalidProfile.pubxml", true)]
         [InlineData("..\\Properties\\PublishProfiles\\invalidProfile.pubxml", true)]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Publish.Tests
         {
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void It_publishes_as_framework_dependent_by_default()
         {
             var testAsset = _testAssetsManager
@@ -147,7 +147,7 @@ namespace Microsoft.NET.Publish.Tests
             });
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [InlineData(null, null)]
         [InlineData(false, null)]
         [InlineData(true, null)]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
@@ -165,7 +165,7 @@ namespace Microsoft.NET.Publish.Tests
             CheckPublishOutput(publishDir, expectedSingleExeFiles.Append("UserData.txt"), expectedNonSingleExeFiles);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [RequiresMSBuildVersionFact("16.8.0")]
         public void It_cleans_for_mvc_projects()
         {
             // Create new mvc app from template

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorMultitargetIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorMultitargetIntegrationTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
     {
         public BlazorMultitargetIntegrationTest(ITestOutputHelper log) : base(log) { }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void MultiTargetApp_LoadsTheCorrectSdkBasedOnTfm()
         {
             // Arrange
@@ -28,7 +28,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             browserDependencies.File("captured-references.txt").Should().NotContain("Microsoft.AspNetCore.Components.Server.dll");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void ReferencedMultiTargetApp_LoadsTheCorrectSdkBasedOnTfm()
         {
             // Arrange

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmStaticWebAssetsIntegrationTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void StaticWebAssets_BuildMinimal_Works()
         {
             // Arrange
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void StaticWebAssets_PublishMinimal_Works()
         {
             // Arrange
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void StaticWebAssets_Build_Hosted_Works()
         {
             // Arrange
@@ -106,7 +106,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void StaticWebAssets_Publish_Hosted_Works()
         {
             // Arrange
@@ -137,7 +137,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void StaticWebAssets_Publish_DoesNotIncludeXmlDocumentationFiles_AsAssets()
         {
             // Arrange
@@ -218,7 +218,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void StaticWebAssets_BackCompatibilityPublish_Hosted_Works()
         {
             // Arrange

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIncrementalismTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIncrementalismTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
     {
         public WasmBuildIncrementalismTest(ITestOutputHelper log) : base(log) { }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_IsIncremental()
         {
             // Arrange
@@ -42,7 +42,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_GzipCompression_IsIncremental()
         {
             // Arrange
@@ -91,7 +91,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_SatelliteAssembliesFileIsPreserved()
         {
             // Arrange
@@ -146,7 +146,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_SatelliteAssembliesFileIsCreated_IfNewFileIsAdded()
         {
             // Arrange
@@ -192,7 +192,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             kvp.Value.Should().ContainKey("blazorwasm.resources.wasm");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_SatelliteAssembliesFileIsDeleted_IfAllSatelliteFilesAreRemoved()
         {
             // Arrange

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             "icudt_no_CJK.dat"
         };
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void BuildMinimal_Works()
         {
             // Arrange
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazorwasm-minimal.wasm")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [InlineData("blazor")]
         [InlineData("blazor spaces")]
         public void Build_Works(string identifier)
@@ -73,7 +73,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "RazorClassLibrary.wasm")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_Works_WithLibraryUsingHintPath()
         {
             // Arrange
@@ -124,7 +124,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "RazorClassLibrary.wasm")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_InRelease_Works()
         {
             // Arrange
@@ -152,7 +152,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "RazorClassLibrary.wasm")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_ProducesBootJsonDataWithExpectedContent()
         {
             // Arrange
@@ -190,7 +190,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             bootJsonData.config.Should().Contain("../appsettings.development.json");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_InRelease_ProducesBootJsonDataWithExpectedContent()
         {
             // Arrange
@@ -225,7 +225,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             bootJsonData.resources.satelliteResources.Should().BeNull();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithBlazorEnableTimeZoneSupportDisabled_DoesNotCopyTimeZoneInfo()
         {
             // Arrange
@@ -257,7 +257,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "dotnet.timezones.blat")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithInvariantGlobalizationEnabled_DoesNotCopyGlobalizationData()
         {
             // Arrange
@@ -294,7 +294,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithInvariantGlobalizationEnabled_DoesNotCopyGlobalizationData()
         {
             // Arrange
@@ -332,7 +332,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithBlazorWebAssemblyLoadCustomGlobalizationData_SetsGlobalizationMode()
         {
             // Arrange
@@ -375,7 +375,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithBlazorWebAssemblyLoadCustomGlobalizationData_SetsGlobalizationMode()
         {
             var testAppName = "BlazorHosted";
@@ -418,7 +418,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithBlazorWebAssemblyLoadAllGlobalizationData_SetsICUDataMode()
         {
             // Arrange
@@ -461,7 +461,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithBlazorWebAssemblyLoadAllGlobalizationData_SetsGlobalizationMode()
         {
             // Arrange
@@ -505,7 +505,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_Hosted_Works()
         {
             // Arrange
@@ -521,7 +521,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "_bin", "blazorwasm.wasm")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_SatelliteAssembliesAreCopiedToBuildOutput()
         {
             // Arrange
@@ -579,7 +579,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             bootJsonPath.Should().Contain("\"Microsoft.CodeAnalysis.CSharp.resources.wasm\"");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithCustomOutputPath_Works()
         {
             var testAppName = "BlazorWasmWithLibrary";
@@ -601,7 +601,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             buildCommand.Execute().Should().Pass();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithTransitiveReference_Works()
         {
             // Regression test for https://github.com/dotnet/aspnetcore/issues/37574.
@@ -650,7 +650,7 @@ public class TestReference
             fileInWwwroot.Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithReference_Works()
         {
             // Regression test for https://github.com/dotnet/aspnetcore/issues/37574.
@@ -699,14 +699,14 @@ public class TestReference
             fileInWwwroot.Should().Exist();
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         [InlineData(null)]
         public void Build_WithStartupMemoryCache(bool? value)
             => BuildWasmMinimalAndValidateBootConfig(new[] { ("BlazorWebAssemblyStartupMemoryCache", value?.ToString()) }, b => b.startupMemoryCache.Should().Be(value));
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         [InlineData(null)]
@@ -724,7 +724,7 @@ public class TestReference
                 }
             });
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithJiterpreter_Advanced()
             => BuildWasmMinimalAndValidateBootConfig(new[] { ("BlazorWebAssemblyJiterpreter", "true"), ("BlazorWebAssemblyRuntimeOptions", "--no-jiterpreter-interp-entry-enabled") }, b =>
             {

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildLazyLoadTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildLazyLoadTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
     {
         public WasmBuildLazyLoadTest(ITestOutputHelper log) : base(log) { }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_LazyLoadExplicitAssembly_Debug_Works()
         {
             // Arrange
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             assemblies.Keys.Should().Contain("blazorwasm.wasm");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_LazyLoadExplicitAssembly_Release_Works()
         {
             // Arrange
@@ -107,7 +107,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             assemblies.Keys.Should().Contain("blazorwasm.wasm");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_LazyLoadExplicitAssembly_Debug_Works()
         {
             // Arrange
@@ -156,7 +156,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             assemblies.Keys.Should().Contain("blazorwasm.wasm");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_LazyLoadExplicitAssembly_Release_Works()
         {
             // Arrange
@@ -204,7 +204,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             assemblies.Keys.Should().Contain("blazorwasm.wasm");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_LazyLoadExplicitAssembly_InvalidAssembly()
         {
             // Arrange
@@ -225,7 +225,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             buildCommand.Execute().Should().Fail().And.HaveStdOutContaining("BLAZORSDK1001");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_LazyLoadExplicitAssembly_InvalidAssembly()
         {
             // Arrange

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmCompressionTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmCompressionTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
     {
         public WasmCompressionTests(ITestOutputHelper log) : base(log) { }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_UpdatesFilesWhenSourcesChange()
         {
             // Arrange
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             Assert.NotEqual(blazorBootJsonCompressedThumbPrint, newBlazorBootJsonCompressedThumbPrint);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithoutLinkerAndCompression_UpdatesFilesWhenSourcesChange()
         {
             // Arrange
@@ -82,7 +82,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             Assert.NotEqual(mainAppCompressedDllThumbPrint, newMainAppCompressedDllThumbPrint);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithLinkerAndCompression_IsIncremental()
         {
             // Arrange
@@ -114,7 +114,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithoutLinkerAndCompression_IsIncremental()
         {
             // Arrange
@@ -146,7 +146,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_CompressesAllFrameworkFiles()
         {
             // Arrange

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmJsModulesIntegrationTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmJsModulesIntegrationTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_DoesNotGenerateManifestJson_IncludesJSModulesOnBlazorBootJsonManifest()
         {
             // Arrange
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(outputPath, "wwwroot", "blazorwasm-minimal.modules.json")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void JSModules_ManifestIncludesModuleTargetPaths()
         {
             // Arrange
@@ -79,7 +79,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(outputPath, "wwwroot", "blazorhosted.modules.json")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_DoesNotGenerateManifestJson_IncludesJSModulesOnBlazorBootJsonManifest()
         {
             // Arrange
@@ -119,7 +119,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void JsModules_CanHaveDifferentBuildAndPublishModules()
         {
             // Arrange
@@ -181,7 +181,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void JsModules_CanCustomizeBlazorInitialization()
         {
             // Arrange
@@ -245,7 +245,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void JsModules_Hosted_CanCustomizeBlazorInitialization()
         {
             // Arrange

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
     {
         public WasmPublishIntegrationTest(ITestOutputHelper log) : base(log) { }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_MinimalApp_Works()
         {
             // Arrange
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             VerifyBootManifestHashes(testInstance, Path.Combine(publishDirectory.ToString(), "wwwroot"));
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithDefaultSettings_Works()
         {
             // Arrange
@@ -89,7 +89,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             VerifyTypeGranularTrimming(blazorPublishDirectory);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_Works_WithLibraryUsingHintPath()
         {
             // Arrange
@@ -137,7 +137,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(publishOutputDirectory, "wwwroot", "_framework", "RazorClassLibrary.wasm")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithScopedCss_Works()
         {
             // Arrange
@@ -179,7 +179,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 assetsManifestPath: "custom-service-worker-assets.js");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_InRelease_Works()
         {
             // Arrange
@@ -215,7 +215,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(blazorPublishDirectory, "css", "app.css")).Should().Contain(".publish");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithExistingWebConfig_Works()
         {
             // Arrange
@@ -235,7 +235,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             webConfig.Should().Contain(webConfigContents);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithNoBuild_Works()
         {
             // Arrange
@@ -279,7 +279,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             VerifyCompression(testInstance, blazorPublishDirectory);
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [InlineData("different-path")]
         [InlineData("/different-path")]
         public void Publish_WithStaticWebBasePathWorks(string basePath)
@@ -341,7 +341,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 staticWebAssetsBasePath: "different-path");
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [InlineData("different-path/")]
         [InlineData("/different-path/")]
         public void Publish_Hosted_WithStaticWebBasePathWorks(string basePath)
@@ -408,7 +408,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             uncompressedText.Should().Be(originalText);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithTrimmingdDisabled_Works()
         {
             // Arrange
@@ -479,7 +479,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             VerifyAssemblyHasTypes(loggingAssemblyPath, new[] { "Microsoft.Extensions.Logging.Abstractions.NullLogger" });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_SatelliteAssemblies_AreCopiedToBuildOutput()
         {
             // Arrange
@@ -520,7 +520,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostedApp_DefaultSettings_Works()
         {
             // Arrange
@@ -604,7 +604,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             VerifyTypeGranularTrimming(blazorPublishDirectory);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostedApp_ProducesBootJsonDataWithExpectedContent()
         {
             // Arrange
@@ -636,7 +636,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             bootJsonData.config.Should().Contain("../appsettings.development.json");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostedApp_WithSatelliteAssemblies()
         {
             // Arrange
@@ -685,7 +685,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             bootJsonData.Should().Contain("\"Microsoft.CodeAnalysis.CSharp.resources.wasm\"");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         // Regression test for https://github.com/dotnet/aspnetcore/issues/18752
         public void Publish_HostedApp_WithoutTrimming_Works()
         {
@@ -786,7 +786,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 assetsManifestPath: "custom-service-worker-assets.js");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostedApp_WithNoBuild_Works()
         {
             // Arrange
@@ -839,7 +839,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 assetsManifestPath: "custom-service-worker-assets.js");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostedApp_VisualStudio()
         {
             // Simulates publishing the same way VS does by setting BuildProjectReferences=false.
@@ -923,7 +923,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 assetsManifestPath: "custom-service-worker-assets.js");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostedAppWithScopedCss_VisualStudio()
         {
             // Simulates publishing the same way VS does by setting BuildProjectReferences=false.
@@ -1015,7 +1015,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 
         // Regression test to verify satellite assemblies from the blazor app are copied to the published app's wwwroot output directory as
         // part of publishing in VS
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostedApp_VisualStudio_WithSatelliteAssemblies()
         {
             var testAppName = "BlazorWasmWithLibrary";
@@ -1067,7 +1067,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostedApp_WithRidSpecifiedInCLI_Works()
         {
             // Arrange
@@ -1081,7 +1081,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             AssertRIDPublishOuput(publishCommand, testInstance, hosted: true);
         }
 
-        [ConditionalFact(Skip="https://github.com/dotnet/installer/issues/17453")]
+        [ConditionalFact()]
         public void Publish_HostedApp_WithRidSpecifiedAsArgument_NoSelfContained_Works()
         {
             // Arrange
@@ -1125,7 +1125,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             AssertRIDPublishOuput(publishCommand, testInstance, hosted: true);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostedApp_WithRid_Works()
         {
             // Arrange
@@ -1302,7 +1302,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 assetsManifestPath: "custom-service-worker-assets.js");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithInvariantGlobalizationEnabled_DoesNotCopyGlobalizationData()
         {
             // Arrange
@@ -1337,7 +1337,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(publishOutputDirectory, "wwwroot", "_framework", "icudt_no_CJK.dat")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_HostingMultipleBlazorWebApps_Works()
         {
             // Regression test for https://github.com/dotnet/aspnetcore/issues/29264
@@ -1394,7 +1394,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(secondAppPublishDirectory, "_framework", "Newtonsoft.Json.wasm.br")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithTransitiveReference_Works()
         {
             // Regression test for https://github.com/dotnet/aspnetcore/issues/37574.

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPwaManifestTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPwaManifestTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
     {
         public WasmPwaManifestTests(ITestOutputHelper log) : base(log) { }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_ServiceWorkerAssetsManifest_Works()
         {
             // Arrange
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                assetsManifestPath: "service-worker-assets.js");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_HostedAppWithServiceWorker_Works()
         {
             // Arrange
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             entries.Should().Contain(e => expectedExtensions.Contains(Path.GetExtension(e)));
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void PublishWithPWA_ProducesAssets()
         {
             // Arrange
@@ -103,7 +103,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Assert.FileContainsLine(result, serviceWorkerFile, "// This is the production service worker");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void PublishHostedWithPWA_ProducesAssets()
         {
             // Arrange
@@ -131,7 +131,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Assert.FileContainsLine(result, serviceWorkerFile, "// This is the production service worker");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_UpdatesServiceWorkerVersionHash_WhenSourcesChange()
         {
             // Arrange
@@ -171,7 +171,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             updatedCapture.Should().NotBe(capture);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_DeterministicAcrossBuilds_WhenNoSourcesChange()
         {
             // Arrange

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ApplicationPartDiscoveryIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ApplicationPartDiscoveryIntegrationTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(outputPath, "AppWithP2PReference.dll")).AssemblyShould().HaveAttribute("Microsoft.AspNetCore.Mvc.ApplicationParts.ApplicationPartAttribute");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_ProjectWithoutMvcReferencingDependencies_DoesNotGenerateAttribute()
         {
             var testAsset = "RazorSimpleMvc";
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         // Regression test for https://github.com/dotnet/aspnetcore/issues/11315
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void BuildIncrementalism_CausingRecompilation_WhenApplicationPartAttributeIsGenerated()
         {
             var testAsset = "RazorAppWithP2PReference";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntegrationTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         public void Build_SimpleMvc_UsingDotnetMSBuildAndWithoutBuildServer_CanBuildSuccessfully()
             => Build_SimpleMvc_WithoutBuildServer_CanBuildSuccessfully();
 
-        [FullMSBuildOnlyFactAttribute(Skip="https://github.com/dotnet/installer/issues/17453")]
+        [FullMSBuildOnlyFactAttribute]
         public void Build_SimpleMvc_UsingDesktopMSBuildAndWithoutBuildServer_CanBuildSuccessfully()
             => Build_SimpleMvc_WithoutBuildServer_CanBuildSuccessfully();
 
@@ -36,7 +36,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(outputPath, "SimpleMvc.Views.pdb")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_SimpleMvc_NoopsWithRazorCompileOnBuild_False()
         {
             var testAsset = "RazorSimpleMvc";
@@ -81,7 +81,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(intermediateOutputPath, "SimpleMvc.dll")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithP2P_CopiesRazorAssembly()
         {
             var testAsset = "RazorAppWithP2PReference";
@@ -102,7 +102,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(outputPath, "ClassLibrary.Views.pdb")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_CompilationContextAndRefsDirectoryAreNotPreserved()
         {
             var testAsset = "RazorSimpleMvc";
@@ -126,7 +126,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new DirectoryInfo(Path.Combine(outputPath, "publish", "refs")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithPreserveCompilationReferencesEnabled_ProducesRefsDirectory()
         {
             var testAsset = "RazorSimpleMvc";
@@ -146,7 +146,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(outputPath, "refs", "mscorlib.dll")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_AddsApplicationPartAttributes()
         {
             var testAsset = "RazorSimpleMvc";
@@ -164,7 +164,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_DoesNotAddRelatedAssemblyPart_IfViewCompilationIsDisabled()
         {
             var testAsset = "RazorSimpleMvc";
@@ -180,7 +180,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(intermediateOutputPath, "SimpleMvc.RazorTargetAssemblyInfo.cs")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithP2P_WorksWhenBuildProjectReferencesIsDisabled()
         {
             var testAsset = "RazorAppWithP2PReference";
@@ -216,7 +216,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             build.Execute("/p:BuildProjectReferences=false").Should().Pass();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithP2P_Referencing21Project_Works()
         {
             // Verifies building with different versions of Razor.Tasks works. Loosely modeled after the repro
@@ -247,7 +247,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(outputPath, "ClassLibraryMvc21.Views.dll")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WithStartupObjectSpecified_Works()
         {
             var testAsset = "RazorSimpleMvc";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntrospectionTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntrospectionTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
     {
         public BuildIntrospectionTest(ITestOutputHelper log) : base(log) {}
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void RazorSdk_AddsCshtmlFilesToUpToDateCheckInput()
         {
             var testAsset = "RazorSimpleMvc";
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 .And.HaveStdOutContaining($"UpToDateCheckInput: {Path.Combine("Views", "_ViewStart.cshtml")}");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void UpToDateReloadFileTypes_Default()
         {
             var testAsset = "RazorSimpleMvc";
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 .And.HaveStdOutContaining("UpToDateReloadFileTypes: ;.cs;.razor;.resx;.cshtml");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void UpToDateReloadFileTypes_WithRuntimeCompilation()
         {
             var testAsset = "RazorSimpleMvc";
@@ -56,7 +56,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 .And.HaveStdOutContaining("UpToDateReloadFileTypes: ;.cs;.razor;.resx;");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void UpToDateReloadFileTypes_WithwWorkAroundRemoved()
         {
             var testAsset = "RazorSimpleMvc";
@@ -69,7 +69,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 .And.HaveStdOutContaining("UpToDateReloadFileTypes: ;.cs;.razor;.resx;.cshtml");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void UpToDateReloadFileTypes_WithRuntimeCompilationAndWorkaroundRemoved()
         {
             var testAsset = "RazorSimpleMvc";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponentsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponentsIntegrationTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         [CoreMSBuildOnlyFact]
         public void Build_Components_WithDotNetCoreMSBuild_Works() => Build_ComponentsWorks();
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [RequiresMSBuildVersionFact("17.8.0.37606")]
         public void Build_Components_WithDesktopMSBuild_Works() => Build_ComponentsWorks();
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/DesignTimeBuildIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/DesignTimeBuildIntegrationTest.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
     {
         public DesignTimeBuildIntegrationTest(ITestOutputHelper log) : base(log) {}
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void DesignTimeBuild_DoesNotRunRazorTargets()
         {
             var testAsset = "RazorSimpleMvc";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/JsModulesIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/JsModulesIntegrationTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         {
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_NoOps_WhenJsModulesIsDisabled()
         {
             var testAsset = "RazorComponentApp";
@@ -29,7 +29,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(intermediateOutputPath, "jsmodules", "jsmodules.build.manifest.json")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_GeneratesManifestWhenItFindsALibrary()
         {
             var testAsset = "RazorComponentApp";
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             file.Should().Contain("ComponentApp.lib.module.js");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_DiscoversJsModulesBasedOnPatterns()
         {
             var testAsset = "RazorComponentApp";
@@ -84,7 +84,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_PublishesBundleToTheRightLocation()
         {
             var testAsset = "RazorComponentApp";
@@ -111,7 +111,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_DoesNotPublishAnyFile_WhenThereAreNoJsModulesFiles()
         {
             var testAsset = "RazorComponentApp";
@@ -126,7 +126,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "ComponentApp.modules.json")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Does_Nothing_WhenThereAreNoJsModulesFiles()
         {
             var testAsset = "RazorComponentApp";
@@ -142,7 +142,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             file.Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_JsModules_IsIncremental()
         {
             // Arrange
@@ -182,7 +182,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void BuildProjectWithReferences_IncorporatesInitializersFromClassLibraries()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -218,7 +218,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             file.Should().Contain("_content/ClassLibrary/ClassLibrary.lib.module.js");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void PublishProjectWithReferences_IncorporatesInitializersFromClassLibrariesAndPublishesAssetsToTheRightLocation()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -262,7 +262,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             file.Should().NotContain("_content/ClassLibrary/AnotherClassLib.lib.module.js");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void PublishProjectWithReferences_DifferentBuildAndPublish_LibraryInitializers()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTest50.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTest50.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         public override string TestProjectName => "SimpleMvc50";
         public override string TargetFramework => "net5.0";
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void BuildComponents_ErrorInGeneratedCode_ReportsMSBuildError_OnIncrementalBuild()
         {
             var testAsset = "RazorMvcWithComponents";
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void IncrementalBuild_WithP2P_WorksWhenBuildProjectReferencesIsDisabled()
         {
             // Simulates building the same way VS does by setting BuildProjectReferences=false.

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/PackIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/PackIntegrationTest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 
         public PackIntegrationTest(ITestOutputHelper log) : base(log) {}
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_NoBuild_Works_IncludesAssembly()
         {
             var testAsset = "RazorClassLibrary";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/PublishIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/PublishIntegrationTest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
     {
         public PublishIntegrationTest(ITestOutputHelper log) : base(log) {}
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_RazorCompileOnPublish_IsDefault()
         {
             var testAsset = "RazorSimpleMvc";
@@ -62,7 +62,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new DirectoryInfo(Path.Combine(publishOutputPath, "Views")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_NoopsWith_RazorCompileOnPublishFalse()
         {
             var testAsset = "RazorSimpleMvc";
@@ -80,7 +80,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(publishOutputPath, "SimpleMvc.pdb")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_IncludeCshtmlAndRefAssemblies_CopiesFiles()
         {
             var testAsset = "RazorSimpleMvc";
@@ -100,7 +100,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new DirectoryInfo(Path.Combine(publishOutputPath, "Views")).Should().NotBeEmpty();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithPreserveCompilationReferencesSetInProjectFile_CopiesRefs()
         {
             var testAsset = "RazorSimpleMvc";
@@ -126,7 +126,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(publishOutputPath, "refs", "mscorlib.dll")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithP2P_AndRazorCompileOnBuild_CopiesRazorAssembly()
         {
             var testAsset = "RazorAppWithP2PReference";
@@ -148,7 +148,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new DirectoryInfo(Path.Combine(publishOutputPath, "Views")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithP2P_WorksWhenBuildProjectReferencesIsDisabled()
         {
             // Simulates publishing the same way VS does by setting BuildProjectReferences=false.
@@ -194,7 +194,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(publishOutputPath, "AnotherClassLib.pdb")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_WithNoBuild_CopiesAlreadyCompiledViews()
         {
             var testAsset = "RazorSimpleMvc";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
     {
         public ScopedCssIntegrationTest(ITestOutputHelper log) : base(log, GenerateBaselines) { }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_NoOps_WhenScopedCssIsDisabled()
         {
             var testAsset = "RazorComponentApp";
@@ -27,7 +27,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "Components", "Pages", "FetchData.razor.rz.scp.css")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_NoOps_ForMvcApp_WhenScopedCssIsDisabled()
         {
             var testAsset = "RazorSimpleMvc";
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "Views", "Home", "About.cshtml.rz.scp.css")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void CanDisableDefaultDiscoveryConvention()
         {
             var testAsset = "RazorComponentApp";
@@ -96,7 +96,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "Components", "Pages", "Index.razor.rz.scp.css")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_GeneratesTransformedFilesAndBundle_ForComponentsWithScopedCss()
         {
             var testAsset = "RazorComponentApp";
@@ -114,7 +114,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "Components", "Pages", "FetchData.razor.rz.scp.css")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_GeneratesTransformedFilesAndBundle_ForViewsWithScopedCss()
         {
             var testAsset = "RazorSimpleMvc";
@@ -132,7 +132,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "Views", "Home", "About.cshtml.rz.scp.css")).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_ScopedCssFiles_ContainsUniqueScopesPerFile()
         {
             var testAsset = "RazorComponentApp";
@@ -161,7 +161,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             Assert.NotEqual(counterScopeId, indexScopeId);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_ScopedCssViews_ContainsUniqueScopesPerView()
         {
             var testAsset = "RazorSimpleMvc";
@@ -199,7 +199,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             Assert.NotEqual(aboutScopeId, contactScopeId);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_WorksWhenViewsAndComponentsArePartOfTheSameProject_ContainsUniqueScopesPerFile()
         {
             var testAsset = "RazorMvcWithComponents";
@@ -230,7 +230,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             Assert.NotEqual(indexScopeId, counterScopeId);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_PublishesBundleToTheRightLocation()
         {
             var testAsset = "RazorComponentApp";
@@ -247,7 +247,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "_content", "ComponentApp", "Components", "Pages", "Counter.razor.rz.scp.css")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_NoBuild_PublishesBundleToTheRightLocation()
         {
             var testAsset = "RazorComponentApp";
@@ -268,7 +268,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "_content", "ComponentApp", "Components", "Pages", "Counter.razor.rz.scp.css")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_DoesNotPublishAnyFile_WhenThereAreNoScopedCssFiles()
         {
             var testAsset = "RazorComponentApp";
@@ -285,7 +285,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "_content", "ComponentApp", "_framework", "scoped.styles.css")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_Publishes_IndividualScopedCssFiles_WhenNoBundlingIsEnabled()
         {
             var testAsset = "RazorComponentApp";
@@ -340,7 +340,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             Assert.NotEqual(bundleThumbprint, newBundleThumbprint);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Does_Nothing_WhenThereAreNoScopedCssFiles()
         {
             var testAsset = "RazorComponentApp";
@@ -359,7 +359,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "_framework", "scoped.styles.css")).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_ScopedCssTransformation_AndBundling_IsIncremental()
         {
             // Arrange
@@ -396,7 +396,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             }
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void BuildProjectWithReferences_CorrectlyBundlesScopedCssFiles()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -429,7 +429,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             appBundle.Should().Contain("_content/PackageLibraryDirectDependency/PackageLibraryDirectDependency.bundle.scp.css");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void ScopedCss_IsBackwardsCompatible_WithPreviousVersions()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -472,7 +472,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             appBundle.Should().Contain("_content/PackageLibraryDirectDependency/PackageLibraryDirectDependency.bundle.scp.css");
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void ScopedCss_PublishIsBackwardsCompatible_WithPreviousVersions()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -516,7 +516,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         // This test verifies if the targets that VS calls to update scoped css works to update these files
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void RegeneratingScopedCss_ForProject()
         {
             // Arrange
@@ -545,7 +545,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         // Regression test for https://github.com/dotnet/aspnetcore/issues/37592
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void RegeneratingScopedCss_ForProjectWithReferences()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsCrossTargetingTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsCrossTargetingTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         public StaticWebAssetsCrossTargetingTests(ITestOutputHelper log) : base(log, GenerateBaselines) { }
 
         // Build Standalone project
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_CrosstargetingTests_CanIncludeBrowserAssets()
         {
             var expectedManifest = LoadBuildManifest();
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(finalPath).Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_CrosstargetingTests_CanIncludeBrowserAssets()
         {
             var testAsset = "RazorComponentAppMultitarget";

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         public StaticWebAssetsIntegrationTest(ITestOutputHelper log) : base(log, GenerateBaselines) { }
 
         // Build Standalone project
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_GeneratesJsonManifestAndCopiesItToOutputFolder()
         {
             var expectedManifest = LoadBuildManifest();
@@ -39,7 +39,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             AssertBuildAssets(manifest1, outputPath, intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_DoesNotUpdateManifest_WhenHasNotChanged()
         {
             var testAsset = "RazorComponentApp";
@@ -85,7 +85,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             secondFinalFile.LastWriteTimeUtc.Should().Be(originalFile.LastWriteTimeUtc);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_UpdatesManifest_WhenFilesChange()
         {
             var testAsset = "RazorComponentApp";
@@ -154,7 +154,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 
         // Project with references
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void BuildProjectWithReferences_GeneratesJsonManifestAndCopiesItToOutputFolder()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -185,7 +185,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void BuildProjectWithReferences_WorksWithStaticWebAssetsV1ClassLibraries()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -240,7 +240,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void PublishProjectWithReferences_WorksWithStaticWebAssetsV1ClassLibraries()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -303,7 +303,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         // Build no dependencies
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void BuildProjectWithReferences_NoDependencies_GeneratesJsonManifestAndCopiesItToOutputFolder()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -362,7 +362,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         // Rebuild
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Rebuild_RegeneratesJsonManifestAndCopiesItToOutputFolder()
         {
             var testAsset = "RazorComponentApp";
@@ -421,7 +421,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         // Publish
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {
             var testAsset = "RazorComponentApp";
@@ -455,7 +455,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {
             var expectedManifest = LoadBuildManifest();
@@ -493,7 +493,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Publish_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {
             var expectedManifest = LoadBuildManifest();
@@ -560,7 +560,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {
             var expectedManifest = LoadBuildManifest();
@@ -595,7 +595,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void PublishProjectWithReferences_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -636,7 +636,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void PublishProjectWithReferences_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -672,7 +672,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void PublishProjectWithReferences_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -738,7 +738,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void PublishProjectWithReferences_AppendTargetFrameworkToOutputPathFalse_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -780,7 +780,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 intermediateOutputPath);
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void BuildProjectWithReferences_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -819,7 +819,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         // Pack
 
         // Clean
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Clean_RemovesManifestFrom_BuildAndIntermediateOutput()
         {
             var expectedManifest = LoadBuildManifest();
@@ -854,7 +854,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(finalPath).Should().NotExist();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_Fails_WhenConflictingAssetsFoundBetweenAStaticWebAssetAndAFileInTheWebRootFolder()
         {
             var testAsset = "RazorAppWithPackageAndP2PReference";
@@ -867,7 +867,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             build.Execute().Should().Fail();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_FailsWhenStaticWebAssetsHaveConflictingPaths()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -894,7 +894,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         // If you modify this test, make sure you also modify the test below this one to assert that things are not included as content.
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_IncludesStaticWebAssets()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -924,7 +924,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_NoAssets_DoesNothing()
         {
             var testAsset = "PackageLibraryNoStaticAssets";
@@ -952,7 +952,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_NoAssets_Multitargeting_DoesNothing()
         {
             var testAsset = "PackageLibraryNoStaticAssets";
@@ -987,7 +987,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_Incremental_IncludesStaticWebAssets()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -1023,7 +1023,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_StaticWebAssets_WithoutFileExtension_AreCorrectlyPacked()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -1056,7 +1056,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_StaticWebAssets_GeneratePackageOnBuild_PacksStaticWebAssets()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -1088,7 +1088,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Build_StaticWebAssets_GeneratePackageOnBuild_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -1119,7 +1119,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_MultipleTargetFrameworks_Works()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -1160,7 +1160,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_MultipleTargetFrameworks_NoBuild_IncludesStaticWebAssets()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -1205,7 +1205,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_MultipleTargetFrameworks_NoBuild_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -1248,7 +1248,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_MultipleTargetFrameworks_GeneratePackageOnBuild_IncludesStaticWebAssets()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -1289,7 +1289,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_MultipleTargetFrameworks_GeneratePackageOnBuild_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -1328,7 +1328,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_BeforeNet60_MultipleTargetFrameworks_WithScopedCss_IncludesAssetsAndProjectBundle()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -1398,7 +1398,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_BeforeNet60_MultipleTargetFrameworks_WithScopedCss_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -1467,7 +1467,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_BeforeNet60_MultipleTargetFrameworks_NoBuild_WithScopedCss_IncludesAssetsAndProjectBundle()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -1543,7 +1543,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_BeforeNet60_MultipleTargetFrameworks_NoBuild_WithScopedCss_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -1618,7 +1618,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_BeforeNet60_MultipleTargetFrameworks_GeneratePackageOnBuild_WithScopedCss_IncludesAssetsAndProjectBundle()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -1688,7 +1688,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_BeforeNet60_MultipleTargetFrameworks_GeneratePackageOnBuild_WithScopedCss_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -1757,7 +1757,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_Net50_WithScopedCss_IncludesAssetsAndProjectBundle()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -1825,7 +1825,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_Net50_WithScopedCss_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -1892,7 +1892,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_Net50_NoBuild_WithScopedCss_IncludesAssetsAndProjectBundle()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -1966,7 +1966,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_Net50_NoBuild_WithScopedCss_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -2039,7 +2039,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_Net50_GeneratePackageOnBuild_WithScopedCss_IncludesAssetsAndProjectBundle()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -2107,7 +2107,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_Net50_GeneratePackageOnBuild_WithScopedCss_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -2174,7 +2174,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_MultipleTargetFrameworks_WithScopedCssAndJsModules_IncludesAssetsAndProjectBundle()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -2251,7 +2251,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_Incremental_MultipleTargetFrameworks_WithScopedCssAndJsModules_IncludesAssetsAndProjectBundle()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -2330,7 +2330,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_MultipleTargetFrameworks_WithScopedCssAndJsModules_DoesNotIncludeApplicationBundleNorModulesManifest()
         {
             var testAsset = "PackageLibraryTransitiveDependency";
@@ -2398,7 +2398,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_MultipleTargetFrameworks_DoesNotIncludeAssetsAsContent()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -2437,7 +2437,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_DoesNotInclude_TransitiveBundleOrScopedCssAsStaticWebAsset()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -2463,7 +2463,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_DoesNotIncludeStaticWebAssetsAsContent()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -2495,7 +2495,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_NoBuild_IncludesStaticWebAssets()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -2526,7 +2526,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_NoBuild_DoesNotIncludeFilesAsContent()
         {
             var testAsset = "PackageLibraryDirectDependency";
@@ -2556,7 +2556,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_DoesNotIncludeAnyCustomPropsFiles_WhenNoStaticAssetsAreAvailable()
         {
             var testAsset = "RazorComponentLibrary";
@@ -2580,7 +2580,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 });
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void Pack_Incremental_DoesNotRegenerateCacheAndPropsFiles()
         {
             var testAsset = "PackageLibraryTransitiveDependency";

--- a/src/Tests/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Sdk.Web.Tests
         {
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [MemberData(nameof(SupportedTfms))]
         public void TrimmingOptions_Are_Defaulted_Correctly_On_Trimmed_Apps(string targetFramework)
         {
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Sdk.Web.Tests
                     .Should().BeFalse();
         }
 
-        [RequiresMSBuildVersionFact("17.8.1.47607")]
+        [Fact]
         public void TrimMode_Defaulted_Correctly_On_Trimmed_Apps_Pre_Net8()
         {
             var projectName = "HelloWorld";
@@ -65,7 +65,7 @@ namespace Microsoft.NET.Sdk.Web.Tests
             buildProperties["TrimMode"].Should().Be("partial");
         }
 
-        [RequiresMSBuildVersionTheory("17.8.1.47607")]
+        [Theory]
         [MemberData(nameof(SupportedTfms))]
         public void TrimmingOptions_Are_Defaulted_Correctly_On_Aot_Apps(string targetFramework)
         {


### PR DESCRIPTION
Reverts:
- https://github.com/dotnet/sdk/pull/36053/commits/64c049db282bcf71d92db70931f5fd0fee17c989
- https://github.com/dotnet/sdk/pull/36053/commits/b02701649410d4195a9f6b761789ff67ba677bfa
- https://github.com/dotnet/sdk/pull/36053/commits/95073a446991f30ba2219b6e522af09c5fc12bff

## Summary
These tests were skipped because the CI agents did not contain the required VS version to run them. Now, the agents have been updated to VS 17.8-preview3 which should allow these tests to run.