### PR TITLE
Allow trailing commas in launch settings JSON for dotnet watch

### DIFF
--- a/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
@@ -10,6 +10,12 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     internal sealed class LaunchSettingsProfile
     {
+        private static readonly JsonSerializerOptions s_serializerOptions = new(JsonSerializerDefaults.Web)
+        {
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+        };
+
         [JsonIgnore]
         public string? LaunchProfileName { get; set; }
         public string? ApplicationUrl { get; init; }
@@ -32,7 +38,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             {
                 launchSettings = JsonSerializer.Deserialize<LaunchSettingsJson>(
                     File.ReadAllText(launchSettingsPath),
-                    new JsonSerializerOptions(JsonSerializerDefaults.Web));
+                    s_serializerOptions);
             }
             catch (Exception ex)
             {

--- a/src/Tests/dotnet-watch.Tests/LaunchSettingsProfileTest.cs
+++ b/src/Tests/dotnet-watch.Tests/LaunchSettingsProfileTest.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Watcher.Internal;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher.Tools;
+
+public class LaunchSettingsProfileTest
+{
+    private readonly IReporter _reporter;
+    private readonly TestAssetsManager _testAssets;
+
+    public LaunchSettingsProfileTest(ITestOutputHelper output)
+    {
+        _reporter = new TestReporter(output);
+        _testAssets = new TestAssetsManager(output);
+    }
+
+    [Fact]
+    public void LoadsLaunchProfile()
+    {
+        var project = _testAssets.CreateTestProject(new TestProject("Project1")
+        {
+            TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+        });
+
+        WriteFile(project, Path.Combine("Properties", "launchSettings.json"),
+        """
+        {
+          "profiles": {
+            "http": {
+              "applicationUrl": "http://localhost:5000",
+              "commandName": "Project",
+              "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+              }
+            },
+            "https": {
+              "applicationUrl": "https://localhost:5001",
+              "commandName": "Project",
+              "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+              }
+            }
+          }
+        }
+        """);
+
+        var projectDirectory = Path.Combine(project.TestRoot, "Project1");
+
+        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectDirectory, "http", _reporter);
+        Assert.NotNull(expected);
+        Assert.Equal("http://localhost:5000", expected.ApplicationUrl);
+
+        expected = LaunchSettingsProfile.ReadLaunchProfile(projectDirectory, "https", _reporter);
+        Assert.NotNull(expected);
+        Assert.Equal("https://localhost:5001", expected.ApplicationUrl);
+
+        expected = LaunchSettingsProfile.ReadLaunchProfile(projectDirectory, "notfound", _reporter);
+        Assert.NotNull(expected);
+    }
+
+    [Fact]
+    public void LoadsLaunchProfileWithTrailingCommas()
+    {
+        var project = _testAssets.CreateTestProject(new TestProject("Project1")
+        {
+            TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+        });
+
+        WriteFile(project, Path.Combine("Properties", "launchSettings.json"),
+        """
+        {
+          "profiles": {
+            "test": {
+              "applicationUrl": "https://localhost:5002",
+              "commandName": "Project",
+              "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+              }
+            },
+          }
+        }
+        """);
+
+        var projectDirectory = Path.Combine(project.TestRoot, "Project1");
+
+        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectDirectory, "test", _reporter);
+
+        Assert.NotNull(expected);
+        Assert.Equal("https://localhost:5002", expected.ApplicationUrl);
+    }
+
+    [Fact]
+    public void LoadsLaunchProfileWithComment()
+    {
+        var project = _testAssets.CreateTestProject(new TestProject("Project1")
+        {
+            TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+        });
+
+        WriteFile(project, Path.Combine("Properties", "launchSettings.json"),
+        """
+        {
+          "profiles": {
+            // This is my launch profile
+            "test": {
+              "applicationUrl": "https://localhost:5002",
+              "commandName": "Project",
+              "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+              }
+            }
+          }
+        }
+        """);
+
+        var projectDirectory = Path.Combine(project.TestRoot, "Project1");
+
+        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectDirectory, "test", _reporter);
+
+        Assert.NotNull(expected);
+        Assert.Equal("https://localhost:5002", expected.ApplicationUrl);
+    }
+
+    private static string WriteFile(TestAsset testAsset, string name, string contents = "")
+    {
+        var path = Path.Combine(GetTestProjectDirectory(testAsset), name);
+        Directory.CreateDirectory(Path.GetDirectoryName(path));
+        File.WriteAllText(path, contents);
+
+        return path;
+    }
+
+    private static string WriteFile(TestDirectory testAsset, string name, string contents = "")
+    {
+        var path = Path.Combine(testAsset.Path, name);
+        Directory.CreateDirectory(Path.GetDirectoryName(path));
+        File.WriteAllText(path, contents);
+
+        return path;
+    }
+
+    private static string GetTestProjectDirectory(TestAsset testAsset)
+        => Path.Combine(testAsset.Path, testAsset.TestProject.Name);
+}

