### PR TITLE
No drive enumerations Fixes #38050

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -42,6 +42,11 @@ namespace Microsoft.DotNet.Cli
 
             bool perfLogEnabled = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_PERF_LOG", false);
 
+            if (string.IsNullOrEmpty(Env.GetEnvironmentVariable("MSBUILDFAILONDRIVEENUMERATINGWILDCARD")))
+            {
+                Environment.SetEnvironmentVariable("MSBUILDFAILONDRIVEENUMERATINGWILDCARD", "1");
+            }
+
             // Avoid create temp directory with root permission and later prevent access in non sudo
             if (SudoEnvironmentDirectoryOverride.IsRunningUnderSudo())
             {


### PR DESCRIPTION
Fixes #38050

~I'm not particularly attached to this implementation at the moment. Here's how I came up with it and why it's useful along with its most noteworthy drawbacks:~
 - ~I tried a few commands, and it doesn't seem like the SDK does any glob expansion itself. I suspected that would be in MSBuild, and my testing seemed to confirm that.~
 - ~This means that all commands that ultimately fall into this "drive enumeration" camp go through MSBuildForwardingApp. In particular, they go through its constructor.~
 - ~That means that this is the only place where I can make a single change and have it affect all of dotnet build, dotnet restore, dotnet pack, etc.~
 - ~Drive enumeration happens when we're at the root directory and try to build a project there. Or we can just try to build a project at the root directory. I cover both cases by having one check for an explicit project or solution specified and check if it is a project sitting in the root directory (i.e., Parent == null). I have a second check that we either found an explicit project/sln or we are not sitting in the root directory. (Note that in MSBuild, all arguments should start with a - unless they are a project or solution, and those arguments would escape from the try statement without throwing the Exception.~
 - ~That means this is a surgical change that covers all possible cases of throwing a drive enumeration problem at MSBuild.~

~What's bad?~
 - ~First off, this code probably needs a comment. That's fixable.~
 - ~This involves a try/catch in a loop that is expected to throw often. That's not ideal. I can probably make it better if I only enter the try if !arg.StartsWith('-'). Also fixable.~
 - ~This feels...icky...I don't know how to explain it...but this isn't my favorite change despite the positive things I said above. I'm curious if others have a concrete reason to not like this as opposed to a vague "something smells"~
 - ~I can add a check for --force-enumeration later if people like this design~
 - ~I can also add localization. I chose a couple random reasonable strings, but I can probably make those a good bit clearer, too.~

No further concerns about this PR! It now just uses a pre-built MSBuild feature to prevent drive enumerations. The results look like this:
```
C:\GitHub\sdk\artifacts\bin\redist\Debug\dotnet\sdk\9.0.100-dev\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.Defaul
tItems.props(30,14): error MSB5029: The value "**/*.cs" of the "Include" attribute in element <ItemGroup> in file "C:\G
itHub\sdk\artifacts\bin\redist\Debug\dotnet\sdk\9.0.100-dev\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultIte
ms.props (30,14)" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Chec
k that referenced properties are always defined. [C:\C.csproj]
```

Though that error message might be improved, that's very difficult outside the MSBuild repo.