### PR TITLE
enforce behavior where ASPNETCORE_URLS overrides ASPNETCORE_HTTP(S)_PORTS

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -239,7 +239,7 @@ internal sealed class ImageBuilder
     {
         // asp.net images control port bindings via three environment variables. we should check for those variables and ensure that ports are created for them.
         // precendence is captured at https://github.com/dotnet/aspnetcore/blob/f49c1c7f7467c184ffb630086afac447772096c6/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs#L68-L119
-        // ASPNETCORE_URLS is the most specific and is the only one used is present, followed by ASPNETCORE_HTTPS_PORT and ASPNETCORE_HTTP_PORT together
+        // ASPNETCORE_URLS is the most specific and is the only one used if present, followed by ASPNETCORE_HTTPS_PORT and ASPNETCORE_HTTP_PORT together
 
         // https://learn.microsoft.com//aspnet/core/fundamentals/host/web-host?view=aspnetcore-8.0#server-urls - the format of ASPNETCORE_URLS has been stable for many years now
         if (_baseImageConfig.EnvironmentVariables.TryGetValue(EnvironmentVariables.ASPNETCORE_URLS, out string? urls))

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -237,13 +237,32 @@ internal sealed class ImageBuilder
     /// </summary>
     internal void AssignPortsFromEnvironment()
     {
-        // asp.net images control port bindings via three environment variables. we should check for those variables and ensure that ports are created for them
+        // asp.net images control port bindings via three environment variables. we should check for those variables and ensure that ports are created for them.
+        // precendence is captured at https://github.com/dotnet/aspnetcore/blob/f49c1c7f7467c184ffb630086afac447772096c6/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs#L68-L119
+        // ASPNETCORE_URLS is the most specific and is the only one used is present, followed by ASPNETCORE_HTTPS_PORT and ASPNETCORE_HTTP_PORT together
 
+        // https://learn.microsoft.com//aspnet/core/fundamentals/host/web-host?view=aspnetcore-8.0#server-urls - the format of ASPNETCORE_URLS has been stable for many years now
+        if (_baseImageConfig.EnvironmentVariables.TryGetValue(EnvironmentVariables.ASPNETCORE_URLS, out string? urls))
+        {
+            foreach (var url in Split(urls))
+            {
+                _logger.LogTrace("Setting ports from ASPNETCORE_URLS environment variable");
+                var match = aspnetPortRegex.Match(url);
+                if (match.Success && int.TryParse(match.Groups["port"].Value, out int port))
+                {
+                    _logger.LogTrace("Added port {port}", port);
+                    ExposePort(port, PortType.tcp);
+                }
+            }
+            return; // we're done here - ASPNETCORE_URLS is the most specific and overrides the other two
+        }
+
+        // port-specific
         // https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-8.0#specify-ports-only - new for .NET 8 - allows just changing port(s) easily
         if (_baseImageConfig.EnvironmentVariables.TryGetValue(EnvironmentVariables.ASPNETCORE_HTTP_PORTS, out string? httpPorts))
         {
             _logger.LogTrace("Setting ports from ASPNETCORE_HTTP_PORTS environment variable");
-            foreach(var port in Split(httpPorts))
+            foreach (var port in Split(httpPorts))
             {
                 if (int.TryParse(port, out int parsedPort))
                 {
@@ -260,7 +279,7 @@ internal sealed class ImageBuilder
         if (_baseImageConfig.EnvironmentVariables.TryGetValue(EnvironmentVariables.ASPNETCORE_HTTPS_PORTS, out string? httpsPorts))
         {
             _logger.LogTrace("Setting ports from ASPNETCORE_HTTPS_PORTS environment variable");
-            foreach(var port in Split(httpsPorts))
+            foreach (var port in Split(httpsPorts))
             {
                 if (int.TryParse(port, out int parsedPort))
                 {
@@ -270,21 +289,6 @@ internal sealed class ImageBuilder
                 else
                 {
                     _logger.LogTrace("Skipped port {port} because it could not be parsed as an integer", port);
-                }
-            }
-        }
-
-        // https://learn.microsoft.com//aspnet/core/fundamentals/host/web-host?view=aspnetcore-8.0#server-urls - the format of ASPNETCORE_URLS has been stable for many years now
-        if (_baseImageConfig.EnvironmentVariables.TryGetValue(EnvironmentVariables.ASPNETCORE_URLS, out string? urls))
-        {
-            foreach(var url in Split(urls))
-            {
-                _logger.LogTrace("Setting ports from ASPNETCORE_URLS environment variable");
-                var match = aspnetPortRegex.Match(url);
-                if (match.Success && int.TryParse(match.Groups["port"].Value, out int port))
-                {
-                    _logger.LogTrace("Added port {port}", port);
-                    ExposePort(port, PortType.tcp);
                 }
             }
         }

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
@@ -221,7 +221,7 @@ public class ImageBuilderTests
 
         Assert.Equal(2, resultPorts.Count);
         Assert.NotNull(resultPorts["6000/tcp"] as JsonObject);
-        Assert.NotNull( resultPorts["6010/udp"] as JsonObject);
+        Assert.NotNull(resultPorts["6010/udp"] as JsonObject);
     }
 
     [Fact]
@@ -562,12 +562,56 @@ public class ImageBuilderTests
         Assert.Equal(assignedPorts, expectedPorts);
     }
 
+    [Fact]
+    public void WhenMultipleUrlSourcesAreSetOnlyAspnetcoreUrlsIsUsed()
+    {
+        var builder = FromBaseImageConfig($$"""
+        {
+            "architecture": "amd64",
+            "config": {
+                "Hostname": "",
+                "Domainname": "",
+                "User": "",
+                "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+                ],
+                "Cmd": ["bash"],
+                "Image": "sha256:d772d27ebeec80393349a4770dc37f977be2c776a01c88b624d43f93fa369d69",
+                "WorkingDir": ""
+            },
+            "created": "2023-02-04T08:14:52.000901321Z",
+            "os": "linux",
+            "rootfs": {
+                "type": "layers",
+                "diff_ids": [
+                "sha256:bd2fe8b74db65d82ea10db97368d35b92998d4ea0e7e7dc819481fe4a68f64cf",
+                "sha256:94100d1041b650c6f7d7848c550cd98c25d0bdc193d30692e5ea5474d7b3b085",
+                "sha256:53c2a75a33c8f971b4b5036d34764373e134f91ee01d8053b4c3573c42e1cf5d",
+                "sha256:49a61320e585180286535a2545be5722b09e40ad44c7c190b20ec96c9e42e4a3",
+                "sha256:8a379cce2ac272aa71aa029a7bbba85c852ba81711d9f90afaefd3bf5036dc48"
+                ]
+            }
+        }
+        """);
+
+        builder.AddEnvironmentVariable(ImageBuilder.EnvironmentVariables.ASPNETCORE_URLS, "https://*:12345");
+        builder.AddEnvironmentVariable(ImageBuilder.EnvironmentVariables.ASPNETCORE_HTTPS_PORTS, "456");
+        var builtImage = builder.Build();
+        JsonNode? result = JsonNode.Parse(builtImage.Config);
+        Assert.NotNull(result);
+        var portsObject = result["config"]?["ExposedPorts"]?.AsObject();
+        var assignedPorts = portsObject?.AsEnumerable().Select(portString => int.Parse(portString.Key.Split('/')[0])).ToArray();
+        Assert.Equal([12345], assignedPorts);
+    }
+
     private ImageBuilder FromBaseImageConfig(string baseImageConfig, [CallerMemberName] string testName = "")
     {
-        var manifest = new ManifestV2() {
+        var manifest = new ManifestV2()
+        {
             SchemaVersion = 2,
             MediaType = SchemaTypes.DockerManifestV2,
-            Config = new ManifestConfig() {
+            Config = new ManifestConfig()
+            {
                 mediaType = "",
                 size = 0,
                 digest = "sha256:0"


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/35845

This is a quick PR to fix the ordering issues that @tmds pointed out. Tests confirm the behavior change.