### PR TITLE
Handle HTTP 403 Forbidden in Containers

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobOperations.cs
@@ -36,7 +36,7 @@ internal class DefaultBlobOperations : IBlobOperations
         {
             HttpStatusCode.OK => true,
             HttpStatusCode.NotFound => false,
-            HttpStatusCode.Unauthorized => throw new UnableToAccessRepositoryException(_registryName, repositoryName),
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => throw new UnableToAccessRepositoryException(_registryName, repositoryName),
             _ => await LogAndThrowContainerHttpException<bool>(response, cancellationToken).ConfigureAwait(false)
         };
     }
@@ -68,7 +68,7 @@ internal class DefaultBlobOperations : IBlobOperations
         return response.StatusCode switch
         {
             HttpStatusCode.OK => response,
-            HttpStatusCode.Unauthorized => throw new UnableToAccessRepositoryException(_registryName, repositoryName),
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => throw new UnableToAccessRepositoryException(_registryName, repositoryName),
             _ => await LogAndThrowContainerHttpException<HttpResponseMessage>(response, cancellationToken).ConfigureAwait(false)
         };
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
@@ -33,7 +33,7 @@ internal class DefaultManifestOperations : IManifestOperations
         {
             HttpStatusCode.OK => response,
             HttpStatusCode.NotFound => throw new RepositoryNotFoundException(_registryName, repositoryName, reference),
-            HttpStatusCode.Unauthorized => throw new UnableToAccessRepositoryException(_registryName, repositoryName),
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => throw new UnableToAccessRepositoryException(_registryName, repositoryName),
             _ => await LogAndThrowContainerHttpException<HttpResponseMessage>(response, cancellationToken).ConfigureAwait(false)
         };
     }


### PR DESCRIPTION
I got the following error when uploading an image to AWS ECR:

> Containerize: error CONTAINER004: CONTAINER1014: Manifest pull failed.

This is a very generic error message, and I had to look in the binlog to see it was caused by a 403 Forbidden HTTP response.

This PR changes this behavior so that 403 Forbidden gets you the same error as 401 Unauthorized. The error message currently provided fits both kinds of errors:

> Unable to access the repository '{0}' in the registry '{1}'. Please confirm your credentials are correct and that you have access to this repository and registry.

