### PR TITLE
Add option to ignore baseline TFMs

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
@@ -30,7 +30,8 @@ namespace Microsoft.DotNet.ApiCompat
             string? baselinePackagePath,
             string? runtimeGraph,
             IReadOnlyDictionary<NuGetFramework, IEnumerable<string>>? packageAssemblyReferences,
-            IReadOnlyDictionary<NuGetFramework, IEnumerable<string>>? baselinePackageAssemblyReferences)
+            IReadOnlyDictionary<NuGetFramework, IEnumerable<string>>? baselinePackageAssemblyReferences,
+            string[]? baselinePackageFrameworksToIgnore)
         {
             // Initialize the service provider
             ApiCompatServiceProvider serviceProvider = new(logFactory,
@@ -70,7 +71,8 @@ namespace Microsoft.DotNet.ApiCompat
                     enableStrictMode: enableStrictModeForBaselineValidation,
                     enqueueApiCompatWorkItems: runApiCompat,
                     executeApiCompatWorkItems: false,
-                    baselinePackage: Package.Create(baselinePackagePath, baselinePackageAssemblyReferences)));
+                    Package.Create(baselinePackagePath, baselinePackageAssemblyReferences),
+                    baselinePackageFrameworksToIgnore));
             }
 
             if (runApiCompat)

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
@@ -118,6 +118,11 @@ namespace Microsoft.DotNet.ApiCompat.Task
         /// </summary>
         public ITaskItem[]? BaselinePackageAssemblyReferences { get; set; }
 
+        /// <summary>
+        /// A set of target frameworks to ignore from the baseline package.
+        /// </summary>
+        public string[]? BaselinePackageFrameworksToIgnore { get; set; }
+
         public override bool Execute()
         {
             RoslynResolver roslynResolver = RoslynResolver.Register(RoslynAssembliesPath!);
@@ -153,15 +158,16 @@ namespace Microsoft.DotNet.ApiCompat.Task
                 BaselinePackageTargetPath,
                 RuntimeGraph,
                 ParsePackageAssemblyReferences(PackageAssemblyReferences),
-                ParsePackageAssemblyReferences(BaselinePackageAssemblyReferences));
+                ParsePackageAssemblyReferences(BaselinePackageAssemblyReferences),
+                BaselinePackageFrameworksToIgnore);
         }
 
         private static Dictionary<NuGetFramework, IEnumerable<string>>? ParsePackageAssemblyReferences(ITaskItem[]? packageAssemblyReferences)
         {
-            if (packageAssemblyReferences == null || packageAssemblyReferences.Length == 0)
+            if (packageAssemblyReferences is null || packageAssemblyReferences.Length == 0)
                 return null;
 
-            Dictionary<NuGetFramework, IEnumerable<string>>? packageAssemblyReferencesDict = new(packageAssemblyReferences.Length);
+            Dictionary<NuGetFramework, IEnumerable<string>> packageAssemblyReferencesDict = new(packageAssemblyReferences.Length);
             foreach (ITaskItem taskItem in packageAssemblyReferences)
             {
                 string targetFrameworkMoniker = taskItem.GetMetadata("TargetFrameworkMoniker");

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/ValidatePackageTask.cs
@@ -120,6 +120,7 @@ namespace Microsoft.DotNet.ApiCompat.Task
 
         /// <summary>
         /// A set of target frameworks to ignore from the baseline package.
+        /// The framework string must exactly match the folder name in the baseilne package.
         /// </summary>
         public string[]? BaselinePackageFrameworksToIgnore { get; set; }
 

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -270,7 +270,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 Arity = ArgumentArity.ZeroOrMore,
                 HelpName = "tfm=file1,file2,..."
             };
-            CliOption<string[]?> baselinePackageFrameworksToIgnoreOption = new("--baseline-package-target-frameworks-to-ignore")
+            CliOption<string[]?> baselinePackageFrameworksToIgnoreOption = new("--baseline-package-frameworks-to-ignore")
             {
                 Description = "A set of target frameworks to ignore from the baseline package.",
                 AllowMultipleArgumentsPerToken = true,

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -270,6 +270,12 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 Arity = ArgumentArity.ZeroOrMore,
                 HelpName = "tfm=file1,file2,..."
             };
+            CliOption<string[]?> baselinePackageFrameworksToIgnoreOption = new("--baseline-package-target-frameworks-to-ignore")
+            {
+                Description = "A set of target frameworks to ignore from the baseline package.",
+                AllowMultipleArgumentsPerToken = true,
+                Arity = ArgumentArity.ZeroOrMore,
+            };
 
             CliCommand packageCommand = new("package", "Validates the compatibility of package assets");
             packageCommand.Arguments.Add(packageArgument);
@@ -281,6 +287,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             packageCommand.Options.Add(baselinePackageOption);
             packageCommand.Options.Add(packageAssemblyReferencesOption);
             packageCommand.Options.Add(baselinePackageAssemblyReferencesOption);
+            packageCommand.Options.Add(baselinePackageFrameworksToIgnoreOption);
             packageCommand.SetAction((ParseResult parseResult) =>
             {
                 // If a roslyn assemblies path isn't provided, use the compiled against version from a subfolder.
@@ -309,6 +316,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 string? runtimeGraph = parseResult.GetValue(runtimeGraphOption);
                 Dictionary<NuGetFramework, IEnumerable<string>>? packageAssemblyReferences = parseResult.GetValue(packageAssemblyReferencesOption);
                 Dictionary<NuGetFramework, IEnumerable<string>>? baselinePackageAssemblyReferences = parseResult.GetValue(baselinePackageAssemblyReferencesOption);
+                string[]? baselinePackageFrameworksToIgnore = parseResult.GetValue(baselinePackageFrameworksToIgnoreOption);
 
                 SuppressibleConsoleLog logFactory(ISuppressionEngine suppressionEngine) => new(suppressionEngine, verbosity);
                 ValidatePackage.Run(logFactory,
@@ -330,7 +338,8 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                     baselinePackage,
                     runtimeGraph,
                     packageAssemblyReferences,
-                    baselinePackageAssemblyReferences);
+                    baselinePackageAssemblyReferences,
+                    baselinePackageFrameworksToIgnore);
 
                 roslynResolver.Unregister();
             });

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -272,7 +272,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
             };
             CliOption<string[]?> baselinePackageFrameworksToIgnoreOption = new("--baseline-package-frameworks-to-ignore")
             {
-                Description = "A set of target frameworks to ignore from the baseline package.",
+                Description = "A set of target frameworks to ignore from the baseline package. The framework string must exactly match the folder name in the baseline package.",
                 AllowMultipleArgumentsPerToken = true,
                 Arity = ArgumentArity.ZeroOrMore,
             };

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/BaselinePackageValidator.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/BaselinePackageValidator.cs
@@ -28,9 +28,15 @@ namespace Microsoft.DotNet.PackageValidation.Validators
 
             ApiCompatRunnerOptions apiCompatOptions = new(options.EnableStrictMode, isBaselineComparison: true);
 
