### PR TITLE
Add SkipGetTargetFrameworkProperties to redist.csproj

### DIFF
--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -59,8 +59,8 @@
     <ProjectReference Include="..\tool_msbuild\tool_msbuild.csproj" />
     <ProjectReference Include="..\tool_nuget\tool_nuget.csproj" />
     <ProjectReference Include="..\..\Cli\dotnet\dotnet.csproj" />
-    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Extensions.Tasks\Microsoft.NET.Build.Extensions.Tasks.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\..\Tasks\Microsoft.NET.Build.Extensions.Tasks\Microsoft.NET.Build.Extensions.Tasks.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
     <ProjectReference Include="..\..\Resolvers\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj" />
     <ProjectReference Include="$(RepoRoot)src\BuiltInTools\dotnet-watch\dotnet-watch.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
   </ItemGroup>

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -55,6 +55,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- These project references with ReferenceOutputAssembly="false" should also set SkipGetTargetFrameworkProperties="true".  Otherwise, only the inner
+         build of a multi-targeted project will be built to fulfill the project reference, and if the redist project depends on output that is created
+         in the outer build (which is the case for some of these references), there may be sporadic incorrect builds if the outer build happens to run concurrently
+         with or after the redist build. -->
     <ProjectReference Include="..\..\Containers\packaging\package.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
     <ProjectReference Include="..\tool_msbuild\tool_msbuild.csproj" />
     <ProjectReference Include="..\tool_nuget\tool_nuget.csproj" />


### PR DESCRIPTION
One of the commits for [this PR](https://github.com/dotnet/installer/pull/17942) failed.  On investigation, the dotnet-toolset-internal zip was missing a lot of Microsoft.NET.Build.Extensions files.  Looking at the binlog for the dotnet/sdk build that produced this zip revealed that the `CopyAdditionalFilesToLayout` target from Microsoft.NET.Build.Extensions.Tasks.csproj ran after the `PublishMSBuildExtensions` target from redist.csproj.  So the target which was laying out some of these files was running after the target that consumed them in another project.

This appears to be because the `CopyAdditionalFilesToLayout` target only runs in the project's outer build.  However, project references by default only build the inner build for the best matching target framework of the referenced project, so even though there was a project reference from redist.csproj to Microsoft.NET.Build.Extensions.Tasks.csproj, it wasn't ensuring the necessary target ordering.  Adding `SkipGetTargetFrameworkProperties="true"` to the project reference should cause the outer build of the referenced project to run before the referencing project is built.