### PR TITLE
Fix sln add for duplicate projects under different paths with same root

### DIFF
--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/App.sln
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/App.sln
@@ -1,0 +1,82 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Base\Test.csproj", "{884E9311-BB85-494C-8588-1FAD4C93C0AC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Base", "Base", "{C6C93973-1CD8-454F-AA3D-41E0052E8E26}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Base\Second\Test.csproj", "{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestCollision", "Base\Second\Third\TestCollision.csproj", "{187AA828-6BDD-48AF-800E-26E65068CADC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Second", "Base\Second\Second.csproj", "{010A3387-74B8-467C-93B5-E07564F11C26}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Debug|x64.Build.0 = Debug|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Debug|x86.Build.0 = Debug|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Release|x64.ActiveCfg = Release|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Release|x64.Build.0 = Release|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Release|x86.ActiveCfg = Release|Any CPU
+		{884E9311-BB85-494C-8588-1FAD4C93C0AC}.Release|x86.Build.0 = Release|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Debug|x64.Build.0 = Debug|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Debug|x86.Build.0 = Debug|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Release|x64.ActiveCfg = Release|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Release|x64.Build.0 = Release|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Release|x86.ActiveCfg = Release|Any CPU
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1}.Release|x86.Build.0 = Release|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Debug|x64.Build.0 = Debug|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Debug|x86.Build.0 = Debug|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Release|x64.ActiveCfg = Release|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Release|x64.Build.0 = Release|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Release|x86.ActiveCfg = Release|Any CPU
+		{187AA828-6BDD-48AF-800E-26E65068CADC}.Release|x86.Build.0 = Release|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Debug|x64.Build.0 = Debug|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Debug|x86.Build.0 = Debug|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Release|x64.ActiveCfg = Release|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Release|x64.Build.0 = Release|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Release|x86.ActiveCfg = Release|Any CPU
+		{010A3387-74B8-467C-93B5-E07564F11C26}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B7DAD6CF-BBE2-49FF-8FA0-84BA67263CB1} = {C6C93973-1CD8-454F-AA3D-41E0052E8E26}
+		{187AA828-6BDD-48AF-800E-26E65068CADC} = {C6C93973-1CD8-454F-AA3D-41E0052E8E26}
+		{010A3387-74B8-467C-93B5-E07564F11C26} = {C6C93973-1CD8-454F-AA3D-41E0052E8E26}
+	EndGlobalSection
+EndGlobal

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Class1.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Test
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Class2.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Class2.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace TestCollision
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Class1.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Test
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Class2.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Class2.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace TestCollision
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Class3.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Class3.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Second
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Second.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Second.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Test.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Test.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/TestCollision.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/TestCollision.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Third/Class1.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Third/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace bar
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Third/Class2.cs
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Third/Class2.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Second
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Third/Second.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Third/Second.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Third/TestCollision.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Third/TestCollision.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Test.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Test.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/TestCollision.csproj
+++ b/src/Assets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/TestCollision.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Cli/dotnet/SlnFileExtensions.cs
+++ b/src/Cli/dotnet/SlnFileExtensions.cs
@@ -486,22 +486,13 @@ namespace Microsoft.DotNet.Tools.Common
 
         private static HashSet<string> GetSolutionFoldersThatContainProjectsInItsHierarchy(
             this SlnFile slnFile,
-            SlnPropertySet nestedProjects,
-            IEnumerable<SlnProject> projectsToSearchFor = null,
-            bool stopAtOne = false)
+            SlnPropertySet nestedProjects)
         {
             var solutionFoldersInUse = new HashSet<string>();
 
             IEnumerable<SlnProject> nonSolutionFolderProjects;
-            if (projectsToSearchFor == null)
-            {
-                nonSolutionFolderProjects = slnFile.Projects.GetProjectsNotOfType(
-                    ProjectTypeGuids.SolutionFolderGuid);
-            }
-            else
-            {
-                nonSolutionFolderProjects = projectsToSearchFor;
-            }
+            nonSolutionFolderProjects = slnFile.Projects.GetProjectsNotOfType(
+                 ProjectTypeGuids.SolutionFolderGuid);
 
             foreach (var nonSolutionFolderProject in nonSolutionFolderProjects)
             {
@@ -510,10 +501,6 @@ namespace Microsoft.DotNet.Tools.Common
                 {
                     id = nestedProjects[id];
                     solutionFoldersInUse.Add(id);
-                    if (stopAtOne)
-                    {
-                        break;
-                    }
                 }
             }
 

--- a/src/Tests/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
+++ b/src/Tests/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
@@ -609,6 +609,33 @@ EndGlobal
 
         }
 
+        [Fact]
+        public void WhenNestedDuplicateProjectIsAddedToASolutionFolder()
+        {
+             var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndCsprojInSubDirVSErrors")
+                .WithSource()
+                .Path;
+            string projectToAdd;
+            CommandResult cmd;
+
+            projectToAdd = Path.Combine("Base", "Second", "TestCollision.csproj");
+            cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"sln", "App.sln", "add", projectToAdd);
+            cmd.Should().Fail()
+                .And.HaveStdErrContaining("TestCollision")
+                .And.HaveStdErrContaining("Base");
+
+            projectToAdd = Path.Combine("Base", "Second", "Third",  "Second.csproj");
+            cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"sln", "App.sln", "add", projectToAdd);
+            cmd.Should().Fail()
+                .And.HaveStdErrContaining("Second")
+                .And.HaveStdErrContaining("Base");
+        }
+
         [Theory]
         [InlineData("TestAppWithSlnAndCsprojFiles")]
         [InlineData("TestAppWithSlnAnd472CsprojFiles")]


### PR DESCRIPTION
Change the logic for how we determine collisions in the SLN file. The item blocked by VS and msbuild is when one solution folder has two items parented by it that have the same name (whether they are projects or solution folders).

Instead of trying to figure out the solution folder and matching it to existing ones, I moved to checking the exact parent at the time of adding it which should be more precise.
