### PR TITLE
[Blazor] Disable accelerated builds in Visual Studio for Blazor webassembly projects (7.0)

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.props
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.props
@@ -32,9 +32,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TrimMode Condition="'$(TrimMode)' == ''">partial</TrimMode>
     <TrimmerRemoveSymbols Condition="'$(TrimmerRemoveSymbols)' == ''">false</TrimmerRemoveSymbols>
 
+    <!-- Disable accelerated builds in Visual Studio -->
+    <AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
+
     <!-- Static web assets defaults -->
     <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">/</StaticWebAssetBasePath>
-    <StaticWebAssetProjectMode Condition="'$(StaticWebAssetProjectMode)' == ''">Root</StaticWebAssetProjectMode>    
+    <StaticWebAssetProjectMode Condition="'$(StaticWebAssetProjectMode)' == ''">Root</StaticWebAssetProjectMode>
     <StaticWebAssetsGetPublishAssetsTargets>ComputeFilesToPublish;GetCurrentProjectPublishStaticWebAssetItems</StaticWebAssetsGetPublishAssetsTargets>
     <StaticWebAssetsAdditionalPublishProperties>$(StaticWebAssetsAdditionalPublishProperties);BuildProjectReferences=false;ResolveAssemblyReferencesFindRelatedSatellites=true;_PublishingBlazorWasmProject=true</StaticWebAssetsAdditionalPublishProperties>
     <StaticWebAssetsAdditionalPublishPropertiesToRemove>$(StaticWebAssetsAdditionalPublishPropertiesToRemove);NoBuild;RuntimeIdentifier</StaticWebAssetsAdditionalPublishPropertiesToRemove>


### PR DESCRIPTION
# [Wasm] Disable accelerated builds in Visual Studio for wasm projects

Disable Accelerated Builds in Visual Studio for WebAssembly projects.

## Description

Visual Studio 17.9 ships with a feature called "Build acceleration" which accelerates the build by avoiding building dependent projects when a dependency changes, and instead, copying the dll to the dependent projects output folder.

This doesn't work for Blazor|Wasm applications as they need to post-process the assemblies and generate several artifacts from that.

The fix is to disable the feature in Blazor WebAssembly projects.

Fixes https://github.com/dotnet/aspnetcore/issues/52148

## Customer Impact

Customers will not see updates when they make a change to a shared Razor Class Library that is used by a project running on webassembly.

## Regression?

- [X] Yes
- [ ] No

VS 17.8.4 (This is visible in 17.9.0 Preview 2.1 as per my validation).

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The change just disables the feature which restores the existing tested behavior.

## Verification

- [X] Manual (required)
- [ ] Automated

Validated by adding the same MSBuild property into a project opened in VS 17.9.0 Preview 2.1. The customer on the issue also confirmed that adding the property into their project fixed the issue for them too.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props