### PR TITLE
Disable Source Link's EmbedUntrackedSources in desktop WPF projects

### DIFF
--- a/src/Assets/TestProjects/DesktopWpf/FxWpf/AssemblyInfo.cs
+++ b/src/Assets/TestProjects/DesktopWpf/FxWpf/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/src/Assets/TestProjects/DesktopWpf/FxWpf/FxWpf.csproj
+++ b/src/Assets/TestProjects/DesktopWpf/FxWpf/FxWpf.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <IntermediateOutputPath>$(MSBuildThisFileDirectory)\..\obj\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
+    <Reference Include="System.Xaml" />
+
+    <Page Include="MainWindow.xaml" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestProjects/DesktopWpf/FxWpf/MainWindow.xaml
+++ b/src/Assets/TestProjects/DesktopWpf/FxWpf/MainWindow.xaml
@@ -1,0 +1,12 @@
+﻿<Window x:Class="FxWpf.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:FxWpf"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+
+    </Grid>
+</Window>

--- a/src/Assets/TestProjects/DesktopWpf/FxWpf/MainWindow.xaml.cs
+++ b/src/Assets/TestProjects/DesktopWpf/FxWpf/MainWindow.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace FxWpf;
+
+/// <summary>
+/// Interaction logic for MainWindow.xaml
+/// </summary>
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        // InitializeComponent();
+    }
+}

--- a/src/Assets/TestProjects/DesktopWpf/FxWpf/Program.cs
+++ b/src/Assets/TestProjects/DesktopWpf/FxWpf/Program.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Windows;
+ 
+class C
+{
+    [STAThread]
+    static void Main(string[] args)
+    {
+        var app = new Application();
+        var window = new Window();
+        app.Run(window);
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
@@ -11,6 +11,23 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Determine whether the project is desktop WPF temp project.
+    Since .NET Framework 4.7.2 WPF temp project name ends with _wpftmp suffix and keeps the language specific extension (e.g. csproj).
+  -->
+  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
+    <IsWpfTempProject>false</IsWpfTempProject>
+    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
+  </PropertyGroup>
+
+  <!--
+    Disable Source Link in desktop WPF temp projects to avoid issues with desktop WPF targets.
+    The generated WPF source files contain incorrect #line paths that cause source embedding to fail.
+  -->
+  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
+    <EnableSourceLink>false</EnableSourceLink>
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- Suppress implicit SourceLink inclusion if any Microsoft.SourceLink package is referenced. -->
@@ -27,5 +44,4 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\build\Microsoft.SourceLink.AzureRepos.Git.props"/>
     <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\build\Microsoft.SourceLink.Bitbucket.Git.props"/>
   </ImportGroup>
-
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
@@ -11,24 +11,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!--
-    Determine whether the project is desktop WPF temp project.
-    Since .NET Framework 4.7.2 WPF temp project name ends with _wpftmp suffix and keeps the language specific extension (e.g. csproj).
-  -->
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
-    <IsWpfTempProject>false</IsWpfTempProject>
-    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
-  </PropertyGroup>
-
-  <!--
-    Disable Source Link in desktop WPF temp projects to avoid issues with desktop WPF targets.
-    The generated WPF source files contain incorrect #line paths that cause source embedding to fail.
-  -->
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
-    <EnableSourceLink>false</EnableSourceLink>
-    <EmbedUntrackedSources>false</EmbedUntrackedSources>
-  </PropertyGroup>
-
   <PropertyGroup>
     <!-- Suppress implicit SourceLink inclusion if any Microsoft.SourceLink package is referenced. -->
     <SuppressImplicitGitSourceLink Condition="'$(PkgMicrosoft_SourceLink_Common)' != ''">true</SuppressImplicitGitSourceLink>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.props
@@ -11,6 +11,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
     <!-- Suppress implicit SourceLink inclusion if any Microsoft.SourceLink package is referenced. -->
     <SuppressImplicitGitSourceLink Condition="'$(PkgMicrosoft_SourceLink_Common)' != ''">true</SuppressImplicitGitSourceLink>
@@ -26,4 +27,5 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.AzureRepos.Git\build\Microsoft.SourceLink.AzureRepos.Git.props"/>
     <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.SourceLink.Bitbucket.Git\build\Microsoft.SourceLink.Bitbucket.Git.props"/>
   </ImportGroup>
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.SourceLink.targets
@@ -20,7 +20,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_SourceLinkSdkSubDir>build</_SourceLinkSdkSubDir>
     <_SourceLinkSdkSubDir Condition="'$(IsCrossTargetingBuild)' == 'true'">buildMultiTargeting</_SourceLinkSdkSubDir>
 
-    <EmbedUntrackedSources Condition="'$(EmbedUntrackedSources)' == ''">true</EmbedUntrackedSources>
+    <!-- Workaround for https://github.com/dotnet/sdk/issues/36585 (Desktop XAML targets do not produce correct #line directives) -->
+    <EmbedUntrackedSources Condition="'$(EmbedUntrackedSources)' == '' and '$(ImportFrameworkWinFXTargets)' != 'true'">true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\Microsoft.Build.Tasks.Git\build\Microsoft.Build.Tasks.Git.targets"/>

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -317,14 +317,9 @@ namespace Microsoft.NET.Build.Tests
             Assert.Contains(expectedSourceLink, pdbText);
         }
 
-        [Fact]
+        [FullMSBuildOnlyFact]
         public void LegacyDesktopWpf()
         {
-            TestContext.Initialize(TestCommandLine.Parse([
-                "-useFullMSBuild",
-                "-fullMSBuildPath",
-                @"D:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\MSBuild.exe"]));
-
             var testAsset = _testAssetsManager
                 .CopyTestAsset("DesktopWpf")
                 .WithSource();
@@ -336,7 +331,7 @@ namespace Microsoft.NET.Build.Tests
                 WorkingDirectory = Path.Combine(testAsset.Path, "FxWpf")
             };
 
-            buildCommand.Execute("-bl").Should().Pass();
+            buildCommand.Execute().Should().Pass();
 
             Assert.True(File.Exists(Path.Combine(testAsset.Path, "obj", "net472", "MainWindow.g.cs")));
         }

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -316,5 +316,24 @@ namespace Microsoft.NET.Build.Tests
             var pdbText = File.ReadAllText(Path.Combine(outputDir, "NETCoreCppCliTest.pdb"), Encoding.UTF8);
             Assert.Contains(expectedSourceLink, pdbText);
         }
