### PR TITLE
[HotReload] Skips Browser refresh middleware when running against an unsupported target framework version

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
@@ -43,8 +43,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 else if (!IsSupportedVersion(context.ProjectGraph))
                 {
                     _reporter.Warn(
-                        "Skipping configuring browser-refresh middleware since the target framework version is not supported." +
-                        " For more information see 'https://aka.ms/dotnet/watch/unsupported-version'.");
+                        " For more information see 'https://aka.ms/dotnet/watch/unsupported-tfm'.");
                     return;
                 }
                 else if (IsWebApp(context.ProjectGraph))

--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 }
                 else if (!IsSupportedVersion(context.ProjectGraph))
                 {
-                    _reporter.Warning(
+                    _reporter.Warn(
                         "Skipping configuring browser-refresh middleware since the target framework version is not supported." +
                         " For more information see 'https://aka.ms/dotnet/watch/unsupported-version'.");
                     return;

--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
@@ -43,6 +43,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 else if (!IsSupportedVersion(context.ProjectGraph))
                 {
                     _reporter.Warn(
+                        "Skipping configuring browser-refresh middleware since the target framework version is not supported." +
                         " For more information see 'https://aka.ms/dotnet/watch/unsupported-tfm'.");
                     return;
                 }

--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshFilter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 {
                     _reporter.Warning(
                         "Skipping configuring browser-refresh middleware since the target framework version is not supported." +
-                        " For more information see aka.ms/dotnet/watch/unsupported-version");
+                        " For more information see 'https://aka.ms/dotnet/watch/unsupported-version'.");
                     return;
                 }
                 else if (IsWebApp(context.ProjectGraph))


### PR DESCRIPTION
* Checks the target framework of the project and emits a warning message if the version is not supported.