### PR TITLE
Ensure workload install state file has proper ACLs

### DIFF
--- a/src/Cli/dotnet/Installer/Windows/InstallMessageDispatcher.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallMessageDispatcher.cs
@@ -146,5 +146,35 @@ namespace Microsoft.DotNet.Installer.Windows
                 SdkFeatureBand = sdkFeatureBand.ToString(),
             });
         }
+
+        /// <summary>
+        /// Send an <see cref="InstallRequestMessage"/> to delete the install state file.
+        /// </summary>
+        /// <param name="path">The path of the install state file to delete.</param>
+        /// <returns></returns>
+        public InstallResponseMessage SendRemoveInstallStateFileRequest(string path)
+        {
+            return Send(new InstallRequestMessage
+            {
+                RequestType = InstallRequestType.RemoveInstallStateFile,
+                InstallStateFile = path
+            });
+        }
+
+        /// <summary>
+        /// Sends an <see cref="InstallRequestMessage"/> to write the install state file.
+        /// </summary>
+        /// <param name="path">the path of the install state file to write.</param>
+        /// <param name="value">A multi-line string containing the formatted JSON data to write.</param>
+        /// <returns></returns>
+        public InstallResponseMessage SendWriteInstallStateFileRequest(string path, IEnumerable<string> jsonLines)
+        {
+            return Send(new InstallRequestMessage
+            {
+                RequestType = InstallRequestType.WriteInstallStateFile,
+                InstallStateFile = path,
+                InstallStateContents = jsonLines.ToArray()
+            });
+        }
     }
 }

--- a/src/Cli/dotnet/Installer/Windows/InstallRequestMessage.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallRequestMessage.cs
@@ -30,6 +30,25 @@ namespace Microsoft.DotNet.Installer.Windows
         }
 
         /// <summary>
+        /// The contents of the install state file. Each element corresponds to a single line of
+        /// the JSON file to be written.
+        /// </summary>
+        public string[] InstallStateContents
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The path of the install state file.
+        /// </summary>
+        public string InstallStateFile
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The path of the MSI log file to generate when installing, uninstalling or repairing a specific MSI.
         /// </summary>
         public string LogFile

--- a/src/Cli/dotnet/Installer/Windows/InstallRequestType.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallRequestType.cs
@@ -53,6 +53,16 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <summary>
         /// Remove a workload installation record.
         /// </summary>
-        DeleteWorkloadInstallationRecord
+        DeleteWorkloadInstallationRecord,
+
+        /// <summary>
+        /// Creates an install state file.
+        /// </summary>
+        WriteInstallStateFile,
+
+        /// <summary>
+        /// Removes an install state file.
+        /// </summary>
+        RemoveInstallStateFile,
     }
 }

--- a/src/Cli/dotnet/Installer/Windows/LocalizableStrings.resx
+++ b/src/Cli/dotnet/Installer/Windows/LocalizableStrings.resx
@@ -120,4 +120,7 @@
   <data name="AuthentiCodeNoTrustedOrg" xml:space="preserve">
     <value>AuthentiCode signature for {0} does not belong to a trusted organization.</value>
   </data>
+  <data name="InvalidInstallStateFile" xml:space="preserve">
+    <value>Invalid install state file: {0}</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO.Pipes;
 using System.Runtime.Versioning;
 using System.Security;
-using System.Security.AccessControl;
 using System.Security.Cryptography.X509Certificates;
-using System.Security.Principal;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Installer.Windows.Security;
 using Microsoft.Win32.Msi;
 using Newtonsoft.Json;
