### PR TITLE
Revert "Swap 9.0 to current target framework"

### DIFF
--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -31,7 +31,7 @@ public class CreateNewImageTests
 
         newProjectDir.Create();
 
-        new DotnetNewCommand(_testOutput, "console", "-f", ToolsetInfo.CurrentTargetFramework)
+        new DotnetNewCommand(_testOutput, "console", "-f", ToolsetInfo.NextTargetFramework)
             .WithVirtualHive()
             .WithWorkingDirectory(newProjectDir.FullName)
             .Execute()
@@ -53,7 +53,7 @@ public class CreateNewImageTests
 
         task.OutputRegistry = "localhost:5010";
         task.LocalRegistry = DockerAvailableFactAttribute.LocalRegistry;
-        task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-arm64", "publish");
+        task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.NextTargetFramework, "linux-arm64", "publish");
         task.Repository = "dotnet/create-new-image-baseline";
         task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";
@@ -82,7 +82,7 @@ public class CreateNewImageTests
 
         newProjectDir.Create();
 
-        new DotnetNewCommand(_testOutput, "console", "-f", ToolsetInfo.CurrentTargetFramework)
+        new DotnetNewCommand(_testOutput, "console", "-f", ToolsetInfo.NextTargetFramework)
             .WithVirtualHive()
             .WithWorkingDirectory(newProjectDir.FullName)
             .Execute()
@@ -119,7 +119,7 @@ public class CreateNewImageTests
         cni.BaseImageTag = pcp.ParsedContainerTag;
         cni.Repository = pcp.NewContainerRepository;
         cni.OutputRegistry = "localhost:5010";
-        cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.CurrentTargetFramework);
+        cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", ToolsetInfo.NextTargetFramework);
         cni.WorkingDirectory = "app/";
         cni.Entrypoint = new TaskItem[] { new(newProjectDir.Name) };
         cni.ImageTags = pcp.NewContainerTags;
@@ -255,7 +255,7 @@ public class CreateNewImageTests
 
         newProjectDir.Create();
 
-        new DotnetNewCommand(_testOutput, "console", "-f", ToolsetInfo.CurrentTargetFramework)
+        new DotnetNewCommand(_testOutput, "console", "-f", ToolsetInfo.NextTargetFramework)
             .WithVirtualHive()
             .WithWorkingDirectory(newProjectDir.FullName)
             .Execute()
@@ -274,7 +274,7 @@ public class CreateNewImageTests
         task.BaseImageTag = "latest";
 
         task.OutputRegistry = "localhost:5010";
-        task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-x64", "publish");
+        task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.NextTargetFramework, "linux-x64", "publish");
         task.Repository = AppImage;
         task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
