### PR TITLE
[release/9.0.1xx-preview1] Fix VSTest MSBuild and Terminal Logger integration

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -180,18 +180,18 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>e4899ee48ff3d7787ee345f546c818ce6b962807</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.10.0-preview-24069-04">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.10.0-preview-24080-01">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>53df73d3373e7964f6fb37f4437bda2720a75ef2</Sha>
+      <Sha>d61759559535f43790211fa53be7829dfe598841</Sha>
       <SourceBuild RepoName="vstest" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.TestPlatform.CLI" Version="17.10.0-preview-24069-04">
+    <Dependency Name="Microsoft.TestPlatform.CLI" Version="17.10.0-preview-24080-01">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>53df73d3373e7964f6fb37f4437bda2720a75ef2</Sha>
+      <Sha>d61759559535f43790211fa53be7829dfe598841</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TestPlatform.Build" Version="17.10.0-preview-24069-04">
+    <Dependency Name="Microsoft.TestPlatform.Build" Version="17.10.0-preview-24080-01">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>53df73d3373e7964f6fb37f4437bda2720a75ef2</Sha>
+      <Sha>d61759559535f43790211fa53be7829dfe598841</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="9.0.0-preview.1.24074.8">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -81,9 +81,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/vstest -->
-    <MicrosoftNETTestSdkPackageVersion>17.10.0-preview-24069-04</MicrosoftNETTestSdkPackageVersion>
-    <MicrosoftTestPlatformCLIPackageVersion>17.10.0-preview-24069-04</MicrosoftTestPlatformCLIPackageVersion>
-    <MicrosoftTestPlatformBuildPackageVersion>17.10.0-preview-24069-04</MicrosoftTestPlatformBuildPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>17.10.0-preview-24080-01</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftTestPlatformCLIPackageVersion>17.10.0-preview-24080-01</MicrosoftTestPlatformCLIPackageVersion>
+    <MicrosoftTestPlatformBuildPackageVersion>17.10.0-preview-24080-01</MicrosoftTestPlatformBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->

--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -62,15 +62,16 @@ namespace Microsoft.DotNet.Tools.Test
             string previousNodeWindowSetting = Environment.GetEnvironmentVariable(NodeWindowEnvironmentName);
             try
             {
+                var forceLegacyOutput = previousNodeWindowSetting == "1";
                 var properties = GetUserSpecifiedExplicitMSBuildProperties(parseResult);
                 var hasUserMSBuildOutputProperty = properties.TryGetValue("VsTestUseMSBuildOutput", out var propertyValue);
-                
+
                 string[] additionalBuildProperties;
-                if (!hasUserMSBuildOutputProperty)
+                if (!forceLegacyOutput && !hasUserMSBuildOutputProperty)
                 {
                     additionalBuildProperties = ["--property:VsTestUseMSBuildOutput=true"];
                 }
-                else if (propertyValue.ToLowerInvariant() == "true")
+                else if (!forceLegacyOutput && propertyValue.ToLowerInvariant() == "true")
                 {
                     // User specified the property themselves. Do nothing.
                     additionalBuildProperties = Array.Empty<string>();
@@ -301,7 +302,7 @@ namespace Microsoft.DotNet.Tools.Test
         private static Dictionary<string, string> GetUserSpecifiedExplicitMSBuildProperties(ParseResult parseResult)
         {
             Dictionary<string, string> globalProperties = new(StringComparer.OrdinalIgnoreCase);
-           IEnumerable<string> globalPropEnumerable = parseResult.UnmatchedTokens;
+            IEnumerable<string> globalPropEnumerable = parseResult.UnmatchedTokens;
             foreach (var unmatchedToken in globalPropEnumerable)
             {
                 var propertyPairs = MSBuildPropertyParser.ParseProperties(unmatchedToken);


### PR DESCRIPTION
VSTest added new MSBuild integration and made it the default because it wants to be consistent with terminal logger usage in commands like `dotnet build`. There were 3 issues discovered during dogfooding: 

- special characters are mangled, because encoding is wrong
- outputting the text "error" to output will fail the build, because msbuild parses it out and reports as error
- it is hard to disable the new approach when wrapping dotnet test in msbuild (such as source build does it)

(summary and links to each issue and PR are here : https://github.com/microsoft/vstest/issues/4843)

This PR fixes all three issues. 

Risk of this fix is small, we are fixing isolated part, which has an opt-out flag. And the fixes are also simple. Setting utf8 encoding that we enforce in vstest.console anyway. And writing out message using a different msbuild api, that avoids re-parsing it.

Full diff between commits in vstest: https://github.com/microsoft/vstest/compare/53df73d3373e7964f6fb37f4437bda2720a75ef2...d61759559535f43790211fa53be7829dfe598841 



