### PR TITLE
[`dotnet list package`]Resolve relative paths

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommand.cs
@@ -16,7 +16,13 @@ namespace Microsoft.DotNet.Tools.List.PackageReferences
         public ListPackageReferencesCommand(
             ParseResult parseResult) : base(parseResult)
         {
-            _fileOrDirectory = parseResult.GetValue(ListCommandParser.SlnOrProjectArgument);
+            _fileOrDirectory = GetAbsolutePath(Directory.GetCurrentDirectory(),
+                parseResult.GetValue(ListCommandParser.SlnOrProjectArgument));
+        }
+
+        private static string GetAbsolutePath(string currentDirectory, string relativePath)
+        {
+            return Path.GetFullPath(Path.Combine(currentDirectory, relativePath));
         }
 
         public override int Execute()

--- a/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
+++ b/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
@@ -353,25 +353,24 @@ class Program
         [Fact]
         public void ItRecognizesRelativePaths()
         {
-            var testAssetName = "TestAppSimple";
+            var sln = "TestAppWithSlnAndSolutionFolders";
             var testAsset = _testAssetsManager
-                .CopyTestAsset(testAssetName)
+                .CopyTestAsset(sln)
                 .WithSource();
 
             var projectDirectory = testAsset.Path;
 
-            new RestoreCommand(testAsset)
+            new RestoreCommand(testAsset, "App.sln")
                 .Execute()
                 .Should()
                 .Pass();
 
             new ListPackageCommand(Log)
-                .WithProject("TestAppSimple.csproj")
+                .WithProject("App.sln")
                 .WithWorkingDirectory(projectDirectory)
                 .Execute()
                 .Should()
                 .Pass();
         }
-
     }
 }

--- a/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
+++ b/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
@@ -351,7 +351,30 @@ class Program
         }
 
         [Fact]
-        public void ItRecognizesRelativePaths()
+        public void ItRecognizesRelativePathsForAProject()
+        {
+            var testAssetName = "TestAppSimple";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
+                .WithSource();
+
+            var projectDirectory = testAsset.Path;
+
+            new RestoreCommand(testAsset)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new ListPackageCommand(Log)
+                .WithProject("TestAppSimple.csproj")
+                .WithWorkingDirectory(projectDirectory)
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
+        [Fact]
+        public void ItRecognizesRelativePathsForASolution()
         {
             var sln = "TestAppWithSlnAndSolutionFolders";
             var testAsset = _testAssetsManager

--- a/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
+++ b/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
@@ -395,5 +395,32 @@ class Program
                 .Should()
                 .Pass();
         }
+
+        [Fact]
+        public void ItRecognizesRelativePathsForASolutionFromSubFolder()
+        {
+            var sln = "TestAppWithSlnAndSolutionFolders";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(sln)
+                .WithSource();
+
+            var projectDirectory = testAsset.Path;
+
+            string subFolderName = "subFolder";
+            var subFolderPath = Path.Combine(projectDirectory, subFolderName);
+            Directory.CreateDirectory(subFolderPath);
+
+            new RestoreCommand(testAsset, "App.sln")
+                .Execute()
+                .Should()
+                .Pass();
+
+            new ListPackageCommand(Log)
+                .WithProject("../App.sln")
+                .WithWorkingDirectory(subFolderPath)
+                .Execute()
+                .Should()
+                .Pass();
+        }
     }
 }

--- a/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
+++ b/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
@@ -359,13 +359,19 @@ class Program
                 .WithSource();
 
             var projectDirectory = testAsset.Path;
-            var relativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), projectDirectory);
 
-            new ListPackageCommand(Log, relativePath)
-                .WithWorkingDirectory(Directory.GetCurrentDirectory())
+            new RestoreCommand(testAsset)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new ListPackageCommand(Log)
+                .WithProject("TestAppSimple.csproj")
+                .WithWorkingDirectory(projectDirectory)
                 .Execute()
                 .Should()
                 .Pass();
         }
+
     }
 }

--- a/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
+++ b/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
@@ -349,5 +349,23 @@ class Program
                 .Should()
                 .Pass();
         }
+
+        [Fact]
+        public void ItRecognizesRelativePaths()
+        {
+            var testAssetName = "TestAppSimple";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
+                .WithSource();
+
+            var projectDirectory = testAsset.Path;
+            var relativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), projectDirectory);
+
+            new ListPackageCommand(Log, relativePath)
+                .WithWorkingDirectory(Directory.GetCurrentDirectory())
+                .Execute()
+                .Should()
+                .Pass();
+        }
     }
 }


### PR DESCRIPTION
Fixes : https://github.com/NuGet/Home/issues/12954

This is a fix to a regression that was caused by https://github.com/dotnet/sdk/pull/20449
- It makes sure the SDK resolves relative paths for a solution/project before calling the NuGet API.