### PR TITLE
Install manifests for rollback after update --from-rollback-file

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             if (!skipManifestUpdate)
             {
                 var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
-                if (File.Exists(installStateFilePath))
+                if (File.Exists(installStateFilePath) && string.IsNullOrWhiteSpace(_fromRollbackDefinition))
                 {
                     //  If there is a rollback state file, then we don't want to automatically update workloads when a workload is installed
                     //  To update to a new version, the user would need to run "dotnet workload update"


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/37958 for 1xx

**Description**
Manifest updates were disabled for Install if the user had previously updated --from-rollback-file, as that clearly indicates they wanted to pin to a specific set of versions, but that did not take into consideration if a user wanted to install --from-rollback-file, which similarly indicates they want a specific version but a different specific version. This takes that into account.

**Customer Impact**
Customers who called `dotnet workload update --from-rollback-file <file>` then `dotnet workload install --from-rollback-file <file>` would have the second command not install the desired versions.

**Regression**?
Yes. The decision to update or not update is made based on the install state file that was only added in 8.0.1xx.

**Risk**
Low

**Tests**
TBD