### PR TITLE
Cleanup _DotNetPublishToBlobFeed variable in .vsts-ci.yml

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -17,8 +17,6 @@ pr:
 variables:
   - name: teamName
     value: Roslyn-Project-System
-  - name: _DotNetPublishToBlobFeed
-    value: false
   - name: _CIBuild
     value: -restore -build -sign -pack -ci
   - name: _DotNetArtifactsCategory


### PR DESCRIPTION
It is no longer used.