### PR TITLE
Enable msbuild terminal logger for dotnet test

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -194,6 +194,9 @@
     <FluentAssertionsVersion>6.12.0</FluentAssertionsVersion>
     <FluentAssertionsJsonVersion>6.1.0</FluentAssertionsJsonVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>9.0.0-beta.24065.5</MicrosoftDotNetXUnitExtensionsVersion>
+    <XUnitRunnerVisualStudioVersion>2.5.6</XUnitRunnerVisualStudioVersion>
+    <XUnitVersion>2.6.6</XUnitVersion>
+    <XUnitAnalyzersVersion>1.10.0</XUnitAnalyzersVersion>
     <MoqPackageVersion>4.18.4</MoqPackageVersion>
     <XunitCombinatorialVersion>1.3.2</XunitCombinatorialVersion>
     <MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>8.0.0-beta.23607.1</MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -194,9 +194,6 @@
     <FluentAssertionsVersion>6.12.0</FluentAssertionsVersion>
     <FluentAssertionsJsonVersion>6.1.0</FluentAssertionsJsonVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>9.0.0-beta.24065.5</MicrosoftDotNetXUnitExtensionsVersion>
-    <XUnitRunnerVisualStudioVersion>2.5.6</XUnitRunnerVisualStudioVersion>
-    <XUnitVersion>2.6.6</XUnitVersion>
-    <XUnitAnalyzersVersion>1.10.0</XUnitAnalyzersVersion>
     <MoqPackageVersion>4.18.4</MoqPackageVersion>
     <XunitCombinatorialVersion>1.3.2</XunitCombinatorialVersion>
     <MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>8.0.0-beta.23607.1</MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>

--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
-using Microsoft.TemplateEngine.Core.Operations;
 
 namespace Microsoft.DotNet.Tools.Test
 {
@@ -74,7 +72,6 @@ namespace Microsoft.DotNet.Tools.Test
                 }
                 else if (propertyValue.ToLowerInvariant() == "true")
                 {
-
                     // User specified the property themselves. Do nothing.
                     additionalBuildProperties = Array.Empty<string>();
                 }

--- a/test/Microsoft.NET.TestFramework/Commands/DotnetTestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/DotnetTestCommand.cs
@@ -5,10 +5,16 @@ namespace Microsoft.NET.TestFramework.Commands
 {
     public class DotnetTestCommand : DotnetCommand
     {
-        public DotnetTestCommand(ITestOutputHelper log, params string[] args) : base(log)
+        public DotnetTestCommand(ITestOutputHelper log, bool disableNewOutput, params string[] args) : base(log)
         {
             Arguments.Add("test");
-            Arguments.AddRange(args);
+            if (disableNewOutput)
+            {
+                Arguments.Add("--property:VsTestUseMSBuildOutput=false");
+                Arguments.Add("-tl:false");
+                Arguments.Add("--logger:console;verbosity=normal");
+            }
+            // Arguments.AddRange(args);
         }
     }
 }

--- a/test/Microsoft.NET.TestFramework/Commands/DotnetTestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/DotnetTestCommand.cs
@@ -13,7 +13,8 @@ namespace Microsoft.NET.TestFramework.Commands
                 Arguments.Add("--property:VsTestUseMSBuildOutput=false");
                 Arguments.Add("-tl:false");
             }
-            // Arguments.AddRange(args);
+
+            Arguments.AddRange(args);
         }
     }
 }

