### PR TITLE
Include MSBuild version as part of --info, not every build.

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             string defaultMSBuildPath = GetMSBuildExePath();
 
-            _argsToForward = includeLogo ? ["-nologo", ..argsToForward] : argsToForward;
+            _argsToForward = includeLogo ? argsToForward : ["-nologo", ..argsToForward];
             string tlpDefault = TerminalLoggerDefault;
             /* TODO: Consider to enable it for dotnet 9+ SDK
             if (!string.IsNullOrWhiteSpace(tlpDefault))

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -50,13 +50,13 @@ namespace Microsoft.DotNet.Cli.Utils
             };
 
         private readonly IEnumerable<string> _msbuildRequiredParameters =
-            new List<string> { "-maxcpucount", "-verbosity:m", "-nologo" };
+            new List<string> { "-maxcpucount", "-verbosity:m" };
 
-        public MSBuildForwardingAppWithoutLogging(IEnumerable<string> argsToForward, string msbuildPath = null)
+        public MSBuildForwardingAppWithoutLogging(IEnumerable<string> argsToForward, string msbuildPath = null, bool includeLogo = false)
         {
             string defaultMSBuildPath = GetMSBuildExePath();
 
-            _argsToForward = argsToForward;
+            _argsToForward = includeLogo ? ["-nologo", ..argsToForward] : argsToForward;
             string tlpDefault = TerminalLoggerDefault;
             /* TODO: Consider to enable it for dotnet 9+ SDK
             if (!string.IsNullOrWhiteSpace(tlpDefault))

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -19,6 +19,10 @@ namespace Microsoft.DotNet.Cli.Utils
         private static readonly bool UseMSBuildServer = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILD_SERVER", false);
         private static readonly string TerminalLoggerDefault = Env.GetEnvironmentVariable("DOTNET_CLI_CONFIGURE_MSBUILD_TERMINAL_LOGGER");
 
+        public static string MSBuildVersion
+        {
+            get => Microsoft.Build.Evaluation.ProjectCollection.DisplayVersion;
+        }
         private const string MSBuildExeName = "MSBuild.dll";
 
         private const string SdksDirectoryName = "Sdks";
@@ -39,14 +43,14 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private readonly Dictionary<string, string> _msbuildRequiredEnvironmentVariables =
             new Dictionary<string, string>
-            {
+        {
                 { "MSBuildExtensionsPath", MSBuildExtensionsPathTestHook ?? AppContext.BaseDirectory },
                 { "MSBuildSDKsPath", GetMSBuildSDKsPath() },
                 { "DOTNET_HOST_PATH", GetDotnetPath() },
             };
 
         private readonly IEnumerable<string> _msbuildRequiredParameters =
-            new List<string> { "-maxcpucount", "-verbosity:m" };
+            new List<string> { "-maxcpucount", "-verbosity:m", "-nologo" };
 
         public MSBuildForwardingAppWithoutLogging(IEnumerable<string> argsToForward, string msbuildPath = null)
         {

--- a/src/Cli/dotnet/CommandLineInfo.cs
+++ b/src/Cli/dotnet/CommandLineInfo.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.Cli
             Reporter.Output.WriteLine($" Version:           {Product.Version}");
             Reporter.Output.WriteLine($" Commit:            {commitSha}");
             Reporter.Output.WriteLine($" Workload version:  {WorkloadCommandParser.GetWorkloadsVersion()}");
+            Reporter.Output.WriteLine($" MSBuild version:   {MSBuildForwardingAppWithoutLogging.MSBuildVersion.ToString()}");
             Reporter.Output.WriteLine();
             Reporter.Output.WriteLine($"{LocalizableStrings.DotNetRuntimeInfoLabel}");
             Reporter.Output.WriteLine($" OS Name:     {RuntimeEnvironment.OperatingSystem}");

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -38,11 +38,12 @@ namespace Microsoft.DotNet.Tools.MSBuild
             return argsToForward;
         }
 
-        public MSBuildForwardingApp(IEnumerable<string> argsToForward, string msbuildPath = null)
+        public MSBuildForwardingApp(IEnumerable<string> argsToForward, string msbuildPath = null, bool includeLogo = false)
         {
             _forwardingAppWithoutLogging = new MSBuildForwardingAppWithoutLogging(
                 ConcatTelemetryLogger(argsToForward),
-                msbuildPath);
+                msbuildPath: msbuildPath,
+                includeLogo: includeLogo);
 
             // Add the performance log location to the environment of the target process.
             if (PerformanceLogManager.Instance != null && !string.IsNullOrEmpty(PerformanceLogManager.Instance.CurrentLogDirectory))

--- a/src/Cli/dotnet/commands/dotnet-msbuild/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/Program.cs
@@ -10,10 +10,9 @@ namespace Microsoft.DotNet.Tools.MSBuild
     {
         public MSBuildCommand
             (IEnumerable<string> msbuildArgs,
-            string msbuildPath = null,
-            bool includeLogo = false
+            string msbuildPath = null
             )
-             : base(msbuildArgs, msbuildPath, includeLogo)
+             : base(msbuildArgs, msbuildPath, includeLogo: true)
         {
         }
 
@@ -34,7 +33,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
             MSBuildCommand command = new MSBuildCommand(
                 msbuildArgs,
-                msbuildPath);
+                msbuildPath: msbuildPath);
             return command;
         }
 

--- a/src/Cli/dotnet/commands/dotnet-msbuild/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/Program.cs
@@ -10,13 +10,15 @@ namespace Microsoft.DotNet.Tools.MSBuild
     {
         public MSBuildCommand
             (IEnumerable<string> msbuildArgs,
-            string msbuildPath = null) 
-             : base(msbuildArgs, msbuildPath)
+            string msbuildPath = null,
+            bool includeLogo = false
+            )
+             : base(msbuildArgs, msbuildPath, includeLogo)
         {
         }
 
         public static MSBuildCommand FromArgs(string[] args, string msbuildPath = null)
-        { 
+        {
             var parser = Cli.Parser.Instance;
             var result = parser.ParseFrom("dotnet msbuild", args);
             return FromParseResult(result, msbuildPath);

--- a/src/Cli/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/Program.cs
@@ -17,27 +17,20 @@ namespace Microsoft.DotNet.Tools.Restore
             NuGetSignatureVerificationEnabler.ConditionallyEnable(this);
         }
 
-        public static RestoreCommand FromArgs(string[] args, string msbuildPath = null, bool noLogo = true)
+        public static RestoreCommand FromArgs(string[] args, string msbuildPath = null)
         {
             var parser = Parser.Instance;
             var result = parser.ParseFrom("dotnet restore", args);
-            return FromParseResult(result, msbuildPath, noLogo);
+            return FromParseResult(result, msbuildPath);
         }
 
-        public static RestoreCommand FromParseResult(ParseResult result, string msbuildPath = null, bool noLogo = true)
+        public static RestoreCommand FromParseResult(ParseResult result, string msbuildPath = null)
         {
             result.HandleDebugSwitch();
 
             result.ShowHelpOrErrorIfAppropriate();
 
-            var msbuildArgs = new List<string>();
-
-            if (noLogo)
-            {
-                msbuildArgs.Add("-nologo");
-            }
-
-            msbuildArgs.Add("-target:Restore");
+            List<string> msbuildArgs = ["-target:Restore"];
 
             msbuildArgs.AddRange(result.OptionValuesToBeForwarded(RestoreCommandParser.GetCommand()));
 

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetBuildInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        const string ExpectedPrefix = "-maxcpucount -verbosity:m";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m -nologo";
 
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetBuildInvocation));

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
@@ -8,9 +8,9 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetCleanInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        const string ExpectedPrefix = "-maxcpucount -verbosity:m -verbosity:normal -target:Clean";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m -nologo -verbosity:normal -target:Clean";
 
-        private static readonly string WorkingDirectory = 
+        private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetCleanInvocation));
 
         [Fact]
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         {
             var msbuildPath = "<msbuildpath>";
             CleanCommand.FromArgs(new string[] { "<project>" }, msbuildPath)
-                .GetArgumentsToMSBuild().Should().Be("-maxcpucount -verbosity:m -verbosity:normal <project> -target:Clean");
+                .GetArgumentsToMSBuild().Should().Be("-maxcpucount -verbosity:m -nologo -verbosity:normal <project> -target:Clean");
         }
 
         [Theory]

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetOsArchOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         {
         }
 
-        const string ExpectedPrefix = "-maxcpucount -verbosity:m";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m -nologo";
 
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetBuildInvocation));
@@ -195,7 +195,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                         .StartWith($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary -property:RuntimeIdentifier={expectedOs}-arch");
                 });
             }
-            finally { CultureInfo.CurrentCulture = currentCultureBefore;}
+            finally { CultureInfo.CurrentCulture = currentCultureBefore; }
         }
     }
 }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
@@ -8,8 +8,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetPackInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        const string ExpectedPrefix = "-maxcpucount -verbosity:m -restore -target:pack";
-        const string ExpectedNoBuildPrefix = "-maxcpucount -verbosity:m -target:pack";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m -nologo -restore -target:pack";
+        const string ExpectedNoBuildPrefix = "-maxcpucount -verbosity:m -nologo -target:pack";
         const string ExpectedProperties = "--property:_IsPacking=true";
 
         private static readonly string WorkingDirectory =

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             this.output = output;
         }
 
-        const string ExpectedPrefix = "-maxcpucount -verbosity:m";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m -nologo";
         const string ExpectedProperties = "--property:_IsPublishing=true";
 
         [Theory]

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetStoreInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        const string ExpectedPrefix = "-maxcpucount -verbosity:m -target:ComposeStore <project>";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m -nologo -target:ComposeStore <project>";
         static readonly string[] ArgsPrefix = { "--manifest", "<project>" };
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetStoreInvocation));

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetTestInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetTestInvocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetTestInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        private const string ExpectedPrefix = "-maxcpucount -verbosity:m -restore -target:VSTest -nodereuse:false -nologo";
+        private const string ExpectedPrefix = "-maxcpucount -verbosity:m -nologo -restore -target:VSTest -nodereuse:false -nologo";
         private static readonly string WorkingDirectory = TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetTestInvocation));
 
         [Theory]


### PR DESCRIPTION
Fixes #37713

We flow through the MSBuild DisplayVersion (the same version used in the current `dotnet build` output) as a first-class value in the current `--info` layout. With that in place, we pass `-nologo` to all MSBuild invocations so that the information isn't duplicated anymore.

![image](https://github.com/dotnet/sdk/assets/573979/96cb2bbe-77be-4d5b-b663-a398ff1170a7)
