### PR TITLE
Add support for test and build commands

### DIFF
--- a/src/Assets/TestProjects/WatchNoDepsApp/WatchNoDepsApp.csproj
+++ b/src/Assets/TestProjects/WatchNoDepsApp/WatchNoDepsApp.csproj
@@ -15,4 +15,8 @@
     <WarningsNotAsErrors>CS9057</WarningsNotAsErrors>
   </PropertyGroup>
 
+  <Target Name="TestTarget">
+    <Warning Text="The value of property is '$(TestProperty)'" />
+  </Target>
+
 </Project>

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -174,7 +174,12 @@ namespace Microsoft.DotNet.Watcher
             var projectGraph = TryReadProject(projectFile, options);
 
             bool enableHotReload;
-            if (options.NoHotReload)
+            if (options.Command != "run")
+            {
+                _reporter.Verbose($"Command '{options.Command}' does not support Hot Reload.");
+                enableHotReload = false;
+            }
+            else if (options.NoHotReload)
             {
                 _reporter.Verbose("Hot Reload disabled by command line switch.");
                 enableHotReload = false;

--- a/src/Tests/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/src/Tests/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -59,11 +59,9 @@ namespace Microsoft.DotNet.Watcher.Tools
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
 
             Assert.True(options.Verbose);
-            Assert.False(options.NoLaunchProfile);
-            Assert.Null(options.LaunchProfileName);
+            Assert.False(options.WatchNoLaunchProfile);
+            Assert.Null(options.WatchLaunchProfileName);
             Assert.Empty(options.RemainingArguments);
-
-            Assert.Null(options.RunOptions);
 
             Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoProfile, out var watchProfileName));
             Assert.False(watchNoProfile);
@@ -84,13 +82,12 @@ namespace Microsoft.DotNet.Watcher.Tools
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
 
             Assert.True(options.Verbose);
-            Assert.False(options.NoLaunchProfile);
-            Assert.Null(options.LaunchProfileName);
+            Assert.False(options.WatchNoLaunchProfile);
+            Assert.Null(options.WatchLaunchProfileName);
             Assert.Empty(options.RemainingArguments);
 
-            Assert.False(options.RunOptions.NoLaunchProfile);
-            Assert.Null(options.RunOptions.LaunchProfileName);
-            Assert.Empty(options.RunOptions.RemainingArguments);
+            Assert.False(options.CommandNoLaunchProfile);
+            Assert.Null(options.CommandLaunchProfileName);
 
             Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoProfile, out var watchProfileName));
             Assert.False(watchNoProfile);
@@ -110,8 +107,8 @@ namespace Microsoft.DotNet.Watcher.Tools
             var args = new[] { "-lp", "P", "run" };
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
 
-            Assert.Equal("P", options.LaunchProfileName);
-            Assert.Null(options.RunOptions.LaunchProfileName);
+            Assert.Equal("P", options.WatchLaunchProfileName);
+            Assert.Null(options.CommandLaunchProfileName);
 
             Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
             Assert.Equal("P", watchProfileName);
@@ -129,8 +126,8 @@ namespace Microsoft.DotNet.Watcher.Tools
             var args = new[] { "run", "-lp", "P" };
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
 