@@ -21,55 +17,6 @@ namespace Microsoft.DotNet.Installer.Windows
     internal class MsiPackageCache : InstallerBase
     {
         /// <summary>
-        /// Default inheritance to apply to directory ACLs.
-        /// </summary>
-        private static readonly InheritanceFlags s_DefaultInheritance = InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit;
-
-        /// <summary>
-        /// SID that matches built-in administrators.
-        /// </summary>
-        private static readonly SecurityIdentifier s_AdministratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
-
-        /// <summary>
-        /// SID that matches everyone.
-        /// </summary>
-        private static readonly SecurityIdentifier s_EveryoneSid = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
-
-        /// <summary>
-        /// Local SYSTEM SID.
-        /// </summary>
-        private static readonly SecurityIdentifier s_LocalSystemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
-
-        /// <summary>
-        /// SID matching built-in user accounts.
-        /// </summary>
-        private static readonly SecurityIdentifier s_UsersSid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
-
-        /// <summary>
-        /// ACL rule associated with the Administrators SID.
-        /// </summary>
-        private static readonly FileSystemAccessRule s_AdministratorRule = new FileSystemAccessRule(s_AdministratorsSid, FileSystemRights.FullControl,
-            s_DefaultInheritance, PropagationFlags.None, AccessControlType.Allow);
-
-        /// <summary>
-        /// ACL rule associated with the Everyone SID.
-        /// </summary>
-        private static readonly FileSystemAccessRule s_EveryoneRule = new FileSystemAccessRule(s_EveryoneSid, FileSystemRights.ReadAndExecute,
-            s_DefaultInheritance, PropagationFlags.None, AccessControlType.Allow);
-
-        /// <summary>
-        /// ACL rule associated with the Local SYSTEM SID.
-        /// </summary>
-        private static readonly FileSystemAccessRule s_LocalSystemRule = new FileSystemAccessRule(s_LocalSystemSid, FileSystemRights.FullControl,
-            s_DefaultInheritance, PropagationFlags.None, AccessControlType.Allow);
-
-        /// <summary>
-        /// ACL rule associated with the built-in users SID.
-        /// </summary>
-        private static readonly FileSystemAccessRule s_UsersRule = new FileSystemAccessRule(s_UsersSid, FileSystemRights.ReadAndExecute,
-            s_DefaultInheritance, PropagationFlags.None, AccessControlType.Allow);
-
-        /// <summary>
         /// The root directory of the package cache where MSI workload packs are stored.
         /// </summary>
         public readonly string PackageCacheRoot;
@@ -80,21 +27,6 @@ namespace Microsoft.DotNet.Installer.Windows
             PackageCacheRoot = string.IsNullOrWhiteSpace(packageCacheRoot)
                 ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "dotnet", "workloads")
                 : packageCacheRoot;
-        }
-
-        /// <summary>
-        /// Creates the specified directory and secures it by configuring access rules (ACLs) that allow sub-directories
-        /// and files to inherit access control entries. 
-        /// </summary>
-        /// <param name="path">The path of the directory to create.</param>
-        public static void CreateSecureDirectory(string path)
-        {
-            if (!Directory.Exists(path))
-            {
-                DirectorySecurity ds = new();
-                SetDirectoryAccessRules(ds);
-                ds.CreateDirectory(path);
-            }
         }
 
         /// <summary>
@@ -123,7 +55,7 @@ namespace Microsoft.DotNet.Installer.Windows
                     Directory.Delete(packageDirectory, recursive: true);
                 }
 
-                CreateSecureDirectory(packageDirectory);
+                SecurityUtils.CreateSecureDirectory(packageDirectory);
 
                 // We cannot assume that the MSI adjacent to the manifest is the one to cache. We'll trust
                 // the manifest to provide the MSI filename.
@@ -134,8 +66,8 @@ namespace Microsoft.DotNet.Installer.Windows
                 string cachedMsiPath = Path.Combine(packageDirectory, Path.GetFileName(msiPath));
                 string cachedManifestPath = Path.Combine(packageDirectory, Path.GetFileName(manifestPath));
 
