### PR TITLE
Change the default for 'EnforceCodeStyleInBuild' to true with AnalysisLevel 9.0 or greater

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -95,7 +95,10 @@ Copyright (c) .NET Foundation. All rights reserved.
                                       '$(IsAotCompatible)' == 'true'
                                   )">true</EnableAotAnalyzer>
 
-    <!-- EnforceCodeStyleInBuild Allows code style analyzers to be disabled in bulk via msbuild if the user wants to -->
+    <!-- EnforceCodeStyleInBuild allows code style analyzers that are configured to warning/error severity to be enabled on build via msbuild if the user wants to.
+         It is defaulted to 'true' for AnalysisLevel/TFM greater than or equals '9.0', and 'false' otherwise.
+    -->
+    <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == '' And $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '9.0'))">true</EnforceCodeStyleInBuild>
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">false</EnforceCodeStyleInBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
Back when we introduced CodeStyle NuGet package and build-time enforcement of IDE CodeStyle analyzers, it was an experimental feature, and hence the MSBuild property `EnforceCodeStyleInBuild` guarding this feature was defaulted to `false`. Now that it has been few release cycles with this package and feature, we will default this property to `true`. The new default value will only apply for AnalysisLevel/TFM 9.0 or greater to avoid any breaking changes in existing projects that configure IDExxxx to warning/error severity in their editorconfig, but do not set this property and hence see warnings/errors in the IDE live analysis, but not on build.

NOTE: This change has been approved in the offline email discussion with Roslyn IDE and compiler teams.