### PR TITLE
accept bare version as NuGet exact version for .NET tools

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -527,7 +527,8 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             VersionRange versionRange,
              PackageSourceLocation packageSourceLocation = null)
         {
-            if(versionRange.MinVersion != null && versionRange.MaxVersion != null && versionRange.MinVersion == versionRange.MaxVersion)
+            if (versionRange.MinVersion != null && !versionRange.IsFloating &&
+                (versionRange.MaxVersion == null || versionRange.MinVersion == versionRange.MaxVersion))
             {
                 return versionRange.MinVersion;
             }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
@@ -1,20 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Parsing;
-using System.Linq;
-using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.NugetSearch;
-using Microsoft.DotNet.ToolPackage;
-using Microsoft.DotNet.Tools.Tool.Search;
-using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Microsoft.DotNet.Tools.Tool.Install
 {

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
@@ -42,8 +42,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             VersionRange versionRange = null;
 
             // accept 'bare' versions and interpret 'bare' versions as NuGet exact versions
-            string text = packageVersion?.Trim();
-            if (!string.IsNullOrEmpty(packageVersion) && IsBarePackageVersion(text))
+            if (!string.IsNullOrEmpty(packageVersion) && SemanticVersion.TryParse(packageVersion, out SemanticVersion version2))
             {
                 packageVersion = "[" + packageVersion + "]";
             }
@@ -56,15 +55,6 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                         packageVersion));
             }
             return versionRange;
-        }
-
-        private static bool IsBarePackageVersion (string packageVersion)
-        {
-            // Define a regular expression pattern to match the "a.b.c" format
-            string pattern = @"^\d+\.\d+\.\d+(-[\w\d]+(\.[\w\d]+)*)?(\+[\w\d]+(\.[\w\d]+)*)?$";
-
-            // Use Regex.IsMatch to check if the input matches the pattern
-            return Regex.IsMatch(packageVersion, pattern);
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
         private static bool IsBarePackageVersion (string packageVersion)
         {
             // Define a regular expression pattern to match the "a.b.c" format
-            string pattern = @"^\d+\.\d+\.\d+$";
+            string pattern = @"^\d+\.\d+\.\d+(-[\w\d]+(\.[\w\d]+)*)?(\+[\w\d]+(\.[\w\d]+)*)?$";
 
             // Use Regex.IsMatch to check if the input matches the pattern
             return Regex.IsMatch(packageVersion, pattern);

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             // accept 'bare' versions and interpret 'bare' versions as NuGet exact versions
             if (!string.IsNullOrEmpty(packageVersion) && NuGetVersion.TryParse(packageVersion, out SemanticVersion version2))
             {
-                packageVersion = "[" + packageVersion + "]";
+                return new VersionRange(minVersion: new NuGetVersion(packageVersion), includeMinVersion: true, maxVersion: new NuGetVersion(packageVersion), includeMaxVersion: true, originalString: "[" + packageVersion + "]");
             }
 
             if (!string.IsNullOrEmpty(packageVersion) && !VersionRange.TryParse(packageVersion, out versionRange))

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
@@ -1,16 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.NugetSearch;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools.Tool.Search;
+using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Microsoft.DotNet.Tools.Tool.Install
 {
@@ -36,6 +40,14 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             }
 
             VersionRange versionRange = null;
+
+            // accept 'bare' versions and interpret 'bare' versions as NuGet exact versions
+            string text = packageVersion?.Trim();
+            if (!string.IsNullOrEmpty(packageVersion) && IsBarePackageVersion(text))
+            {
+                packageVersion = "[" + packageVersion + "]";
+            }
+
             if (!string.IsNullOrEmpty(packageVersion) && !VersionRange.TryParse(packageVersion, out versionRange))
             {
                 throw new GracefulException(
@@ -44,6 +56,15 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                         packageVersion));
             }
             return versionRange;
+        }
+
+        private static bool IsBarePackageVersion (string packageVersion)
+        {
+            // Define a regular expression pattern to match the "a.b.c" format
+            string pattern = @"^\d+\.\d+\.\d+$";
+
+            // Use Regex.IsMatch to check if the input matches the pattern
+            return Regex.IsMatch(packageVersion, pattern);
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             VersionRange versionRange = null;
 
             // accept 'bare' versions and interpret 'bare' versions as NuGet exact versions
-            if (!string.IsNullOrEmpty(packageVersion) && SemanticVersion.TryParse(packageVersion, out SemanticVersion version2))
+            if (!string.IsNullOrEmpty(packageVersion) && NuGetVersion.TryParse(packageVersion, out SemanticVersion version2))
             {
                 packageVersion = "[" + packageVersion + "]";
             }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ParseResultExtension.cs
@@ -32,9 +32,9 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             VersionRange versionRange = null;
 
             // accept 'bare' versions and interpret 'bare' versions as NuGet exact versions
-            if (!string.IsNullOrEmpty(packageVersion) && NuGetVersion.TryParse(packageVersion, out SemanticVersion version2))
+            if (!string.IsNullOrEmpty(packageVersion) && NuGetVersion.TryParse(packageVersion, out NuGetVersion version2))
             {
-                return new VersionRange(minVersion: new NuGetVersion(packageVersion), includeMinVersion: true, maxVersion: new NuGetVersion(packageVersion), includeMaxVersion: true, originalString: "[" + packageVersion + "]");
+                return new VersionRange(minVersion: version2, includeMinVersion: true, maxVersion: version2, includeMaxVersion: true, originalString: "[" + packageVersion + "]");
             }
 
             if (!string.IsNullOrEmpty(packageVersion) && !VersionRange.TryParse(packageVersion, out versionRange))

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -370,6 +370,23 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         }
 
         [Fact]
