### PR TITLE
Silence workload install logging on `dotnet --info` and related commands.

### DIFF
--- a/src/Cli/dotnet/Installer/Windows/ISynchronizingLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/ISynchronizingLogger.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Installer.Windows
+{
+    /// <summary>
+    /// Represents a type used to log setup operations that can manage a series of named pipes writing to it.
+    /// </summary>
+    internal interface ISynchronizingLogger : ISetupLogger
+    {
+        /// <summary>
+        /// Starts a new thread to listen for log requests messages from external processes.
+        /// </summary>
+        /// <param name="pipeName">The name of the pipe.</param>
+        void AddNamedPipe(string pipeName);
+    }
+}

--- a/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
@@ -14,13 +14,13 @@ namespace Microsoft.DotNet.Installer.Windows
     [SupportedOSPlatform("windows")]
     internal sealed class InstallClientElevationContext : InstallElevationContextBase
     {
-        private TimestampedFileLogger _log;
+        private ISynchronizingLogger _log;
 
         private Process _serverProcess;
 
         public override bool IsClient => true;
 
-        public InstallClientElevationContext(TimestampedFileLogger logger)
+        public InstallClientElevationContext(ISynchronizingLogger logger)
         {
             _log = logger;
         }
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Installer.Windows
 
                     // Add a pipe to the logger to allow the server to send log requests. This avoids having an elevated process writing
                     // to a less privileged location. It also simplifies troubleshooting because log events will be chronologically
-                    // ordered in a single file. 
+                    // ordered in a single file.
                     _log.AddNamedPipe(WindowsUtils.CreatePipeName(_serverProcess.Id, "log"));
 
                     HasElevated = true;

--- a/src/Cli/dotnet/Installer/Windows/NullInstallerLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/NullInstallerLogger.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace Microsoft.DotNet.Installer.Windows;
+
+/// <summary>
+/// A class that swallows all logging - used for code paths where logging setup operations isn't valuable, like <c>dotnet --info<c>.
+/// </summary>
+internal class NullInstallerLogger : ISynchronizingLogger
+{
+    public string LogPath => String.Empty;
+
+    public void AddNamedPipe(string pipeName)
+    {
+
+    }
+
+    public void LogMessage(string message)
+    {
+
+    }
+}

--- a/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Installer.Windows
     /// queue messages.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    internal class TimestampedFileLogger : SetupLoggerBase, IDisposable, ISetupLogger
+    internal class TimestampedFileLogger : SetupLoggerBase, IDisposable, ISynchronizingLogger
     {
         /// <summary>
         /// Thread safe queue use to store incoming log request messages.
@@ -81,10 +81,6 @@ namespace Microsoft.DotNet.Installer.Windows
             LogMessage($"=== Logging started ===");
         }
 
-        /// <summary>
-        /// Starts a new thread to listen for log requests messages from external processes.
-        /// </summary>
-        /// <param name="pipeName">The name of the pipe.</param>
         public void AddNamedPipe(string pipeName)
         {
             Thread logRequestThread = new Thread(ProcessLogRequests) { IsBackground = true };

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
@@ -56,7 +56,8 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 userProfileDir,
                 verifySignatures ?? !SignCheck.IsDotNetSigned(),
                 restoreActionConfig: restoreConfig,
-                elevationRequired: false);
+                elevationRequired: false,
+                shouldLog: false);
 
             WorkloadRecordRepo = workloadRecordRepo ?? Installer.GetWorkloadInstallationRecordRepository();
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -1019,9 +1019,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             PackageSourceLocation packageSourceLocation = null,
             IReporter reporter = null,
             string tempDirPath = null,
-            RestoreActionConfig restoreActionConfig = null)
+            RestoreActionConfig restoreActionConfig = null,
+            bool shouldLog = true)
         {
-            TimestampedFileLogger logger = new(Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log"));
+            ISynchronizingLogger logger =
+                shouldLog ? new TimestampedFileLogger(Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log"))
+                          : new NullInstallerLogger();
             InstallClientElevationContext elevationContext = new(logger);
 
             if (nugetPackageDownloader == null)

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallerFactory.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallerFactory.cs
@@ -23,7 +23,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             string tempDirPath = null,
             PackageSourceLocation packageSourceLocation = null,
             RestoreActionConfig restoreActionConfig = null,
-            bool elevationRequired = true)
+            bool elevationRequired = true,
+            bool shouldLog = true)
         {
             dotnetDir = string.IsNullOrWhiteSpace(dotnetDir) ? Path.GetDirectoryName(Environment.ProcessPath) : dotnetDir;
             var installType = WorkloadInstallType.GetWorkloadInstallType(sdkFeatureBand, dotnetDir);
@@ -34,9 +35,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 {
                     throw new InvalidOperationException(LocalizableStrings.OSDoesNotSupportMsi);
                 }
-
+                // TODO: should restoreActionConfig be flowed through to the client here as well like it is for the FileBasedInstaller below?
                 return NetSdkMsiInstallerClient.Create(verifySignatures, sdkFeatureBand, workloadResolver,
-                    nugetPackageDownloader, verbosity, packageSourceLocation, reporter, tempDirPath);
+                    nugetPackageDownloader, verbosity, packageSourceLocation, reporter, tempDirPath, shouldLog: shouldLog);
             }
 
             if (elevationRequired && !WorkloadFileBasedInstall.IsUserLocal(dotnetDir, sdkFeatureBand.ToString()) && !CanWriteToDotnetRoot(dotnetDir))


### PR DESCRIPTION
Fixes #36441

This creates a NullLogger which can be used in place of TimestampedFileLogger and wires it up when the codepath triggered by `dotnet --info` is used. This should result in fewer scattered files in the temp directory for workload logs.