### PR TITLE
Don't overwrite user-provided ContainerUser values

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -110,7 +110,7 @@ internal sealed class ImageBuilder
     /// <summary>
     /// Sets the USER for the image.
     /// </summary>
-    internal void SetUser(string user) => _baseImageConfig.SetUser(user);
+    internal void SetUser(string user, bool isExplicitUserInteraction = true) => _baseImageConfig.SetUser(user, isExplicitUserInteraction);
 
     internal static (string[] entrypoint, string[] cmd) DetermineEntrypointAndCmd(
         string[] entrypoint,
@@ -227,7 +227,7 @@ internal sealed class ImageBuilder
         if (_baseImageConfig.EnvironmentVariables.TryGetValue(EnvironmentVariables.APP_UID, out string? appUid))
         {
             _logger.LogTrace("Setting user from APP_UID environment variable");
-            SetUser(appUid);
+            SetUser(appUid, isExplicitUserInteraction: false);
         }
     }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -20,6 +20,7 @@ internal sealed class ImageConfig
     private string[]? _newEntrypoint;
     private string[]? _newCmd;
     private string? _user;
+    private bool _userHasBeenExplicitlySet;
 
     /// <summary>
     /// Models the file system of the image. Typically has a key 'type' with value 'layers' and a key 'diff_ids' with a list of layer digests.
@@ -216,7 +217,16 @@ internal sealed class ImageConfig
         _rootFsLayers.Add(l.Descriptor.UncompressedDigest!);
     }
 
-    internal void SetUser(string user) => _user = user;
+    internal void SetUser(string user, bool isUserInteraction = false) {
+        // we don't let automatic/inferred user settings overwrite an explicit user request
+        if (_userHasBeenExplicitlySet && !isUserInteraction)
+        {
+            return;
+        }
+
+        _user = user;
+        _userHasBeenExplicitlySet = isUserInteraction;
+    }
 
     private HashSet<Port> GetExposedPorts()
     {

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
@@ -562,6 +562,46 @@ public class ImageBuilderTests
         Assert.Equal(assignedPorts, expectedPorts);
     }
 
+
+    [Fact]
+    public void CanSetContainerUserAndOverrideAppUID()
+    {
+      var userId = "1646";
+      var baseConfigBuilder = FromBaseImageConfig($$"""
+        {
+            "architecture": "amd64",
+            "config": {
+                "Hostname": "",
+                "Domainname": "",
+                "User": "",
+                "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                "{{ImageBuilder.EnvironmentVariables.APP_UID}}=12345"
+                ],
+                "Cmd": ["bash"],
+                "Image": "sha256:d772d27ebeec80393349a4770dc37f977be2c776a01c88b624d43f93fa369d69",
+                "WorkingDir": ""
+            },
+            "created": "2023-02-04T08:14:52.000901321Z",
+            "os": "linux",
+            "rootfs": {
+                "type": "layers",
+                "diff_ids": [
+                "sha256:bd2fe8b74db65d82ea10db97368d35b92998d4ea0e7e7dc819481fe4a68f64cf",
+                "sha256:94100d1041b650c6f7d7848c550cd98c25d0bdc193d30692e5ea5474d7b3b085",
+                "sha256:53c2a75a33c8f971b4b5036d34764373e134f91ee01d8053b4c3573c42e1cf5d",
+                "sha256:49a61320e585180286535a2545be5722b09e40ad44c7c190b20ec96c9e42e4a3",
+                "sha256:8a379cce2ac272aa71aa029a7bbba85c852ba81711d9f90afaefd3bf5036dc48"
+                ]
+            }
+        }
+        """);
+
+      baseConfigBuilder.SetUser(userId);
+      var config = JsonNode.Parse(baseConfigBuilder.Build().Config);
+      config!["config"]?["User"]?.GetValue<string>().Should().Be(expected: userId, because: "The precedence of SetUser should override inferred user ids");
+    }
+
     private ImageBuilder FromBaseImageConfig(string baseImageConfig, [CallerMemberName] string testName = "")
     {
         var manifest = new ManifestV2() {


### PR DESCRIPTION
Fix https://github.com/dotnet/sdk-container-builds/issues/520

In .NET 8, the .NET Container base images allow for opting to run in a rootless mode by setting a particular user id as the default user for the container. The SDK Container feature opts into this mode by default, inspecting the base images for this value and setting it in our generated images on behalf of the user.

Because this is an impactful change, we also created a mechanism to allow users to opt out of this behavior. Users set `<ContainerUser>root</ContainerUser>` in their project file or their build command and we take that and flow it through the container creation process accordingly.

Or at least we used to. At some point we messed up the sequencing and since we never had an end-to-end test for the way that the implicit user id for the base image interacted with the feature we released in a broken state.

## Customer Impact

Users building containers with the SDK always build containers in rootless mode, and the MSBuild switch to opt out of this has no effect. If the user code does things that require admin permissions, for example creating files in the application's working directory), the application may crash. There are two workarounds:

* As part of container execution (so long after the build), have your container runtime (docker, kubernetes, etc) explicitly run the SDK-generated container image as a user with root permissions. For example, here is how you might run a container as the `root` user: `docker run --user root my-webapp:latest`. This requires users to find and alter their deployment steps, which may not be located with their code.
* Update the application to work in a rootless mode of execution. This can vary wildly in terms of effort. While this is the long-term best option from a security perspective, most users will likely want to schedule and plan for such changes.

## Regression

**Yes** - this probably broke as a result of the changes introduced in https://github.com/dotnet/sdk/pull/34154 prior to RC1.

## Risk

**Low** - tests cover the changes and this path is only hit when a user is explicitly asking for a change.

## Verification/Testing

Automated tests now verify the expected changes to image manifest configurations and enforce the expected ordering of implicit user id selection vs explicit user-provided actions.
