### PR TITLE
Fix issue where applying rollback file would incorrectly uninstall workload packs

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -216,6 +216,11 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         installer.InstallWorkloadManifest(manifestUpdate, context, offlineCache, rollback);
                     }
 
+                    if (usingRollback)
+                    {
+                        UpdateInstallState(true, manifestsToUpdate);
+                    }
+
                     _workloadResolver.RefreshWorkloadManifests();
 
                     installer.InstallWorkloads(workloadIds, sdkFeatureBand, context, offlineCache);
@@ -227,10 +232,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         recordRepo.WriteWorkloadInstallationRecord(workloadId, sdkFeatureBand);
                     }
 
-                    if (usingRollback)
-                    {
-                        UpdateInstallState(true, manifestsToUpdate);
-                    }
                 },
                 rollback: () =>
                 {
@@ -242,6 +243,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         installer.GetWorkloadInstallationRecordRepository()
                             .DeleteWorkloadInstallationRecord(workloadId, sdkFeatureBand);
                     }
+
+                    //  Refresh the workload manifests to make sure that the resolver has the updated state after the rollback
+                    _workloadResolver.RefreshWorkloadManifests();
                 });
 
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -150,17 +150,19 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                         _workloadInstaller.InstallWorkloadManifest(manifestUpdate, context, offlineCache, rollback);
                     }
 
+					UpdateInstallState(useRollback, manifestsToUpdate);
+
                     _workloadResolver.RefreshWorkloadManifests();
 
                     var workloads = GetUpdatableWorkloads();
 
                     _workloadInstaller.InstallWorkloads(workloads, sdkFeatureBand, context, offlineCache);
-
-                    UpdateInstallState(useRollback, manifestsToUpdate);
                 },
                 rollback: () =>
                 {
                     //  Nothing to roll back at this level, InstallWorkloadManifest and InstallWorkloadPacks handle the transaction rollback
+                    //  We will refresh the workload manifests to make sure that the resolver has the updated state after the rollback
+                    _workloadResolver.RefreshWorkloadManifests();
                 });
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
@@ -9,6 +9,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     /// </summary>
     public interface IWorkloadManifestProvider
     {
+        void RefreshWorkloadManifests();
         IEnumerable<ReadableWorkloadManifest> GetManifests();
 
         string GetSdkFeatureBand();

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
@@ -14,6 +14,8 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             _sdkVersionBand = sdkFeatureBand;
         }
 
+        public void RefreshWorkloadManifests() { }
+
         public IEnumerable<ReadableWorkloadManifest>
             GetManifests()
         {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -102,6 +102,8 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             {
                 throw new InvalidOperationException("Resolver was created without provider and cannot be refreshed");
             }
+
+            _manifestProvider.RefreshWorkloadManifests();
             _manifests.Clear();
             LoadManifestsFromProvider(_manifestProvider);
             ComposeWorkloadManifests();
@@ -735,6 +737,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 _sdkFeatureBand = sdkFeatureBand;
             }
 
+            public void RefreshWorkloadManifests() { }
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
@@ -20,6 +20,8 @@ namespace ManifestReaderTests
             _filePaths = filePaths;
         }
 
+        public void RefreshWorkloadManifests() { }
+
         public IEnumerable<ReadableWorkloadManifest> GetManifests()
         {
             foreach (var filePath in _filePaths)
@@ -45,6 +47,8 @@ namespace ManifestReaderTests
         readonly List<(string id, byte[] content)> _manifests = new List<(string, byte[])>();
 
         public void Add(string id, string content) => _manifests.Add((id, Encoding.UTF8.GetBytes(content)));
+
+        public void RefreshWorkloadManifests() { }
 
         public IEnumerable<ReadableWorkloadManifest> GetManifests()
             => _manifests.Select(m => new ReadableWorkloadManifest(

--- a/src/Tests/dotnet-workload-install.Tests/MockManifestProvider.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockManifestProvider.cs
@@ -29,6 +29,8 @@ namespace ManifestReaderTests
 
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
 
+        public void RefreshWorkloadManifests() { }
+
         public IEnumerable<ReadableWorkloadManifest> GetManifests()
             {
                 foreach ((var id, var path, var featureBand) in _manifests)


### PR DESCRIPTION
Port of #38712 to release/8.0.1xx

Fix issue when applying workload rollback file where the rollback file would not be active when updating installed packs, leaving workloads in a partially installed state.

**Customer Impact**

Rollback files are the current way to install a specific version of .NET SDK workloads (they will be mostly superseded by workload sets in the future).  Rollback files are used commonly for early adopters or internal users of the Maui and Aspire workloads.

This bug can leave workloads in a partially installed state after applying a rollback file.  You would get a message saying the workload wasn't installed, even though you had previously installed it (and `dotnet workload list` would list it as installed).

Workarounds include running `dotnet workload repair`, `dotnet workload restore` or re-applying the same rollback file.

**Testing**

Wrote new semi-automated test for this scenario.

**Risk**

Low - This is a fairly straightforward change to make sure the rollback file changes are applied to the in-memory workload resolver before updating which packs are installed.  Still, it is not a one-line fix.

**Regression**

This regressed in 8.0.100 with the support for [side-by-side workload manifests](https://github.com/dotnet/sdk/pull/35106).

