### PR TITLE
Remove all sdks when switching branches

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -153,7 +153,7 @@ function CleanOutStage0ToolsetsAndRuntimes {
       Remove-Item (Join-Path $aspnetRuntimePath "$majorVersion.*") -Recurse
       Remove-Item (Join-Path $coreRuntimePath "$majorVersion.*") -Recurse
       Remove-Item (Join-Path $wdRuntimePath "$majorVersion.*") -Recurse
-      Remove-Item (Join-Path $sdkPath "$majorVersion.*") -Recurse
+      Remove-Item (Join-Path $sdkPath "*") -Recurse
       Remove-Item (Join-Path $dotnetRoot "packs") -Recurse
       Remove-Item (Join-Path $dotnetRoot "sdk-manifests") -Recurse
       Remove-Item (Join-Path $dotnetRoot "templates") -Recurse

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -93,7 +93,7 @@ function CleanOutStage0ToolsetsAndRuntimes {
   local aspnetRuntimePath="$dotnetRoot/shared/Microsoft.AspNetCore.App/$majorVersion.*"
   local coreRuntimePath="$dotnetRoot/shared/Microsoft.NETCore.App/$majorVersion.*"
   local wdRuntimePath="$dotnetRoot/shared/Microsoft.WindowsDesktop.App/$majorVersion.*"
-  local sdkPath="$dotnetRoot/sdk/$majorVersion.*"
+  local sdkPath="$dotnetRoot/sdk/*"
 
   if [ -f "$versionPath" ]; then
     local lastInstalledSDK=$(cat $versionPath)


### PR DESCRIPTION
I found that if you go to main and then back to an 8.0 branch, we can… end up in a state where we're using the 9.0 SDK that was left behind. Let's just delete them all.

I'll do more testing before merging.