### PR TITLE
Add System.Data.Client to the set of centrally managed versions for tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,6 +30,7 @@
     <MicrosoftApplicationInsightsPackageVersion>2.21.0</MicrosoftApplicationInsightsPackageVersion>
     <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</NETStandardLibraryNETFrameworkVersion>
     <NewtonsoftJsonPackageVersion>13.0.3</NewtonsoftJsonPackageVersion>
+    <SystemDataSqlClientPackageVersion>4.8.6</SystemDataSqlClientPackageVersion>
     <StyleCopAnalyzersPackageVersion>1.2.0-beta.435</StyleCopAnalyzersPackageVersion>
     <SystemCollectionsImmutablePackageVersion>8.0.0</SystemCollectionsImmutablePackageVersion>
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>

--- a/src/Assets/TestProjects/CompilationContext/TestApp/TestApp.csproj
+++ b/src/Assets/TestProjects/CompilationContext/TestApp/TestApp.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.3.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NET.Publish.Tests
 
             testProject.ReferencedProjects.Add(testLibraryProject);
             testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", ToolsetInfo.GetNewtonsoftJsonPackageVersion()));
-            testProject.PackageReferences.Add(new TestPackageReference("System.Data.SqlClient", "4.4.3"));
+            testProject.PackageReferences.Add(new TestPackageReference("System.Data.SqlClient", ToolsetInfo.GetSystemDataSqlClientPackageVersion()));
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: appTargetFramework + withoutCopyingRefs);
 
@@ -185,7 +185,7 @@ namespace Microsoft.NET.Publish.Tests
             {
                 "<StoreArtifacts>",
                 $@"  <Package Id=""Newtonsoft.Json"" Version=""{ToolsetInfo.GetNewtonsoftJsonPackageVersion()}"" />",
-                @"  <Package Id=""System.Data.SqlClient"" Version=""4.3.0"" />",
+                $@"  <Package Id=""System.Data.SqlClient"" Version=""{ToolsetInfo.GetSystemDataSqlClientPackageVersion()}"" />",
                 "</StoreArtifacts>",
             });
 

--- a/test/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/test/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -425,5 +425,16 @@ namespace Microsoft.NET.TestFramework
             return _NewtonsoftJsonPackageVersion.Value;
         }
 
+        private static readonly Lazy<string> _SystemDataSqlClientPackageVersion = new(() =>
+        {
+            Assembly assembly = Assembly.GetExecutingAssembly();
+            return assembly.GetCustomAttributes(true).OfType<AssemblyMetadataAttribute>().FirstOrDefault(a => a.Key == "SystemDataSqlClientPackageVersion").Value;
+        });
+
+        public static string GetSystemDataSqlClientPackageVersion()
+        {
+            return _SystemDataSqlClientPackageVersion.Value;
+        }
+
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/security/dependabot/23

@v-wuzhai do you know if there are other packages we commonly use in tests that it would be worth centralizing like you did for newtonsoft? This one was flagged for a security issue and I noticed we used it in three places so copied what you had done for newtonsoft.