--- a/test/Microsoft.NET.TestFramework/Commands/DotnetTestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/DotnetTestCommand.cs
@@ -12,7 +12,6 @@ namespace Microsoft.NET.TestFramework.Commands
             {
                 Arguments.Add("--property:VsTestUseMSBuildOutput=false");
                 Arguments.Add("-tl:false");
-                Arguments.Add("--logger:console;verbosity=normal");
             }
             // Arguments.AddRange(args);
         }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsArtifactPostProcessing.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsArtifactPostProcessing.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             string runsettings = GetRunsetting(testInstance.Path);
 
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                     .WithWorkingDirectory(testInstance.Path)
                                     .WithEnvironmentVariable(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING, "0")
                                     .Execute(
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             new PublishCommand(Log, Path.Combine(testInstance.Path, "sln.sln")).Execute("/p:Configuration=Release").Should().Pass();
 
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                     .WithWorkingDirectory(testInstance.Path)
                                     .WithEnvironmentVariable(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING, "0")
                                     .WithEnvironmentVariable("DOTNET_CLI_VSTEST_TRACE", "1")

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsArtifactPostProcessing.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsArtifactPostProcessing.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             new PublishCommand(Log, Path.Combine(testInstance.Path, "sln.sln")).Execute("/p:Configuration=Release").Should().Pass();
 
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
                                     .WithEnvironmentVariable(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING, "0")
                                     .WithEnvironmentVariable("DOTNET_CLI_VSTEST_TRACE", "1")

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute()
                 .Should().Pass();
 
-            var result = new DotnetTestCommand(Log, "-r", runtime)
+            var result = new DotnetTestCommand(Log, disableNewOutput: true, "-r", runtime)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute(ConsoleLoggerOutputNormal);
 
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Pass();
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                        .WithWorkingDirectory(testProjectDirectory)
                                        .Execute(ConsoleLoggerOutputNormal);
 
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             }
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log, ConsoleLoggerOutputNormal)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true, ConsoleLoggerOutputNormal)
                                        .WithWorkingDirectory(testProjectDirectory)
                                        .Execute("--collect", "Code Coverage", "--results-directory", resultsDirectory);
 
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             string projectDirectory = Path.Combine(testInstance.Path, "XUnitProject");
 
-            new DotnetTestCommand(Log, ConsoleLoggerOutputNormal)
+            new DotnetTestCommand(Log, disableNewOutput: true, ConsoleLoggerOutputNormal)
                .WithWorkingDirectory(projectDirectory)
                .Execute("--framework", ToolsetInfo.CurrentTargetFramework)
                .Should().Pass();
@@ -179,7 +179,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Should()
                 .Pass();
 
-            new DotnetTestCommand(Log, ConsoleLoggerOutputNormal)
+            new DotnetTestCommand(Log, disableNewOutput: true, ConsoleLoggerOutputNormal)
                .WithWorkingDirectory(testAsset.TestRoot)
                .Execute()
                .Should().Pass();

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromDll.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromDll.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var outputDll = Path.Combine(buildCommand.GetOutputDirectory(configuration: configuration).FullName, $"{testAppName}.dll");
 
             // Call vstest
