### PR TITLE
Create dummy AfterSdkPublish target Fixes #26710

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -12,6 +12,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <_AfterSdkPublishDependsOn Condition="'$(_IsAspNetCoreProject)' == 'true'">AfterPublish</_AfterSdkPublishDependsOn>
+    <_AfterSdkPublishDependsOn Condition="'$(_IsAspNetCoreProject)' != 'true'">Publish</_AfterSdkPublishDependsOn>
+  </PropertyGroup>
+
+  <Target Name="AfterSdkPublish" AfterTargets="$(_AfterSdkPublishDependsOn)"></Target>
+
+  <PropertyGroup>
     <!--
       Indicate to other targets that Microsoft.NET.Sdk is being used.
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -151,6 +151,25 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Fact]
+        public void Target_after_AfterSdkPublish_executes()
+        {
+            var projectChanges = (XDocument doc) =>
+            {
+                var ns = doc.Root.Name.Namespace;
+                var target = new XElement("Target");
+                target.ReplaceAttributes(new XAttribute[] { new XAttribute("Name", "AfterAfterSdkPublish"), new XAttribute("AfterTargets", "AfterSdkPublish") });
+                var message = new XElement("Message");
+                message.ReplaceAttributes(new XAttribute[] { new XAttribute("Importance", "High"), new XAttribute("Text", "Executed AfterAfterSdkPublish") });
+                target.Add(message);
+                doc.Root.Add(target);
+            };
+
+            var publishResults = GetPublishCommand(projectChanges: projectChanges).Execute();
+            publishResults.Should().Pass();
+            publishResults.Should().HaveStdOutContaining("Executed AfterAfterSdkPublish");
+        }
+
+        [Fact]
         public void It_errors_when_publishing_single_file_lib()
         {
             var testProject = new TestProject()


### PR DESCRIPTION
Fixes #26710

After discussions with @baronfel and @vijayrkn, it sounds like the cleanest solution for customers who want an "AfterPublish" target in non-web projects is to introduce a new dummy "AfterSdkPublish" target in the base SDK. There appear to be no references to such a target on GitHub, through an online search, or in the DevDiv repo on AzDO, so this is likely safe and hopefully helpful.