### PR TITLE
Move SB metadata to intermediates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,6 +9,7 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>cbb8d0a278a06ad0166564ba4bb8fdcdc550bb16</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.templating" Version="9.0.100-preview.2.24103.1">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>cbb8d0a278a06ad0166564ba4bb8fdcdc550bb16</Sha>
@@ -21,7 +22,6 @@
     <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.9.0" Version="9.0.0-preview.2.24104.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f8629e62f7c8486af108a9ae10fec65e7c85c6af</Sha>
-      <SourceBuild RepoName="runtime" ManagedOnly="false" />
     </Dependency>
     <Dependency Name="VS.Redist.Common.NetCore.TargetingPack.x64.9.0" Version="9.0.0-preview.2.24104.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -47,7 +47,18 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f8629e62f7c8486af108a9ae10fec65e7c85c6af</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.runtime" Version="9.0.0-preview.2.24104.4">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>f8629e62f7c8486af108a9ae10fec65e7c85c6af</Sha>
+      <SourceBuild RepoName="runtime" ManagedOnly="false" />
+    </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-preview.2.24079.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>c7b4dbc857259968a0892cf94cfa9ae4f2ca53cd</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.emsdk" Version="9.0.0-preview.2.24079.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>c7b4dbc857259968a0892cf94cfa9ae4f2ca53cd</Sha>
       <SourceBuild RepoName="emsdk" ManagedOnly="true" />
@@ -60,6 +71,7 @@
       <Uri>https://github.com/dotnet/msbuild</Uri>
       <Sha>07fd5d51f25134ea3ab3620c66f6501a74df2921</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.10.0-preview-24101-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
       <Sha>07fd5d51f25134ea3ab3620c66f6501a74df2921</Sha>
@@ -69,6 +81,7 @@
       <Uri>https://github.com/dotnet/fsharp</Uri>
       <Sha>052d1133c78aa5af36c8e100afb91b1b5fc478af</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.fsharp" Version="8.0.300-beta.24101.1">
       <Uri>https://github.com/dotnet/fsharp</Uri>
       <Sha>052d1133c78aa5af36c8e100afb91b1b5fc478af</Sha>
@@ -77,9 +90,19 @@
     <Dependency Name="dotnet-format" Version="9.0.510301">
       <Uri>https://github.com/dotnet/format</Uri>
       <Sha>6fe8c258d1fded670eb2c1772bd1cce01229e288</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.format" Version="9.0.510301">
+      <Uri>https://github.com/dotnet/format</Uri>
+      <Sha>6fe8c258d1fded670eb2c1772bd1cce01229e288</Sha>
       <SourceBuild RepoName="format" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.10.0-2.24104.1">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>d9272a3f01928b1c3614a942bdbbfeb0fb17a43b</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.10.0-2.24104.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>d9272a3f01928b1c3614a942bdbbfeb0fb17a43b</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
@@ -183,7 +206,6 @@
     <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.10.0-preview-24101-03">
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>edaf4ff11b2b706e88c74d870035d2025776ec06</Sha>
-      <SourceBuild RepoName="vstest" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.TestPlatform.CLI" Version="17.10.0-preview-24101-03">
       <Uri>https://github.com/microsoft/vstest</Uri>
@@ -192,6 +214,12 @@
     <Dependency Name="Microsoft.TestPlatform.Build" Version="17.10.0-preview-24101-03">
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>edaf4ff11b2b706e88c74d870035d2025776ec06</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.vstest" Version="17.10.0-preview-24101-03">
+      <Uri>https://github.com/microsoft/vstest</Uri>
+      <Sha>edaf4ff11b2b706e88c74d870035d2025776ec06</Sha>
+      <SourceBuild RepoName="vstest" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="9.0.0-preview.2.24104.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -253,7 +281,6 @@
     <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.9.0" Version="9.0.0-preview.2.24104.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>e6c79485899829b1849b9f7b441d7e58f679603c</Sha>
-      <SourceBuild RepoName="aspnetcore" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="dotnet-dev-certs" Version="9.0.0-preview.2.24104.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
@@ -283,10 +310,15 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>e6c79485899829b1849b9f7b441d7e58f679603c</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.aspnetcore" Version="9.0.0-preview.2.24104.1">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>e6c79485899829b1849b9f7b441d7e58f679603c</Sha>
+      <SourceBuild RepoName="aspnetcore" ManagedOnly="true" />
+    </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="7.0.0-preview.24103.1">
       <Uri>https://github.com/dotnet/razor</Uri>
       <Sha>7c2bfb5912f042717fb113c7a6ba472a90e5beec</Sha>
-      <SourceBuild RepoName="razor" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal" Version="7.0.0-preview.24103.1">
       <Uri>https://github.com/dotnet/razor</Uri>
@@ -295,6 +327,12 @@
     <Dependency Name="Microsoft.NET.Sdk.Razor.SourceGenerators.Transport" Version="7.0.0-preview.24103.1">
       <Uri>https://github.com/dotnet/razor</Uri>
       <Sha>7c2bfb5912f042717fb113c7a6ba472a90e5beec</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.razor" Version="7.0.0-preview.24103.1">