@@ -66,7 +66,7 @@ public class PackageTests
     public void PackageContentTest()
     {
         string ignoredZipFileEntriesPrefix = "package/services/metadata";
-        var netTFM = ToolsetInfo.CurrentTargetFramework;
+        var netTFM = ToolsetInfo.NextTargetFramework;
         IReadOnlyList<string> packageContents = new List<string>()
         {
               "_rels/.rels",

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Build.Tests
             var project = new TestProject
             {
                 Name = "packagethatwillgomissing",
-                TargetFrameworks = targetFrameworkIdentifier == ".NETCoreApp" ? ToolsetInfo.CurrentTargetFramework : "netstandard2.1",
+                TargetFrameworks = targetFrameworkIdentifier == ".NETCoreApp" ? ToolsetInfo.NextTargetFramework : "netstandard2.1",
             };
 
             TestAsset asset = _testAssetsManager

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -361,9 +361,9 @@ namespace Microsoft.NET.Build.Tests
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(true, true, "net5.0")]
-        [InlineData(true, true, ToolsetInfo.CurrentTargetFramework)]
-        [InlineData(true, false, ToolsetInfo.CurrentTargetFramework)]
-        [InlineData(false, false, ToolsetInfo.CurrentTargetFramework)]
+        [InlineData(true, true, ToolsetInfo.NextTargetFramework)]
+        [InlineData(true, false, ToolsetInfo.NextTargetFramework)]
+        [InlineData(false, false, ToolsetInfo.NextTargetFramework)]
         public void TestPreviewFeatures(bool enablePreviewFeatures, bool generateRequiresPreviewFeaturesAttribute, string targetFramework)
         {
             var testAsset = _testAssetsManager
@@ -410,7 +410,7 @@ namespace Microsoft.NET.Build.Tests
 
             if (enablePreviewFeatures && generateRequiresPreviewFeaturesAttribute)
             {
-                if (targetFramework == ToolsetInfo.CurrentTargetFramework)
+                if (targetFramework == ToolsetInfo.NextTargetFramework)
                 {
                     Assert.Equal("Preview", langVersion);
                     Assert.True(contains);

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -156,7 +156,7 @@ namespace Microsoft.NET.Build.Tests
             buildResult.StdErr.Should().Be(string.Empty);
         }
 
-        [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.CurrentTargetFrameworkVersion)]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.NextTargetFrameworkVersion)]
         [RequiresMSBuildVersionTheory("16.8")]
         public void It_defaults_preview_AnalysisLevel_to_the_next_tfm(string currentTFM, string nextTFMVersionNumber)
         {

--- a/test/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
+++ b/test/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
@@ -365,7 +365,7 @@ public class ReferencedExeProgram
             var testConsoleProject = new TestProject("ConsoleApp")
             {
                 IsExe = true,
-                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                TargetFrameworks = ToolsetInfo.NextTargetFramework,
                 RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid()
             };
 

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToTestAMultitargetedSolutionWithPublishReleaseOrPackRelease.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToTestAMultitargetedSolutionWithPublishReleaseOrPackRelease.cs
@@ -75,9 +75,9 @@ namespace Microsoft.NET.Publish.Tests
         {
             var secondProjectTfm = ToolsetInfo.CurrentTargetFramework; // Net8 here is a 'net 8+' project
             var expectedConfiguration = Release;
-            var expectedTfm = "net9.0";
+            var expectedTfm = "net8.0";
 
-            var (testAsset, testProjects) = Setup(new List<string> { "net6.0", "net7.0", "net8.0", "net9.0" }, new List<string> { secondProjectTfm }, PublishRelease, "", "", identifier: string.Join('-', args));
+            var (testAsset, testProjects) = Setup(new List<string> { "net6.0", "net7.0", "net8.0" }, new List<string> { secondProjectTfm }, PublishRelease, "", "", identifier: string.Join('-', args));
 
             var dotnetCommand = new DotnetCommand(Log, publish);
             dotnetCommand

--- a/test/Microsoft.NET.Publish.Tests/PublishTestUtils.cs
+++ b/test/Microsoft.NET.Publish.Tests/PublishTestUtils.cs
@@ -13,9 +13,8 @@ namespace Microsoft.NET.Publish.Tests
             new object[] { "net5.0" },
             new object[] { "net6.0" },
             new object[] { "net7.0" },
-            new object[] { "net8.0" },
             new object[] { ToolsetInfo.CurrentTargetFramework },
-            // new object[] { ToolsetInfo.NextTargetFramework },
+            new object[] { ToolsetInfo.NextTargetFramework },
         };
 
         // This list should contain all supported TFMs after net5.0
@@ -24,9 +23,8 @@ namespace Microsoft.NET.Publish.Tests
             new object[] { "net5.0" },
             new object[] { "net6.0" },
             new object[] { "net7.0" },
-            new object[] { "net8.0" },
             new object[] { ToolsetInfo.CurrentTargetFramework },
-            // new object[] { ToolsetInfo.NextTargetFramework },
+            new object[] { ToolsetInfo.NextTargetFramework },
         };
 
         // This list should contain all supported TFMs after net6.0