-            // Iterate over all target frameworks in the package.
             foreach (NuGetFramework baselineTargetFramework in options.BaselinePackage.FrameworksInPackage)
             {
+                // Skip target frameworks excluded from the baseline package.
+                if (options.BaselinePackageFrameworksToIgnore is not null &&
+                   options.BaselinePackageFrameworksToIgnore.Contains(baselineTargetFramework.GetShortFolderName()))
+                {
+                    continue;
+                }
+
                 // Retrieve the compile time assets from the baseline package
                 IReadOnlyList<ContentItem>? baselineCompileAssets = options.BaselinePackage.FindBestCompileAssetForFramework(baselineTargetFramework);
                 if (baselineCompileAssets != null)

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/PackageValidatorOption.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/PackageValidatorOption.cs
@@ -13,7 +13,8 @@ namespace Microsoft.DotNet.PackageValidation.Validators
         bool enableStrictMode = false,
         bool enqueueApiCompatWorkItems = true,
         bool executeApiCompatWorkItems = true,
-        Package? baselinePackage = null)
+        Package? baselinePackage = null,
+        string[]? baselinePackageFrameworksToIgnore = null)
     {
         /// <summary>
         /// The latest package that should be validated.
@@ -39,5 +40,13 @@ namespace Microsoft.DotNet.PackageValidation.Validators
         /// The baseline package to validate the latest package.
         /// </summary>
         public Package? BaselinePackage { get; } = baselinePackage;
+
+        /// <summary>
+        /// A set of frameworks to ignore from the baseline package.
+        /// </summary>
+        public HashSet<string>? BaselinePackageFrameworksToIgnore { get; } =
+            baselinePackageFrameworksToIgnore is not null ?
+                new HashSet<string>(baselinePackageFrameworksToIgnore) :
+                null;
     }
 }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/PackageValidatorOption.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/PackageValidatorOption.cs
@@ -43,10 +43,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators
 
         /// <summary>
         /// A set of frameworks to ignore from the baseline package.
