### PR TITLE
Fix install state file for MSI based installs

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
@@ -499,9 +499,9 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <param name="sdkFeatureBand">The feature band of the install state file.</param>
         protected void RemoveInstallStateFile(SdkFeatureBand sdkFeatureBand)
         {
-            string path = WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, null);
+            string path = Path.Combine(WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, null), "default.json");
 
-            if (File.Exists(path))
+            if (!File.Exists(path))
             {
                 Log?.LogMessage($"Install state file does not exist: {path}");
                 return;
@@ -527,7 +527,7 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <param name="jsonLines">The contents of the JSON file, formatted as a single line.</param>
         protected void WriteInstallStateFile(SdkFeatureBand sdkFeatureBand, IEnumerable<string> jsonLines)
         {
-            string path = WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, null);
+            string path = Path.Combine(WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, null), "default.json");
             Elevate();
 
             if (IsElevated)


### PR DESCRIPTION
In addressing the final PR feedback, a number of mistakes slipped in that won't be caught by the unit tests because this is running elevated and we don't have a testable installation until code flows to installer.

- Fix the `File.Exists` check
- Add the `default.json` filename to the actual path. Originally the full path was send through the dispatcher, but in subsequent iteration it was decided to just send the feature band, so the message handlers need to set up the full path.