### PR TITLE
Add filtering to SdkSupportedTargetPlatformVersion validation. Fixes #38016.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -222,7 +222,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     BeforeTargets="ProcessFrameworkReferences"
     Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and ('$(Language)' != 'C++' or '$(_EnablePackageReferencesInVCProjects)' == 'true')">
     <ItemGroup>
-      <_ValidTargetPlatformVersion Include="@(SdkSupportedTargetPlatformVersion)" Condition="'@(SdkSupportedTargetPlatformVersion)' != '' and $([MSBuild]::VersionEquals(%(Identity), $(TargetPlatformVersion)))" />
+      <_ApplicableTargetPlatformVersion Include="@(SdkSupportedTargetPlatformVersion)" Condition="'@(SdkSupportedTargetPlatformVersion)' != '' and '%(SdkSupportedTargetPlatformVersion.OrGreaterHistoricalValue)' != 'true'" RemoveMetadata="OrGreaterHistoricalValue" />
+      <_ValidTargetPlatformVersion Include="@(_ApplicableTargetPlatformVersion)" Condition="'@(_ApplicableTargetPlatformVersion)' != '' and $([MSBuild]::VersionEquals(%(Identity), $(TargetPlatformVersion)))" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -236,8 +237,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and ('$(Language)' != 'C++' or '$(_EnablePackageReferencesInVCProjects)' == 'true')">
     <PropertyGroup>
       <TargetPlatformVersionSupported Condition="'$(TargetPlatformVersionSupported)' == '' and '@(_ValidTargetPlatformVersion)' != ''" >true</TargetPlatformVersionSupported>
-      <_ValidTargetPlatformVersions Condition="'@(SdkSupportedTargetPlatformVersion)' != ''" >@(SdkSupportedTargetPlatformVersion, '%0a')</_ValidTargetPlatformVersions>
-      <_ValidTargetPlatformVersions Condition="'@(SdkSupportedTargetPlatformVersion)' == ''" >None</_ValidTargetPlatformVersions>
+      <_ValidTargetPlatformVersions Condition="'@(_ApplicableTargetPlatformVersion)' != ''" >@(_ApplicableTargetPlatformVersion, '%0a')</_ValidTargetPlatformVersions>
+      <_ValidTargetPlatformVersions Condition="'@(_ApplicableTargetPlatformVersion)' == ''" >None</_ValidTargetPlatformVersions>
     </PropertyGroup>
 
     <NetSdkError Condition="'$(TargetPlatformVersionSupported)' != 'true'"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -222,7 +222,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     BeforeTargets="ProcessFrameworkReferences"
     Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and ('$(Language)' != 'C++' or '$(_EnablePackageReferencesInVCProjects)' == 'true')">
     <ItemGroup>
-      <_ApplicableTargetPlatformVersion Include="@(SdkSupportedTargetPlatformVersion)" Condition="'@(SdkSupportedTargetPlatformVersion)' != '' and '%(SdkSupportedTargetPlatformVersion.OrGreaterHistoricalValue)' != 'true'" RemoveMetadata="OrGreaterHistoricalValue" />
+      <_ApplicableTargetPlatformVersion Include="@(SdkSupportedTargetPlatformVersion)" Condition="'@(SdkSupportedTargetPlatformVersion)' != '' and '%(SdkSupportedTargetPlatformVersion.DefineConstantsOnly)' != 'true'" RemoveMetadata="DefineConstantsOnly" />
       <_ValidTargetPlatformVersion Include="@(_ApplicableTargetPlatformVersion)" Condition="'@(_ApplicableTargetPlatformVersion)' != '' and $([MSBuild]::VersionEquals(%(Identity), $(TargetPlatformVersion)))" />
     </ItemGroup>
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
@@ -92,11 +92,11 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
-        public void It_fails_if_targetplatformversion_is_historical()
+        public void It_fails_if_targetplatformversion_is_constant_only()
         {
             var testProject = new TestProject()
             {
-                Name = "It_fails_if_targetplatform_version_is_historical",
+                Name = "It_fails_if_targetplatformversion_is_constant_only",
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
             };
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -105,7 +105,7 @@ namespace Microsoft.NET.Build.Tests
             string DirectoryBuildTargetsContent = $@"
 <Project>
   <ItemGroup>
-    <SdkSupportedTargetPlatformVersion Include=""111.0"" OrGreaterHistoricalValue=""true"" />
+    <SdkSupportedTargetPlatformVersion Include=""111.0"" DefineConstantsOnly=""true"" />
     <SdkSupportedTargetPlatformVersion Include=""222.0"" />
   </ItemGroup>
   <PropertyGroup>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
@@ -165,7 +165,7 @@ namespace Microsoft.NET.Build.Tests
                 .And
                 .HaveStdOutContaining("NETSDK1140")
                 .And
-                .HaveStdOutContaining("111.0 is not a valid TargetPlatformVersion")
+                .HaveStdOutContaining(string.Format(Strings.InvalidTargetPlatformVersion, "111.0", "ios", "222.0").Split ('\n', '\r') [0])
                 .And
                 .HaveStdOutContaining("222.0");
         }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