--- a/src/Tests/dotnet-watch.Tests/LaunchSettingsProfileTest.cs
+++ b/src/Tests/dotnet-watch.Tests/LaunchSettingsProfileTest.cs
@@ -18,7 +18,7 @@ public class LaunchSettingsProfileTest
     }
 
     [Fact]
-    public void LoadsLaunchProfile()
+    public void LoadsLaunchProfiles()
     {
         var project = _testAssets.CreateTestProject(new TestProject("Project1")
         {
@@ -42,7 +42,7 @@ public class LaunchSettingsProfileTest
               "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
               }
-            }
+            }, // This comment and trailing comma shouldn't cause any issues
           }
         }
         """);
@@ -59,69 +59,6 @@ public class LaunchSettingsProfileTest
 
         expected = LaunchSettingsProfile.ReadLaunchProfile(projectDirectory, "notfound", _reporter);
         Assert.NotNull(expected);
-    }
-
-    [Fact]
-    public void LoadsLaunchProfileWithTrailingCommas()
-    {
-        var project = _testAssets.CreateTestProject(new TestProject("Project1")
-        {
-            TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
-        });
-
-        WriteFile(project, Path.Combine("Properties", "launchSettings.json"),
-        """
-        {
-          "profiles": {
-            "test": {
-              "applicationUrl": "https://localhost:5002",
-              "commandName": "Project",
-              "environmentVariables": {
-                "ASPNETCORE_ENVIRONMENT": "Development",
-              }
-            },
-          }
-        }
-        """);
-
-        var projectDirectory = Path.Combine(project.TestRoot, "Project1");
-
-        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectDirectory, "test", _reporter);
-
-        Assert.NotNull(expected);
-        Assert.Equal("https://localhost:5002", expected.ApplicationUrl);
-    }
-
-    [Fact]
-    public void LoadsLaunchProfileWithComment()
-    {
-        var project = _testAssets.CreateTestProject(new TestProject("Project1")
-        {
-            TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
-        });
-
-        WriteFile(project, Path.Combine("Properties", "launchSettings.json"),
-        """
-        {
-          "profiles": {
-            // This is my launch profile
-            "test": {
-              "applicationUrl": "https://localhost:5002",
-              "commandName": "Project",
-              "environmentVariables": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-              }
-            }
-          }
-        }
-        """);
-
-        var projectDirectory = Path.Combine(project.TestRoot, "Project1");
-
-        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectDirectory, "test", _reporter);
-
-        Assert.NotNull(expected);
-        Assert.Equal("https://localhost:5002", expected.ApplicationUrl);
     }
 
     private static string WriteFile(TestAsset testAsset, string name, string contents = "")


### PR DESCRIPTION
Make `dotnet watch` resilient to trailing commas and comments in `launchSettings.json` files like `dotnet run` is:

https://github.com/dotnet/sdk/blob/f52240f11ad291e6ee3cff86e83c0f7a21b60370/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs#L31-L35

Relates to #32233 and dotnet/aspnetcore#51921.
