### PR TITLE
Remove the workload feature band

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,6 @@
   <!-- Repo Version Information -->
   <PropertyGroup>
     <VersionPrefix>8.0.102</VersionPrefix>
-    <WorkloadsFeatureBand>8.0.100</WorkloadsFeatureBand>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>


### PR DESCRIPTION
This was originally supposed to be used in the overlay but I ended up using separate ones for emsdk and mono. So this property was never used and now it's causing confusion. Remove it.