-                MoveAndSecureFile(manifestPath, cachedManifestPath, Log);
-                MoveAndSecureFile(msiPath, cachedMsiPath, Log);
+                SecurityUtils.MoveAndSecureFile(manifestPath, cachedManifestPath, Log);
+                SecurityUtils.MoveAndSecureFile(msiPath, cachedMsiPath, Log);
             }
             else if (IsClient)
             {
@@ -152,46 +84,6 @@ namespace Microsoft.DotNet.Installer.Windows
         public string GetPackageDirectory(string packageId, string packageVersion)
         {
             return Path.Combine(PackageCacheRoot, packageId, packageVersion);
-        }
-
-        /// <summary>
-        /// Moves a file from one location to another if the destination file does not already exist and
-        /// configure its permissions.
-        /// </summary>
-        /// <param name="sourceFile">The source file to move.</param>
-        /// <param name="destinationFile">The destination where the source file will be moved.</param>
-        /// <param name="log">The underlying setup log to use.</param>
-        public static void MoveAndSecureFile(string sourceFile, string destinationFile, ISetupLogger log = null)
-        {
-            if (!File.Exists(destinationFile))
-            {
-                FileAccessRetrier.RetryOnMoveAccessFailure(() =>
-                {
-                    // Moving the file preserves the owner SID and fails to inherit the WD ACE.
-                    File.Copy(sourceFile, destinationFile, overwrite: true);
-                    File.Delete(sourceFile);
-                });
-                log?.LogMessage($"Moved '{sourceFile}' to '{destinationFile}'");
-
-                SecureFile(destinationFile);
-            }
-        }
-
-        /// <summary>
-        /// Secures a file by setting the owner and group to built-in administrators (BA). All other ACE values are inherited from
-        /// the parent directory.
-        /// </summary>
-        /// <param name="path">The path of the file to secure.</param>
-        public static void SecureFile(string path)
-        {
-            FileInfo fi = new(path);
-            FileSecurity fs = new();
-            
-            // See https://github.com/dotnet/sdk/issues/28450. If the directory's descriptor
-            // is correctly configured, we should end up with an inherited ACE for Everyone: (A;ID;0x1200a9;;;WD)
-            fs.SetOwner(s_AdministratorsSid);
-            fs.SetGroup(s_AdministratorsSid);
-            fi.SetAccessControl(fs);
         }
 
         /// <summary>
@@ -244,22 +136,6 @@ namespace Microsoft.DotNet.Installer.Windows
 
             msiPath = possibleMsiPath;
             return true;
-        }
-
-        /// <summary>
-        /// Apply a standard set of access rules to the directory security descriptor. The owner and group will
-        /// be set to built-in Administrators. Full access is granted to built-in administators and SYSTEM with
-        /// read, execute, synchronize permssions for built-in users and Everyone.
-        /// </summary>
-        /// <param name="ds">The security descriptor to update.</param>
-        private static void SetDirectoryAccessRules(DirectorySecurity ds)
-        {
-            ds.SetOwner(s_AdministratorsSid);
-            ds.SetGroup(s_AdministratorsSid);
-            ds.SetAccessRule(s_AdministratorRule);
-            ds.SetAccessRule(s_LocalSystemRule);
-            ds.SetAccessRule(s_UsersRule);
-            ds.SetAccessRule(s_EveryoneRule);
         }
 
         /// <summary>

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -173,16 +173,25 @@ namespace Microsoft.DotNet.Installer.Windows
                 });
                 log?.LogMessage($"Moved '{sourceFile}' to '{destinationFile}'");
 
-                FileInfo fi = new(destinationFile);
-                FileSecurity fs = new();
-
-                // Set the owner and group to built-in administrators (BA). All other ACE values are inherited from
-                // the parent directory. See https://github.com/dotnet/sdk/issues/28450. If the directory's descriptor
-                // is correctly configured, we should end up with an inherited ACE for Everyone: (A;ID;0x1200a9;;;WD)
-                fs.SetOwner(s_AdministratorsSid);
-                fs.SetGroup(s_AdministratorsSid);
-                fi.SetAccessControl(fs);
+                SecureFile(destinationFile);
             }
