### PR TITLE
Remove unneeded strings from an error message

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -107,7 +107,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             else if (_skipManifestUpdate && usedRollback)
             {
                 throw new GracefulException(string.Format(LocalizableStrings.CannotCombineSkipManifestAndRollback,
-                    WorkloadInstallCommandParser.SkipManifestUpdateOption.Name, InstallingWorkloadCommandParser.FromRollbackFileOption.Name,
                     WorkloadInstallCommandParser.SkipManifestUpdateOption.Name, InstallingWorkloadCommandParser.FromRollbackFileOption.Name), isUserError: true);
             }
             else

--- a/test/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/test/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdErrContaining(string.Format(Workloads.Workload.Install.LocalizableStrings.CannotCombineSkipManifestAndRollback, "skip-manifest-update", "from-rollback-file", "skip-manifest-update", "from-rollback-file"));
+                .HaveStdErrContaining(string.Format(Workloads.Workload.Install.LocalizableStrings.CannotCombineSkipManifestAndRollback, "skip-manifest-update", "from-rollback-file"));
         }
 
 


### PR DESCRIPTION
I noticed the format command had 4 strings but the underlying string only had {0} and {1}. I assume this was a cut/paste error