### PR TITLE
Workaround missing ref modifier for ref structs

### DIFF
--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
@@ -113,6 +114,15 @@ namespace Microsoft.DotNet.GenAPI
                 SyntaxNode typeDeclaration = _syntaxGenerator
                     .DeclarationExt(typeMember, _symbolFilter)
                     .AddMemberAttributes(_syntaxGenerator, typeMember, _attributeDataSymbolFilter);
+
+                // workaround until we have Roslyn with https://github.com/dotnet/roslyn/pull/71760/
+                if (typeMember.IsRefLikeType &&
+                    typeDeclaration is StructDeclarationSyntax structDeclaration)
+                {
+                    Debug.Assert(!structDeclaration.Modifiers.Any(m => m.Text == "ref"), "remove this workaround");
+                    SyntaxToken refToken = SyntaxFactory.Token(SyntaxKind.RefKeyword);
+                    typeDeclaration = structDeclaration.AddModifiers(refToken);
+                }
 
                 typeDeclaration = Visit(typeDeclaration, typeMember);
 

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -119,9 +119,15 @@ namespace Microsoft.DotNet.GenAPI
                 if (typeMember.IsRefLikeType &&
                     typeDeclaration is StructDeclarationSyntax structDeclaration)
                 {
-                    Debug.Assert(!structDeclaration.Modifiers.Any(m => m.Text == "ref"), "remove this workaround");
-                    SyntaxToken refToken = SyntaxFactory.Token(SyntaxKind.RefKeyword);
-                    typeDeclaration = structDeclaration.AddModifiers(refToken);
+                    if (structDeclaration.Modifiers.Any(m => m.Text == "ref"))
+                    {
+                        Debug.Fail("remove this workaround");
+                    }
+                    else
+                    {
+                        SyntaxToken refToken = SyntaxFactory.Token(SyntaxKind.RefKeyword);
+                        typeDeclaration = structDeclaration.AddModifiers(refToken);
+                    }
                 }
 
                 typeDeclaration = Visit(typeDeclaration, typeMember);

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     {
                     }
 
-                    public readonly partial struct PublicReadonlyRefStruct
+                    public readonly ref partial struct PublicReadonlyRefStruct
                     {
                     }
 
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     {
                     }
 
-                    public partial struct PublicRefStruct
+                    public ref partial struct PublicRefStruct
                     {
                     }
 
@@ -2919,7 +2919,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 expected: """                
                 namespace N
                 {
-                    public partial struct C<T>
+                    public ref partial struct C<T>
                         where T : unmanaged
                     {
                         public required (string? k, dynamic v, nint n) X { get { throw null; } init { } }


### PR DESCRIPTION
This updates the tests and adds a workaround.  The workaround is not required once https://github.com/dotnet/roslyn/pull/71760 is merged and we pick it up.

At that point this workaround will fail tests with an assert (reminding us to remove it), but will not break the functionality of GenAPI (in case we are used with a newer compiler before picking it up).