+      <Uri>https://github.com/dotnet/razor</Uri>
+      <Sha>7c2bfb5912f042717fb113c7a6ba472a90e5beec</Sha>
+      <SourceBuild RepoName="razor" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0-preview.2.24104.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
@@ -315,6 +353,11 @@
     <Dependency Name="Microsoft.Web.Xdt" Version="9.0.0-preview.24079.2">
       <Uri>https://github.com/dotnet/xdt</Uri>
       <Sha>23e11f8312f853a3f694c6680c0e3762bdf1d9fd</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.xdt" Version="9.0.0-preview.24079.2">
+      <Uri>https://github.com/dotnet/xdt</Uri>
+      <Sha>23e11f8312f853a3f694c6680c0e3762bdf1d9fd</Sha>
       <SourceBuild RepoName="xdt" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24104.1">
@@ -325,6 +368,7 @@
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>
       <Sha>0e11212f35272998888c79f974a4f685acd00cd0</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn-analyzers" Version="3.11.0-beta1.24104.1">
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>
       <Sha>0e11212f35272998888c79f974a4f685acd00cd0</Sha>
@@ -334,16 +378,19 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>46fea71e3d98dad0d676950522004b7f295dd372</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.510201">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>46fea71e3d98dad0d676950522004b7f295dd372</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="9.0.0-alpha.1.24101.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
       <Sha>949db2fd23b687c0d545e954943feada8b361ed6</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24101.2">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>69b60d2af1775f374c91b3e52da02de6b7de1943</Sha>
@@ -356,7 +403,6 @@
     <Dependency Name="Microsoft.Build.Tasks.Git" Version="9.0.0-beta.24102.2">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
       <Sha>7378b26120437e4984e322d07bfd5028e10bc5ad</Sha>
-      <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.Common" Version="9.0.0-beta.24102.2">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
@@ -378,13 +424,19 @@
       <Uri>https://github.com/dotnet/sourcelink</Uri>
       <Sha>7378b26120437e4984e322d07bfd5028e10bc5ad</Sha>
     </Dependency>
-    <!-- Explicit dependency because Microsoft.Deployment.DotNet.Releases has different versioning
-         than the SB intermediate -->
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.sourcelink" Version="9.0.0-beta.24102.2">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>7378b26120437e4984e322d07bfd5028e10bc5ad</Sha>
+      <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.deployment-tools" Version="9.0.0-preview.1.24075.2">
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
       <Sha>643a0cb2966b097763158082a138189e22205d3b</Sha>
       <SourceBuild RepoName="deployment-tools" ManagedOnly="true" />
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.symreader" Version="2.0.0-beta-23228-03">
       <Uri>https://github.com/dotnet/symreader</Uri>
       <Sha>27e584661980ee6d82c419a2a471ae505b7d122e</Sha>
@@ -420,7 +472,6 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24102.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2fb543a45580400a559b5ae41c96a815ea14dac5</Sha>
-      <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="9.0.0-beta.24102.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -434,13 +485,19 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2fb543a45580400a559b5ae41c96a815ea14dac5</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="9.0.0-preview.2.24104.4">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f8629e62f7c8486af108a9ae10fec65e7c85c6af</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="9.0.0-beta.24102.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2fb543a45580400a559b5ae41c96a815ea14dac5</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="9.0.0-beta.24102.4">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>2fb543a45580400a559b5ae41c96a815ea14dac5</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="9.0.0-preview.2.24104.4">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>f8629e62f7c8486af108a9ae10fec65e7c85c6af</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -125,7 +125,6 @@
     <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
     <MicrosoftTemplateEngineUtilsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineUtilsPackageVersion>
     <MicrosoftTemplateSearchCommonPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateSearchCommonPackageVersion>
-    <MicrosoftSourceBuildIntermediatetemplatingPackageVersion>9.0.100-preview.2.24103.1</MicrosoftSourceBuildIntermediatetemplatingPackageVersion>
     <!-- test dependencies -->
     <MicrosoftTemplateEngineMocksPackageVersion>9.0.100-preview.2.24103.1</MicrosoftTemplateEngineMocksPackageVersion>
     <MicrosoftTemplateEngineTestHelperPackageVersion>$(MicrosoftTemplateEngineMocksPackageVersion)</MicrosoftTemplateEngineTestHelperPackageVersion>


### PR DESCRIPTION
The changes in this pull request aim to [improve the UX and guideance around the SourceBuild metadata](https://github.com/dotnet/source-build/issues/3373) by placing the metadata on explicit source-build intermediates.

The changes include:

- Removing existing SourceBuild metadata from all non-intermediate dependencies.
- Defining new explicit intermediate dependencies and adding SourceBuild metadata to those dependencies.

Related to https://github.com/dotnet/source-build/issues/3373 and https://github.com/dotnet/source-build/issues/4073