### PR TITLE
Fix PublishAot with PublishSingleFile

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -194,7 +194,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                  ResourceName="CannotIncludeSymbolsInSingleFile" />
     <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="CannotHaveSingleFileWithoutRuntimeIdentifier" />
-    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(UseAppHost)' != 'true'"
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(UseAppHost)' != 'true' and '$(PublishAot)' != 'true'"
                  ResourceName="CannotHaveSingleFileWithoutAppHost" />
     <NETSdkError Condition="'$(PublishSingleFile)' == 'true' And
                             '$(EnableCompressionInSingleFile)' == 'true' And


### PR DESCRIPTION
Setting both PublishSingleFile and PublishAot should be okay - this will do PublishAot since AOT is single file (same as PublishTrimmed and PublishAot means PublishAot).

Cc @dotnet/ilc-contrib 