### PR TITLE
Remove Microsoft.SourceBuild.Intermediate from prebuilt baseline

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -3,8 +3,6 @@
 
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
-
     <!-- TODO: Ignore needed until https://github.com/NuGet/Home/issues/11059 is addressed. -->
     <UsagePattern IdentityGlob="Nuget.*/*" />
     <UsagePattern IdentityGlob="Microsoft.Build.NuGetSdkResolver/*" />


### PR DESCRIPTION
Prebuilt detection no longer detects Microsoft.SourceBuild.Intermediates as prebuilts due to https://github.com/dotnet/arcade/pull/13935. 

Addresses https://github.com/dotnet/source-build/issues/3010