### PR TITLE
filter references for satellite assembly generation down to just the primary assemblies

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1191,13 +1191,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <ItemGroup>
-      <SatelliteAssemblyReferences Include="@(ReferencePath)" Condition="'%(Filename)' == 'mscorlib' or '%(Filename)' == 'netstandard' or '%(Filename)' == 'System.Runtime' " />
+      <_SatelliteAssemblyReferences Remove="@(_SatelliteAssemblyReferences)" />
+      <_SatelliteAssemblyReferences Include="@(ReferencePath)" Condition="'%(Filename)' == 'mscorlib' or '%(Filename)' == 'netstandard' or '%(Filename)' == 'System.Runtime' " />
     </ItemGroup>
 
     <Csc Resources="@(_SatelliteAssemblyResourceInputs)"
          Sources="$(_AssemblyInfoFile)"
          OutputAssembly="$(_OutputAssembly)"
-         References="@(SatelliteAssemblyReferences)"
+         References="@(_SatelliteAssemblyReferences)"
          KeyContainer="$(KeyContainerName)"
          KeyFile="$(KeyOriginatorFile)"
          NoConfig="true"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1190,10 +1190,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <UseSharedCompilation>true</UseSharedCompilation>
     </PropertyGroup>
 
+    <ItemGroup>
+      <SatelliteAssemblyReferences Include="@(ReferencePath)" Condition="'%(Filename)' == 'mscorlib' or '%(Filename)' == 'netstandard' or '%(Filename)' == 'System.Runtime' " />
+    </ItemGroup>
+
     <Csc Resources="@(_SatelliteAssemblyResourceInputs)"
          Sources="$(_AssemblyInfoFile)"
          OutputAssembly="$(_OutputAssembly)"
-         References="@(ReferencePath)"
+         References="@(SatelliteAssemblyReferences)"
          KeyContainer="$(KeyContainerName)"
          KeyFile="$(KeyOriginatorFile)"
          NoConfig="true"

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -39,16 +39,17 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_does_not_pass_excess_references_to_the_compiler()
         {
+            var tfm = ToolsetInfo.CurrentTargetFramework;
             var testProject = new TestProject()
             {
-                TargetFrameworks = "net8.0",
+                TargetFrameworks = tfm,
                 IsExe = true,
                 ProjectSdk = "Microsoft.NET.Sdk"
             };
 
-            var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource().WithTargetFramework("net8.0");
+            var testAsset = _testAssetsManager.CopyTestAsset("AllResourcesInSatellite").WithSource().WithTargetFramework(tfm);
 
-            var getValues = new GetValuesCommand(testAsset, "_SatelliteAssemblyReferences", GetValuesCommand.ValueType.Item, "net8.0");
+            var getValues = new GetValuesCommand(testAsset, "_SatelliteAssemblyReferences", GetValuesCommand.ValueType.Item, tfm);
             getValues.DependsOnTargets = "Compile;CoreGenerateSatelliteAssemblies";
             getValues.Execute().Should().Pass();
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -36,6 +36,22 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
+        [Fact]
+        public void It_does_not_pass_excess_references_to_the_compiler()
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = "net8.0",
+                IsExe = true,
+                ProjectSdk = "Microsoft.NET.Sdk"
+            };
+
+            testProject("")
+            var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource().WithTargetFramework("net8.0");
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute().Should().Pass();
+        }
+
         [WindowsOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -36,7 +36,7 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public void It_does_not_pass_excess_references_to_the_compiler()
         {
             var tfm = ToolsetInfo.CurrentTargetFramework;

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -46,10 +46,13 @@ namespace Microsoft.NET.Build.Tests
                 ProjectSdk = "Microsoft.NET.Sdk"
             };
 
-            testProject("")
             var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource().WithTargetFramework("net8.0");
-            var buildCommand = new BuildCommand(testAsset);
-            buildCommand.Execute().Should().Pass();
+
+            var getValues = new GetValuesCommand(testAsset, "_SatelliteAssemblyReferences", GetValuesCommand.ValueType.Item, "net8.0");
+            getValues.DependsOnTargets = "Compile;CoreGenerateSatelliteAssemblies";
+            getValues.Execute().Should().Pass();
+
+            getValues.GetValues().Count.Should().Be(1);
         }
 
         [WindowsOnlyTheory]


### PR DESCRIPTION
Fixes #38478.

Satellite assemblies have a very constrained dependency list - essentially just the 'primary assembly' for the runtime platform being compiled for. This means one of mscorlib, netstandard, or System.Runtime. We currently pass the entire set of reference assemblies to the Csc Task when generating satellite assemblies, which means that the Roslyn compiler has to spend quite a bit of time on reference metadata reads, often evicting other more useful assemblies from the Roslyn compiler server's caches.

We can take advantage of this constrained generation domain to limit the set of references passed to the compiler invocation to just the 'primary assemblies', which should save quite a lot of time in aggregate.

## Results

On my machine, for each 'cluster' of CSC invocations for satellite assemblies during the Roslyn build, the first call took ~800ms, and subsequent calls took ~75ms. After this change, the numbers are ~6ms and ~4ms respectively.

Aggregated across a single run of the Roslyn solution on my machine, I get

| Name | Total CoreGenerateSatelliteAssemblies Duration (s) |
| - | - |
| Before | 107.2 |
| After | 66.0 |


<details>
<summary>quick F# Interactive script to grab out the duration of satellite assembly generation from a before.binlog and after.binlog file in the current directory</summary>

```fsharp
#r "nuget: MSBuild.StructuredLogger"

open Microsoft.Build.Logging.StructuredLogger
let beforeLog = Serialization.Read("./before.binlog")
let afterLog = Serialization.Read("./after.binlog")

let getCompilationTimes (b: Build) =
    let satelliteCalls = ResizeArray<_>()

    b.VisitAllChildren<Target> (fun t ->
        if t.Name = "CoreGenerateSatelliteAssemblies" then
            satelliteCalls.Add(t.Duration))

    satelliteCalls
    |> Seq.sumBy (fun d -> d.TotalSeconds)

printfn "Before: %A" (getCompilationTimes beforeLog)
printfn "After: %A" (getCompilationTimes afterLog)
```
</details>