### PR TITLE
Avoid copying containerize to SDK root

### DIFF
--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Containers\packaging\package.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\..\Containers\packaging\package.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
     <ProjectReference Include="..\tool_msbuild\tool_msbuild.csproj" />
     <ProjectReference Include="..\tool_nuget\tool_nuget.csproj" />
     <ProjectReference Include="..\..\Cli\dotnet\dotnet.csproj" />


### PR DESCRIPTION
It was being picked up as transitive content from the reference to `Containers\packaging`, but we don't actually need or want `containerize.exe` in the SDK root. `_GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences` checks
for `Private != false` as a flag to control the copy.

```diff
--- before.txt  2023-12-04 15:45:32.535278200 -0600
+++ after.txt   2023-12-04 15:43:07.315726600 -0600
@@ -1,9 +1,6 @@
 S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\8.0.200-dev\.toolsetversion
 S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\8.0.200-dev\.version
 S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\8.0.200-dev\AppHostTemplate
-S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\8.0.200-dev\containerize.deps.json
-S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\8.0.200-dev\containerize.exe
-S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\8.0.200-dev\containerize.runtimeconfig.json
 S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\8.0.200-dev\Containers
 S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\8.0.200-dev\cs
 S:\sdk\artifacts\bin\redist\Debug\dotnet\sdk\8.0.200-dev\Current
```