### PR TITLE
Parse SdkFeatureBand from .version file

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/DotnetVersionFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/DotnetVersionFile.cs
@@ -5,22 +5,26 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     internal class DotnetVersionFile
     {
-        public bool Exists { get; set; }
+        public bool Exists { get; init; }
 
-        public string CommitSha { get; set; }
+        public string CommitSha { get; init; }
 
-        public string BuildNumber { get; set; }
+        public string BuildNumber { get; init; }
+
+        public string FullNugetVersion { get; init; }
+
+        public string SdkFeatureBand { get; init; }
 
         /// <summary>
         /// The runtime identifier (rid) that this CLI was built for.
         /// </summary>
         /// <remarks>
-        /// This is different than RuntimeInformation.RuntimeIdentifier because the 
+        /// This is different than RuntimeInformation.RuntimeIdentifier because the
         /// BuildRid is a RID that is guaranteed to exist and works on the current machine. The
-        /// RuntimeInformation.RuntimeIdentifier may be for a new version of the OS that 
+        /// RuntimeInformation.RuntimeIdentifier may be for a new version of the OS that
         /// doesn't have full support yet.
         /// </remarks>
-        public string BuildRid { get; set; }
+        public string BuildRid { get; init; }
 
         public DotnetVersionFile(string versionFilePath)
         {
@@ -44,6 +48,14 @@ namespace Microsoft.DotNet.Cli.Utils
                     else if (index == 2)
                     {
                         BuildRid = line;
+                    }
+                    else if (index == 3)
+                    {
+                        FullNugetVersion = line;
+                    }
+                    else if (index == 4)
+                    {
+                        SdkFeatureBand = line;
                     }
                     else
                     {

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Polyfills.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Polyfills.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+#if NET472
+
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit
+{
+}
+
+#endif


### PR DESCRIPTION
Companion to https://github.com/dotnet/installer/pull/18687 - this parses the feature band that's now written to that file so that we can use it inside the SDK if required.