### PR TITLE
Use .NET 9.0 versions for task dependencies

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -32,10 +32,5 @@
     <UsagePattern IdentityGlob="System.Diagnostics.EventLog/*7.0.0*" />
     <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/*7.0.0*" />
     <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/*7.0.0*" />
-    
-    <!-- msbuild is still on 8.0 versions of these so we have to pin in SDK main for now or tasks will fail -->
-    <UsagePattern IdentityGlob="Microsoft.NET.HostModel/*8.0.0*" />
-    <UsagePattern IdentityGlob="Microsoft.Extensions.DependencyModel/*8.0.0*" />
-    <UsagePattern IdentityGlob="Microsoft.Bcl.AsyncInterfaces/*8.0.0*" />
   </IgnorePatterns>
 </UsageData>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -52,10 +52,10 @@
     <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" VersionOverride="8.0.0-rc.1.23419.4"/>
-    <PackageReference Include="Microsoft.NET.HostModel" VersionOverride="8.0.0-rc.1.23419.4"/>
-    <PackageReference Include="System.Text.Json" VersionOverride="8.0.0-rc.1.23419.4"/>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="8.0.0-rc.1.23419.4"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
+    <PackageReference Include="Microsoft.NET.HostModel" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="NuGet.Build.Tasks.Pack" ExcludeAssets="All" />
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />


### PR DESCRIPTION
Addresses https://github.com/dotnet/source-build/issues/3665

The following 9.0 prebuilts are eliminated in this PR:

      "Microsoft.Bcl.AsyncInterfaces": {
          "8.0.0-rc.1.23419.4": [
              "src/sdk/artifacts/buildObj/source-build/self/src/artifacts/obj/Release/Sdks/Microsoft.NET.Sdk/tools/project.assets.json"
          ]
      },
      "Microsoft.Extensions.DependencyModel": {
          "8.0.0-rc.1.23419.4": [
              "src/sdk/artifacts/buildObj/source-build/self/src/artifacts/obj/Release/Sdks/Microsoft.NET.Sdk/tools/project.assets.json"
          ]
      },
      "Microsoft.NET.HostModel": {
          "8.0.0-rc.1.23419.4": [
              "src/sdk/artifacts/buildObj/source-build/self/src/artifacts/obj/Release/Sdks/Microsoft.NET.Sdk/tools/project.assets.json"
          ]
      },
      "System.Text.Json": {
          "8.0.0-rc.1.23419.4": [
              "src/sdk/artifacts/buildObj/source-build/self/src/artifacts/obj/Release/Sdks/Microsoft.NET.Sdk/tools/project.assets.json"
          ]
      }