### PR TITLE
Using dotnet workoad update --mode hits NRE on success with MSI-based installs

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
                         case InstallRequestType.AdjustWorkloadMode:
                             UpdateInstallMode(new SdkFeatureBand(request.SdkFeatureBand), request.UseWorkloadSets);
-                            string newMode = request.ProductCode.Equals("true", StringComparison.OrdinalIgnoreCase) ? "workload sets" : "loose manifests";
+                            string newMode = request.UseWorkloadSets ? "workload sets" : "loose manifests";
                             Dispatcher.ReplySuccess($"Updated install mode to use {newMode}.");
                             break;
 


### PR DESCRIPTION
Fixes #38078 

Description
`dotnet workload update --mode <parameter>` throws a null reference exception. This is a new option. After the operation succeeds, the server sends a response to the client to indicate success. That message is customized using information from the request to make a more useful message. Just before merging the PR introducing it, the name of the variable used in crafting that message was changed to a new value. That means the old value is no longer set, and it throws a null reference exception when we try to access it to craft the message.

Customer Impact
Customers trying to specify whether they want to use workload sets or loose manifests see a null-reference exception instead of a success message. (The command otherwise works as intended.)

Regression
No. This is a new flag.

Risk
Low - the fix is specific to a method only used for this new subcommand and is entirely after the part that currently works.

Testing
I verified that the update --mode operation was broken in both main and 8.0.2xx. I then checked the output of the command is correct other than the error message.