### PR TITLE
Upgrade Ubuntu image for Template Engine pipeline to 2204

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -14,7 +14,6 @@ pr:
     - release/*
     - internal/release/*
 
-
 variables:
   - name: teamName
     value: Roslyn-Project-System

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -27,7 +27,8 @@ jobs:
         agentOs: Ubuntu_22_04_TemplateEngine
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            vmImage: 'ubuntu-22.04'
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals build.ubuntu.2204.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals build.ubuntu.2204.amd64

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -27,13 +27,12 @@ jobs:
         agentOs: Ubuntu_22_04_TemplateEngine
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals 1es-ubuntu-2204-open
+            vmImage: 'ubuntu-22.04'
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals 1es-ubuntu-2204
+            demands: ImageOverride -equals build.ubuntu.2204.amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64'
+          helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
           helixTargetQueue: Ubuntu.2204.Amd64
         strategy:

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -24,18 +24,18 @@ jobs:
 
     - template: /eng/build.yml
       parameters:
-        agentOs: Ubuntu_20_04_TemplateEngine
+        agentOs: Ubuntu_22_04_TemplateEngine
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals 1es-ubuntu-2004-open
+            demands: ImageOverride -equals 1es-ubuntu-2204-open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals 1es-ubuntu-2004
+            demands: ImageOverride -equals 1es-ubuntu-2204
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: 'ubuntu.2004.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64'
+          helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64'
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Ubuntu.2004.Amd64
+          helixTargetQueue: Ubuntu.2204.Amd64
         strategy:
           matrix:
             Build_Release:


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/36323

## Summary
After chatting with the engineering systems team, it seems the out of space issue was [already known](https://github.com/dotnet/arcade/issues/13036). It was recommended that I update from the 2004 images for Ubuntu to the 2204 images to circumvent the issue.

I'll backport it to 8.0.2xx if it works properly here.