### PR TITLE
Use MSBuild CLI in the test framework to get Property/Item data

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Polyfills.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Polyfills.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+#if NET472
+
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit
+{
+}
+
+#endif

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -274,25 +274,11 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = tfm,
             };
             testProject.AdditionalProperties[property] = "true";
+            // mimic calling `dotnet publish`
+            testProject.AdditionalProperties["_IsPublishing"] = "true";
 
             testProject.RecordProperties("SelfContained");
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: $"{property}-{useFrameworkDependentDefaultTargetFramework}");
-
-            var publishCommand = new DotnetPublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            if (property == "PublishTrimmed" && !useFrameworkDependentDefaultTargetFramework)
-            {
-                publishCommand
-                   .Execute()
-                   .Should()
-                   .Fail();
-            }
-            else
-            {
-                publishCommand
-                    .Execute()
-                    .Should()
-                    .Pass();
-            }
 
             var properties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework: tfm, configuration: useFrameworkDependentDefaultTargetFramework ? "Release" : "Debug");
 

--- a/src/Tests/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs
@@ -170,9 +170,10 @@ namespace Microsoft.NET.TestFramework.Assertions
             return s + $"{Environment.NewLine}" +
                        $"File Name: {_commandResult.StartInfo?.FileName}{Environment.NewLine}" +
                        $"Arguments: {_commandResult.StartInfo?.Arguments}{Environment.NewLine}" +
+                       $"Working Directory: {_commandResult.StartInfo?.WorkingDirectory}{Environment.NewLine}" +
                        $"Exit Code: {_commandResult.ExitCode}{Environment.NewLine}" +
                        $"StdOut:{Environment.NewLine}{_commandResult.StdOut}{Environment.NewLine}" +
-                       $"StdErr:{Environment.NewLine}{_commandResult.StdErr}{Environment.NewLine}"; ;
+                       $"StdErr:{Environment.NewLine}{_commandResult.StdErr}{Environment.NewLine}";
         }
 
         public AndConstraint<CommandResultAssertions> HaveSkippedProjectCompilation(string skippedProject, string frameworkFullName)
@@ -217,7 +218,7 @@ namespace Microsoft.NET.TestFramework.Assertions
 
         }
 
-        private string ReadNuPkg(string nupkgPath, params string[] filePaths) 
+        private string ReadNuPkg(string nupkgPath, params string[] filePaths)
         {
             if (nupkgPath == null)
             {
@@ -247,7 +248,7 @@ namespace Microsoft.NET.TestFramework.Assertions
             if (expected == null)
             {
                 throw new ArgumentNullException(nameof(expected));
-            }    
+            }
 
             new FileInfo(nuspecPath).Should().Exist();
             var content = File.ReadAllText(nuspecPath);
@@ -268,7 +269,7 @@ namespace Microsoft.NET.TestFramework.Assertions
             if (expected == null)
             {
                 throw new ArgumentNullException(nameof(expected));
-            }    
+            }
 
             new FileInfo(nuspecPath).Should().Exist();
             var content = File.ReadAllText(nuspecPath);

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -61,6 +61,15 @@ namespace Microsoft.NET.TestFramework.Commands
             return this;
         }
 
+        private TestCommand WithArguments(params string[] arguments)
+        {
+            Arguments.AddRange(arguments);
+            return this;
+        }
+        public TestCommand WithConfiguration(string config) => config is null ? this : WithArguments("--configuration", config);
+
+        public TestCommand WithTargetFramework(string tfm) => tfm is null ? this : WithArguments("--framework", tfm);
+
         private SdkCommandSpec CreateCommandSpec(IEnumerable<string> args)
         {
             var commandSpec = CreateCommand(args);
@@ -119,7 +128,7 @@ namespace Microsoft.NET.TestFramework.Commands
         }
 
         public virtual CommandResult Execute(IEnumerable<string> args)
-        { 
+        {
             var command = CreateCommandSpec(args)
                 .ToCommand(_doNotEscapeArguments)
                 .CaptureStdOut()

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -568,12 +568,13 @@ namespace {safeThisName}
         {
             var trackedProperties = PropertiesToRecord.Select(p => $"--getProperty:{p}");
             var trackedItems = ItemsToRecord.Select(i => $"--getItem:{i}");
+            var additionalProperties = AdditionalProperties.Select(p => $"/p:{p.Key}={p.Value}");
             var commandResult =
                 new DotnetBuildCommand(new NullOutputHelper())
                 .WithWorkingDirectory(testRoot)
                 .WithConfiguration(configuration)
                 .WithTargetFramework(targetFramework)
-                .Execute([Name, .. trackedProperties, .. trackedItems]);
+                .Execute([Name, .. trackedProperties, .. trackedItems, .. additionalProperties]);
 
             commandResult.Should().Pass();
             if (PropertiesToRecord.Count == 1 && ItemsToRecord.Count == 0)

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -593,7 +593,7 @@ namespace {safeThisName}
                 }
                 catch (System.Text.Json.JsonException e)
                 {
-                    throw new InvalidOperationException($"Failed to parse build result JSON.\nStdOut:\n{commandResult.StdOut}", e);
+                    throw new InvalidOperationException($"Failed to parse build result JSON.\nStdOut:\n```\n{commandResult.StdOut}\n```", e);
                 }
             }
         }

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -495,7 +495,7 @@ namespace {safeThisName}
             }
             else
             {
-                throw new InvalidOperationException("Expected 'properties' element in build result JSON");
+                return new();
             }
         }
 
@@ -529,7 +529,7 @@ namespace {safeThisName}
             }
             else
             {
-                throw new InvalidOperationException("Expected 'items' element in build result JSON");
+                return new();
             }
 
             static ITaskItem[] ReadTaskItemArray(JsonNode value)

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -577,10 +576,17 @@ namespace {safeThisName}
                 .Execute([Name, .. trackedProperties, .. trackedItems]);
 
             commandResult.Should().Pass();
-            var json = JsonDocument.Parse(commandResult.StdOut);
-            var properties = ParseProperties(json.RootElement);
-            var items = ParseItems(json.RootElement);
-            return new BuildResult(properties, items);
+            try
+            {
+                var json = JsonDocument.Parse(commandResult.StdOut);
+                var properties = ParseProperties(json.RootElement);
+                var items = ParseItems(json.RootElement);
+                return new BuildResult(properties, items);
+            }
+            catch (System.Text.Json.JsonException e)
+            {
+                throw new InvalidOperationException($"Failed to parse build result JSON.\nStdOut:\n{commandResult.StdOut}", e);
+            }
         }
 
         /// <returns>

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -574,7 +574,7 @@ namespace {safeThisName}
                 .WithWorkingDirectory(testRoot)
                 .WithConfiguration(configuration)
                 .WithTargetFramework(targetFramework)
-                .Execute([.. trackedProperties, .. trackedItems]);
+                .Execute([Name, .. trackedProperties, .. trackedItems]);
 
             commandResult.Should().Pass();
             var json = JsonDocument.Parse(commandResult.StdOut);


### PR DESCRIPTION
This seemed like a much easier way to get Item data out after thinking about how I'd start to approach that task. If we're happy with this, I can use it to test https://github.com/dotnet/sdk/pull/38504 more easily.