@@ -90,5 +90,82 @@ namespace Microsoft.NET.Build.Tests
                 .And
                 .HaveStdOutContaining("NETSDK1139");
         }
+
+        [Fact]
+        public void It_fails_if_targetplatformversion_is_historical()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "It_fails_if_targetplatform_version_is_historical",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+            };
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+
+            string DirectoryBuildTargetsContent = $@"
+<Project>
+  <ItemGroup>
+    <SdkSupportedTargetPlatformVersion Include=""111.0"" OrGreaterHistoricalValue=""true"" />
+    <SdkSupportedTargetPlatformVersion Include=""222.0"" />
+  </ItemGroup>
+  <PropertyGroup>
+    <TargetPlatformVersion>111.0</TargetPlatformVersion>
+    <TargetPlatformIdentifier>ios</TargetPlatformIdentifier>
+    <TargetPlatformSupported>true</TargetPlatformSupported>
+  </PropertyGroup>
+</Project>
+";
+
+            File.WriteAllText(Path.Combine(testAsset.TestRoot, "Directory.Build.targets"), DirectoryBuildTargetsContent);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1140")
+                .And
+                .HaveStdOutContaining("111.0 is not a valid TargetPlatformVersion")
+                .And
+                .HaveStdOutContaining("222.0");
+        }
+
+        [Fact]
+        public void It_fails_if_targetplatformversion_is_invalid()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "It_fails_if_targetplatformversion_is_invalid",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+            };
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+
+            string DirectoryBuildTargetsContent = $@"
+<Project>
+  <ItemGroup>
+    <SdkSupportedTargetPlatformVersion Include=""222.0"" />
+  </ItemGroup>
+  <PropertyGroup>
+    <TargetPlatformVersion>111.0</TargetPlatformVersion>
+    <TargetPlatformIdentifier>ios</TargetPlatformIdentifier>
+    <TargetPlatformSupported>true</TargetPlatformSupported>
+  </PropertyGroup>
+</Project>
+";
+
+            File.WriteAllText(Path.Combine(testAsset.TestRoot, "Directory.Build.targets"), DirectoryBuildTargetsContent);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1140")
+                .And
+                .HaveStdOutContaining("111.0 is not a valid TargetPlatformVersion")
+                .And
+                .HaveStdOutContaining("222.0");
+        }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithATargetPlatform.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.NET.Build.Tasks;
+
 namespace Microsoft.NET.Build.Tests
 {
     public class GivenThatWeWantToBuildWithATargetPlatform : SdkTest
@@ -125,7 +127,7 @@ namespace Microsoft.NET.Build.Tests
                 .And
                 .HaveStdOutContaining("NETSDK1140")
                 .And
-                .HaveStdOutContaining("111.0 is not a valid TargetPlatformVersion")
+                .HaveStdOutContaining(string.Format(Strings.InvalidTargetPlatformVersion, "111.0", "ios", "222.0").Split ('\n', '\r') [0])
                 .And
                 .HaveStdOutContaining("222.0");
         }


### PR DESCRIPTION
The SdkSupportedTargetPlatformVersion item group is used for (at least) two things:

1. Generate the _OR_GREATER preprocessing symbols:

https://github.com/dotnet/sdk/blob/bfd2919bc446cad68d11de90cec4025d3683591c/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets#L230-L237

2. Validate the TargetPlatformVersion:

https://github.com/dotnet/sdk/blob/bfd2919bc446cad68d11de90cec4025d3683591c/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets#L233-L246

The problem is that these two uses aren't equivalent.

Take for example the following scenario:

We release bindings for iOS 10, and a library developer takes advantage of the
bindings for the new iOS version, while at the same time supporting
multi-targeting to older platforms:

```csharp
    #if IOS10_0_OR_GREATER
        UseNewApi ();
    #else
        UseOldApi ();
    #endif
```

Time passes, iOS 11 comes out, and we stop shipping bindings specifically for
iOS 10 (the APIs themselves would be included in the bindings for iOS 11). The
code above should continue to work, but iOS 10 is not a valid
TargetPlatformVersion anymore. However, with the current situation there's no
way to express this, because the moment we remove the "10.0" version from
SdkSupportedTargetPlatformVersion, the IOS10_0_OR_GREATER define isn't
generated anymore.

We discussed this in a meeting internally, and the suggestion that came up
was to use metadata to handle this situation.

So to solve this, I've added metadata to the SdkSupportedTargetPlatformVersion
item group to indicate that a particular value is only valid to produce the
_OR_GREATER processing symbol:

```xml
<ItemGroup>
    <SdkSupportedTargetPlatformVersion Include="10.0" OrGreaterHistoricalValue="true" />
    <SdkSupportedTargetPlatformVersion Include="12.0" />
</ItemGroup>
```

And then filter out these historical values when validating the
TargetPlatformVersion.

Fixes https://github.com/dotnet/sdk/issues/38016.