### PR TITLE
Update BaselinePackageValidator.cs

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/BaselinePackageValidator.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Validators/BaselinePackageValidator.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.PackageValidation.Validators
             {
                 // Skip target frameworks excluded from the baseline package.
                 if (options.BaselinePackageFrameworkFilter is not null &&
-                   !options.BaselinePackageFrameworkFilter.IsExcluded(baselineTargetFramework))
+                   options.BaselinePackageFrameworkFilter.IsExcluded(baselineTargetFramework))
                 {
                     continue;
                 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/SuppressibleTestLog.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/SuppressibleTestLog.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.ApiCompatibility.Logging;
@@ -8,8 +8,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
 {
     internal class SuppressibleTestLog : ISuppressibleLog
     {
-        public List<string> errors = new();
-        public List<string> warnings = new();
+        public List<string> info = [];
+        public List<string> errors = [];
+        public List<string> warnings = [];
 
         public bool HasLoggedErrors => errors.Count != 0;
         public bool HasLoggedErrorSuppressions { get; private set; }
@@ -33,7 +34,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         public void LogWarning(string message) => warnings.Add(message);
         public void LogWarning(string code, string message) => warnings.Add($"{code} {message}");
 
-        public void LogMessage(string message) { }
-        public void LogMessage(MessageImportance importance, string message) { }
+        public void LogMessage(string message) => info.Add(message);
+        public void LogMessage(MessageImportance importance, string message) => info.Add(message);
     }
 }

--- a/test/Microsoft.DotNet.PackageValidation.Tests/Validators/BaselinePackageValidatorTests.cs
+++ b/test/Microsoft.DotNet.PackageValidation.Tests/Validators/BaselinePackageValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.ApiCompatibility.Runner;
@@ -60,6 +60,7 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
                 baselinePackage: baselinePackage,
                 targetFrameworkFilter: targetFrameworkRegexFilter));
 
+            Assert.Contains(string.Format(Resources.BaselineTargetFrameworksIgnored, "netcoreapp3.1"), log.info);
             Assert.Empty(log.warnings);
             Assert.Empty(log.errors);
         }
@@ -87,10 +88,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
                 baselinePackage: baselinePackage,
                 targetFrameworkFilter: targetFrameworkRegexFilter));
 
-            Assert.Empty(log.errors);
+            Assert.Contains(string.Format(Resources.BaselineTargetFrameworksIgnored, "portable-net45+win8+wp8+wpa81"), log.info);
             Assert.Contains(DiagnosticIds.BaselineTargetFrameworkIgnoredButPresentInCurrentPackage + " " +
                 string.Format(Resources.BaselineTargetFrameworkIgnoredButPresentInCurrentPackage, "portable-net45+win8+wp8+wpa81"),
                 log.warnings);
+            Assert.Empty(log.errors);
         }
     }
 }


### PR DESCRIPTION
Mistake from https://github.com/dotnet/sdk/commit/5bf96c7fa734f503fa14a88d06dbf7ed819ed78e

Fixing the tests here as well. They didn't actually check if the TFM was ignored.