### PR TITLE
Allow for GenAPI to include additional API

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.ApiCompat
                     .Add(accessibilitySymbolFilter);
                 if (excludeAttributesFiles is not null)
                 {
-                    attributeDataSymbolFilter.Add(new DocIdSymbolFilter(excludeAttributesFiles));
+                    attributeDataSymbolFilter.Add(DocIdSymbolFilter.CreateFromFiles(excludeAttributesFiles));
                 }
 
                 ApiComparerSettings apiComparerSettings = new(

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
@@ -50,6 +50,17 @@ namespace Microsoft.DotNet.GenAPI.Task
         public string[]? ExcludeAttributesFiles { get; set; }
 
         /// <summary>
+        /// If true API Compat will not include internal attributes commonly defined to
+        /// represent language features (Eg: System.Runtime.CompilerServices.NullableAttribute, etc).
+        /// </summary>
+        public bool ExcludeInternalCompilerAttributes { get; set; }
+
+        /// <summary>
+        /// The path to one or more api inclusion files with types in DocId format.
+        /// </summary>
+        public string[]? IncludeApiFiles { get; set; }
+
+        /// <summary>
         /// If true, includes both internal and public API.
         /// </summary>
         public bool RespectInternals { get; set; }
@@ -70,6 +81,8 @@ namespace Microsoft.DotNet.GenAPI.Task
                 ExceptionMessage,
                 ExcludeApiFiles,
                 ExcludeAttributesFiles,
+                ExcludeInternalCompilerAttributes,
+                IncludeApiFiles,
                 RespectInternals,
                 IncludeAssemblyAttributes
             );

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -50,6 +50,8 @@
       ExceptionMessage="$(GenAPIExceptionMessage)"
       ExcludeApiFiles="@(GenAPIExcludeApiList)"
       ExcludeAttributesFiles="@(GenAPIExcludeAttributesList)"
+      ExcludeInternalCompilerAttributes="$(GenAPIExcludeInternalCompilerAttributes)"
+      IncludeApiFiles="@(GenAPIIncludeApiList)"
       RespectInternals="$(GenAPIRespectInternals)"
       IncludeAssemblyAttributes="$(GenAPIIncludeAssemblyAttributes)" />
 

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
@@ -50,6 +50,20 @@ namespace Microsoft.DotNet.GenAPI.Tool
                 Recursive = true
             };
 
