### PR TITLE
Add $(_InternalRuntimeDownloadArgs) to Aot Helix Tests

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -272,6 +272,7 @@ jobs:
                 -configuration $(_BuildConfig)
                 /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\TestInHelix.binlog
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
+                $(_InternalRuntimeDownloadArgs)
           displayName: Run AoT Tests in Helix
           env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -304,6 +305,7 @@ jobs:
                 --projects $(Build.SourcesDirectory)/src/Tests/UnitTests.proj
                 /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/TestInHelix.binlog
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
+                $(_InternalRuntimeDownloadArgs)
           displayName: Run AoT Tests in Helix
           env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
This should fix https://dev.azure.com/dnceng/internal/_build/results?buildId=2301426&view=logs&j=e0ea1dd1-b56f-550d-c202-0c362938b47b&t=f171a33f-5a94-52fc-9bfb-a5e271e27b6b