### PR TITLE
[fix #37501] Consolidate message emission for dotnet tool install in default verbosity mode(quiet)

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/INuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/INuGetPackageDownloader.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool includeUnlisted = false,
             DirectoryPath? downloadFolder = null,
+            VerbosityOptions verbosity = VerbosityOptions.quiet,
             PackageSourceMapping packageSourceMapping = null);
 
         Task<string> GetPackageUrl(PackageId packageId,

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -81,6 +81,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool includeUnlisted = false,
             DirectoryPath? downloadFolder = null,
+            VerbosityOptions verbosity = VerbosityOptions.quiet,
             PackageSourceMapping packageSourceMapping = null)
         {
             CancellationToken cancellationToken = CancellationToken.None;
@@ -125,19 +126,22 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                         packageVersion.ToNormalizedString()));
             }
 
-            VerifySigning(nupkgPath);
+            VerifySigning(nupkgPath, verbosity);
 
             return nupkgPath;
         }
 
-        private void VerifySigning(string nupkgPath)
+        private void VerifySigning(string nupkgPath, VerbosityOptions verbosity)
         {
             if (!_verifySignatures)
             {
                 if (!_validationMessagesDisplayed)
                 {
-                    _reporter.WriteLine(
-                        LocalizableStrings.NuGetPackageSignatureVerificationSkipped);
+                    if (!verbosity.IsQuiet())
+                    {
+                        _reporter.WriteLine(
+                            LocalizableStrings.NuGetPackageSignatureVerificationSkipped);
+                    }
                     _validationMessagesDisplayed = true;
                 }
 

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Cli.ToolPackage
         }
 
         public IToolPackage InstallPackage(PackageLocation packageLocation, PackageId packageId,
-            VerbosityOptions verbosity = VerbosityOptions.normal,
+            VerbosityOptions verbosity = VerbosityOptions.quiet,
             VersionRange versionRange = null,
             string targetFramework = null,
             bool isGlobalTool = false
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Cli.ToolPackage
 
                     if (package == null)
                     {
-                        DownloadAndExtractPackage(packageLocation, packageId, nugetPackageDownloader, toolDownloadDir.Value, _toolPackageStore, packageVersion, packageSourceLocation, includeUnlisted: givenSpecificVersion).GetAwaiter().GetResult();
+                        DownloadAndExtractPackage(packageLocation, packageId, nugetPackageDownloader, toolDownloadDir.Value, _toolPackageStore, packageVersion, packageSourceLocation, verbosity, includeUnlisted: givenSpecificVersion).GetAwaiter().GetResult();
                     }
                     else if(isGlobalTool)
                     {
@@ -248,10 +248,11 @@ namespace Microsoft.DotNet.Cli.ToolPackage
             IToolPackageStore toolPackageStore,
             NuGetVersion packageVersion,
             PackageSourceLocation packageSourceLocation,
+            VerbosityOptions verbosity, 
             bool includeUnlisted = false
             )
         {
-            var packagePath = await nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation, includeUnlisted: includeUnlisted).ConfigureAwait(false);
+            var packagePath = await nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation, verbosity: verbosity, includeUnlisted: includeUnlisted).ConfigureAwait(false);
 
             // look for package on disk and read the version
             NuGetVersion version;

--- a/src/Tests/dotnet-workload-install.Tests/FailingNuGetPackageInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/FailingNuGetPackageInstaller.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool includeUnlisted = false,
             DirectoryPath? downloadFolder = null,
+            VerbosityOptions verbosity = VerbosityOptions.quiet,
             PackageSourceMapping packageSourceMapping = null)
         {
             var mockPackagePath = Path.Combine(MockPackageDir, $"{packageId}.{packageVersion}.nupkg");

--- a/src/Tests/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
@@ -38,6 +38,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool includeUnlisted = false,
             DirectoryPath? downloadFolder = null,
+            VerbosityOptions verbosity = VerbosityOptions.quiet,
             PackageSourceMapping packageSourceMapping = null)
         {
             DownloadCallParams.Add((packageId, packageVersion, downloadFolder, packageSourceLocation));

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -426,6 +426,22 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         }
 
         [Fact]
+        public void WhenRunWithPackageIdWithQuietItShouldShowNoSignatureVerifySigningMessage()
+        {
+            var result = Parser.Instance.Parse($"dotnet tool install -g {PackageId}");
+            var toolInstallGlobalOrToolPathCommand = new ToolInstallGlobalOrToolPathCommand(
+                result,
+                _createToolPackageStoresAndDownloader,
+                _createShellShimRepository,
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
+                _reporter);
+
+            toolInstallGlobalOrToolPathCommand.Execute().Should().Be(0);
+
+            _reporter.Lines.Should().NotContain(string.Format(Cli.NuGetPackageDownloader.LocalizableStrings.NuGetPackageSignatureVerificationSkipped).Green());
+        }
+
+        [Fact]
         public void WhenRunWithPrereleaseAndPackageVersionItShouldThrow()
         {
             IToolPackageDownloader toolToolPackageDownloader = GetToolToolPackageDownloaderWithPreviewInFeed();
@@ -469,26 +485,6 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     }
                 });
             return toolToolPackageDownloader;
-        }
-
-        [Fact]
-        public void WhenRunWithPackageIdWithQuietItShouldShowNoSignatureVerifySigningMessage()
-        {
-            var parseResultQuiet = Parser.Instance.Parse($"dotnet tool install -g {PackageId} --verbosity quiet");
-            var toolInstallGlobalOrToolPathCommand = new ToolInstallGlobalOrToolPathCommand(
-                parseResultQuiet,
-                _createToolPackageStoresAndDownloader,
-                _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
-                _reporter);
-
-            toolInstallGlobalOrToolPathCommand.Execute().Should().Be(0);
-
-            _reporter
-                .Lines
-                .Should()
-                .NotContain(string.Format(
-                    Cli.NuGetPackageDownloader.LocalizableStrings.NuGetPackageSignatureVerificationSkipped).Green());
         }
 
         [Fact]

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -472,6 +472,26 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         }
 
         [Fact]
+        public void WhenRunWithPackageIdWithQuietItShouldShowNoSignatureVerifySigningMessage()
+        {
+            var parseResultQuiet = Parser.Instance.Parse($"dotnet tool install -g {PackageId} --verbosity quiet");
+            var toolInstallGlobalOrToolPathCommand = new ToolInstallGlobalOrToolPathCommand(
+                parseResultQuiet,
+                _createToolPackageStoresAndDownloader,
+                _createShellShimRepository,
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
+                _reporter);
+
+            toolInstallGlobalOrToolPathCommand.Execute().Should().Be(0);
+
+            _reporter
+                .Lines
+                .Should()
+                .NotContain(string.Format(
+                    Cli.NuGetPackageDownloader.LocalizableStrings.NuGetPackageSignatureVerificationSkipped).Green());
+        }
+
+        [Fact]
         public void WhenRunWithoutAMatchingRangeItShouldFail()
         {
             ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {PackageId} --version [5.0,10.0]");


### PR DESCRIPTION
#37501 

**Description**
Per #37501, we should consolidate the message in different verbosity mode. In the default verbosity mode of quiet, no message should be emitted for `dotnet tool install`, including the verify signing message.

**Use case**

```
$ dotnet tool install Sample.tool -g

(message empty)


$ dotnet tool install Sample.tool -g --verbosity minimal
Skipping NuGet package signature verification.
You can invoke the tool using the following command: sample-command
Tool 'sample.tool' (version '1.0.0') was successfully installed.
```