### PR TITLE
Fix the parsing of ContainerImageTags to report invalid tags instead of silently swallowing them.

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
@@ -100,12 +100,12 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
                 Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidTag), nameof(ContainerImageTag), ContainerImageTag);
             }
         }
-        else if (ContainerImageTags.Length != 0 && TryValidateTags(ContainerImageTags, out var valids, out var invalids))
+        else if (ContainerImageTags.Length != 0)
         {
-            validTags = valids;
-            if (invalids.Any())
+            (validTags, var invalidTags) = TryValidateTags(ContainerImageTags);
+            if (invalidTags.Any())
             {
-                Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidTags), nameof(ContainerImageTags), String.Join(",", invalids));
+                Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidTags), nameof(ContainerImageTags), String.Join(",", invalidTags));
                 return !Log.HasLoggedErrors;
             }
         }
@@ -200,7 +200,7 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
         }
     }
 
-    private static bool TryValidateTags(string[] inputTags, out string[] validTags, out string[] invalidTags)
+    private static (string[] validTags, string[] invalidTags) TryValidateTags(string[] inputTags)
     {
         var v = new List<string>();
         var i = new List<string>();
@@ -215,8 +215,6 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
                 i.Add(tag);
             }
         }
-        validTags = v.ToArray();
-        invalidTags = i.ToArray();
-        return invalidTags.Length == 0;
+        return (v.ToArray(), i.ToArray());
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -8,13 +8,13 @@ using static Microsoft.NET.Build.Containers.KnownStrings.Properties;
 
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
-[Collection("Docker tests")]
 public class ParseContainerPropertiesTests
 {
-    [DockerAvailableFact]
+    [Fact]
     public void Baseline()
     {
-        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerRepository] = "dotnet/testimage",
@@ -22,7 +22,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(instance.Build(new[]{ComputeContainerConfig}, new [] { logs }, null, out var outputs));
+        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.Equal("mcr.microsoft.com", instance.GetPropertyValue(ContainerBaseRegistry));
         Assert.Equal("dotnet/runtime", instance.GetPropertyValue(ContainerBaseName));
@@ -33,26 +33,28 @@ public class ParseContainerPropertiesTests
         instance.GetItems("ProjectCapability").Select(i => i.EvaluatedInclude).ToArray().Should().BeEquivalentTo(new[] { "NetSdkOCIImageBuild" });
     }
 
-    [DockerAvailableFact]
+    [Fact]
     public void SpacesGetReplacedWithDashes()
     {
-         var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet runtime:7.0",
             [ContainerRegistry] = "localhost:5010"
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(instance.Build(new[]{ComputeContainerConfig}, new [] { logs }, null, out var outputs));
+        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
-        Assert.Equal("mcr.microsoft.com",instance.GetPropertyValue(ContainerBaseRegistry));
+        Assert.Equal("mcr.microsoft.com", instance.GetPropertyValue(ContainerBaseRegistry));
         Assert.Equal("dotnet-runtime", instance.GetPropertyValue(ContainerBaseName));
         Assert.Equal("7.0", instance.GetPropertyValue(ContainerBaseTag));
     }
 
-    [DockerAvailableFact]
+    [Fact]
     public void RegexCatchesInvalidContainerNames()
     {
-         var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerRepository] = "dotnet testimage",
@@ -60,14 +62,15 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(instance.Build(new[]{ComputeContainerConfig}, new [] { logs }, null, out var outputs));
+        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
         Assert.Contains(logs.Messages, m => m.Message?.Contains("'dotnet testimage' was not a valid container image name, it was normalized to 'dotnet-testimage'") == true);
     }
 
-    [DockerAvailableFact]
+    [Fact]
     public void RegexCatchesInvalidContainerTags()
     {
-        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerRepository] = "dotnet/testimage",
@@ -75,16 +78,17 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2007);
     }
 
-    [DockerAvailableFact]
+    [Fact]
     public void CanOnlySupplyOneOfTagAndTags()
     {
-        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerRepository] = "dotnet/testimage",
@@ -93,16 +97,34 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2008);
     }
 
-    [DockerAvailableFact]
+    [Fact]
+    public void InvalidTagsThrowError()
+    {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
+            [ContainerBaseImage] = "mcr.microsoft.com/dotnet/aspnet:8.0",
+            [ContainerRepository] = "dotnet/testimage",
+            [ContainerImageTags] = "'latest;oldest'"
+        });
+        using var _ = d;
+        var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+
+        Assert.True(logs.Errors.Count > 0);
+        Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2010);
+    }
+
+    [Fact]
     public void FailsOnCompletelyInvalidRepositoryNames()
     {
-        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerImageName] = "㓳㓴㓵㓶㓷㓹㓺㓻",
@@ -110,16 +132,17 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);
     }
 
-    [DockerAvailableFact]
+    [Fact]
     public void FailsWhenFirstCharIsAUnicodeLetterButNonLatin()
     {
-        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerImageName] = "㓳but-otherwise-valid",
@@ -127,7 +150,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);


### PR DESCRIPTION
Fixes part of #37610 

## Description

Users can customize container images generated for a project in a number of ways. One of the most common is setting a custom tag, which is often a semantic label like `latest` for convenience, or a specific version number for reproducibility. It's very common for multiple tags to point to the same logical image, so the SDK tooling provides the `ContainerImageTags` MSBuild property to enable this behavior. An example of this might be

```terminal
$ dotnet publish -p:PublishProfile=DefaultContainer -p ContainerImageTags="'\"3.1.2;latest\"'"
```
However this encoding of an MSBuild semicolon-delimited property value is incorrect - MSbuild will parse it into an Item like `'\3.1.2` - no `latest` tag at all, at least on Windows with Powershell.

Each image tag is intended to be validated before the image generation process continues, but due to a bug in boolean logic the validation checks were never reported to the user, and image creation always continued regardless of success.

This PR fixes the validation checks so that they log MSBuild errors as intended, preventing user confusion around tag values.

## Customer Impact 

When users built containers with invalid tag names (either through providing bad values or incorrect MSBuild property escaping on the CLI) the containers would be built with empty tags, which for most container registries corresponds to the `latest` tag.


## Regression
**Yes,** this regressed in 7.0.300 and a user report of a related issue brought it to our attention

## Risk
Low - the fix is very obvious and we have new test coverage to prevent regressions in this area

## Testing
An automated test that validates that corrupt tag names like users sometimes pass via CLI mangling are caught and the build correctly errors.