### PR TITLE
Do not import LKG overlay targets in VMR build in general

### DIFF
--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -22,7 +22,7 @@
   <Import Project="targets\PublishDotnetWatch.targets" />
   <Import Project="targets\GenerateLayout.targets" />
   <Import Project="targets\GenerateArchive.targets" />
-  <Import Project="targets\OverlaySdkOnLKG.targets" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+  <Import Project="targets\OverlaySdkOnLKG.targets" Condition="'$(DotNetBuild)' != 'true'" />
   <Import Project="targets\MSBuildExtensions.targets" />
 
   <ItemGroup>


### PR DESCRIPTION
These attempt to download and prep an overlay layout for testing. This is unnecessary in VMR where the SDK will be immediately built after this repo.