### PR TITLE
Fix typos of Register-ArgumentCompleter parameters

### DIFF
--- a/scripts/register-completions.ps1
+++ b/scripts/register-completions.ps1
@@ -1,7 +1,7 @@
-# PowerShell parameter completion shim for the dotnet CLI 
+# PowerShell parameter completion shim for the dotnet CLI
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {
-     param($commandName, $wordToComplete, $cursorPosition)
-         dotnet complete --position $cursorPosition "$wordToComplete" | ForEach-Object {
-            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
-         }
- }
+   param($wordToComplete, $commandAst, $cursorPosition)
+   dotnet complete --position $cursorPosition "$commandAst" | ForEach-Object {
+      [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+   }
+}


### PR DESCRIPTION
related to dotnet/docs#38425

The parameter names provided in register-completions.ps1 do not align with the [Register-ArgumentCompleter documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/register-argumentcompleter?view=powershell-7.4#-scriptblock).
While it functions as is, I think it would be less confusing to follow the documentation as it is written.

> When you specify the Native parameter, the script block must take the following parameters in the specified order. The names of the parameters aren't important because PowerShell passes in the values by position.
> * `$wordToComplete` (Position 0) - This parameter is set to value the user has provided before they pressed Tab. Your script block should use this value to determine tab completion values.
> * `$commandAst` (Position 1) - This parameter is set to the Abstract Syntax Tree (AST) for the current input line. For more information, see Ast Class.
> * `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the user pressed Tab.