-            var result = new DotnetTestCommand(Log, disableNewOutput: true)
+            var result = new DotnetTestCommand(Log, disableNewOutput: false)
                 .Execute(outputDll, "--logger:console;verbosity=normal");
             if (!TestContext.IsLocalized())
             {

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromDll.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromDll.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var outputDll = Path.Combine(buildCommand.GetOutputDirectory(configuration: configuration).FullName, $"{testAppName}.dll");
 
             // Call vstest
-            var result = new DotnetTestCommand(Log)
+            var result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .Execute(outputDll, "--logger:console;verbosity=normal");
             if (!TestContext.IsLocalized())
             {
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var outputDll = Path.Combine(testRoot, "bin", configuration, ToolsetInfo.CurrentTargetFramework, $"{testAppName}.dll");
 
             // Call dotnet test + dll
-            var result = new DotnetTestCommand(Log)
+            var result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .Execute(outputDll, "--logger:console;verbosity=normal");
 
             result.ExitCode.Should().Be(1);
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var outputDll = Path.Combine(testRoot, "bin", configuration, ToolsetInfo.CurrentTargetFramework, $"{testAppName}.dll");
 
             // Call vstest
-            var result = new DotnetTestCommand(Log)
+            var result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .Execute(outputDll, "--arch", "wrongArchitecture");
             if (!TestContext.IsLocalized())
             {
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute()
                 .Should().Pass();
 
-            var result = new DotnetTestCommand(Log)
+            var result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .Execute(arg);
             if (!TestContext.IsLocalized())
             {

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("3");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(ConsoleLoggerOutputNormal);
 
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var testProjectDirectory = testInstance.Path;
 
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(ConsoleLoggerOutputNormal);
 
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var testProjectDirectory = testInstance.Path;
 
-            new DotnetTestCommand(Log)
+            new DotnetTestCommand(Log, disableNewOutput: true)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute(ConsoleLoggerOutputNormal.Concat(new[] { "--no-restore", "/p:IsTestProject=true" }))
                 .Should().Fail()
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var testProjectDirectory = testInstance.Path;
 
-            new DotnetTestCommand(Log, ConsoleLoggerOutputNormal)
+            new DotnetTestCommand(Log, disableNewOutput: true, ConsoleLoggerOutputNormal)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute("--no-restore", "/p:IsTestProject=''")
                 .Should().Pass();
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Pass();
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(ConsoleLoggerOutputNormal);
 
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithSource()
                 .WithVersionVariables();
 
-            var result = new DotnetTestCommand(Log)
+            var result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .WithWorkingDirectory(testInstance.Path)
                 .Execute();
 
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             }
 
             // Call test with logger enable
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                        .WithWorkingDirectory(testProjectDirectory)
                                        .Execute("--logger", "trx;logfilename=custom.trx", "--logger",
                                             "console;verbosity=normal", "--", "RunConfiguration.ResultsDirectory=" + trxLoggerDirectory);
@@ -204,7 +204,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             expectedError = "The test source file " + "\"" + expectedError + "\"" + " provided was not found.";
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                        .WithWorkingDirectory(testProjectDirectory)
                                        .Execute("--no-build", "-v:m");
 
@@ -236,7 +236,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             }
 
             // Call test with trx logger enabled and results directory explicitly specified.
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                        .WithWorkingDirectory(testProjectDirectory)
                                        .Execute("--logger", "trx", "--results-directory", trxLoggerDirectory);
 
@@ -267,7 +267,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             }
 
             // Call test with logger enable
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                        .WithWorkingDirectory(testProjectDirectory)
                                        .Execute("--logger", "trx;logfilename=custom.trx", "--",
                                                 "RunConfiguration.ResultsDirectory=" + trxLoggerDirectory);
@@ -317,7 +317,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Pass()
                 .And.NotHaveStdErr();
 
-            CommandResult result = new DotnetTestCommand(Log, ConsoleLoggerOutputNormal)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true, ConsoleLoggerOutputNormal)
                                         .WithWorkingDirectory(rootPath)
                                         .Execute("--no-restore");
 
@@ -345,7 +345,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp($"9_{verbosity}");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute("-v", verbosity);
 
@@ -390,7 +390,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Pass()
                 .And.NotHaveStdErr();
 
-            var result = new DotnetTestCommand(Log, ConsoleLoggerOutputNormal)
+            var result = new DotnetTestCommand(Log, disableNewOutput: true, ConsoleLoggerOutputNormal)
                 .WithWorkingDirectory(rootPath)
                 .Execute("--no-build", "--runtime", rid);
 
@@ -417,7 +417,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("14");
 
             // Call test with logger enable
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                        .WithWorkingDirectory(testProjectDirectory)
                                        .Execute("--nologo");
 
