### PR TITLE
Skip flaky tests

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Build.Tests
                 .Pass();
         }
 
-        [RequiresMSBuildVersionFact("16.8.0")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/38268")]
         public void CanBuildProjectWithMultiplePackageReferencesWithAliases()
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;

--- a/test/dotnet-run.Tests/GivenDotnetRunIsInterrupted.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunIsInterrupted.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             }
         }
 
-        [WindowsOnlyFact]
+        [WindowsOnlyFact(Skip = "https://github.com/dotnet/sdk/issues/38268")]
         public void ItTerminatesTheChildWhenKilled()
         {
             var asset = _testAssetsManager.CopyTestAsset("TestAppThatWaits")


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/issues/38268

## Summary

I've noticed 2 tests that frequently are failing the PR CI pipeline, but rerunning the pipeline often results in success. Meaning, these tests are flaky. So, I'm skipping them for the time being. I've [added an issue](https://github.com/dotnet/sdk/issues/38268) that documents the test failures and information.