+        }
+
+        /// <summary>
+        /// Secures a file by setting the owner and group to built-in administrators (BA). All other ACE values are inherited from
+        /// the parent directory.
+        /// </summary>
+        /// <param name="path">The path of the file to secure.</param>
+        public static void SecureFile(string path)
+        {
+            FileInfo fi = new(path);
+            FileSecurity fs = new();
+            
+            // See https://github.com/dotnet/sdk/issues/28450. If the directory's descriptor
+            // is correctly configured, we should end up with an inherited ACE for Everyone: (A;ID;0x1200a9;;;WD)
+            fs.SetOwner(s_AdministratorsSid);
+            fs.SetGroup(s_AdministratorsSid);
+            fi.SetAccessControl(fs);
         }
 
         /// <summary>

--- a/src/Cli/dotnet/Installer/Windows/SecurityUtils.cs
+++ b/src/Cli/dotnet/Installer/Windows/SecurityUtils.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipes;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Installer.Windows
+{
+    /// <summary>
+    /// Defines some generic security related helper methods.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    internal static class SecurityUtils
+    {
+        /// <summary>
+        /// Default inheritance to apply to directory ACLs.
+        /// </summary>
+        private static readonly InheritanceFlags s_DefaultInheritance = InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit;
+
+        /// <summary>
+        /// SID that matches built-in administrators.
+        /// </summary>
+        private static readonly SecurityIdentifier s_AdministratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+
+        /// <summary>
+        /// SID that matches everyone.
+        /// </summary>
+        private static readonly SecurityIdentifier s_EveryoneSid = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+
+        /// <summary>
+        /// Local SYSTEM SID.
+        /// </summary>
+        private static readonly SecurityIdentifier s_LocalSystemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+
+        /// <summary>
+        /// SID matching built-in user accounts.
+        /// </summary>
+        private static readonly SecurityIdentifier s_UsersSid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+
+        /// <summary>
+        /// ACL rule associated with the Administrators SID.
+        /// </summary>
+        private static readonly FileSystemAccessRule s_AdministratorRule = new FileSystemAccessRule(s_AdministratorsSid, FileSystemRights.FullControl,
+            s_DefaultInheritance, PropagationFlags.None, AccessControlType.Allow);
+
+        /// <summary>
+        /// ACL rule associated with the Everyone SID.
+        /// </summary>
+        private static readonly FileSystemAccessRule s_EveryoneRule = new FileSystemAccessRule(s_EveryoneSid, FileSystemRights.ReadAndExecute,
+            s_DefaultInheritance, PropagationFlags.None, AccessControlType.Allow);
+
+        /// <summary>
+        /// ACL rule associated with the Local SYSTEM SID.
+        /// </summary>
+        private static readonly FileSystemAccessRule s_LocalSystemRule = new FileSystemAccessRule(s_LocalSystemSid, FileSystemRights.FullControl,
+            s_DefaultInheritance, PropagationFlags.None, AccessControlType.Allow);
+
+        /// <summary>
+        /// ACL rule associated with the built-in users SID.
+        /// </summary>
+        private static readonly FileSystemAccessRule s_UsersRule = new FileSystemAccessRule(s_UsersSid, FileSystemRights.ReadAndExecute,
+            s_DefaultInheritance, PropagationFlags.None, AccessControlType.Allow);
+
+        /// <summary>
+        /// Creates the specified directory and secures it by configuring access rules (ACLs) that allow sub-directories
+        /// and files to inherit access control entries. 
+        /// </summary>
+        /// <param name="path">The path of the directory to create.</param>
+        public static void CreateSecureDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                DirectorySecurity ds = new();
+                SecurityUtils.SetDirectoryAccessRules(ds);
+                ds.CreateDirectory(path);
+            }
+        }
+
+        /// <summary>
+        /// Moves a file from one location to another if the destination file does not already exist and
+        /// configure its permissions.
+        /// </summary>
+        /// <param name="sourceFile">The source file to move.</param>
+        /// <param name="destinationFile">The destination where the source file will be moved.</param>
+        /// <param name="log">The underlying setup log to use.</param>
+        public static void MoveAndSecureFile(string sourceFile, string destinationFile, ISetupLogger log = null)
+        {
+            if (!File.Exists(destinationFile))
+            {
+                FileAccessRetrier.RetryOnMoveAccessFailure(() =>
+                {
+                    // Moving the file preserves the owner SID and fails to inherit the WD ACE.
+                    File.Copy(sourceFile, destinationFile, overwrite: true);
+                    File.Delete(sourceFile);
+                });
+                log?.LogMessage($"Moved '{sourceFile}' to '{destinationFile}'");
+
+                SecureFile(destinationFile);
+            }
+        }
+
+        /// <summary>
+        /// Secures a file by setting the owner and group to built-in administrators (BA). All other ACE values are inherited from
+        /// the parent directory.
+        /// </summary>
+        /// <param name="path">The path of the file to secure.</param>
+        public static void SecureFile(string path)
+        {
+            FileInfo fi = new(path);
+            FileSecurity fs = new();
+
+            // See https://github.com/dotnet/sdk/issues/28450. If the directory's descriptor
+            // is correctly configured, we should end up with an inherited ACE for Everyone: (A;ID;0x1200a9;;;WD)
+            fs.SetOwner(s_AdministratorsSid);
+            fs.SetGroup(s_AdministratorsSid);
+            fi.SetAccessControl(fs);
+        }
+
+        /// <summary>
+        /// Apply a standard set of access rules to the directory security descriptor. The owner and group will
+        /// be set to built-in Administrators. Full access is granted to built-in administators and SYSTEM with
+        /// read, execute, synchronize permssions for built-in users and Everyone.
+        /// </summary>
+        /// <param name="ds">The security descriptor to update.</param>
+        private static void SetDirectoryAccessRules(DirectorySecurity ds)
+        {
+            ds.SetOwner(s_AdministratorsSid);
+            ds.SetGroup(s_AdministratorsSid);
+            ds.SetAccessRule(s_AdministratorRule);
+            ds.SetAccessRule(s_LocalSystemRule);
+            ds.SetAccessRule(s_UsersRule);
+            ds.SetAccessRule(s_EveryoneRule);
+        }
+    }
+}

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Podpis AuthentiCode pro {0} nepatří důvěryhodné organizaci.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Die AuthentiCode-Signatur für {0} gehört nicht zu einer vertrauenswürdigen Organisation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">La firma AuthentiCode para {0} no pertenece a una organización de confianza.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">La signature AuthentiCode pour {0} n’appartient pas à une organisation approuvée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">La firma AuthentiCode per {0} non appartiene a un'organizzazione attendibile.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">{0} の AuthentiCode 署名は、信頼されている組織に属していません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">{0}에 대한 AuthentiCode 서명이 신뢰할 수 있는 조직에 속해 있지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Podpis AuthentiCode dla {0} nie należy do zaufanej organizacji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">A assinatura AuthentiCode para {0} não pertence a uma organização confiável.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Подпись AuthentiCode для {0} не принадлежит доверенной организации.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">{0} için AuthentiCode imzası güvenilir bir kuruluşa ait değil.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">{0} 的 AuthentiCode 签名不属于受信任的组织。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Installer/Windows/xlf/LocalizableStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">{0} 的 AuthentiCode 簽章不屬於信任的組織。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidInstallStateFile">
+        <source>Invalid install state file: {0}</source>
+        <target state="new">Invalid install state file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.Workloads.Workload
             _defaultJsonPath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
         }
 
