### PR TITLE
[release/7.0.3xx] Fix the parsing of ContainerImageTags to report invalid tags instead of silently swallowing them

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ParseContainerProperties.cs
@@ -103,12 +103,12 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
                 Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidTag), nameof(ContainerImageTag), ContainerImageTag);
             }
         }
-        else if (ContainerImageTags.Length != 0 && TryValidateTags(ContainerImageTags, out var valids, out var invalids))
+        else if (ContainerImageTags.Length != 0)
         {
-            validTags = valids;
-            if (invalids.Any())
+            (validTags, var invalidTags) = TryValidateTags(ContainerImageTags);
+            if (invalidTags.Any())
             {
-                Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidTags), nameof(ContainerImageTags), String.Join(",", invalids));
+                Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidTags), nameof(ContainerImageTags), String.Join(",", invalidTags));
                 return !Log.HasLoggedErrors;
             }
         }
@@ -197,7 +197,7 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
         }
     }
 
-    private static bool TryValidateTags(string[] inputTags, out string[] validTags, out string[] invalidTags)
+    private static (string[] validTags, string[] invalidTags) TryValidateTags(string[] inputTags)
     {
         var v = new List<string>();
         var i = new List<string>();
@@ -212,8 +212,6 @@ public sealed class ParseContainerProperties : Microsoft.Build.Utilities.Task
                 i.Add(tag);
             }
         }
-        validTags = v.ToArray();
-        invalidTags = i.ToArray();
-        return invalidTags.Length == 0;
+        return (v.ToArray(), i.ToArray());
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/MSBuildCollection.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/MSBuildCollection.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Build.Containers.IntegrationTests;
+
+using Xunit;
+
+/// <summary>
+/// Collection definition for tests that require MSBuild to be run.
+/// </summary>
+/// <remarks>
+/// This collection is used to ensure that tests that require MSBuild are run serially.
+/// The MSBuild engine only allows a single logical Build to run at once, so running tests
+/// that require MSBuild in parallel can cause tests to fail./
+/// </remarks>
+[CollectionDefinition(nameof(MSBuildCollection), DisableParallelization = true)]
+public class MSBuildCollection : ICollectionFixture<MSBuildCollection>
+{
+    // This class has no code, and is never created. Its purpose is simply
+    // to be the place to apply [CollectionDefinition] and all the
+    // ICollectionFixture<> interfaces.
+}

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -12,6 +12,16 @@ namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
 public class ParseContainerPropertiesTests
 {
+
+    public static object _syncObject = new object();
+    private static bool SynchronizedBuild(Microsoft.Build.Execution.ProjectInstance project, string target, Microsoft.Build.Framework.ILogger logger)
+    {
+        lock (_syncObject)
+        {
+            return project.Build(target, new[] { logger });
+        }
+    }
+
     [Fact]
     public void Baseline()
     {
@@ -24,7 +34,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+        Assert.True(SynchronizedBuild(instance, ComputeContainerConfig, logs));
 
         Assert.Equal("mcr.microsoft.com", instance.GetPropertyValue(ContainerBaseRegistry));
         Assert.Equal("dotnet/runtime", instance.GetPropertyValue(ContainerBaseName));
@@ -45,7 +55,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+        Assert.True(SynchronizedBuild(instance, ComputeContainerConfig, logs));
 
         Assert.Equal("mcr.microsoft.com", instance.GetPropertyValue(ContainerBaseRegistry));
         Assert.Equal("dotnet-runtime", instance.GetPropertyValue(ContainerBaseName));
@@ -64,7 +74,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+        Assert.True(SynchronizedBuild(instance, ComputeContainerConfig, logs));
         Assert.Contains(logs.Messages, m => m.Message?.Contains("'dotnet testimage' was not a valid container image name, it was normalized to 'dotnet-testimage'") == true);
     }
 
@@ -80,7 +90,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2007);
@@ -99,7 +109,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2008);
@@ -116,7 +126,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2010);
@@ -134,7 +144,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);
@@ -152,7 +162,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -10,13 +10,13 @@ using static Microsoft.NET.Build.Containers.KnownStrings.Properties;
 
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
-[Collection("Docker tests")]
 public class ParseContainerPropertiesTests
 {
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void Baseline()
     {
-        var (project, _, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerImageName] = "dotnet/testimage",
@@ -24,7 +24,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(instance.Build(new[]{ComputeContainerConfig}, null, null, out var outputs));
+        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.Equal("mcr.microsoft.com", instance.GetPropertyValue(ContainerBaseRegistry));
         Assert.Equal("dotnet/runtime", instance.GetPropertyValue(ContainerBaseName));
@@ -35,26 +35,28 @@ public class ParseContainerPropertiesTests
         instance.GetItems("ProjectCapability").Select(i => i.EvaluatedInclude).ToArray().Should().BeEquivalentTo(new[] { "NetSdkOCIImageBuild" });
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void SpacesGetReplacedWithDashes()
     {
-         var (project, _, d) = ProjectInitializer.InitProject(new () {
-            [ContainerBaseImage] = "mcr microsoft com/dotnet runtime:7.0",
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
+            [ContainerBaseImage] = "mcr.microsoft.com/dotnet runtime:7.0",
             [ContainerRegistry] = "localhost:5010"
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(instance.Build(new[]{ComputeContainerConfig}, null, null, out var outputs));
+        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
-        Assert.Equal("mcr-microsoft-com",instance.GetPropertyValue(ContainerBaseRegistry));
+        Assert.Equal("mcr.microsoft.com", instance.GetPropertyValue(ContainerBaseRegistry));
         Assert.Equal("dotnet-runtime", instance.GetPropertyValue(ContainerBaseName));
         Assert.Equal("7.0", instance.GetPropertyValue(ContainerBaseTag));
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void RegexCatchesInvalidContainerNames()
     {
-         var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerImageName] = "dotnet testimage",
@@ -62,14 +64,15 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(instance.Build(new[]{ComputeContainerConfig}, new [] { logs }, null, out var outputs));
+        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
         Assert.Contains(logs.Messages, m => m.Message?.Contains("'dotnet testimage' was not a valid container image name, it was normalized to 'dotnet-testimage'") == true);
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void RegexCatchesInvalidContainerTags()
     {
-        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerImageName] = "dotnet/testimage",
@@ -77,16 +80,17 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2007);
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void CanOnlySupplyOneOfTagAndTags()
     {
-        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerImageName] = "dotnet/testimage",
@@ -95,16 +99,34 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2008);
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
+    public void InvalidTagsThrowError()
+    {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
+            [ContainerBaseImage] = "mcr.microsoft.com/dotnet/aspnet:8.0",
+            [ContainerImageName] = "dotnet/testimage",
+            [ContainerImageTags] = "'latest;oldest'"
+        });
+        using var _ = d;
+        var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
+
+        Assert.True(logs.Errors.Count > 0);
+        Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2010);
+    }
+
+    [Fact]
     public void FailsOnCompletelyInvalidRepositoryNames()
     {
-        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerImageName] = "㓳㓴㓵㓶㓷㓹㓺㓻",
@@ -112,16 +134,17 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);
     }
 