+        public void WhenRunWithValidBareVersionItShouldInterpretAsNuGetExactVersion()
+        {
+            const string nugetSourcePath = "https://api.nuget.org/v3/index.json";
+            var testDir = _testAssetsManager.CreateTestDirectory().Path;
+
+            var toolInstallGlobalOrToolPathCommand = new DotnetCommand(Log, "tool", "install", "-g", UnlistedPackageId, "--version", "0.5.0", "--add-source", nugetSourcePath)
+                .WithEnvironmentVariable("DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK", "true")
+                .WithWorkingDirectory(testDir);
+
+            toolInstallGlobalOrToolPathCommand.Execute().Should().Pass();
+
+            // Uninstall the unlisted package
+            var toolUninstallCommand = new DotnetCommand(Log, "tool", "uninstall", "-g", UnlistedPackageId);
+            toolUninstallCommand.Execute().Should().Pass();
+        }
+
+        [Fact]
         public void WhenRunWithoutValidVersionUnlistedToolItShouldThrow()
         {
             const string nugetSourcePath = "https://api.nuget.org/v3/index.json";


### PR DESCRIPTION
**Customer Impact**

In .NET 8 we made a breaking change that changes the current .NET tool installation mechanism from restore a local temporary project to downloading the .NET tool from NuGet. This change was introduced because this previous mechanism has number of side effects, often show up as flaky restore errors because MSBuild concepts like Directory.Build.props, or other heirarchical notions, pollute the restore. 

Per user feedback in #35566, he change, however, disable users from installing unlisted tools. This feature was added in #36021 if specifying exact match. However, since the exact match refers to input `[version]`. (referred to [NuGet package version reference](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning)) come with bracket, this caused surprise for some users using bare version as exact version match.

The intended way to fix this is to allow bare version of .NET tool to interpret as specific version, i.e.  version `5.0.0` refers to the exact version match of `5.0.0` instead of `[5.0.0, )`. To add this feature, a semvar detection is added when getting and parsing the version range in `GetVersionRange()`. Changes are validated by tests.

**Testing**
Existing unit tests passed without changes. New tested are added to validate an unlisted bar version tool can be installed with exact version match withtout bracket specified. The new testing scenarios pass with changes in the pull request. 

**Risk**
Low. This change adds a notation that was missed from breaking change without adding complexity to the behavior. 

**Original description**
Per conversation #35566, specifically [discussions on comment](https://github.com/dotnet/sdk/issues/35566#issuecomment-1788852933), this change is made to accept bare versions in .NET tools as NuGet exact version. For example, e.g. `--version 1.2.3` would be interpreted by the NuGet package downloader as `[1.2.3]`