-        protected IEnumerable<string> GetInstallState(IEnumerable<ManifestVersionUpdate> manifestVersionUpdates) =>
+        protected IEnumerable<string> GetInstallStateContents(IEnumerable<ManifestVersionUpdate> manifestVersionUpdates) =>
             ToJsonEnumerable(WorkloadSet.FromManifests(
                     manifestVersionUpdates.Select(update => new WorkloadManifestInfo(update.ManifestId.ToString(), update.NewVersion.ToString(), /* We don't actually use the directory here */ string.Empty, update.NewFeatureBand))
                     ).ToDictionaryForJson());

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
-using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.Utils;
@@ -451,6 +450,20 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 DeleteAllWorkloadInstallationRecords();
             }
 
+        }
+
+        public void DeleteInstallState(string path)
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+
+        public void WriteInstallState(string path, IEnumerable<string> jsonLines)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllLines(path, jsonLines);
         }
 
         /// <summary>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
@@ -33,6 +33,19 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         void ReplaceWorkloadResolver(IWorkloadResolver workloadResolver);
 
         void Shutdown();
+
+        /// <summary>
+        /// Delete the install state file at the specified path.
+        /// </summary>
+        /// <param name="path">The full path of the default.json install state file.</param>
+        void DeleteInstallState(string path);
+
+        /// <summary>
+        /// Writes the specified JSON contents to the install state file.
+        /// </summary>
+        /// <param name="path">The full path of the default.json install state file.</param>
+        /// <param name="jsonLines">The JSON contents describing the install state.</param>
+        void WriteInstallState(string path, IEnumerable<string> jsonLines);
     }
 
     // Interface to pass to workload manifest updater

