### PR TITLE
Append command line arguments to project specified RunArguments

### DIFF
--- a/src/Assets/TestProjects/WatchHotReloadAppCustomHost/Program.cs
+++ b/src/Assets/TestProjects/WatchHotReloadAppCustomHost/Program.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Threading;
+
+var assembly = typeof(C).Assembly;
+
+Console.WriteLine("Started");
+
+// Process ID is insufficient because PID's may be reused.
+Console.WriteLine($"Process identifier = {Process.GetCurrentProcess().Id}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
+Console.WriteLine($"DOTNET_WATCH = {Environment.GetEnvironmentVariable("DOTNET_WATCH")}");
+Console.WriteLine($"DOTNET_WATCH_ITERATION = {Environment.GetEnvironmentVariable("DOTNET_WATCH_ITERATION")}");
+Console.WriteLine($"Arguments = {string.Join(",", args)}");
+Console.WriteLine($"Version = {assembly.GetCustomAttributes<AssemblyVersionAttribute>().FirstOrDefault()?.Version ?? "<unspecified>"}");
+Console.WriteLine($"TFM = {assembly.GetCustomAttributes<TargetFrameworkAttribute>().FirstOrDefault()?.FrameworkName ?? "<unspecified>"}");
+Console.WriteLine($"Configuration = {assembly.GetCustomAttributes<AssemblyConfigurationAttribute>().FirstOrDefault()?.Configuration ?? "<unspecified>"}");
+
+Loop();
+
+static void Loop()
+{
+    while (true)
+    {
+        Console.WriteLine(".");
+        Thread.Sleep(1000);
+    }
+}
+
+class C { }

--- a/src/Assets/TestProjects/WatchHotReloadAppCustomHost/Properties/launchSettings.json
+++ b/src/Assets/TestProjects/WatchHotReloadAppCustomHost/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+    "profiles": {
+      "app": {
+        "commandName": "Project",
+        "environmentVariables": {
+          "EnvironmentFromProfile": "Development"
+        }
+      },
+      "P1": {
+        "commandName": "Project",
+        "commandLineArgs": "\"Arg1 from launch profile\" \"Arg2 from launch profile\""
+      }
+    }
+  }

--- a/src/Assets/TestProjects/WatchHotReloadAppCustomHost/WatchHotReloadApp.csproj
+++ b/src/Assets/TestProjects/WatchHotReloadAppCustomHost/WatchHotReloadApp.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RunArguments>&quot;Argument Specified in Props&quot;</RunArguments>
+  </PropertyGroup>
+</Project>

