### PR TITLE
Re-enable env var directives in the .NET CLI

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.Cli
             EnableDefaultExceptionHandler = false,
             EnableParseErrorReporting = true,
             EnablePosixBundling = false,
-            Directives = { new DiagramDirective(), new SuggestDirective() },
+            Directives = { new DiagramDirective(), new SuggestDirective(), new EnvironmentVariablesDirective() },
             ResponseFileTokenReplacer = TokenPerLine
         };
 

--- a/src/Tests/dotnet.Tests/ParserTests/EnvironmentVariableDirectiveTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/EnvironmentVariableDirectiveTests.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.Tests.ParserTests;
+
+public class EnvironmentVariablesDirectiveTests : SdkTest
+{
+    public EnvironmentVariablesDirectiveTests(ITestOutputHelper log) : base(log)
+    {
+    }
+
+    [Fact]
+    public void CanApplyEnvVarToInvocation()
+    {
+        var envVarName = "mything";
+        var envVarValue = "foo";
+        var parseResult = Parser.Instance.Parse([$"[env:{envVarName}={envVarValue}]", "--info"]);
+        var result = parseResult.Invoke();
+
+        System.Environment.GetEnvironmentVariable(envVarName).Should().Be(envVarValue);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/37686

## Description

This re-adds the EnvironmentVariableDirective, which used to be a default part of the CLI configuration but was removed in a refactoring.

## Customer Impact

Customers that set environment variables using this mechanism (which is OS agnostic and scoped only to a single command) suddenly had their commands break. After this change, their scripts will work again.

## Regression?

**Yes**, a System.CommandLine update broke silently in the 8.0.100 preview cycles.

## Risk

Low

## Tests

Automated tests were added to ensure the env-var setting functionality is verified at the SDK-level, not just the S.CL-level.

