### PR TITLE
Parse -d command differently based on position

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -142,9 +142,14 @@ namespace Microsoft.DotNet.Cli
                             ToolPathSentinelFileName)));
                 if (parseResult.GetValue(Parser.DiagOption) && parseResult.IsDotnetBuiltInCommand())
                 {
-                    Environment.SetEnvironmentVariable(CommandLoggingContext.Variables.Verbose, bool.TrueString);
-                    CommandLoggingContext.SetVerbose(true);
-                    Reporter.Reset();
+                    // We found --diagnostic or -d, but we still need to determine whether the option should
+                    // be attached to the dotnet command or the subcommand.
+                    if (args.DiagOptionPrecedesSubcommand(parseResult.RootSubCommandResult()))
+                    {
+                        Environment.SetEnvironmentVariable(CommandLoggingContext.Variables.Verbose, bool.TrueString);
+                        CommandLoggingContext.SetVerbose(true);
+                        Reporter.Reset();
+                    }
                 }
                 if (parseResult.HasOption(Parser.VersionOption) && parseResult.IsTopLevelDotnetCommand())
                 {

--- a/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
         [Theory]
         [InlineData(new string[] { "dotnet", "build" }, new string[] { })]
         [InlineData(new string[] { "build" }, new string[] { })]
-        [InlineData(new string[] { "dotnet", "test", "-d" }, new string[] { })]
+        [InlineData(new string[] { "dotnet", "test", "-d" }, new string[] { "-d" })]
         [InlineData(new string[] { "dotnet", "publish", "-o", "foo" }, new string[] { "-o", "foo" })]
         [InlineData(new string[] { "publish", "-o", "foo" }, new string[] { "-o", "foo" })]
         [InlineData(new string[] { "dotnet", "add", "package", "-h" }, new string[] { "package", "-h" })]


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/29839

Description
If -d is at the beginning of the list of subarguments, that is, before the subcommand, it should be associated with 'dotnet' and therefore ignored when getting at the list of subarguments. If it's after the subcommand, however, it should be parsed as part of the subcommand.

This differentiates between the two positionings.

Impact
Some users specify -d, intending to get diagnostic-verbosity output. Other specify it as a subcommand for dotnet-ef to indicate that it should use attributes to configure the model. There is currently no way to disambiguate between the two, and dotnet (as the initial command) takes preference, automatically stripping any -d anywhere in the input, preventing users from using it as an option to their subcommands (in this case dotnet-ef).

Changes
Alter -d parsing to parse the -d as diagnostic if it comes before the subcommand but as an option to the subcommand if it comes after it.

Risk
Some people might append -d to the end of their command, intending to get diagnostic output, and that would no longer work as intended. I don't know how common that is.

Testing
I changed a unit test to ensure -d is parsed as intended.