+        /// Entries are stored with invariant culture and ignored casing.
         /// </summary>
         public HashSet<string>? BaselinePackageFrameworksToIgnore { get; } =
             baselinePackageFrameworksToIgnore is not null ?
-                new HashSet<string>(baselinePackageFrameworksToIgnore) :
+                new HashSet<string>(baselinePackageFrameworksToIgnore, StringComparer.InvariantCultureIgnoreCase) :
                 null;
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -55,7 +55,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       SuppressionOutputFile="$(ApiCompatSuppressionOutputFile)"
       BaselinePackageTargetPath="$(_packageValidationBaselinePath)"
       RoslynAssembliesPath="$(RoslynAssembliesPath)"
-      PackageAssemblyReferences="@(PackageValidationReferencePath)" />
+      PackageAssemblyReferences="@(PackageValidationReferencePath)"
+      BaselinePackageFrameworksToIgnore="@(BaselinePackageFrameworkToIgnore)" />
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(ApiCompatValidatePackageSemaphoreFile)'))" />
     <Touch Files="$(ApiCompatValidatePackageSemaphoreFile)" AlwaysCreate="true" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets
@@ -56,7 +56,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       BaselinePackageTargetPath="$(_packageValidationBaselinePath)"
       RoslynAssembliesPath="$(RoslynAssembliesPath)"
       PackageAssemblyReferences="@(PackageValidationReferencePath)"
-      BaselinePackageFrameworksToIgnore="@(BaselinePackageFrameworkToIgnore)" />
+      BaselinePackageFrameworksToIgnore="@(PackageValidationBaselineFrameworkToIgnore)" />
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(ApiCompatValidatePackageSemaphoreFile)'))" />
     <Touch Files="$(ApiCompatValidatePackageSemaphoreFile)" AlwaysCreate="true" />

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/Validators/BaselinePackageValidatorTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/Validators/BaselinePackageValidatorTests.cs
@@ -22,18 +22,13 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
         [Fact]
         public void TfmDroppedInLatestVersion()
         {
-            string[] previousFilePaths = new[]
-            {
-                @"ref/netcoreapp3.1/TestPackage.dll",
-                @"ref/netstandard2.0/TestPackage.dll"
-            };
-            Package baselinePackage = new(string.Empty, "TestPackage", "1.0.0", previousFilePaths, null);
+            Package baselinePackage = new(string.Empty, "TestPackage", "1.0.0",
+            [
+                @"lib/netcoreapp3.1/TestPackage.dll",
+                @"lib/netstandard2.0/TestPackage.dll"
+            ]);
+            Package package = new(string.Empty, "TestPackage", "2.0.0", [ @"lib/netcoreapp3.1/TestPackage.dll" ]);
 
-            string[] currentFilePaths = new[]
-            {
-                @"ref/netcoreapp3.1/TestPackage.dll"
-            };
-            Package package = new(string.Empty, "TestPackage", "2.0.0", currentFilePaths, null);
             (SuppressibleTestLog log, BaselinePackageValidator validator) = CreateLoggerAndValidator();
 
             validator.Validate(new PackageValidatorOption(package,
@@ -43,6 +38,27 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             Assert.NotEmpty(log.errors);
             Assert.Contains(DiagnosticIds.TargetFrameworkDropped + " " + string.Format(Resources.MissingTargetFramework, ".NETStandard,Version=v2.0"), log.errors);
+        }
+
+        [Fact]
+        public void BaselineFrameworksExcluded()
+        {
+            Package baselinePackage = new(string.Empty, "TestPackage", "1.0.0",
+            [
+                @"lib/netcoreapp3.1/TestPackage.dll",
+                @"lib/netstandard2.0/TestPackage.dll"
+            ]);
+            Package package = new(string.Empty, "TestPackage", "2.0.0", [ @"lib/netstandard2.0/TestPackage.dll" ]);
+
+            (SuppressibleTestLog log, BaselinePackageValidator validator) = CreateLoggerAndValidator();
+
+            validator.Validate(new PackageValidatorOption(package,
+                enableStrictMode: false,
+                enqueueApiCompatWorkItems: false,
+                baselinePackage: baselinePackage,
+                baselinePackageFrameworksToIgnore: [ "netcoreapp3.1" ]));
+
+            Assert.Empty(log.errors);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/22901

Add frontend option to allow ignoring TFMs when performing baseline package validation.

MSBuild item: `@(PackageValidationBaselineFrameworkToIgnore)`
CLI option: `--baseline-package-frameworks-to-ignore`

See https://github.com/dotnet/runtime/pull/94432 which reacts to this change in runtime.