--- a/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
@@ -550,11 +550,11 @@ namespace Microsoft.DotNet.Installer.Windows
             if (IsElevated)
             {
                 // Create the parent folder for the state file and set up all required ACLs
-                MsiPackageCache.CreateSecureDirectory(Path.GetDirectoryName(path));
+                SecurityUtils.CreateSecureDirectory(Path.GetDirectoryName(path));
 
                 File.WriteAllLines(path, jsonLines);
 
-                MsiPackageCache.SecureFile(path);
+                SecurityUtils.SecureFile(path);
             }
             else if (IsClient)
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -182,6 +182,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
+        public void DeleteInstallState(string path) =>
+            RemoveInstallStateFile(path);
+
+        public void WriteInstallState(string path, IEnumerable<string> jsonLines) =>
+            WriteInstallStateFile(path, jsonLines);
+
         /// <summary>
         /// Find all the dependents that look like they belong to SDKs. We only care
         /// about dependents that match the SDK host we're running under. For example, an x86 SDK should not be

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
@@ -93,6 +93,16 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                             Dispatcher.ReplySuccess($"Updated dependent '{request.Dependent}' for provider key '{request.ProviderKeyName}'");
                             break;
 
+                        case InstallRequestType.WriteInstallStateFile:
+                            WriteInstallStateFile(request.InstallStateFile, request.InstallStateContents);
+                            Dispatcher.ReplySuccess($"Created install state file: {request.InstallStateFile}");
+                            break;
+
+                        case InstallRequestType.RemoveInstallStateFile:
+                            RemoveInstallStateFile(request.InstallStateFile);
+                            Dispatcher.ReplySuccess($"Deleted install state file: {request.InstallStateFile}");
+                            break;
+
                         default:
                             throw new InvalidOperationException($"Unknown message request: {(int)request.RequestType}");
                     }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -229,7 +229,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
                     if (usingRollback)
                     {
-                        UpdateInstallState(true, manifestsToUpdate);
+                        installer.WriteInstallState(_defaultJsonPath, GetInstallState(manifestsToUpdate));
                     }
                 },
                 rollback: () =>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -229,7 +229,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
                     if (usingRollback)
                     {
-                        installer.WriteInstallState(_defaultJsonPath, GetInstallState(manifestsToUpdate));
+                        installer.WriteInstallState(_defaultJsonPath, GetInstallStateContents(manifestsToUpdate));
                     }
                 },
                 rollback: () =>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -158,7 +158,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
 
                     if (useRollback)
                     {
-                        _workloadInstaller.WriteInstallState(_defaultJsonPath, GetInstallState(manifestsToUpdate));
+                        _workloadInstaller.WriteInstallState(_defaultJsonPath, GetInstallStateContents(manifestsToUpdate));
                     }
                     else
                     {

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -156,7 +156,14 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
 
                     _workloadInstaller.InstallWorkloads(workloads, sdkFeatureBand, context, offlineCache);
 
-                    UpdateInstallState(useRollback, manifestsToUpdate);
+                    if (useRollback)
+                    {
+                        _workloadInstaller.WriteInstallState(_defaultJsonPath, GetInstallState(manifestsToUpdate));
+                    }
+                    else
+                    {
+                        _workloadInstaller.DeleteInstallState(_defaultJsonPath);
+                    }
                 },
                 rollback: () =>
                 {

--- a/src/Tests/SDDLTests/Program.cs
+++ b/src/Tests/SDDLTests/Program.cs
@@ -167,8 +167,8 @@ namespace SDDLTests
         /// </summary>
         private static void RelocateAndSecureAsset()
         {
-            MsiPackageCache.CreateSecureDirectory(s_workloadPackCacheDirectory);
-            MsiPackageCache.MoveAndSecureFile(s_userTestAssetPath, s_cachedTestAssetPath);
+            SecurityUtils.CreateSecureDirectory(s_workloadPackCacheDirectory);
+            SecurityUtils.MoveAndSecureFile(s_userTestAssetPath, s_cachedTestAssetPath);
         }
 
         /// <summary>
@@ -248,9 +248,9 @@ namespace SDDLTests
 
         private static void CreateInstallStateAsset()
         {
-            MsiPackageCache.CreateSecureDirectory(s_installStateDirectory);
+            SecurityUtils.CreateSecureDirectory(s_installStateDirectory);
             File.WriteAllLines(s_installStateFileAssetPath, new[] { "line1", "line2" });
-            MsiPackageCache.SecureFile(s_installStateFileAssetPath);
+            SecurityUtils.SecureFile(s_installStateFileAssetPath);
         }
 
         private static void VerifyInstallStateDescriptors()

--- a/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
@@ -156,6 +156,20 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         {
             WorkloadResolver = workloadResolver;
         }
+
+        public void DeleteInstallState(string path)
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+
+        public void WriteInstallState(string path, IEnumerable<string> jsonLines)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllLines(path, jsonLines);
+        }
     }
 
     internal class MockInstallationRecordRepository : IWorkloadInstallationRecordRepository


