### PR TITLE
Pass SelfContained=true in CheckIlcVersions

### DIFF
--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -935,7 +935,7 @@ namespace Microsoft.NET.Publish.Tests
             {
                 DependsOnTargets = "WriteIlcRspFileForCompilation"
             };
-            ilcReferenceCommand.Execute($"/p:RuntimeIdentifier={rid}").Should().Pass();
+            ilcReferenceCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:SelfContained=true").Should().Pass();
             var ilcReference = ilcReferenceCommand.GetValues();
             var corelibReference = ilcReference.Where(r => Path.GetFileName(r).Equals("System.Private.CoreLib.dll")).Single();
             var ilcReferenceVersion = Path.GetFileName(Path.GetDirectoryName(Path.GetDirectoryName(corelibReference)));


### PR DESCRIPTION
This should be enough so that we can revert the revert in https://github.com/dotnet/runtime/pull/95881.

I panicked and reverted the whole thing.

@dotnet/ilc-contrib could someone have a look at this test only-change?