### PR TITLE
wrap and handle cancellation exceptions in .NET Task

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -31,7 +31,19 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
     public override bool Execute()
     {
-        return Task.Run(() => ExecuteAsync(_cancellationTokenSource.Token)).GetAwaiter().GetResult();
+        try
+        {
+            Task.Run(() => ExecuteAsync(_cancellationTokenSource.Token)).ContinueWith(t => t).GetAwaiter().GetResult();
+        }
+        catch (TaskCanceledException ex)
+        {
+            Log.LogWarningFromException(ex);
+        }
+        catch (OperationCanceledException ex)
+        {
+            Log.LogWarningFromException(ex);
+        }
+        return !Log.HasLoggedErrors;
     }
 
     internal async Task<bool> ExecuteAsync(CancellationToken cancellationToken)

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -33,7 +33,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
     {
         try
         {
-            Task.Run(() => ExecuteAsync(_cancellationTokenSource.Token)).ContinueWith(t => t).GetAwaiter().GetResult();
+            Task.Run(() => ExecuteAsync(_cancellationTokenSource.Token)).GetAwaiter().GetResult();
         }
         catch (TaskCanceledException ex)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/36593

Instead of letting the Task cancellation bubble up, we internalize those two errors specifically. This provides a very clean error experience:

![image](https://github.com/dotnet/sdk/assets/573979/a15d7716-8a8d-49ce-854c-910dea891c67)
