### PR TITLE
Safely dispose of loggers in the MSI installer

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -1067,7 +1067,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 }
                 finally
                 {
-                    ((TimestampedFileLogger)Log).Dispose();
+                    if (Log is IDisposable tfl)
+                    {
+                        tfl.Dispose();
+                    }
                 }
             }
         }


### PR DESCRIPTION
When I did https://github.com/dotnet/sdk/pull/36443 I added a new kind of MSI logger that wouldn't log on simple read-only operations, but missed that there was a hard-coded assumption in the MSI Installer Client that all loggers would be `TimestampedFileLogger`s. This caused https://github.com/dotnet/sdk/issues/36757. This PR safely checks if the logger can be disposed before disposing it.

Fixes https://github.com/dotnet/sdk/issues/36757.