### PR DESCRIPTION
# Description

Workload commands are performing arbitrary file operations when creating and removing the workload install state file. The state files were added during RC1. While this is acceptable for file-based installations, global installs on Windows require a specific pattern to ensure that the command is properly elevated and the install server perform all the file operations including setting access control entries.

# Impact

Install state files are limited to using rollback files with workload commands. The current implementation may fail if the state file is created/removed because the install client won't have sufficient permissions. If users decide to run from an elevated prompt they can still encounter errors since the security descriptor is incorrect.

# Changes

* Install state file operations were moved to the respective workload installers
* MSI dispatcher was updated to include operations for writing and removing install state files
* Validation logic was added to avoid abusing the new server operations to write to arbitrary locations.
* Manual tests were updated.

# Risk
Low

# Testing

We have manual tests for security descriptors. The tests were updated to include the new install state scenario. Below is the sample output from running the manual tests from a non-elevated prompt and going through UAC before verifying the directory/file descriptors created by the elevated process. Group and owner are set to built-in administrators, full access is granted to built-in administrators and SYSTEM with read/execute/synchronize permissions for built-in users and Everyone. File ACEs should all be inherited from the parent directory.

```
Verifying directory expectations for C:\ProgramData\SDDLTest\workloads\8.0.100\InstallState
Verifying descriptor: O:BAG:BAD:(A;OICIID;0x1200a9;;;WD)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;0x1200a9;;;BU)
Verifying file expectations for C:\ProgramData\SDDLTest\workloads\8.0.100\InstallState\default.json
Verifying descriptor: O:BAG:BAD:(A;ID;0x1200a9;;;WD)(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU)
```