### PR TITLE
Use NetToolMinimum for Compatibility tools

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -57,15 +57,15 @@
 
   <Target Name="_AddBuildOutputToPackageCore" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ItemGroup>
-      <!-- Publish .NET Core assets and include them in the package under tools directory. -->
-      <TfmSpecificPackageFile Include="$(PublishDir)**" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)" />
+      <!-- Publish .NET assets and include them in the package under tools directory. -->
+      <TfmSpecificPackageFile Include="$(PublishDir)**" PackagePath="tools/net/%(RecursiveDir)%(FileName)%(Extension)" />
     </ItemGroup>
   </Target>
 
   <Target Name="_AddBuildOutputToPackageDesktop" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <ItemGroup>
       <!-- Include .NET Framework build outputs in the package under tools directory. -->
-      <TfmSpecificPackageFile Include="$(OutputPath)**" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)" />
+      <TfmSpecificPackageFile Include="$(OutputPath)**" PackagePath="tools/netframework/%(RecursiveDir)%(FileName)%(Extension)" />
     </ItemGroup>
   </Target>
 

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.Task.targets
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.Task.targets
@@ -2,9 +2,8 @@
 <Project>
 
   <PropertyGroup>
-    <DotNetApiCompatTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.ApiCompat.Task.dll</DotNetApiCompatTaskAssembly>
-    <DotNetApiCompatTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and Exists('$(MSBuildThisFileDirectory)..\tools\net9.0\Microsoft.DotNet.ApiCompat.Task.dll')">$(MSBuildThisFileDirectory)..\tools\net9.0\Microsoft.DotNet.ApiCompat.Task.dll</DotNetApiCompatTaskAssembly>
-    <DotNetApiCompatTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(DotNetApiCompatTaskAssembly)' == ''">$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.DotNet.ApiCompat.Task.dll</DotNetApiCompatTaskAssembly>
+    <DotNetApiCompatTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\netframework\Microsoft.DotNet.ApiCompat.Task.dll</DotNetApiCompatTaskAssembly>
+    <DotNetApiCompatTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net\Microsoft.DotNet.ApiCompat.Task.dll</DotNetApiCompatTaskAssembly>
     <UseApiCompatPackage>true</UseApiCompatPackage>
     <!-- TODO: Remove when the consumers of this package upgraded to a newer SDK with this change. -->
     <UseCompatibilityPackage>true</UseCompatibilityPackage>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Microsoft.DotNet.ApiCompat.Tool.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetToolMinimum)</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <!-- We need to compare ISymbols in a special way (by name) and roslyn symbol comparers take more heuristics into consideration.-->
     <NoWarn>$(NoWarn);RS1024</NoWarn>
   </PropertyGroup>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
@@ -39,14 +39,14 @@
   <Target Name="_AddBuildOutputToPackageCore" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ItemGroup>
       <!-- Publish .NET Core assets and include them in the package under tools directory. -->
-      <TfmSpecificPackageFile Include="$(PublishDir)**" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)" />
+      <TfmSpecificPackageFile Include="$(PublishDir)**" PackagePath="tools/net/%(RecursiveDir)%(FileName)%(Extension)" />
     </ItemGroup>
   </Target>
 
   <Target Name="_AddBuildOutputToPackageDesktop" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <ItemGroup>
       <!-- Include .NET Framework build outputs in the package under tools directory. -->
-      <TfmSpecificPackageFile Include="$(OutputPath)**" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)" />
+      <TfmSpecificPackageFile Include="$(OutputPath)**" PackagePath="tools/netframework/%(RecursiveDir)%(FileName)%(Extension)" />
     </ItemGroup>
   </Target>
 

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -2,9 +2,8 @@
 <Project>
 
   <PropertyGroup>
-    <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
-    <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and Exists('$(MSBuildThisFileDirectory)..\tools\net9.0\Microsoft.DotNet.GenAPI.Task.dll')">$(MSBuildThisFileDirectory)..\tools\net9.0\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
-    <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(DotNetGenAPITaskAssembly)' == ''">$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
+    <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\netframework\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
+    <DotNetGenAPITaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net\Microsoft.DotNet.GenAPI.Task.dll</DotNetGenAPITaskAssembly>
 
     <!-- Hook onto the TargetsTriggeredByCompilation target which only runs when the compiler is invoked. -->
     <TargetsTriggeredByCompilation Condition="'$(GenAPIGenerateReferenceAssemblySource)' == 'true'">

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tool/Microsoft.DotNet.GenAPI.Tool.csproj
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tool/Microsoft.DotNet.GenAPI.Tool.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetToolMinimum)</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Exclude files that depend on Microsoft.Build.Framework and Microsoft.Build.Utilities.Core. These should be manually included by other projects. -->


### PR DESCRIPTION
... those tools should be useable on the minimum supported .NET SDK version that corresponds to the current (.NET 9) release => net8.0. This regressed when sdk branded from .NET 8 to .NET 9.

Simplify the targets by avoiding hardcoded tfm versions in them. The APICompat.targets file in the SDK will continue to use the hardcoded TFM values but that's fine.

@carlossanlop this fixes https://github.com/dotnet/maintenance-packages/pull/52#issuecomment-1922817942. Thanks for letting me know.

Validated offline 👍 