### PR TITLE
Freeze Microsoft.DotNet.MSBuildSdkResolver assembly version

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- The version is frozen to allow MSBuild.exe loading it into the default load context -->
+    <AssemblyVersion>8.0.100.0</AssemblyVersion>
     <TargetFrameworks>$(ResolverTargetFramework);net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(ResolverTargetFramework)</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
MSBuild.exe currently spends a significant amount of time JITting `Microsoft.DotNet.MSBuildSdkResolver` and its dependencies, see https://github.com/dotnet/msbuild/issues/9303 for details.

The most straightforward way to fix this is to load the assembly into the default load context using `Assembly.Load` rather than the load-from context where native images are not used. For this to work without creating a secondary AppDomain with a custom app.config, MSBuild needs to know the version of the resolver assembly statically - at its own build time. Since MSBuild and SDK insert into Visual Studio independently, we have basically two options:

- Be OK with a temporary perf regression every time SDK inserts vNext into VS (or trying to make a combined SDK + MSBuild insertion with MSBuild compensating for the version bump). Note: The assembly load can be made such that it falls back to `LoadFrom` if the assembly identity doesn't match.
- Freeze the version of the assembly. The exact version is not important as long as it's fixed. This should be safe because the assembly should have no other consumers outside of MSBuild.

There are other approaches but I consider them non-practical / unattractive:

- Redesign the code flow so MSBuild always knows the version of the SDK it's going to run with in VS.
- Update `MSBuild.exe.config` as a post-install step on the customer machine.

cc @joeloff @marcpopMSFT