### PR TITLE
Correct emsdk Version.Details.xml sha

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -49,7 +49,7 @@
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>2406616d0e3a31d80b326e27c156955bfa41c791</Sha>
+      <Sha>8219dd3f8f022dcd2fd8df2319ab4222fa11aa39</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="17.9.0-preview-23605-02">
       <Uri>https://github.com/dotnet/msbuild</Uri>


### PR DESCRIPTION
The emsdk Version.Details.xml dependency is incoherent in that the version and sha do not match.  This messes up source-build when flowed into installer (see https://github.com/dotnet/installer/pull/17695).  I have updated the sha to match the version.

This was introduced in https://github.com/dotnet/sdk/pull/36340. (Sorry I missed it in review)