### PR TITLE
Add custom props imports around DB.props import Fixes #36749

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -51,7 +51,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsBasePath)' != '' and '$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildPropsBasePath)', '$(_DirectoryBuildPropsFile)'))</DirectoryBuildPropsPath>
   </PropertyGroup>
 
+  <Import Project="$(CustomBeforeDirectoryBuildProps)" Condition="'$(CustomBeforeDirectoryBuildProps)' != '' and exists('$(CustomBeforeDirectoryBuildProps)')" />
+
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
+
+  <Import Project="$(CustomAfterDirectoryBuildProps)" Condition="'$(CustomAfterDirectoryBuildProps)' != '' and exists('$(CustomAfterDirectoryBuildProps)')" />
 
   <PropertyGroup>
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -30,58 +30,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       Similar to the property above, it must be set here.
     -->
     <UsingNETSdkDefaults>true</UsingNETSdkDefaults>
-  </PropertyGroup>
 
-
-  
-  <!-- We need to put the UseArtifactsOutput logic after the import of Directory.Build.props, but before the MSBuild Project Extensions .props import.
-       However, both of these things happen in Microsoft.Common.props with no opportunity to insert logic in between them.
-
-       So what we do here is duplicate the Directory.Build.props import logic from Microsoft.Common.props, and then set ImportDirectoryBuildProps to
-       false so that it doesn't get imported twice.
-
-       Alternatively, we could add a hook in MSBuild to define a file to import at the right location, to avoid duplicating the logic here.
-       -->
-  <PropertyGroup>
-    <ImportDirectoryBuildProps Condition="'$(ImportDirectoryBuildProps)' == ''">true</ImportDirectoryBuildProps>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(ImportDirectoryBuildProps)' == 'true' and '$(DirectoryBuildPropsPath)' == ''">
-    <_DirectoryBuildPropsFile Condition="'$(_DirectoryBuildPropsFile)' == ''">Directory.Build.props</_DirectoryBuildPropsFile>
-    <_DirectoryBuildPropsBasePath Condition="'$(_DirectoryBuildPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectoryBuildPropsFile)'))</_DirectoryBuildPropsBasePath>
-    <DirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsBasePath)' != '' and '$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildPropsBasePath)', '$(_DirectoryBuildPropsFile)'))</DirectoryBuildPropsPath>
-  </PropertyGroup>
-
-  <Import Project="$(CustomBeforeDirectoryBuildProps)" Condition="'$(CustomBeforeDirectoryBuildProps)' != '' and exists('$(CustomBeforeDirectoryBuildProps)')" />
-
-  <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
-
-  <Import Project="$(CustomAfterDirectoryBuildProps)" Condition="'$(CustomAfterDirectoryBuildProps)' != '' and exists('$(CustomAfterDirectoryBuildProps)')" />
-
-  <PropertyGroup>
-    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-  </PropertyGroup>
-
-  <!-- If ArtifactsPath or UseArtifactsOutput are set, then import .props to set ArtifactsPath here, so that BaseIntermediateOutputPath can be
-       set in the ArtifactsPath.
-       If the .props file is not imported here, it will be imported from Microsoft.NET.DefaultOutputPaths.targets, so that artifacts output
-       properties can be set directly in the project file too (only in that case they won't affect the intermediate output). -->
-  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.DefaultArtifactsPath.props"
-          Condition="'$(UseArtifactsOutput)' == 'true' Or '$(ArtifactsPath)' != ''"/>
-
-  <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true'">
-    <UseArtifactsIntermediateOutput Condition="'$(UseArtifactsIntermediateOutput)' == ''">true</UseArtifactsIntermediateOutput>
-    <ArtifactsProjectName Condition="'$(ArtifactsProjectName)' == ''">$(MSBuildProjectName)</ArtifactsProjectName>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true' And '$(BaseIntermediateOutputPath)' == '' And '$(UseArtifactsIntermediateOutput)' == 'true'">
-    <BaseIntermediateOutputPath Condition="'$(IncludeProjectNameInArtifactsPaths)' == 'true'">$(ArtifactsPath)\obj\$(ArtifactsProjectName)\</BaseIntermediateOutputPath>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(ArtifactsPath)\obj\</BaseIntermediateOutputPath>
-  </PropertyGroup>
-
-  <!-- Record whether ArtifactsPath / UseArtifactsOutput was set at this point in evaluation.  We will generate an error if these properties are set
-       after this point (ie in the project file). -->
-  <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true'">
-    <_ArtifactsPathSetEarly>true</_ArtifactsPathSetEarly>
+    <CustomAfterDirectoryBuildProps>$(MSBuildThisFileDirectory)UseArtifactsOutputPath.props</CustomAfterDirectoryBuildProps>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectFullPath)' == '$(ProjectToOverrideProjectExtensionsPath)'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -31,7 +31,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
     <UsingNETSdkDefaults>true</UsingNETSdkDefaults>
 
-    <CustomAfterDirectoryBuildProps>$(MSBuildThisFileDirectory)UseArtifactsOutputPath.props</CustomAfterDirectoryBuildProps>
+    <CustomAfterDirectoryBuildProps>$(CustomAfterDirectoryBuildProps);$(MSBuildThisFileDirectory)UseArtifactsOutputPath.props</CustomAfterDirectoryBuildProps>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectFullPath)' == '$(ProjectToOverrideProjectExtensionsPath)'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/UseArtifactsOutputPath.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/UseArtifactsOutputPath.props
@@ -1,0 +1,35 @@
+<!--
+***********************************************************************************************
+UseArtifactsOutputPath.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- If ArtifactsPath or UseArtifactsOutput are set, then import .props to set ArtifactsPath here, so that BaseIntermediateOutputPath can be
+       set in the ArtifactsPath.
+       If the .props file is not imported here, it will be imported from Microsoft.NET.DefaultOutputPaths.targets, so that artifacts output
+       properties can be set directly in the project file too (only in that case they won't affect the intermediate output). -->
+  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.DefaultArtifactsPath.props"
+          Condition="'$(UseArtifactsOutput)' == 'true' Or '$(ArtifactsPath)' != ''"/>
+
+  <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true'">
+    <UseArtifactsIntermediateOutput Condition="'$(UseArtifactsIntermediateOutput)' == ''">true</UseArtifactsIntermediateOutput>
+    <ArtifactsProjectName Condition="'$(ArtifactsProjectName)' == ''">$(MSBuildProjectName)</ArtifactsProjectName>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true' And '$(BaseIntermediateOutputPath)' == '' And '$(UseArtifactsIntermediateOutput)' == 'true'">
+    <BaseIntermediateOutputPath Condition="'$(IncludeProjectNameInArtifactsPaths)' == 'true'">$(ArtifactsPath)\obj\$(ArtifactsProjectName)\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(ArtifactsPath)\obj\</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <!-- Record whether ArtifactsPath / UseArtifactsOutput was set at this point in evaluation.  We will generate an error if these properties are set
+       after this point (ie in the project file). -->
+  <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true'">
+    <_ArtifactsPathSetEarly>true</_ArtifactsPathSetEarly>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes #36749

Sdk.props imports Directory.Build.props. There's new custom logic to import something immediately before or after that import in MSBuild, but it was missed here.