### PR TITLE
don't use cookies to unblock CSRF workflows

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
@@ -30,7 +30,10 @@ internal class DefaultRegistryAPI : IRegistryAPI
 
     private static HttpClient CreateClient(string registryName, Uri baseUri, ILogger logger, bool isAmazonECRRegistry = false)
     {
-        var innerHandler = new SocketsHttpHandler();
+        var innerHandler = new SocketsHttpHandler()
+        {
+            UseCookies = false,
+        };
 
         // Ignore certificate for https localhost repository.
         if (baseUri.Host == "localhost" && baseUri.Scheme == "https")


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/418 (possibly)

Since Harbor enforces CSRF tokens we have to reject all uses of cookies to unblock our support of it. This seems to be what [other registry clients](https://github.com/moby/moby/blob/master/registry/search_session.go#L167C1-L171C18) do.