-    [DockerDaemonAvailableFact]
+    [Fact]
     public void FailsWhenFirstCharIsAUnicodeLetterButNonLatin()
     {
-        var (project, logs, d) = ProjectInitializer.InitProject(new () {
+        var (project, logs, d) = ProjectInitializer.InitProject(new()
+        {
             [ContainerBaseImage] = "mcr.microsoft.com/dotnet/runtime:7.0",
             [ContainerRegistry] = "localhost:5010",
             [ContainerImageName] = "㓳but-otherwise-valid",
@@ -129,7 +152,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(instance.Build(new[]{ComputeContainerConfig},  new [] { logs }, null, out var outputs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -10,6 +10,7 @@ using static Microsoft.NET.Build.Containers.KnownStrings.Properties;
 
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
+[Collection(nameof(MSBuildCollection))]
 public class ParseContainerPropertiesTests
 {
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -13,16 +13,6 @@ namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 [Collection(nameof(MSBuildCollection))]
 public class ParseContainerPropertiesTests
 {
-
-    public static object _syncObject = new object();
-    private static bool SynchronizedBuild(Microsoft.Build.Execution.ProjectInstance project, string target, Microsoft.Build.Framework.ILogger logger)
-    {
-        lock (_syncObject)
-        {
-            return project.Build(target, new[] { logger });
-        }
-    }
-
     [Fact]
     public void Baseline()
     {
@@ -35,7 +25,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(SynchronizedBuild(instance, ComputeContainerConfig, logs));
+        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.Equal("mcr.microsoft.com", instance.GetPropertyValue(ContainerBaseRegistry));
         Assert.Equal("dotnet/runtime", instance.GetPropertyValue(ContainerBaseName));
@@ -56,7 +46,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(SynchronizedBuild(instance, ComputeContainerConfig, logs));
+        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.Equal("mcr.microsoft.com", instance.GetPropertyValue(ContainerBaseRegistry));
         Assert.Equal("dotnet-runtime", instance.GetPropertyValue(ContainerBaseName));
@@ -75,7 +65,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.True(SynchronizedBuild(instance, ComputeContainerConfig, logs));
+        Assert.True(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
         Assert.Contains(logs.Messages, m => m.Message?.Contains("'dotnet testimage' was not a valid container image name, it was normalized to 'dotnet-testimage'") == true);
     }
 
@@ -91,7 +81,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2007);
@@ -110,7 +100,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2008);
@@ -127,7 +117,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2010);
@@ -145,7 +135,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);
@@ -163,7 +153,7 @@ public class ParseContainerPropertiesTests
         });
         using var _ = d;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
-        Assert.False(SynchronizedBuild(instance, ComputeContainerConfig, logs));
+        Assert.False(instance.Build(new[] { ComputeContainerConfig }, new[] { logs }, null, out var outputs));
 
         Assert.True(logs.Errors.Count > 0);
         Assert.Equal(logs.Errors[0].Code, ErrorCodes.CONTAINER2005);

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 
 namespace Microsoft.NET.Build.Containers.Targets.IntegrationTests;
 
+[Collection(nameof(MSBuildCollection))]
 public class TargetsTests
 {
     [InlineData(true, "/app/foo.exe")]


### PR DESCRIPTION
This is a manual backport of https://github.com/dotnet/sdk/pull/37832 since the backport action ran into conflicts.