### PR TITLE
Ensure dotnet/aspnet base image can be inferred for ASP.Net applications

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
@@ -40,6 +40,11 @@ internal static class KnownStrings
         public static readonly string InvariantGlobalization = nameof(InvariantGlobalization);
     }
 
+    public static class Items
+    {
+        public static readonly string FrameworkReference = nameof(FrameworkReference);
+    }
+
     public static class ErrorCodes
     {
         public static readonly string CONTAINER002 = nameof(CONTAINER002);

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
@@ -74,7 +74,10 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
     [Output]
     public string? ComputedContainerBaseImage { get; private set; }
 
-    private bool IsAspNetCoreProject => FrameworkReferences.Length > 0 && FrameworkReferences.Any(x => x.ItemSpec.Equals("Microsoft.AspnetCore.App", StringComparison.Ordinal));
+    private bool IsAspNetCoreProject =>
+        FrameworkReferences.Length > 0
+        && FrameworkReferences.Any(x => x.ItemSpec.Equals("Microsoft.AspNetCore.App", StringComparison.OrdinalIgnoreCase));
+
     private bool IsMuslRid => TargetRuntimeIdentifier.StartsWith("linux-musl", StringComparison.Ordinal);
     private bool IsBundledRuntime => IsSelfContained;
     private bool NeedsNightlyImages => IsAotPublished;

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -357,4 +357,30 @@ public class TargetsTests
         var computedBaseImageTag = instance.GetProperty(ContainerBaseImage)?.EvaluatedValue;
         computedBaseImageTag.Should().BeEquivalentTo(expectedImage);
     }
+
+    [Fact]
+    public void AspNetFDDAppsGetAspNetBaseImage()
+    {
+        var expectedImage = "mcr.microsoft.com/dotnet/aspnet:8.0";
+        var (project, logger, d) = ProjectInitializer.InitProject(new()
+        {
+            ["NetCoreSdkVersion"] = "8.0.200",
+            ["TargetFrameworkVersion"] = "v8.0",
+            [KnownStrings.Properties.ContainerRuntimeIdentifier] = "linux-x64",
+        }, bonusItems: new()
+        {
+            [KnownStrings.Items.FrameworkReference] = KnownFrameworkReferences.WebApp
+        }, projectName: $"{nameof(AspNetFDDAppsGetAspNetBaseImage)}");
+        using var _ = d;
+        var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
+        instance.Build(new[] { ComputeContainerBaseImage }, null, null, out var outputs).Should().BeTrue(String.Join(Environment.NewLine, logger.Errors));
+        var computedBaseImageTag = instance.GetProperty(ContainerBaseImage)?.EvaluatedValue;
+        computedBaseImageTag.Should().BeEquivalentTo(expectedImage);
+    }
+
+    private static class KnownFrameworkReferences
+    {
+        public static Microsoft.Build.Framework.ITaskItem[] ConsoleApp { get; } = [new Microsoft.Build.Utilities.TaskItem("Microsoft.NETCore.App")];
+        public static Microsoft.Build.Framework.ITaskItem[] WebApp { get; } = [.. ConsoleApp, new Microsoft.Build.Utilities.TaskItem("Microsoft.AspNetCore.App")];
+    }
 }


### PR DESCRIPTION
## Description

Starting in 8.0.200 previews, framework dependent ASP.Net applications would choose an incorrect base image during containerization. The root cause was incorrect casing when checking for the ASP.Net Framework Reference when making decisions about the kind of base image to choose. This was found and reported by @bradygaster when doing some testing with Aspire on 8.0.200 previews - thanks @bradygaster!

## Customer Impact 

When the user started the container, the app would crash because the ASP.Net Runtime is missing. Customers have a workaround (publishing the application as SelfContained) but this has nontrivial impacts on maintenance, image size, etc.

## Regression
**Yes,** this regressed from 8.0.100

## Risk
Low - the fix is very obvious and we have new test coverage.

## Testing
An automated test was added to prevent regressions