+
+        [FullMSBuildOnlyFact]
+        public void LegacyDesktopWpf()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("DesktopWpf")
+                .WithSource();
+
+            CreateGitFiles(testAsset.Path, "https://github.com/org/repo");
+
+            var buildCommand = new BuildCommand(testAsset, relativePathToProject: "FxWpf")
+            {
+                WorkingDirectory = Path.Combine(testAsset.Path, "FxWpf")
+            };
+
+            buildCommand.Execute().Should().Pass();
+
+            Assert.True(File.Exists(Path.Combine(testAsset.Path, "obj", "net472", "MainWindow.g.cs")));
+        }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -308,7 +308,7 @@ namespace Microsoft.NET.Build.Tests
                 WorkingDirectory = testAsset.Path
             };
 
-            buildCommand.Execute("-p:Platform=x64", "-bl").Should().Pass();
+            buildCommand.Execute("-p:Platform=x64").Should().Pass();
 
             var sourceLinkFilePath = Path.Combine(intDir, "NETCoreCppCliTest.sourcelink.json");
             var actualContent = File.ReadAllText(sourceLinkFilePath, Encoding.UTF8);

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -295,7 +295,11 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("NetCoreCsharpAppReferenceCppCliLib")
                 .WithSource();
 
-            testAsset = WithProperties(testAsset, ("EnableManagedPackageReferenceSupport", "true"));
+            var intDir = Path.Combine(testAsset.Path, "NETCoreCppCliTest", "IntDir");
+
+            testAsset = WithProperties(testAsset,
+                ("EnableManagedPackageReferenceSupport", "true"),
+                ("IntermediateOutputPath", intDir));
 
             CreateGitFiles(testAsset.Path, "https://github.com/org/repo");
 
@@ -304,15 +308,15 @@ namespace Microsoft.NET.Build.Tests
                 WorkingDirectory = testAsset.Path
             };
 
-            buildCommand.Execute("-p:Platform=x64").Should().Pass();
+            buildCommand.Execute("-p:Platform=x64", "-bl").Should().Pass();
 
-            var outputDir = Path.Combine(testAsset.Path, "NETCoreCppCliTest", "x64", "Debug");
-            var sourceLinkFilePath = Path.Combine(outputDir, "NETCoreCppCliTest.sourcelink.json");
+            var sourceLinkFilePath = Path.Combine(intDir, "NETCoreCppCliTest.sourcelink.json");
             var actualContent = File.ReadAllText(sourceLinkFilePath, Encoding.UTF8);
             var expectedPattern = Path.Combine(testAsset.Path, "*").Replace("\\", "\\\\");
             var expectedSourceLink = $$$"""{"documents":{"{{{expectedPattern}}}":"https://raw.githubusercontent.com/org/repo/1200000000000000000000000000000000000000/*"}}""";
             Assert.Equal(expectedSourceLink, actualContent);
 
+            var outputDir = Path.Combine(testAsset.Path, "NETCoreCppCliTest", "x64", "Debug");
             var pdbText = File.ReadAllText(Path.Combine(outputDir, "NETCoreCppCliTest.pdb"), Encoding.UTF8);
             Assert.Contains(expectedSourceLink, pdbText);
         }

--- a/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -317,9 +317,14 @@ namespace Microsoft.NET.Build.Tests
             Assert.Contains(expectedSourceLink, pdbText);
         }
 
-        [FullMSBuildOnlyFact]
+        [Fact]
         public void LegacyDesktopWpf()
         {
+            TestContext.Initialize(TestCommandLine.Parse([
+                "-useFullMSBuild",
+                "-fullMSBuildPath",
+                @"D:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\MSBuild.exe"]));
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("DesktopWpf")
                 .WithSource();
@@ -331,7 +336,7 @@ namespace Microsoft.NET.Build.Tests
                 WorkingDirectory = Path.Combine(testAsset.Path, "FxWpf")
             };
 
-            buildCommand.Execute().Should().Pass();
+            buildCommand.Execute("-bl").Should().Pass();
 
             Assert.True(File.Exists(Path.Combine(testAsset.Path, "obj", "net472", "MainWindow.g.cs")));
         }


### PR DESCRIPTION
Adds a workaround for https://github.com/dotnet/sdk/issues/34438:

Suppress EmbedUntrackedSources set by Source Link for Desktop WPF projects, which produce incorrect `#line` directive in generated .g.cs files under certain circumstances. When EmbedUntrackedSources  is enabled it triggers embedding of source files into the PDB, which fails due to the incorrect `#line` directives.

https://github.com/dotnet/wpf/issues/10600 tracks the core issue.

## Customer Impact

Project with the following properties fails to build with .NET SDK 8:

- targets .NET Framework
- uses .NET SDK
- does not set `UseWPF` property to `true`
- uses manual XAML assembly references
- customizes `IntermediateOutputPath`
- is in a git repository

## Regression?

- [x] Yes
- [ ] No

7.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change sets property that enables the same code path that's already executed in regular build to run in design-time build.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [x] No
- [ ] N/A