--- a/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Watcher
                     currentRunCancellationSource.Token))
                 using (var fileSetWatcher = new FileSetWatcher(fileSet, _reporter))
                 {
-                    _reporter.Verbose($"Running {processSpec.ShortDisplayName()} with the following arguments: '{string.Join(" ", processSpec.Arguments)}'");
+                    _reporter.Verbose($"Running {processSpec.ShortDisplayName()} with the following arguments: '{processSpec.GetArgumentsDisplay()}'");
                     var processTask = _processRunner.RunAsync(processSpec, combinedCancellationSource.Token);
 
                     _reporter.Output("Started", emoji: "🚀");

--- a/src/BuiltInTools/dotnet-watch/Internal/CommandLineUtilities.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/CommandLineUtilities.cs
@@ -1,0 +1,111 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copied from dotnet/runtime/src/libraries/System.Private.CoreLib/src/System/PasteArguments.cs
+namespace Microsoft.DotNet.Watcher;
+
+internal static class CommandLineUtilities
+{
+    public static string JoinArguments(IEnumerable<string> arguments)
+    {
+        var builder = new StringBuilder();
+        AppendArguments(builder, arguments);
+        return builder.ToString();
+    }
+
+    public static void AppendArguments(StringBuilder builder, IEnumerable<string> arguments)
+    {
+        foreach (var arg in arguments)
+        {
+            AppendArgument(builder, arg);
+        }
+    }
+
+    private static void AppendArgument(StringBuilder stringBuilder, string argument)
+    {
+        if (stringBuilder.Length != 0)
+        {
+            stringBuilder.Append(' ');
+        }
+
+        // Parsing rules for non-argv[0] arguments:
+        //   - Backslash is a normal character except followed by a quote.
+        //   - 2N backslashes followed by a quote ==> N literal backslashes followed by unescaped quote
+        //   - 2N+1 backslashes followed by a quote ==> N literal backslashes followed by a literal quote
+        //   - Parsing stops at first whitespace outside of quoted region.
+        //   - (post 2008 rule): A closing quote followed by another quote ==> literal quote, and parsing remains in quoting mode.
+        if (argument.Length != 0 && ContainsNoWhitespaceOrQuotes(argument))
+        {
+            // Simple case - no quoting or changes needed.
+            stringBuilder.Append(argument);
+        }
+        else
+        {
+            stringBuilder.Append(Quote);
+            int idx = 0;
+            while (idx < argument.Length)
+            {
+                char c = argument[idx++];
+                if (c == Backslash)
+                {
+                    int numBackSlash = 1;
+                    while (idx < argument.Length && argument[idx] == Backslash)
+                    {
+                        idx++;
+                        numBackSlash++;
+                    }
+
+                    if (idx == argument.Length)
+                    {
+                        // We'll emit an end quote after this so must double the number of backslashes.
+                        stringBuilder.Append(Backslash, numBackSlash * 2);
+                    }
+                    else if (argument[idx] == Quote)
+                    {
+                        // Backslashes will be followed by a quote. Must double the number of backslashes.
+                        stringBuilder.Append(Backslash, numBackSlash * 2 + 1);
+                        stringBuilder.Append(Quote);
+                        idx++;
+                    }
+                    else
+                    {
+                        // Backslash will not be followed by a quote, so emit as normal characters.
+                        stringBuilder.Append(Backslash, numBackSlash);
+                    }
+
+                    continue;
+                }
+
+                if (c == Quote)
+                {
+                    // Escape the quote so it appears as a literal. This also guarantees that we won't end up generating a closing quote followed
+                    // by another quote (which parses differently pre-2008 vs. post-2008.)
+                    stringBuilder.Append(Backslash);
+                    stringBuilder.Append(Quote);
+                    continue;
+                }
+
+                stringBuilder.Append(c);
+            }
+
+            stringBuilder.Append(Quote);
+        }
+    }
+
+    private static bool ContainsNoWhitespaceOrQuotes(string s)
+    {
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (char.IsWhiteSpace(c) || c == Quote)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private const char Quote = '\"';
+    private const char Backslash = '\\';
+}

--- a/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
@@ -65,8 +65,7 @@ namespace Microsoft.DotNet.Watcher.Internal
                 stopwatch.Start();
                 process.Start();
 
-                var args = processSpec.EscapedArguments ?? string.Join(" ", processSpec.Arguments ?? Array.Empty<string>());
-                _reporter.Verbose($"Started '{processSpec.Executable}' '{args}' with process id {process.Id}", emoji: "🚀");
+                _reporter.Verbose($"Started '{processSpec.Executable}' with arguments '{processSpec.GetArgumentsDisplay()}': process id {process.Id}", emoji: "🚀");
 
                 if (readOutput)
                 {

--- a/src/BuiltInTools/dotnet-watch/ProcessSpec.cs
+++ b/src/BuiltInTools/dotnet-watch/ProcessSpec.cs
@@ -31,5 +31,8 @@ namespace Microsoft.DotNet.Watcher
 
         public string? ShortDisplayName()
             => Path.GetFileNameWithoutExtension(Executable);
+
+        public string GetArgumentsDisplay()
+            => EscapedArguments ?? CommandLineUtilities.JoinArguments(Arguments ?? []);
     }
 }

--- a/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/src/Tests/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -55,6 +55,24 @@ namespace Microsoft.DotNet.Watcher.Tests
             Assert.Equal(expectedApplicationArgs, await App.AssertOutputLineStartsWith("Arguments = "));
         }
 
+        [Theory]
+        [InlineData(new[] { "--no-hot-reload", "--", "run", "args" }, "Argument Specified in Props,run,args")]
+        [InlineData(new[] { "--", "run", "args" }, "Argument Specified in Props,run,args")]
+        // if arguments specified on command line the ones from launch profile are ignored
+        [InlineData(new[] { "-lp", "P1", "--", "run", "args" },"Argument Specified in Props,run,args")]
+        // if no arguments specified on command line the ones from launch profile are added
+        [InlineData(new[] { "-lp", "P1" }, "Argument Specified in Props,Arg1 from launch profile,Arg2 from launch profile")]
+        public async Task Arguments_HostArguments(string[] arguments, string expectedApplicationArgs)
+        {
+            var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppCustomHost", identifier: string.Join(",", arguments))
+                .WithSource()
+                .Path;
+
+            App.Start(testAsset, arguments);
+
+            Assert.Equal(expectedApplicationArgs, await App.AssertOutputLineStartsWith("Arguments = "));
+        }
+
         [Fact]
         public async Task RunArguments_NoHotReload()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/52294

## Customer Impact

`dotnet watch` customers unable to pass command line arguments to applications that are launched via a custom host specified by the project (e.g. Blazor WebAssembly).

## Regression?

- [x] Yes
- [ ] No

7.0

## Workaround

As a workaround the customer can pass `--no-hot-reload` to `dotnet watch` in addition to the arguments. The behavior would then be the same as SDK 7, which implicitly disabled Hot Reload in this scenario.

## Risk

- [ ] High
- [] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [x] No
- [ ] N/A