+            CliOption<bool> excludeInternalCompilerAttributesOption = new("--exclude-internal-compiler-attributes")
+            {
+                Description = "If true, will not include internally defined compiler attributes.",
+                Recursive = true
+            };
+
+            CliOption<string[]?> includeApiFilesOption = new("--include-api-file")
+            {
+                Description = "The path to one or more api inclusion files with types in DocId format.",
+                CustomParser = ParseAssemblyArgument,
+                Arity = ArgumentArity.ZeroOrMore,
+                Recursive = true
+            };
+
             CliOption<string?> outputPathOption = new("--output-path")
             {
                 Description = @"Output path. Default is the console. Can specify an existing directory as well
@@ -89,6 +103,8 @@ namespace Microsoft.DotNet.GenAPI.Tool
             rootCommand.Options.Add(assemblyReferencesOption);
             rootCommand.Options.Add(excludeApiFilesOption);
             rootCommand.Options.Add(excludeAttributesFilesOption);
+            rootCommand.Options.Add(excludeInternalCompilerAttributesOption);
+            rootCommand.Options.Add(includeApiFilesOption);
             rootCommand.Options.Add(outputPathOption);
             rootCommand.Options.Add(headerFileOption);
             rootCommand.Options.Add(exceptionMessageOption);
@@ -105,6 +121,8 @@ namespace Microsoft.DotNet.GenAPI.Tool
                     parseResult.GetValue(exceptionMessageOption),
                     parseResult.GetValue(excludeApiFilesOption),
                     parseResult.GetValue(excludeAttributesFilesOption),
+                    parseResult.GetValue(excludeInternalCompilerAttributesOption),
+                    parseResult.GetValue(includeApiFilesOption),
                     parseResult.GetValue(respectInternalsOption),
                     parseResult.GetValue(includeAssemblyAttributesOption)
                 );

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -78,20 +78,18 @@ namespace Microsoft.DotNet.GenAPI
             if (!excludeInternalCompilerAttributes)
             {
                 includeAdditionalApiFilter ??= new DocIdSymbolFilter(includeDocIds: true);
-                includeAdditionalApiFilter.DocIds.UnionWith(s_compilerAttributes);
+                includeAdditionalApiFilter.AddRange(s_compilerAttributes);
             }
 
             if (includeAdditionalApiFilter is not null)
             {
-                typeFilter = new CompositeSymbolFilter()
+                CompositeSymbolFilter combinedTypeFilter = new()
                 {
-                    Mode = CompositeSymbolFilterMode.Or,
-                    Filters =
-                    {
-                        typeFilter,
-                        includeAdditionalApiFilter
-                    }
+                    Mode = CompositeSymbolFilterMode.Or
                 };
+                combinedTypeFilter.Add(typeFilter);
+                combinedTypeFilter.Add(includeAdditionalApiFilter);
+                typeFilter = combinedTypeFilter;
             }
 
             // Configure the symbol filter

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.GenAPI
             {
                 includeAdditionalApiFilter ??= new DocIdSymbolFilter(includeDocIds: true);
                 includeAdditionalApiFilter.DocIds.UnionWith(s_compilerAttributes);
-            }    
+            }
 
             if (includeAdditionalApiFilter is not null)
             {

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -23,16 +23,33 @@ namespace Microsoft.DotNet.GenAPI
         // see https://github.com/dotnet/roslyn/blob/859f94ef2d8bf88527217bc9ad7661b6fbdf33a9/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs#L343
         private static readonly string[] s_compilerAttributes =
         [
+            // init feature
             "T:System.Runtime.CompilerServices.IsExternalInit",
-            "T:System.Runtime.CompilerServices.NullableAttribute",
-            "T:System.Runtime.CompilerServices.NullableContextAttribute",
-            "T:System.Runtime.CompilerServices.NullablePublicOnlyAttribute",
-            "T:System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute",
+
+            // interpolated string handler
             "T:System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute",
             "T:System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute",
+
+            // required members
             "T:System.Runtime.CompilerServices.RequiredMemberAttribute",
             "T:System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute",
-            "T:System.Runtime.CompilerServices.CollectionBuilderAttribute"
+            "T:System.Diagnostics.CodeAnalysis.CompilerFeatureRequiredAttribute",
+
+            // collection expressions
+            "T:System.Runtime.CompilerServices.CollectionBuilderAttribute",
+
+            // User authored Nullable attributes
+            "T:System.Diagnostics.CodeAnalysis.AllowNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.DisallowNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.MaybeNullAttribute ",
+            "T:System.Diagnostics.CodeAnalysis.NotNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute",
+            "T:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute",
+            "T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute",
+            "T:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute",
+            "T:System.Diagnostics.CodeAnalysis.MemberNotNullAtribute",
+            "T:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute"
         ];
 
         /// <summary>

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Net.Http.Headers;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
@@ -11,20 +9,21 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
     /// Implements the composite pattern, group the list of <see cref="ISymbol"/> and interact with them
     /// the same way as a single instance of a <see cref="ISymbol"/> object.
     /// </summary>
-    public sealed class CompositeSymbolFilter : ISymbolFilter
+    public sealed class CompositeSymbolFilter(CompositeSymbolFilterMode mode = CompositeSymbolFilterMode.And,
+        params ISymbolFilter[] symbolFilters) : ISymbolFilter
     {
-        private readonly List<ISymbolFilter> _filters = new();
+        private readonly List<ISymbolFilter> _filters = new(symbolFilters);
 
         /// <summary>
         /// Behavior of combination.  Default is `And` which requires all filters to include the symbol.
         /// `Or` will include the symbol if any filter includes the symbol.
         /// </summary>
-        public CompositeSymbolFilterMode Mode { get; set; } = CompositeSymbolFilterMode.And;
+        public CompositeSymbolFilterMode Mode { get; } = mode;
 
         /// <summary>
         /// List on inner filters.
         /// </summary>
-        public IReadOnlyList<ISymbolFilter> Filters { get => _filters.AsReadOnly(); }
+        public IReadOnlyList<ISymbolFilter> Filters => _filters.AsReadOnly();
 
         /// <summary>
         /// Determines whether the <see cref="ISymbol"/> should be included.

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
@@ -11,6 +11,13 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
     /// </summary>
     public sealed class CompositeSymbolFilter : ISymbolFilter
     {
+
+        /// <summary>
+        /// Behavior of combination.  Default is `And` which requires all filters to include the symbol.
+        /// `Or` will include the symbol if any filter includes the symbol.
+        /// </summary>
+        public CompositeSymbolFilterMode Mode { get; set; } = CompositeSymbolFilterMode.And;
+
         /// <summary>
         /// List on inner filters.
         /// </summary>
@@ -21,7 +28,12 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
         /// </summary>
         /// <param name="symbol"><see cref="ISymbol"/> to evaluate.</param>
         /// <returns>True to include the <paramref name="symbol"/> or false to filter it out.</returns>
-        public bool Include(ISymbol symbol) => Filters.All(f => f.Include(symbol));
+        public bool Include(ISymbol symbol) => Mode switch
+        {
+            CompositeSymbolFilterMode.And => Filters.All(f => f.Include(symbol)),
+            CompositeSymbolFilterMode.Or => Filters.Any(f => f.Include(symbol)),
+            _ => throw new NotImplementedException()
+        };
 
         /// <summary>
         /// Add a filter object to a list of filters.
@@ -33,5 +45,21 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
             Filters.Add(filter);
             return this;
         }
+    }
+
+    /// <summary>
+    /// Mode of combination of symbol filters
+    /// </summary>
+    public enum CompositeSymbolFilterMode
+    {
+        /// <summary>
+        /// All filters must be true for a symbol to be included.
+        /// </summary>
+        And,
+
+        /// <summary>
+        /// Any filter can be true for a symbol to be included.
+        /// </summary>
+        Or
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
@@ -32,8 +32,8 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
         /// <returns>True to include the <paramref name="symbol"/> or false to filter it out.</returns>
         public bool Include(ISymbol symbol) => Mode switch
         {
-            CompositeSymbolFilterMode.And => Filters.All(f => f.Include(symbol)),
-            CompositeSymbolFilterMode.Or => Filters.Any(f => f.Include(symbol)),
+            CompositeSymbolFilterMode.And => _filters.All(f => f.Include(symbol)),
+            CompositeSymbolFilterMode.Or => _filters.Any(f => f.Include(symbol)),
             _ => throw new NotImplementedException()
         };
 

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Net.Http.Headers;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
@@ -11,6 +13,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
     /// </summary>
     public sealed class CompositeSymbolFilter : ISymbolFilter
     {
+        private readonly List<ISymbolFilter> _filters = new();
 
         /// <summary>
         /// Behavior of combination.  Default is `And` which requires all filters to include the symbol.
@@ -21,7 +24,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
         /// <summary>
         /// List on inner filters.
         /// </summary>
-        public List<ISymbolFilter> Filters { get; } = [];
+        public IReadOnlyList<ISymbolFilter> Filters { get => _filters.AsReadOnly(); }
 
         /// <summary>
         /// Determines whether the <see cref="ISymbol"/> should be included.
@@ -42,7 +45,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
         /// <returns>Returns the current instance of the class.</returns>
         public CompositeSymbolFilter Add(ISymbolFilter filter)
         {
-            Filters.Add(filter);
+            _filters.Add(filter);
             return this;
         }
     }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
@@ -6,14 +6,14 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
 {
     /// <summary>
-    /// Implements the logic of filtering out api.
+    /// Implements the logic of filtering API.
     /// Reads the file with the list of attributes, types, members in DocId format.
     /// </summary>
     /// <param name="docIdsFiles">List of files which contain DocIds to operate on.</param>
     /// <param name="includeDocIds">Determines if DocIds should be included or excluded.  Defaults to false which excludes specified DocIds.</param>
     public class DocIdSymbolFilter(IEnumerable<string>? docIdsFiles = null, bool includeDocIds = false) : ISymbolFilter
     {
-        public ISet<string> DocIds { get;  } = new HashSet<string>(ReadDocIdsAttributes(docIdsFiles));
+        private readonly HashSet<string> _docIds = new(ReadDocIdsAttributes(docIdsFiles));
 
         /// <summary>
         /// Determines if DocIds should be included or excluded.
@@ -28,12 +28,30 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
         public bool Include(ISymbol symbol)
         {
             string? docId = symbol.GetDocumentationCommentId();
-            if (docId is not null && DocIds.Contains(docId))
+            if (docId is not null && _docIds.Contains(docId))
             {
                 return IncludeDocIds;
             }
 
             return !IncludeDocIds;
+        }
+
+        /// <summary>
+        /// Add a single DocID to the filtered set.
+        /// </summary>
+        /// <param name="docId">DocID to add to the filtered set.</param>
+        public void Add(string docId)
+        {
+            _docIds.Add(docId);
+        }
+
+        /// <summary>
+        /// Add multiple docIDs to the filtered set.
+        /// </summary>
+        /// <param name="docIds">DocIDs to add to the filtered set.</param>
+        public void AddRange(IEnumerable<string> docIds)
+        {
+            _docIds.UnionWith(docIds);
         }
 
         private static IEnumerable<string> ReadDocIdsAttributes(IEnumerable<string>? docIdsToExcludeFiles)

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -29,7 +29,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
 
         private static ISymbolFilter GetAccessibilityAndAttributeSymbolFiltersAsComposite(params string[] excludeAttributeFiles) =>
-            new CompositeSymbolFilter().Add(new AccessibilitySymbolFilter(false)).Add(new DocIdSymbolFilter(excludeAttributeFiles));
+            new CompositeSymbolFilter(default,
+              new AccessibilitySymbolFilter(false),
+              DocIdSymbolFilter.CreateFromFiles(excludeAttributeFiles));
 
         public static TheoryData<string, string, CompatDifference[]> TypesCases => new()
         {

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
 
         private static ISymbolFilter GetAccessibilityAndAttributeSymbolFiltersAsComposite(params string[] excludeAttributeFiles) =>
-            new CompositeSymbolFilter(default,
+            new CompositeSymbolFilter(mode: CompositeSymbolFilterMode.And,
               new AccessibilitySymbolFilter(false),
               DocIdSymbolFilter.CreateFromFiles(excludeAttributeFiles));
 

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
         private static SyntaxTree GetSyntaxTree(string syntax) =>
             CSharpSyntaxTree.ParseText(syntax);
 
-        private void RunTest(string original,
+        private static void RunTest(string original,
             string expected,
             bool includeInternalSymbols = true,
             bool includeEffectivelyPrivateSymbols = true,
@@ -45,23 +45,19 @@ namespace Microsoft.DotNet.GenAPI.Tests
 
             if (includeDocIdFile is not null)
             {
-                CompositeSymbolFilter combinedTypeFilter = new()
-                {
-                    Mode = CompositeSymbolFilterMode.Or,
-                };
-                combinedTypeFilter.Add(typeFilter);
-                combinedTypeFilter.Add(new DocIdSymbolFilter(new[] { includeDocIdFile }, includeDocIds: true));
-                typeFilter = combinedTypeFilter;
+                typeFilter = new CompositeSymbolFilter(mode: CompositeSymbolFilterMode.Or,
+                    typeFilter,
+                    DocIdSymbolFilter.CreateFromFiles(new[] { includeDocIdFile }, includeDocIds: true));
             }
 
-            CompositeSymbolFilter symbolFilter = new CompositeSymbolFilter()
-                .Add(new ImplicitSymbolFilter())
-                .Add(typeFilter);
+            CompositeSymbolFilter symbolFilter = new(default,
+                new ImplicitSymbolFilter(),
+                typeFilter);
 
             CompositeSymbolFilter attributeDataSymbolFilter = new();
             if (excludedAttributeFile is not null)
             {
-                attributeDataSymbolFilter.Add(new DocIdSymbolFilter(new string[] { excludedAttributeFile }));
+                attributeDataSymbolFilter.Add(DocIdSymbolFilter.CreateFromFiles(new[] { excludedAttributeFile }));
             }
             attributeDataSymbolFilter.Add(typeFilter);
 

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     DocIdSymbolFilter.CreateFromFiles(new[] { includeDocIdFile }, includeDocIds: true));
             }
 
-            CompositeSymbolFilter symbolFilter = new(default,
+            CompositeSymbolFilter symbolFilter = new(mode: CompositeSymbolFilterMode.And,
                 new ImplicitSymbolFilter(),
                 typeFilter);
 

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -31,26 +32,40 @@ namespace Microsoft.DotNet.GenAPI.Tests
             bool includeExplicitInterfaceImplementationSymbols = true,
             bool allowUnsafe = false,
             string excludedAttributeFile = null,
+            string includeDocIdFile = null,
             [CallerMemberName] string assemblyName = "")
         {
             StringWriter stringWriter = new();
 
             // Configure symbol filters
-            AccessibilitySymbolFilter accessibilitySymbolFilter = new(
+            ISymbolFilter typeFilter = new AccessibilitySymbolFilter(
                 includeInternalSymbols,
                 includeEffectivelyPrivateSymbols,
                 includeExplicitInterfaceImplementationSymbols);
 
+            if (includeDocIdFile is not null)
+            {
+                typeFilter = new CompositeSymbolFilter()
+                {
+                    Mode = CompositeSymbolFilterMode.Or,
+                    Filters =
+                    {
+                        typeFilter,
+                        new DocIdSymbolFilter(new [] { includeDocIdFile }, includeDocIds: true)
+                    }
+                };
+            }
+
             CompositeSymbolFilter symbolFilter = new CompositeSymbolFilter()
                 .Add(new ImplicitSymbolFilter())
-                .Add(accessibilitySymbolFilter);
+                .Add(typeFilter);
 
             CompositeSymbolFilter attributeDataSymbolFilter = new();
             if (excludedAttributeFile is not null)
             {
                 attributeDataSymbolFilter.Add(new DocIdSymbolFilter(new string[] { excludedAttributeFile }));
             }
-            attributeDataSymbolFilter.Add(accessibilitySymbolFilter);
+            attributeDataSymbolFilter.Add(typeFilter);
 
             IAssemblySymbolWriter csharpFileBuilder = new CSharpFileBuilder(
                 new ConsoleLog(MessageImportance.Low),
@@ -3048,6 +3063,85 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     }
                     """,
                 includeInternalSymbols: false);
+        }
+
+
+        [Fact]
+        public void TestIncludeOOBInternalAttribute()
+        {
+            using TempDirectory root = new();
+            string includeDocIdFilePath = Path.Combine(root.DirPath, "exclusions.txt");
+            File.WriteAllText(includeDocIdFilePath, """
+            T:System.Runtime.CompilerServices.CollectionBuilderAttribute
+            """);
+
+            RunTest(original: """
+                    using System;
+                    using System.Collections;
+                    using System.Collections.Generic;
+                    using System.Runtime.CompilerServices;
+                    namespace a
+                    {
+                        #pragma warning disable CS0436
+                        [CollectionBuilder(typeof(LineBufferBuilder), "Create")]
+                        #pragma warning restore CS0436
+                        public class LineBuffer : IEnumerable<char>
+                        {
+                            public LineBuffer(ReadOnlySpan<char> buffer) { }
+
+                            public IEnumerator<char> GetEnumerator() => default!;
+                            IEnumerator IEnumerable.GetEnumerator() => default!;
+                        }
+
+                        public static class LineBufferBuilder
+                        {
+                            public static LineBuffer Create(ReadOnlySpan<char> values) => new LineBuffer(values);
+                        }
+                    }
+                    namespace System.Runtime.CompilerServices
+                    {
+                        internal sealed class CollectionBuilderAttribute(Type builderType, string methodName) : Attribute
+                        {
+                            public Type BuilderType { get; } = builderType;
+
+                            public string MethodName { get; } = methodName;
+                        }
+                    }
+                    """,
+                expected: """
+                    
+                    namespace a
+                    {
+                        [System.Runtime.CompilerServices.CollectionBuilder(typeof(LineBufferBuilder), "Create")]
+                        public partial class LineBuffer : System.Collections.Generic.IEnumerable<char>, System.Collections.IEnumerable
+                        {
+                            public LineBuffer(System.ReadOnlySpan<char> buffer) { }
+
+                            public System.Collections.Generic.IEnumerator<char> GetEnumerator() { throw null; }
+
+                            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+                        }
+
+                        public static partial class LineBufferBuilder
+                        {
+                            public static LineBuffer Create(System.ReadOnlySpan<char> values) { throw null; }
+                        }
+                    }
+
+                    namespace System.Runtime.CompilerServices
+                    {
+                        internal sealed partial class CollectionBuilderAttribute : Attribute
+                        {
+                            public CollectionBuilderAttribute(Type builderType, string methodName) { }
+
+                            public Type BuilderType { get { throw null; } }
+
+                            public string MethodName { get { throw null; } }
+                        }
+                    }
+                    """,
+                includeInternalSymbols: false,
+                includeDocIdFile: includeDocIdFilePath);
         }
     }
 }

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -3109,7 +3109,6 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     }
                     """,
                 expected: """
-                    
                     namespace a
                     {
                         [System.Runtime.CompilerServices.CollectionBuilder(typeof(LineBufferBuilder), "Create")]

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -45,15 +45,13 @@ namespace Microsoft.DotNet.GenAPI.Tests
 
             if (includeDocIdFile is not null)
             {
-                typeFilter = new CompositeSymbolFilter()
+                CompositeSymbolFilter combinedTypeFilter = new()
                 {
                     Mode = CompositeSymbolFilterMode.Or,
-                    Filters =
-                    {
-                        typeFilter,
-                        new DocIdSymbolFilter(new [] { includeDocIdFile }, includeDocIds: true)
-                    }
                 };
+                combinedTypeFilter.Add(typeFilter);
+                combinedTypeFilter.Add(new DocIdSymbolFilter(new[] { includeDocIdFile }, includeDocIds: true));
+                typeFilter = combinedTypeFilter;
             }
 
             CompositeSymbolFilter symbolFilter = new CompositeSymbolFilter()


### PR DESCRIPTION
Today GenAPI only allows for public | public + internal, and exclusions. 

This allows for inclusions - which can be helpful when a library wants to include some internal API in its generated code. 

It's also beneficial for a library that's OOB'ing some language support types - like nullable, init properties, etc.  I've made those included by default, with the ability to disable that inclusion.

Alternatives:
1. Don't have a default list, only expose the user-provided list.  This works, but it's less friendly since folks need to know to opt-into these.  Since we can "know" which types represent public API behavior (even when defined as internal) we can do better.
2. Include all internal attributes, let folks exclude the ones they don't want.  This is too noisy - not all attributes are relevant to the public API.  It also wouldn't capture the types used for modreqs (like IsExternalInit).
3. Do nothing and ask folks to include internals and remove any internals they don't want.  This is also too noisy.