@@ -447,7 +447,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var settingsPath = Path.Combine(AppContext.BaseDirectory, "CollectCodeCoverage.runsettings");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(
                                             "--settings", settingsPath,
@@ -486,7 +486,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             }
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(
                                             "--collect", "Code Coverage",
@@ -522,7 +522,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             }
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(
                                             "--collect", "Code Coverage;Format=Cobertura",
@@ -558,7 +558,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             }
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(
                                             "--collect", "XPlat Code Coverage;arg1=val1",
@@ -591,7 +591,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("13");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(
                                             "--collect", "Code Coverage",
@@ -615,7 +615,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("13");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(
                                             "--collect", "Code Coverage",
@@ -645,7 +645,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = testInstance.Path;
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute();
 
@@ -668,7 +668,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var testProjectDirectory = testInstance.Path;
 
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(ConsoleLoggerOutputNormal);
 
@@ -692,7 +692,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = testInstance.Path;
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute("--arch", "wrongArchitecture");
 
@@ -720,7 +720,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = testInstance.Path;
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute("--filter", filter);
 
@@ -743,7 +743,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var pathWithComma = Path.Combine(AppContext.BaseDirectory, "a,b");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute(flag, pathWithComma);
 
@@ -791,7 +791,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             string flagDirectory = Path.Combine(testProjectDirectory, "flag-dir");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute(flag, flagDirectory + slashesOrBackslashes);
 
@@ -815,7 +815,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp();
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .Execute(testProjectDirectory, arg);
 
             // Verify

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp("2");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(ConsoleLoggerOutputNormal.Concat(new[] {
                                             "--",
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var outputDll = Path.Combine(OutputPathCalculator.FromProject(testProjectDirectory).GetOutputDirectory(configuration: configuration), "VSTestTestRunParameters.dll");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .Execute(ConsoleLoggerOutputNormal.Concat(new[] {
                                             outputDll,
                                             "--",

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var outputDll = Path.Combine(OutputPathCalculator.FromProject(testProjectDirectory).GetOutputDirectory(configuration: configuration), "VSTestTestRunParameters.dll");
 
             // Call test
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                         .Execute(ConsoleLoggerOutputNormal.Concat(new[] {
                                             outputDll,
                                             "--",

--- a/test/dotnet-test.Tests/GivenDotnetTestContainsEnvironmentVariables.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestContainsEnvironmentVariables.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var outputDll = Path.Combine(buildCommand.GetOutputDirectory(configuration: configuration).FullName, $"{TestAppName}.dll");
 
-            var result = new DotnetTestCommand(Log, disableNewOutput: true, EnvironmentVariables)
+            var result = new DotnetTestCommand(Log, disableNewOutput: false, EnvironmentVariables)
                 .Execute(outputDll, $"{ConsoleLoggerOutputDetailed[0]}:{ConsoleLoggerOutputDetailed[1]}");
 
             result.StartInfo.Arguments

--- a/test/dotnet-test.Tests/GivenDotnetTestContainsEnvironmentVariables.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestContainsEnvironmentVariables.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var testRoot = testAsset.Path;
 
-            CommandResult result = new DotnetTestCommand(Log, EnvironmentVariables)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true, EnvironmentVariables)
                                         .WithWorkingDirectory(testRoot)
                                         .Execute(ConsoleLoggerOutputDetailed);
 
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var outputDll = Path.Combine(buildCommand.GetOutputDirectory(configuration: configuration).FullName, $"{TestAppName}.dll");
 
-            var result = new DotnetTestCommand(Log, EnvironmentVariables)
+            var result = new DotnetTestCommand(Log, disableNewOutput: true, EnvironmentVariables)
                 .Execute(outputDll, $"{ConsoleLoggerOutputDetailed[0]}:{ConsoleLoggerOutputDetailed[1]}");
 
             result.StartInfo.Arguments

--- a/test/dotnet-test.Tests/GivenDotnetTestContainsMSBuildParameters.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestContainsMSBuildParameters.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var testRoot = testAsset.Path;
 
-            CommandResult result = (projectName is null ? new DotnetTestCommand(Log) : new DotnetTestCommand(Log, projectName))
+            CommandResult result = (projectName is null ? new DotnetTestCommand(Log, disableNewOutput: true) : new DotnetTestCommand(Log, disableNewOutput: true, projectName))
                                     .WithWorkingDirectory(testRoot)
                                     .Execute("--logger", "console;verbosity=detailed", MSBuildParameter);
 

--- a/test/dotnet-test.Tests/GivenDotnetTestForwardDotnetRootEnvironmentVariables.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestForwardDotnetRootEnvironmentVariables.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithSource()
                 .WithVersionVariables();
 
-            var command = new DotnetTestCommand(Log).WithWorkingDirectory(testAsset.Path);
+            var command = new DotnetTestCommand(Log, disableNewOutput: true).WithWorkingDirectory(testAsset.Path);
             command.EnvironmentToRemove.Add("DOTNET_ROOT");
             command.EnvironmentToRemove.Add("DOTNET_ROOT(x86)");
             var result = command.Execute(ConsoleLoggerOutputDetailed);

--- a/test/dotnet-test.Tests/GivenDotnetTestsRunsInDifferentCultures.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestsRunsInDifferentCultures.cs
@@ -22,7 +22,7 @@ public class CultureAwareTestProject : SdkTest
                 .WithSource()
                 .WithVersionVariables();
 
-        var command = new DotnetTestCommand(Log).WithWorkingDirectory(testAsset.Path).WithCulture(locale);
+        var command = new DotnetTestCommand(Log, disableNewOutput: true).WithWorkingDirectory(testAsset.Path).WithCulture(locale);
         var result = command.Execute();
 
         result.ExitCode.Should().Be(0);

--- a/test/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("XunitCore")
                 .WithSource();
 
-            App.Start(testAsset, ["--verbose", "test", "--list-tests"]);
+            App.Start(testAsset, ["--verbose", "test", "--list-tests", "--property:VSTestUseMSBuildOutput=false"]);
 
             await App.AssertOutputLineEquals("The following Tests are available:");
             await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitPassTest");
@@ -207,7 +207,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("XunitMulti")
                 .WithSource();
 
-            App.Start(testAsset, ["--verbose", "--framework", ToolsetInfo.CurrentTargetFramework, "test", "--list-tests"]);
+            App.Start(testAsset, ["--verbose", "--framework", ToolsetInfo.CurrentTargetFramework, "test", "--list-tests", "--property:VSTestUseMSBuildOutput=false"]);
 
             await App.AssertOutputLineEquals("The following Tests are available:");
             await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitFailTestNetCoreApp");

--- a/test/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("XunitCore")
                 .WithSource();
 
-            App.Start(testAsset, ["--verbose", "test", "--list-tests", "--property:VSTestUseMSBuildOutput=false"]);
+            App.Start(testAsset, ["--verbose", "test", "--list-tests", "/p:VSTestUseMSBuildOutput=false"]);
 
             await App.AssertOutputLineEquals("The following Tests are available:");
             await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitPassTest");
@@ -207,7 +207,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("XunitMulti")
                 .WithSource();
 
-            App.Start(testAsset, ["--verbose", "--framework", ToolsetInfo.CurrentTargetFramework, "test", "--list-tests", "--property:VSTestUseMSBuildOutput=false"]);
+            App.Start(testAsset, ["--verbose", "--framework", ToolsetInfo.CurrentTargetFramework, "test", "--list-tests", "/p:VSTestUseMSBuildOutput=false"]);
 
             await App.AssertOutputLineEquals("The following Tests are available:");
             await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitFailTestNetCoreApp");

--- a/test/dotnet.Tests/dotnet-msbuild/GivenDotnetTestInvocation.cs
+++ b/test/dotnet.Tests/dotnet-msbuild/GivenDotnetTestInvocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetTestInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        private const string ExpectedPrefix = "-maxcpucount -verbosity:m -tlp:default=auto -restore -target:VSTest -nodereuse:false -nologo";
+        private const string ExpectedPrefix = "-maxcpucount -verbosity:m -tlp:default=auto -restore -target:VSTest -nologo";
         private static readonly string WorkingDirectory = TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetTestInvocation));
 
         [Theory]


### PR DESCRIPTION
Enable terminal logger, and the new [MSBuild test logger](https://github.com/microsoft/vstest/pull/2702) integration by default for dotnet test. 

![image](https://github.com/dotnet/sdk/assets/5735905/4bfc499f-886b-4031-a94d-c00f6fd47bba)

`--property:VSTestUseMSBuildOutput=false` can be used to opt out from both terminal logger and the new msbuild logger. 

![image](https://github.com/dotnet/sdk/assets/5735905/36867b42-4d60-4b7e-b935-3de0944a5363)

`-tl:false` can be used to opt out from terminal logger, but keep using the new msbuild logger.

![image](https://github.com/dotnet/sdk/assets/5735905/1b08a29e-2531-4aee-a0d7-efd7d3c7794f)
