### PR TITLE
add missing --archiveoutputpath option to .NET Framework container tool task

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -187,6 +187,11 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
             builder.AppendSwitchIfNotNull("--container-user ", ContainerUser);
         }
 
+        if (!string.IsNullOrWhiteSpace(ArchiveOutputPath))
+        {
+            builder.AppendSwitchIfNotNull("--archiveoutputpath ", ArchiveOutputPath);
+        }
+
         return builder.ToString();
 
         void AppendSwitchIfNotNullSantized(CommandLineBuilder builder, string commandArgName, string propertyName, ITaskItem[] value)


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/36651

I'd love to have a better idea of how we could enforce remembering these properties in both task variants.