### PR TITLE
Fix incorrect app host used in build when PublishSingleFile=true

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -708,7 +708,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(PublishSingleFile)' == 'true' and
                      '$(SelfContained)' == 'true' and
                      '$(SingleFileHostSourcePath)' != '' and
-                     '$(_TargetFrameworkVersionWithoutV)' >= '5.0' and
+                     $([MSBuild]::IsTargetFrameworkCompatible('net5.0', '$(TargetFrameworkVersion)')) and
                      Exists('@(IntermediateAssembly)') and
                      Exists('$(SingleFileHostSourcePath)')">
     <PropertyGroup>
@@ -861,7 +861,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                             Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '5.0' and Exists('$(SingleFileHostIntermediatePath)')">
+    <ItemGroup Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true' and $([MSBuild]::IsTargetFrameworkCompatible('net5.0', '$(TargetFrameworkVersion)')) and Exists('$(SingleFileHostIntermediatePath)')">
       <!-- Remove non-single-file apphost from items to publish -->
       <_SourceItemsToCopyToPublishDirectoryAlways Remove="$(AppHostIntermediatePath)" />
       <_SourceItemsToCopyToPublishDirectory Remove="$(AppHostIntermediatePath)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -39,7 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemDefinitionGroup>
 
   <Target Name="_ComputeToolPackInputsToProcessFrameworkReferences" BeforeTargets="ProcessFrameworkReferences">
-    <!-- Keep this in sync with the warnings produced for RequiresILLinkPack in ProcessFrameworkReferences.cs. 
+    <!-- Keep this in sync with the warnings produced for RequiresILLinkPack in ProcessFrameworkReferences.cs.
          Must be set late enough to see the inferred value of EnableSingleFileAnalyzer. -->
     <PropertyGroup>
       <_RequiresILLinkPack Condition="'$(_RequiresILLinkPack)' == '' And (
@@ -101,7 +101,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Don't warn if the library multitargets and includes TFM that's supported by trimming/AOT and is supported by the min non-EOL TFM that supports trimming/AOT. -->
       <_SilenceIsTrimmableUnsupportedWarning Condition="'$(_SilenceIsTrimmableUnsupportedWarning)' == '' And
                                                         @(_TargetFrameworkToSilenceIsTrimmableUnsupportedWarning->Count()) > 0">true</_SilenceIsTrimmableUnsupportedWarning>
-      <_SilenceIsAotCompatibleUnsupportedWarning Condition="'$(_SilenceIsAotCompatibleUnsupportedWarning)' == '' And 
+      <_SilenceIsAotCompatibleUnsupportedWarning Condition="'$(_SilenceIsAotCompatibleUnsupportedWarning)' == '' And
                                                             @(_TargetFrameworkToSilenceIsAotCompatibleUnsupportedWarning->Count()) > 0">true</_SilenceIsAotCompatibleUnsupportedWarning>
       <_SilenceEnableSingleFileAnalyzerUnsupportedWarning Condition="'$(_SilenceEnableSingleFileAnalyzerUnsupportedWarning)' == '' And
                                                           @(_TargetFrameworkToSilenceEnableSingleFileAnalyzerUnsupportedWarning->Count()) > 0">true</_SilenceEnableSingleFileAnalyzerUnsupportedWarning>
