### PR TITLE
Unset SuppressTfmSupportBuildWarnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,8 +12,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IsShippingPackage>false</IsShippingPackage>
     <SdkTargetFramework>net9.0</SdkTargetFramework>
-    <!-- Temporarily disable build warnings while upgrading to the net9.0 TFM -->
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <ToolsetTargetFramework>$(SdkTargetFramework)</ToolsetTargetFramework>
 
     <!-- VS for Mac may run on a lower version of .NET than the SDK is targeting, but needs to load the resolvers.  So the resolvers and dependencies


### PR DESCRIPTION
The switch should not be set in product construction and was only added as a workaround while updating TFMs