### PR TITLE
Added test for .user file in outer build

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
@@ -140,5 +140,46 @@ namespace Microsoft.NET.Build.Tests
             string outputPathValue = File.ReadAllText(Path.Combine(testAsset.TestRoot, testProject.Name, "OutputPathValue.txt"));
             outputPathValue.Trim().Should().NotContain("\\\\");
         }
+
+        [Fact]
+        public void OuterBuildImportsUserFile()
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = $"{ToolsetInfo.CurrentTargetFramework};net7.0"
+            };
+
+            testProject.ProjectChanges.Add(xml =>
+            {
+                var target = """
+                    <Target Name="WriteValue" AfterTargets="Build">
+                        <WriteLinesToFile File="$(MSBuildProjectDirectory)\OutputPathValue.txt"
+                                      Lines="User value is: $(UserValue)"
+                                      Overwrite="true" />
+                    </Target>
+                """;
+
+                xml.Root.Add(XElement.Parse(target));
+            });
+
+            string temp = $"{testProject.Name}.csproj.user";
+            testProject.SourceFiles[temp] = """
+                 <Project>
+                    <PropertyGroup>
+                        <UserValue>A User defined value</UserValue>
+                    </PropertyGroup>
+                </Project>
+                """;
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            new BuildCommand(testAsset)
+                .Execute()
+                .Should()
+                .Pass();
+
+            string outputPathValue = File.ReadAllText(Path.Combine(testAsset.TestRoot, testProject.Name, "OutputPathValue.txt"));
+            outputPathValue.Should().Contain("User value is: A User defined value");
+        }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
@@ -141,7 +141,7 @@ namespace Microsoft.NET.Build.Tests
             outputPathValue.Trim().Should().NotContain("\\\\");
         }
 
-        [Fact]
+        [RequiresMSBuildVersionFact("17.9.0.61803")]
         public void OuterBuildImportsUserFile()
         {
             var testProject = new TestProject()


### PR DESCRIPTION
Adding a test for this change in MSBuild (https://github.com/dotnet/msbuild/pull/9444).

The `.user` file is currently not available in the outer build. The PR adds the import to the outer build, and the test is best suited for the SDK repo as this affects mostly SDK style projects.