@@ -696,6 +696,40 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+                                        _CreateSingleFileHost
+      Create the single-file host for the publish scenario if app is being published as a self-contained single-file .net5+ app
+    ============================================================
+     -->
+  <UsingTask TaskName="CreateAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="_CreateSingleFileHost"
+          Inputs="@(IntermediateAssembly);$(SingleFileHostSourcePath)"
+          Outputs="$(SingleFileHostIntermediatePath)"
+          DependsOnTargets="_GetAppHostPaths"
+          Condition="'$(PublishSingleFile)' == 'true' and
+                     '$(SelfContained)' == 'true' and
+                     '$(SingleFileHostSourcePath)' != '' and
+                     '$(_TargetFrameworkVersionWithoutV)' >= '5.0' and
+                     Exists('@(IntermediateAssembly)') and
+                     Exists('$(SingleFileHostSourcePath)')">
+    <PropertyGroup>
+      <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
+      <_EnableMacOSCodeSign Condition="'$(_EnableMacOSCodeSign)' == '' and $([MSBuild]::IsOSPlatform(`OSX`)) and Exists('/usr/bin/codesign') and
+                                      ($(RuntimeIdentifier.StartsWith('osx')) or $(AppHostRuntimeIdentifier.StartsWith('osx')))">true</_EnableMacOSCodeSign>
+    </PropertyGroup>
+
+    <CreateAppHost AppHostSourcePath="$(SingleFileHostSourcePath)"
+                   AppHostDestinationPath="$(SingleFileHostIntermediatePath)"
+                   AppBinaryName="$(AssemblyName)$(TargetExt)"
+                   IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')"
+                   WindowsGraphicalUserInterface="$(_UseWindowsGraphicalUserInterface)"
+                   Retries="$(CopyRetryCount)"
+                   RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+                   EnableMacOSCodeSign="$(_EnableMacOSCodeSign)"
+                   />
+  </Target>
+
+  <!--
+    ============================================================
                                         _ComputeCopyToPublishDirectoryItems
     ============================================================
     -->
@@ -736,6 +770,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           KeepDuplicateOutputs=" '$(MSBuildDisableGetCopyToPublishDirectoryItemsOptimization)' == '' "
           DependsOnTargets="AssignTargetPaths;
                             DefaultCopyToPublishDirectoryMetadata;
+                            _CreateSingleFileHost;
                             _SplitProjectReferencesByFileExistence;
                             _GetProjectReferenceTargetFrameworkProperties">
 
@@ -824,6 +859,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_SourceItemsToCopyToPublishDirectory KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(_NoneWithTargetPath->'%(FullPath)')"
                                             Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '5.0'">
+      <!-- Remove non-single-file apphost from items to publish -->
+      <_SourceItemsToCopyToPublishDirectoryAlways Remove="$(AppHostIntermediatePath)" />
+      <_SourceItemsToCopyToPublishDirectory Remove="$(AppHostIntermediatePath)" />
+
+      <!-- Add the single-file host created as part of publish -->
+      <_SourceItemsToCopyToPublishDirectoryAlways Include="$(SingleFileHostIntermediatePath)" CopyToOutputDirectory="Always" TargetPath="$(AssemblyName)$(_NativeExecutableExtension)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -708,7 +708,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(PublishSingleFile)' == 'true' and
                      '$(SelfContained)' == 'true' and
                      '$(SingleFileHostSourcePath)' != '' and
-                     $([MSBuild]::IsTargetFrameworkCompatible('net5.0', '$(TargetFrameworkVersion)')) and
+                     $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0')) and
                      Exists('@(IntermediateAssembly)') and
                      Exists('$(SingleFileHostSourcePath)')">
     <PropertyGroup>
@@ -861,7 +861,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                             Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true' and $([MSBuild]::IsTargetFrameworkCompatible('net5.0', '$(TargetFrameworkVersion)')) and Exists('$(SingleFileHostIntermediatePath)')">
+    <ItemGroup Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0')) and Exists('$(SingleFileHostIntermediatePath)')">
       <!-- Remove non-single-file apphost from items to publish -->
       <_SourceItemsToCopyToPublishDirectoryAlways Remove="$(AppHostIntermediatePath)" />
       <_SourceItemsToCopyToPublishDirectory Remove="$(AppHostIntermediatePath)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -700,7 +700,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       Create the single-file host for the publish scenario if app is being published as a self-contained single-file .net5+ app
     ============================================================
      -->
-  <UsingTask TaskName="CreateAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_CreateSingleFileHost"
           Inputs="@(IntermediateAssembly);$(SingleFileHostSourcePath)"
           Outputs="$(SingleFileHostIntermediatePath)"
@@ -708,7 +707,8 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(PublishSingleFile)' == 'true' and
                      '$(SelfContained)' == 'true' and
                      '$(SingleFileHostSourcePath)' != '' and
