### PR TITLE
Add missing SDK dependency to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -15,6 +15,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24080.3",
-    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.24080.3"
+    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.24080.3",
+    "Microsoft.Build.NoTargets": "3.7.0"
   }
 }

--- a/src/Containers/packaging/package.csproj
+++ b/src/Containers/packaging/package.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+﻿<Project Sdk="Microsoft.Build.NoTargets">
     <PropertyGroup>
         <TargetFramework>$(SdkTargetFramework)</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/source-build/issues/3170

Backport of changes in https://github.com/dotnet/installer/pull/18478

### Description

Each .NET repo needs to specify all used SDKs in `global.json` file. This change adds the missing SDK.