### PR TITLE
Bump dockercredsprovider to pick up a bugfix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -102,7 +102,7 @@
     <PackageVersion Include="System.Text.Json" Version="$(MicrosoftNETCoreAppRefPackageVersion)" />
     <PackageVersion Include="System.Windows.Extensions" Version="$(MicrosoftNETCoreAppRefPackageVersion)" />
     <PackageVersion Include="System.Xml.XmlDocument" Version="$(SystemXmlXmlDocumentPackageVersion)" />
-    <PackageVersion Include="Valleysoft.DockerCredsProvider" Version="2.2.0" />
+    <PackageVersion Include="Valleysoft.DockerCredsProvider" Version="2.2.1" />
     <PackageVersion Include="xunit" Version="$(XUnitVersion)" />
     <PackageVersion Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
     <PackageVersion Include="xunit.console" Version="$(XUnitVersion)"/>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -32,5 +32,9 @@
     <UsagePattern IdentityGlob="System.Diagnostics.EventLog/*7.0.0*" />
     <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/*7.0.0*" />
     <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/*7.0.0*" />
+
+    <!-- (Don't include this for 9.0) Allow 8.0.2xx and higher to use any version of DockerCredsProvider since source build
+         is only applicable to 8.0.1xx. -->
+    <UsagePattern IdentityGlob="Valleysoft.DockerCredsProvider/*" />
   </IgnorePatterns>
 </UsageData>


### PR DESCRIPTION
Version 2.2.1 includes a fix for Docker credential keys that contain scheme information, not just domain names. This is the only change from 2.2.0.