-                     $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0')) and
+                     '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                     $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and
                      Exists('@(IntermediateAssembly)') and
                      Exists('$(SingleFileHostSourcePath)')">
     <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -703,20 +703,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CreateSingleFileHost"
           Inputs="@(IntermediateAssembly);$(SingleFileHostSourcePath)"
           Outputs="$(SingleFileHostIntermediatePath)"
-          DependsOnTargets="_GetAppHostPaths"
-          Condition="'$(PublishSingleFile)' == 'true' and
-                     '$(SelfContained)' == 'true' and
-                     '$(SingleFileHostSourcePath)' != '' and
-                     '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
-                     $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and
+          DependsOnTargets="_GetAppHostPaths;_GetAppHostCreationConfiguration"
+          Condition="'$(_UseSingleFileHostForPublish)' == 'true' and
                      Exists('@(IntermediateAssembly)') and
                      Exists('$(SingleFileHostSourcePath)')">
-    <PropertyGroup>
-      <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
-      <_EnableMacOSCodeSign Condition="'$(_EnableMacOSCodeSign)' == '' and $([MSBuild]::IsOSPlatform(`OSX`)) and Exists('/usr/bin/codesign') and
-                                      ($(RuntimeIdentifier.StartsWith('osx')) or $(AppHostRuntimeIdentifier.StartsWith('osx')))">true</_EnableMacOSCodeSign>
-    </PropertyGroup>
-
     <CreateAppHost AppHostSourcePath="$(SingleFileHostSourcePath)"
                    AppHostDestinationPath="$(SingleFileHostIntermediatePath)"
                    AppBinaryName="$(AssemblyName)$(TargetExt)"
@@ -861,7 +851,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                             Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0')) and Exists('$(SingleFileHostIntermediatePath)')">
+    <ItemGroup Condition="'$(_UseSingleFileHostForPublish)' == 'true' and Exists('$(SingleFileHostIntermediatePath)')">
       <!-- Remove non-single-file apphost from items to publish -->
       <_SourceItemsToCopyToPublishDirectoryAlways Remove="$(AppHostIntermediatePath)" />
       <_SourceItemsToCopyToPublishDirectory Remove="$(AppHostIntermediatePath)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -861,7 +861,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                             Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '5.0'">
+    <ItemGroup Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '5.0' and Exists('$(SingleFileHostIntermediatePath)')">
       <!-- Remove non-single-file apphost from items to publish -->
       <_SourceItemsToCopyToPublishDirectoryAlways Remove="$(AppHostIntermediatePath)" />
       <_SourceItemsToCopyToPublishDirectory Remove="$(AppHostIntermediatePath)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -700,7 +700,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CreateAppHost"
           Inputs="@(IntermediateAssembly);$(AppHostSourcePath)"
           Outputs="$(AppHostIntermediatePath)"
-          DependsOnTargets="_ChooseAppHost;CoreCompile"
+          DependsOnTargets="_GetAppHostPaths;CoreCompile"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true' and
                      '$(AppHostSourcePath)' != '' and
                      Exists('@(IntermediateAssembly)') and
@@ -724,26 +724,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        _ChooseAppHost
-      Choose the correct app-host for the build scenario:
-      * SingleFileHost if an app being published as a self-contained single-file .net5+ app
-      * AppHost otherwise
-    ============================================================
-     -->
-  <Target Name="_ChooseAppHost"
-          DependsOnTargets="_GetAppHostPaths"
-          Condition="'$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true'">
-    <PropertyGroup Condition="'$(PublishSingleFile)' == 'true' and
-                              '$(SelfContained)' == 'true' and
-                              '$(_TargetFrameworkVersionWithoutV)' >= '5.0' and
-                              '$(SingleFileHostSourcePath)' != ''">
-      <AppHostSourcePath>$(SingleFileHostSourcePath)</AppHostSourcePath>
-      <AppHostIntermediatePath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)singlefilehost$(_NativeExecutableExtension)'))</AppHostIntermediatePath>
-    </PropertyGroup>
-  </Target>
-
-  <!--
-    ============================================================
                                         _GetAppHostPaths
     Gets the path to apphost (restored via packages or in an apphost pack),
     and computes the path for the destination apphost.
