### PR TITLE
Don't attempt to run APICompat in design time builds

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.ValidateAssemblies.Common.targets
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.ValidateAssemblies.Common.targets
@@ -11,7 +11,7 @@
                   @(ApiCompatSuppressionFile);
                   $(ApiCompatSuppressionOutputFile)"
           Outputs="$(_ApiCompatValidateAssembliesSemaphoreFile)"
-          Condition="'@(ApiCompatLeftAssemblies)' != '' and '@(ApiCompatRightAssemblies)' != ''"
+          Condition="'@(ApiCompatLeftAssemblies)' != '' and '@(ApiCompatRightAssemblies)' != '' and '$(DesignTimeBuild)' != 'true'"
           DependsOnTargets="$(ApiCompatValidateAssembliesDependsOn)">
     <Microsoft.DotNet.ApiCompat.Task.ValidateAssembliesTask
       RoslynAssembliesPath="$(RoslynAssembliesPath)"


### PR DESCRIPTION
Reported in https://github.com/dotnet/sdk/issues/33396#issue-1764135020

> pretty sure I didn't even hit build

VS Design Time build runs targets like PrepareForRun. Gate APICompat to not run as part of design time builds.