### PR TITLE
Change the format of tool exceptions and NuGet API exceptions to be graceful

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/GracefulException.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/GracefulException.cs
@@ -8,6 +8,10 @@ namespace Microsoft.DotNet.Cli.Utils
         public bool IsUserError { get; } = true;
         public string VerboseMessage { get; } = string.Empty;
 
+        public GracefulException()
+        {
+        }
+
         public GracefulException(string message) : base(message)
         {
             Data.Add(ExceptionExtensions.CLI_User_Displayed_Exception, true);

--- a/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
+++ b/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
@@ -144,4 +144,19 @@
   <data name="FailedToMapSourceUnderPackageSourceMapping" xml:space="preserve">
     <value>Package Source Mapping is enabled, but no source mapped under the specified package ID: {0}. See the documentation for Package Source Mapping at https://aka.ms/nuget-package-source-mapping for more details.</value>
   </data>
+  <data name="PackageVersionDescriptionDefault" xml:space="preserve">
+    <value>A version of {0} of package {1}</value>
+  </data>
+  <data name="PackageVersionDescriptionForExactVersionMatch" xml:space="preserve">
+    <value>Version {0} of package {1}</value>
+  </data>
+  <data name="PackageVersionDescriptionForVersionWithLowerAndUpperBounds" xml:space="preserve">
+    <value>A version between {0} and {1} of package {2}</value>
+  </data>
+  <data name="PackageVersionDescriptionForVersionWithLowerBound" xml:space="preserve">
+    <value>A version higher than {0} of package {1}</value>
+  </data>
+  <data name="PackageVersionDescriptionForVersionWithUpperBound" xml:space="preserve">
+    <value>A version less than {0} of package {1}</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -463,25 +463,29 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             {
                 return $"{packageIdentifier}";
             }
-            else if(versionRange.HasLowerAndUpperBounds && versionRange.MinVersion == versionRange.MaxVersion)
+            else if (versionRange.HasLowerAndUpperBounds && versionRange.MinVersion == versionRange.MaxVersion)
             {
-                return $"Version {versionRange.MinVersion} of package {packageIdentifier}";
+                return string.Format(LocalizableStrings.PackageVersionDescriptionForExactVersionMatch,
+                    versionRange.MinVersion, packageIdentifier);
             }
-            else if(versionRange.HasLowerAndUpperBounds)
+            else if (versionRange.HasLowerAndUpperBounds)
             {
-                return $"A version between {versionRange.MinVersion} and {versionRange.MaxVersion} of package {packageIdentifier}";
+                return string.Format(LocalizableStrings.PackageVersionDescriptionForVersionWithLowerAndUpperBounds,
+                    versionRange.MinVersion, versionRange.MaxVersion, packageIdentifier);
             }
-            else if(versionRange.HasLowerBound)
+            else if (versionRange.HasLowerBound)
             {
-                return $"A version higher than {versionRange.MinVersion} of package {packageIdentifier}";
+                return string.Format(LocalizableStrings.PackageVersionDescriptionForVersionWithLowerBound,
+                    versionRange.MinVersion, packageIdentifier);
             }
-            else if(versionRange.HasUpperBound)
+            else if (versionRange.HasUpperBound)
             {
-                return $"A version less than {versionRange.MaxVersion} of package {packageIdentifier}";
+                return string.Format(LocalizableStrings.PackageVersionDescriptionForVersionWithUpperBound,
+                    versionRange.MaxVersion, packageIdentifier);
             }
 
             // Default message if the format doesn't match any of the expected cases
-            return $"A version of {versionRange} of package {packageIdentifier}";
+            return string.Format(LocalizableStrings.PackageVersionDescriptionDefault, versionRange, packageIdentifier);
         }
 
         private async Task<(PackageSource, IPackageSearchMetadata)> GetLatestVersionInternalAsync(

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -459,7 +459,11 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
         private string GenerateVersionRangeErrorDescription(string packageIdentifier, VersionRange versionRange)
         {
-            if(versionRange.HasLowerAndUpperBounds && versionRange.MinVersion == versionRange.MaxVersion)
+            if (!string.IsNullOrEmpty(versionRange.OriginalString) && versionRange.OriginalString == "*")
+            {
+                return $"{packageIdentifier}";
+            }
+            else if(versionRange.HasLowerAndUpperBounds && versionRange.MinVersion == versionRange.MaxVersion)
             {
                 return $"Version {versionRange.MinVersion} of package {packageIdentifier}";
             }

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -450,10 +450,9 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                 throw new NuGetPackageNotFoundException(
                     string.Format(
                         LocalizableStrings.IsNotFoundInNuGetFeeds,
-                        $"{packageIdentifier}::{versionRange}",
+                        $"{packageIdentifier} of version range {versionRange}",
                         string.Join(", ", packageSources.Select(source => source.Source))));
             }
-
         }
 
             private async Task<(PackageSource, IPackageSearchMetadata)> GetLatestVersionInternalAsync(

--- a/src/Cli/dotnet/NugetPackageDownloader/ToolPackageException.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/ToolPackageException.cs
@@ -1,9 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Cli.Utils;
+
 namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 {
-    internal class NuGetPackageInstallerException : Exception
+    internal class NuGetPackageInstallerException : GracefulException
     {
         public NuGetPackageInstallerException()
         {

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
@@ -42,6 +42,31 @@
         <target state="translated">Přeskakuje se ověření podpisu balíčku NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">Přeskočit ověřování podepisování balíčku NuGet. Ověřování podepisování balíčku NuGet není k dispozici na Linuxu nebo v macOS https://aka.ms/workloadskippackagevalidation.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
@@ -42,6 +42,31 @@
         <target state="translated">Die Überprüfung der NuGet-Paketsignatur wird übersprungen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">Überprüfung der NuGet-Paketsignierung überspringen. Die Überprüfung der NuGet-Signierung ist auf Linux- oder macOS nicht verfügbar https://aka.ms/workloadskippackagevalidation.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
@@ -42,6 +42,31 @@
         <target state="translated">Omitiendo la comprobación de la firma del paquete NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">Omitir la validación de firma del paquete NuGet. La validación de firma de NuGet no está disponible en Linux o macOS https://aka.ms/workloadskippackagevalidation.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
@@ -42,6 +42,31 @@
         <target state="translated">La vérification de la signature du package NuGet est ignorée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">Ignorer la validation de signature de package NuGet. La validation de signature NuGet n’est pas disponible sur Linux ou macOS https://aka.ms/workloadskippackagevalidation.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
@@ -42,6 +42,31 @@
         <target state="translated">La verifica della firma del pacchetto NuGet verrà ignorata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">Ignorare la convalida della firma del pacchetto NuGet. La convalida della firma NuGet non è disponibile in Linux o macOS https://aka.ms/workloadskippackagevalidation.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
@@ -42,6 +42,31 @@
         <target state="translated">NuGet パッケージ署名の認証をスキップしています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">NuGet パッケージ署名の検証をスキップします。NuGet 署名の検証は、Linux または macOS https://aka.ms/workloadskippackagevalidation では使用できません。</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
@@ -42,6 +42,31 @@
         <target state="translated">NuGet 패키지 서명 확인을 건너뛰는 중입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">NuGet 패키지 서명 유효성 검사를 건너뜁니다. NuGet 서명 유효성 검사는 Linux 또는 macOS https://aka.ms/workloadskippackagevalidation에서 사용할 수 없습니다.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
@@ -42,6 +42,31 @@
         <target state="translated">Pomijanie weryfikacji podpisu pakietu NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">Pomiń weryfikację podpisywania pakietu NuGet. Sprawdzanie podpisywania NuGet nie jest dostępne w systemie Linux ani MacOS https://aka.ms/workloadskippackagevalidation .</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
@@ -42,6 +42,31 @@
         <target state="translated">Ignorando a verificação de assinatura do pacote NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">Ignorar a validação da assinatura do pacote NuGet. A validação da assinatura do NuGet não está disponível no Linux ou macOS https://aka.ms/workloadskippackagevalidation .</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
@@ -42,6 +42,31 @@
         <target state="translated">Пропуск проверки подписи пакета NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">Пропустить проверку подписи пакета NuGet. Проверка подписи NuGet недоступна в Linux или macOS https://aka.ms/workloadskippackagevalidation.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
@@ -42,6 +42,31 @@
         <target state="translated">NuGet paket imzası doğrulaması atlanıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">NuGet paketi imza doğrulamasını atlayın. NuGet imza doğrulaması Linux veya macOS üzerinde kullanılamıyor. Daha fazla bilgi için bkz. https://aka.ms/workloadskippackagevalidation.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
@@ -42,6 +42,31 @@
         <target state="translated">正在跳过 NuGet 包签名验证。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">跳过 NuGet 包签名验证。Linux 或 macOS 上不提供 NuGet 签名验证。https://aka.ms/workloadskippackagevalidation。</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
@@ -42,6 +42,31 @@
         <target state="translated">正在略過 NuGet 套件簽章驗證。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageVersionDescriptionDefault">
+        <source>A version of {0} of package {1}</source>
+        <target state="new">A version of {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForExactVersionMatch">
+        <source>Version {0} of package {1}</source>
+        <target state="new">Version {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerAndUpperBounds">
+        <source>A version between {0} and {1} of package {2}</source>
+        <target state="new">A version between {0} and {1} of package {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithLowerBound">
+        <source>A version higher than {0} of package {1}</source>
+        <target state="new">A version higher than {0} of package {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionDescriptionForVersionWithUpperBound">
+        <source>A version less than {0} of package {1}</source>
+        <target state="new">A version less than {0} of package {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkipNuGetpackageSigningValidationmacOSLinux">
         <source>Skip NuGet package signing validation. NuGet signing validation is not available on Linux or macOS https://aka.ms/workloadskippackagevalidation .</source>
         <target state="translated">略過 NuGet 套件簽署驗證。NuGet 套件簽署驗證在 Linux 或 macOS 上無法使用 https://aka.ms/workloadskippackagevalidation。</target>

--- a/src/Cli/dotnet/ToolPackage/ToolPackageException.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageException.cs
@@ -1,9 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.ToolPackage
 {
-    internal class ToolPackageException : Exception
+    internal class ToolPackageException : GracefulException
     {
         public ToolPackageException()
         {


### PR DESCRIPTION
#36557 

Change the format of tool exceptions and NuGet API exceptions to be graceful without default stack dump