@@ -763,6 +743,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
     <PropertyGroup Condition="'$(UseAppHostFromAssetsFile)' == 'false' Or '@(_NativeRestoredAppHostNETCore)' != ''">
       <AppHostIntermediatePath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)apphost$(_NativeExecutableExtension)'))</AppHostIntermediatePath>
+      <SingleFileHostIntermediatePath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)singlefilehost$(_NativeExecutableExtension)'))</SingleFileHostIntermediatePath>
     </PropertyGroup>
 
   </Target>
@@ -878,7 +859,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="_ComputeNETCoreBuildOutputFiles"
-          DependsOnTargets="_ChooseAppHost;_GetComHostPaths;_GetIjwHostPaths"
+          DependsOnTargets="_GetAppHostPaths;_GetComHostPaths;_GetIjwHostPaths"
           BeforeTargets="AssignTargetPaths"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true'">
 
@@ -894,7 +875,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </None>
     </ItemGroup>
-
 
     <ItemGroup Condition="'$(AppHostIntermediatePath)' != '' or '$(_CopyAndRenameDotnetHost)' == 'true'">
       <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -691,6 +691,27 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+                                        _GetAppHostPaths
+    Gets the path to apphost (restored via packages or in an apphost pack),
+    and computes the path for the destination apphost.
+    ============================================================
+     -->
+  <Target Name="_GetAppHostCreationConfiguration"
+          Condition="'$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true'">
+    <PropertyGroup>
+      <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
+      <_EnableMacOSCodeSign Condition="'$(_EnableMacOSCodeSign)' == '' and $([MSBuild]::IsOSPlatform(`OSX`)) and Exists('/usr/bin/codesign') and
+                                      ($(RuntimeIdentifier.StartsWith('osx')) or $(AppHostRuntimeIdentifier.StartsWith('osx')))">true</_EnableMacOSCodeSign>
+      <_UseSingleFileHostForPublish Condition="'$(PublishSingleFile)' == 'true' and
+                                               '$(SelfContained)' == 'true' and
+                                               '$(SingleFileHostSourcePath)' != '' and
+                                               '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                                               $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">true</_UseSingleFileHostForPublish>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    ============================================================
                                         _CreateAppHost
     If we found a restored apphost, create the modified destination apphost
     with options from the project.
@@ -700,17 +721,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CreateAppHost"
           Inputs="@(IntermediateAssembly);$(AppHostSourcePath)"
           Outputs="$(AppHostIntermediatePath)"
-          DependsOnTargets="_GetAppHostPaths;CoreCompile"
+          DependsOnTargets="_GetAppHostPaths;_GetAppHostCreationConfiguration;CoreCompile"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true' and
                      '$(AppHostSourcePath)' != '' and
                      Exists('@(IntermediateAssembly)') and
                      Exists('$(AppHostSourcePath)')">
-    <PropertyGroup>
-      <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
-      <_EnableMacOSCodeSign Condition="'$(_EnableMacOSCodeSign)' == '' and $([MSBuild]::IsOSPlatform(`OSX`)) and Exists('/usr/bin/codesign') and
-                                      ($(RuntimeIdentifier.StartsWith('osx')) or $(AppHostRuntimeIdentifier.StartsWith('osx')))">true</_EnableMacOSCodeSign>
-    </PropertyGroup>
-
     <CreateAppHost AppHostSourcePath="$(AppHostSourcePath)"
                    AppHostDestinationPath="$(AppHostIntermediatePath)"
                    AppBinaryName="$(AssemblyName)$(TargetExt)"


### PR DESCRIPTION
- Always use `apphost` for build
- Make creating single-file app host using `singlefilehost` part of publish
  - Only if single-file, self-contained, and .NET 5+ - otherwise just uses the app host created during by build

Fixes https://github.com/dotnet/sdk/issues/29795