@@ -34,26 +32,23 @@ namespace Microsoft.NET.Publish.Tests
         {
             new object[] { "net6.0" },
             new object[] { "net7.0" },
-            new object[] { "net8.0" },
             new object[] { ToolsetInfo.CurrentTargetFramework },
-            // new object[] { ToolsetInfo.NextTargetFramework },
+            new object[] { ToolsetInfo.NextTargetFramework },
         };
 
         // This list should contain all supported TFMs after net7.0
         public static IEnumerable<object[]> Net7Plus { get; } = new List<object[]>
         {
             new object[] { "net7.0" },
-            new object[] { "net8.0" },
             new object[] { ToolsetInfo.CurrentTargetFramework },
-            // new object[] { ToolsetInfo.NextTargetFramework },
+            new object[] { ToolsetInfo.NextTargetFramework },
         };
 
         // This list should contain all supported TFMs after net8.0
         public static IEnumerable<object[]> Net8Plus { get; } = new List<object[]>
         {
-            new object[] { "net8.0" },
             new object[] { ToolsetInfo.CurrentTargetFramework },
-            // new object[] { ToolsetInfo.NextTargetFramework },
+            new object[] { ToolsetInfo.NextTargetFramework },
         };
 #else
 #error If building for a newer TFM, please update the values above to include both the old and new TFMs.

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
@@ -93,7 +93,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                     reference.Name = "Reference";
                     reference.Add(new XElement(
                         "HintPath",
-                        Path.Combine("..", "razorclasslibrary", "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "RazorClassLibrary.dll")));
+                        Path.Combine("..", "razorclasslibrary", "bin", "Debug", ToolsetInfo.NextTargetFramework, "RazorClassLibrary.dll")));
                 }
             });
 

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
@@ -109,7 +109,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                     reference.Name = "Reference";
                     reference.Add(new XElement(
                         "HintPath",
-                        Path.Combine("..", "razorclasslibrary", "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "RazorClassLibrary.dll")));
+                        Path.Combine("..", "razorclasslibrary", "bin", "Debug", ToolsetInfo.NextTargetFramework, "RazorClassLibrary.dll")));
                 }
             });
 

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
@@ -2185,12 +2185,12 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 var parse = XDocument.Parse($@"<Project Sdk=""Microsoft.NET.Sdk.Razor"">
 
   <PropertyGroup>
-    <TargetFrameworks>{ToolsetInfo.CurrentTargetFramework};net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>{ToolsetInfo.NextTargetFramework};net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <SupportedPlatform Condition=""'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == '{ToolsetInfo.CurrentTargetFramework}'"" Include=""browser"" />
+    <SupportedPlatform Condition=""'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == '{ToolsetInfo.NextTargetFramework}'"" Include=""browser"" />
   </ItemGroup>
 
   <ItemGroup>
@@ -2262,12 +2262,12 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 var parse = XDocument.Parse($@"<Project Sdk=""Microsoft.NET.Sdk.Razor"">
 
   <PropertyGroup>
-    <TargetFrameworks>{ToolsetInfo.CurrentTargetFramework};net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>{ToolsetInfo.NextTargetFramework};net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <SupportedPlatform Condition=""'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == '{ToolsetInfo.CurrentTargetFramework}'"" Include=""browser"" />
+    <SupportedPlatform Condition=""'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == '{ToolsetInfo.NextTargetFramework}'"" Include=""browser"" />
   </ItemGroup>
 
   <ItemGroup>
@@ -2341,12 +2341,12 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 var parse = XDocument.Parse($@"<Project Sdk=""Microsoft.NET.Sdk.Razor"">
 
   <PropertyGroup>
-    <TargetFrameworks>{ToolsetInfo.CurrentTargetFramework};net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>{ToolsetInfo.NextTargetFramework};net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <SupportedPlatform Condition=""'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == '{ToolsetInfo.CurrentTargetFramework}'"" Include=""browser"" />
+    <SupportedPlatform Condition=""'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == '{ToolsetInfo.NextTargetFramework}'"" Include=""browser"" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/test/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -8,10 +8,10 @@ namespace Microsoft.NET.TestFramework
 {
     public class ToolsetInfo
     {
-        public const string CurrentTargetFramework = "net9.0";
-        public const string CurrentTargetFrameworkVersion = "9.0";
-        public const string NextTargetFramework = "net10.0";
-        public const string NextTargetFrameworkVersion = "10.0";
+        public const string CurrentTargetFramework = "net8.0";
+        public const string CurrentTargetFrameworkVersion = "8.0";
+        public const string NextTargetFramework = "net9.0";
+        public const string NextTargetFrameworkVersion = "9.0";
 
         public const string LatestWinRuntimeIdentifier = "win";
         public const string LatestLinuxRuntimeIdentifier = "linux";


### PR DESCRIPTION
Reverts dotnet/sdk#37609

This pull request was merged with stale (2-week old) CI results. The build of the `main` branch has been broken ever since it merged.

Ref: https://github.com/dotnet/sdk/pull/37675#issuecomment-1872517894