-            Assert.Null(options.LaunchProfileName);
-            Assert.Equal("P", options.RunOptions.LaunchProfileName);
+            Assert.Null(options.WatchLaunchProfileName);
+            Assert.Equal("P", options.CommandLaunchProfileName);
 
             Assert.Equal(new[] { "run", "--launch-profile", "P" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
             Assert.Null(watchProfileName);
@@ -148,8 +145,8 @@ namespace Microsoft.DotNet.Watcher.Tools
             var args = new[] { "-lp", "P1", "run", "-lp", "P2" };
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
 
-            Assert.Equal("P1", options.LaunchProfileName);
-            Assert.Equal("P2", options.RunOptions.LaunchProfileName);
+            Assert.Equal("P1", options.WatchLaunchProfileName);
+            Assert.Equal("P2", options.CommandLaunchProfileName);
 
             Assert.Equal(new[] { "run", "--launch-profile", "P2" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
             Assert.Equal("P1", watchProfileName);
@@ -168,8 +165,8 @@ namespace Microsoft.DotNet.Watcher.Tools
             var args = new[] { "--no-launch-profile", "run" };
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
 
-            Assert.True(options.NoLaunchProfile);
-            Assert.False(options.RunOptions.NoLaunchProfile);
+            Assert.True(options.WatchNoLaunchProfile);
+            Assert.False(options.CommandNoLaunchProfile);
 
             Assert.Equal(new[] { "run", }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoLaunchProfile, out _));
             Assert.True(watchNoLaunchProfile);
@@ -187,8 +184,8 @@ namespace Microsoft.DotNet.Watcher.Tools
             var args = new[] { "run", "--no-launch-profile" };
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
 
-            Assert.False(options.NoLaunchProfile);
-            Assert.True(options.RunOptions.NoLaunchProfile);
+            Assert.False(options.WatchNoLaunchProfile);
+            Assert.True(options.CommandNoLaunchProfile);
 
             Assert.Equal(new[] { "run", "--no-launch-profile" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoLaunchProfile, out _));
             Assert.False(watchNoLaunchProfile);
@@ -206,8 +203,8 @@ namespace Microsoft.DotNet.Watcher.Tools
             var args = new[] { "--no-launch-profile", "run", "--no-launch-profile" };
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
 
-            Assert.True(options.NoLaunchProfile);
-            Assert.True(options.RunOptions.NoLaunchProfile);
+            Assert.True(options.WatchNoLaunchProfile);
+            Assert.True(options.CommandNoLaunchProfile);
 
             Assert.Equal(new[] { "run", "--no-launch-profile" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoLaunchProfile, out _));
             Assert.True(watchNoLaunchProfile);
@@ -226,11 +223,10 @@ namespace Microsoft.DotNet.Watcher.Tools
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
             //dotnet watch -- --verbose run
             Assert.True(options.Verbose);
-            Assert.Equal(new[] { "-watchArg" }, options.RemainingArguments);
-            Assert.Equal(new[] { "-runArg" }, options.RunOptions.RemainingArguments);
+            Assert.Equal(["-watchArg", "-runArg"], options.RemainingArguments);
 
-            Assert.Equal(new[] { "run", "-watchArg", "-runArg" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
-            Assert.Equal(new[] { "-watchArg", "-runArg" }, options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
+            Assert.Equal(["run", "-watchArg", "-runArg"], options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
+            Assert.Equal(["-watchArg", "-runArg"], options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
 
             Assert.Empty(output.ToString());
         }
@@ -244,7 +240,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             Assert.False(options.Verbose);
             Assert.Equal(new[] { "-watchArg", "--verbose", "run", "-runArg" }, options.RemainingArguments);
-            Assert.Null(options.RunOptions);
 
             Assert.Equal(new[] { "run", "-watchArg", "--verbose", "run", "-runArg" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
             Assert.Equal(new[] { "-watchArg", "--verbose", "run", "-runArg" }, options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
@@ -261,7 +256,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             Assert.False(options.Verbose);
             Assert.Equal(new[] { "run" }, options.RemainingArguments);
-            Assert.Null(options.RunOptions);
 
             Assert.Equal(new[] { "run", "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
             Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
@@ -369,23 +363,22 @@ namespace Microsoft.DotNet.Watcher.Tools
         }
 
         [Theory]
-        [InlineData(new[] { "--unrecognized-arg" }, new[] { "--unrecognized-arg" }, new string[0])]
-        [InlineData(new[] { "run" }, new string[0], new string[0])]
-        [InlineData(new[] { "run", "--", "runarg" }, new string[0], new[] { "runarg" })]
-        [InlineData(new[] { "-watcharg", "run", "runarg1", "-runarg2" }, new[] { "-watcharg" }, new[] { "runarg1", "-runarg2" })]
+        [InlineData(new[] { "--unrecognized-arg" }, new[] { "--unrecognized-arg" })]
+        [InlineData(new[] { "run" }, new string[0])]
+        [InlineData(new[] { "run", "--", "runarg" }, new[] { "runarg" })]
+        [InlineData(new[] { "-watcharg", "run", "runarg1", "-runarg2" }, new[] { "-watcharg", "runarg1", "-runarg2" })]
         // run is after -- and therefore not parsed as a command:
-        [InlineData(new[] { "-watcharg", "--", "run", "--", "runarg" }, new[] { "-watcharg", "run", "--", "runarg" }, new string[0])]
+        [InlineData(new[] { "-watcharg", "--", "run", "--", "runarg" }, new[] { "-watcharg", "run", "--", "runarg" })]
         // run is before -- and therefore parsed as a command:
-        [InlineData(new[] { "-watcharg", "run", "--", "--", "runarg" }, new[] { "-watcharg" }, new[] { "--", "runarg" })]
-        public void ParsesRemainingArgs(string[] args, string[] expectedWatch, string[] expectedRun)
+        [InlineData(new[] { "-watcharg", "run", "--", "--", "runarg" }, new[] { "-watcharg" , "--", "runarg" })]
+        public void ParsesRemainingArgs(string[] args, string[] expected)
         {
             StringWriter output = new();
             var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
 
             Assert.NotNull(options);
 
-            Assert.Equal(expectedWatch, options.RemainingArguments);
-            Assert.Equal(expectedRun, options.RunOptions?.RemainingArguments ?? Array.Empty<string>());
+            Assert.Equal(expected, options.RemainingArguments);
             Assert.Empty(output.ToString());
         }
 
@@ -429,7 +422,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             Assert.Empty(_testReporter.Messages);
             Assert.NotNull(options);
-            Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
+            Assert.Equal("CustomLaunchProfile", options.WatchLaunchProfileName);
         }
 
         [Fact]
@@ -440,7 +433,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             Assert.Empty(_testReporter.Messages);
             Assert.NotNull(options);
-            Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
+            Assert.Equal("CustomLaunchProfile", options.WatchLaunchProfileName);
         }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -194,10 +194,10 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("XunitMulti")
                 .WithSource();
 
-            App.Start(testAsset.Path, ["--verbose", "--framework", "net46", "test", "--list-tests"]);
+            App.Start(testAsset.Path, ["--verbose", "--framework", ToolsetInfo.CurrentTargetFramework, "test", "--list-tests"]);
 
             await App.AssertOutputLineEquals("The following Tests are available:");
-            await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitPassTestDesktop");
+            await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitFailTestNetCoreApp");
         }
 
         [Fact]

--- a/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -43,7 +43,10 @@ namespace Microsoft.DotNet.Watcher.Tests
         [InlineData(new[] { "run" }, "")]
         [InlineData(new[] { "run", "args" }, "args")]
         [InlineData(new[] { "--", "run", "args" }, "run,args")]
+        [InlineData(new[] { "--", "test", "args" }, "test,args")]
+        [InlineData(new[] { "--", "build", "args" }, "build,args")]
         [InlineData(new[] { "abc" }, "abc")]
+        [InlineData(new[] { "workload", "list" }, "workload,list")]
         public async Task Arguments(string[] arguments, string expectedApplicationArgs)
         {
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: string.Join(",", arguments))
@@ -163,6 +166,49 @@ namespace Microsoft.DotNet.Watcher.Tests
             Assert.Equal(expectedArgs, await App.AssertOutputLineStartsWith("Arguments: "));
 
             Assert.Contains(App.Process.Output, l => l.Contains($"Found named launch profile '{profileName}'."));
+        }
+
+        [Fact]
+        public async Task TestCommand()
+        {
+            var testAsset = TestAssets.CopyTestAsset("XunitCore")
+                .WithSource();
+
+            App.Start(testAsset.Path, ["--verbose", "test", "--list-tests"]);
+
+            await App.AssertOutputLineEquals("The following Tests are available:");
+            await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitPassTest");
+
+            // update file:
+            var testFile = Path.Combine(testAsset.Path, "UnitTest1.cs");
+            var content = File.ReadAllText(testFile, Encoding.UTF8);
+            File.WriteAllText(testFile, content.Replace("VSTestXunitPassTest", "VSTestXunitPassTest2"), Encoding.UTF8);
+
+            await App.AssertOutputLineEquals("The following Tests are available:");
+            await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitPassTest2");
+        }
+
+        [Fact]
+        public async Task TestCommand_MultiTargeting()
+        {
+            var testAsset = TestAssets.CopyTestAsset("XunitMulti")
+                .WithSource();
+
+            App.Start(testAsset.Path, ["--verbose", "--framework", "net46", "test", "--list-tests"]);
+
+            await App.AssertOutputLineEquals("The following Tests are available:");
+            await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitPassTestDesktop");
+        }
+
+        [Fact]
+        public async Task BuildCommand()
+        {
+            var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
+                .WithSource();
+
+            App.Start(testAsset.Path, ["--verbose", "--property", "TestProperty=123", "build", "/t:TestTarget"]);
+
+            await App.AssertOutputLine(line => line.Contains("warning : The value of property is '123'", StringComparison.Ordinal));
         }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -46,6 +46,11 @@ namespace Microsoft.DotNet.Watcher.Tests
             return line.Substring(expectedPrefix.Length);
         }
 
+        public Task<string> AssertOutputLine(Predicate<string> predicate, Predicate<string> failure = null)
+            => Process.GetOutputLineAsync(
+                success: predicate,
+                failure: failure ?? new Predicate<string>(line => line.Contains(WatchErrorOutputEmoji, StringComparison.Ordinal)));
+
         public async Task AssertOutputLineEquals(string expectedLine)
             => Assert.Equal("", await AssertOutputLineStartsWith(expectedLine));
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/34949

Handle `test` and `build` as valid commands that may be specified on `dotnet watch` command line.

The original implementation of command line parsing allowed `dotnet watch test` and `dotnet watch build` to work, although without any tests. PR https://github.com/dotnet/sdk/pull/31054 broke this when fixing other command line parsing issues.

## Customer Impact

Customers unable to use `dotnet watch test` and `dotnet watch build` with .NET SDK 8.

## Regression?

- [x] Yes
- [ ] No

7.0

## Risk

- [ ] High
- [x] Medium
- [] Low

Some risk of breaking command line parsing for other scenarios that we don't have test coverage for.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [x] No
- [ ] N/A
