### PR TITLE
Run tests in different tfms in parallel

### DIFF
--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
@@ -44,10 +44,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />
-      <_MSBuildProjectFile Include="$(MSBuildProjectFile)" Properties="TargetFramework=%(_TargetFramework.Identity);VSTestNoBuild=true" />
+      <_ProjectToTestWithTFM Include="$(MSBuildProjectFile)" Properties="TargetFramework=%(_TargetFramework.Identity);VSTestNoBuild=true" />
     </ItemGroup>
     <Message Importance="High" Text="Starting custom DispatchToInnerBuildsWithVSTestTarget" />
-    <MSBuild Projects="@(_MSBuildProjectFile)"
+    <MSBuild Projects="@(_ProjectToTestWithTFM)"
              Condition="'$(TargetFrameworks)' != '' "
              Targets="$(InnerVSTestTargets)"
              ContinueOnError="ErrorAndContinue"

--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
@@ -34,14 +34,24 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
 
   <Target Name="DispatchToInnerBuildsWithVSTestTarget" Returns="@(InnerOutput)">
+    <PropertyGroup>
+      <!-- 
+        Emulating technique found in Microsoft.Build.Traversal for deciding whether to run tests in parallel.
+        Setting either property will revert to previous behavior of running tests in parallel, but without their
+        different TFMs running in parallel.
+      -->
+      <_TestTfmInParallel>$([MSBuild]::ValueOrDefault('$(TestTfmInParallel)', '$(BuildInParallel)'))</_TestTfmInParallel>
+    </PropertyGroup>
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />
+      <_MSBuildProjectFile Include="$(MSBuildProjectFile)" Properties="TargetFramework=%(_TargetFramework.Identity);VSTestNoBuild=true" />
     </ItemGroup>
-    <MSBuild Projects="$(MSBuildProjectFile)"
+    <Message Importance="High" Text="Starting custom DispatchToInnerBuildsWithVSTestTarget" />
+    <MSBuild Projects="@(_MSBuildProjectFile)"
              Condition="'$(TargetFrameworks)' != '' "
              Targets="$(InnerVSTestTargets)"
-             Properties="TargetFramework=%(_TargetFramework.Identity);VSTestNoBuild=true"
-             ContinueOnError="ErrorAndContinue">
+             ContinueOnError="ErrorAndContinue"
+             BuildInParallel="$(_TestTfmInParallel)">
       <Output ItemName="InnerOutput" TaskParameter="TargetOutputs" />
     </MSBuild>
   </Target>

--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
@@ -40,7 +40,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         Setting either property will revert to previous behavior of running tests in parallel, but without their
         different TFMs running in parallel.
       -->
-      <_TestTfmInParallel>$([MSBuild]::ValueOrDefault('$(TestTfmInParallel)', '$(BuildInParallel)'))</_TestTfmInParallel>
+      <_TestTfmsInParallel>$([MSBuild]::ValueOrDefault('$(TestTfmsInParallel)', '$(BuildInParallel)'))</_TestTfmsInParallel>
     </PropertyGroup>
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />
@@ -51,7 +51,7 @@ Copyright (c) .NET Foundation. All rights reserved.
              Condition="'$(TargetFrameworks)' != '' "
              Targets="$(InnerVSTestTargets)"
              ContinueOnError="ErrorAndContinue"
-             BuildInParallel="$(_TestTfmInParallel)">
+             BuildInParallel="$(_TestTfmsInParallel)">
       <Output ItemName="InnerOutput" TaskParameter="TargetOutputs" />
     </MSBuild>
   </Target>


### PR DESCRIPTION
Test projects currently parallelize by default, but their TFMs run in series. This change will run the tfms also in parallel. To revert to the original behavior (e.g. tests that access a common resource from the different TFMs) user can provide `-p:TestTfmsInParallel=false`  To control the overall amount of parallelism user can use the standard `-m:<number>` e.g. `-m:1` to run just one project at a time, or `-m:10` to run at most 10 projects in parallel. 

Fix #19147


### New 

All projects and tfms run at the same time up to the max parallel level which is the count of logical cpu cores by default:

mstest1.csproj net8
mstest1.csproj net7
mstest2.csproj net8
mstest2.csproj net7

### Old 
(or with `-p:TestTfmsInParallel=false`). 

All projects will run at the same time, up to the max parallel level (number of logical cpus), but the TFMs  in single project will never run at the same time.

mstest1.csproj net8, mstest1.csproj net7
mstest2.csproj net8, mstest2.csproj net7

### Disabling parallelism 

With -m:1: all projects and tfms will run in sequence: 

mstest1.csproj net8, mstest1.csproj net7, mstest2.csproj net8, mstest2.csproj net7

Code taken from this comment https://github.com/dotnet/sdk/issues/19147#issuecomment-883739548 thanks @ghost!