### PR TITLE
Fix unbalanced quote in error message

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
+++ b/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
@@ -124,7 +124,7 @@
     <value>Failed to load NuGet source {0}: the source is not valid. It will be skipped in further processing.</value>
   </data>
   <data name="IsNotFoundInNuGetFeeds" xml:space="preserve">
-    <value>{0} is not found in NuGet feeds {1}".</value>
+    <value>{0} is not found in NuGet feeds {1}.</value>
   </data>
   <data name="DownloadVersionFailed" xml:space="preserve">
     <value>Downloading {0} version {1} failed.</value>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
-        <target state="translated">Balíček {0} se nenašel v informačních kanálech NuGet {1}“.</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="translated">Balíček {0} se nenašel v informačních kanálech NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">Balíček {0} se nenašel v informačních kanálech NuGet {1}.</target>
+        <target state="needs-review-translation">Balíček {0} se nenašel v informačních kanálech NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
+        <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">"{0}" wurde in NuGet-Feeds "{1}" nicht gefunden.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">"{0}" wurde in NuGet-Feeds "{1}" nicht gefunden.</target>
+        <target state="needs-review-translation">"{0}" wurde in NuGet-Feeds "{1}" nicht gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
-        <target state="translated">No se encuentra {0} en las fuentes de NuGet {1}".</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="translated">No se encuentra {0} en las fuentes de NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">No se encuentra {0} en las fuentes de NuGet {1}.</target>
+        <target state="needs-review-translation">No se encuentra {0} en las fuentes de NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
+        <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">{0} est introuvable dans les flux NuGet {1}.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">{0} est introuvable dans les flux NuGet {1}.</target>
+        <target state="needs-review-translation">{0} est introuvable dans les flux NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
-        <target state="translated">{0} non è stato trovato nei feed NuGet {1}“.</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="translated">{0} non è stato trovato nei feed NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">{0} non è stato trovato nei feed NuGet {1}.</target>
+        <target state="needs-review-translation">{0} non è stato trovato nei feed NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">{0} が NuGet フィード {1} に見つかりません。</target>
+        <target state="needs-review-translation">{0} が NuGet フィード {1} に見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
-        <target state="translated">{0} が NuGet フィード {1}" に見つかりません。</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="translated">{0} が NuGet フィード {1} に見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">NuGet 피드 {1} 에서 {0}을(를) 찾을 수 없습니다.</target>
+        <target state="needs-review-translation">NuGet 피드 {1} 에서 {0}을(를) 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
-        <target state="translated">NuGet 피드 {1}"에서 {0}을(를) 찾을 수 없습니다.</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="translated">NuGet 피드 {1} 에서 {0}을(를) 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">Nie znaleziono pakietu {0} w kanałach informacyjnych NuGet {1}.</target>
+        <target state="needs-review-translation">Nie znaleziono pakietu {0} w kanałach informacyjnych NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
-        <target state="translated">Nie znaleziono pakietu {0} w kanałach informacyjnych NuGet {1}".</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="translated">Nie znaleziono pakietu {0} w kanałach informacyjnych NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
-        <target state="translated">{0} não foi encontrado no NuGet feeds {1}".</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="translated">{0} não foi encontrado no NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">{0} não foi encontrado no NuGet feeds {1}.</target>
+        <target state="needs-review-translation">{0} não foi encontrado no NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
-        <target state="translated">{0} не найдено в веб-каналах NuGet {1}".</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="translated">{0} не найдено в веб-каналах NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">{0} не найдено в веб-каналах NuGet {1}.</target>
+        <target state="needs-review-translation">{0} не найдено в веб-каналах NuGet {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
+        <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">{0}, {1} NuGet akışlarında bulunamadı.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">{0}, {1} NuGet akışlarında bulunamadı.</target>
+        <target state="needs-review-translation">{0}, {1} NuGet akışlarında bulunamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
+        <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">在 NuGet 源 {1} 中找不到 {0}。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">在 NuGet 源 {1} 中找不到 {0}。</target>
+        <target state="needs-review-translation">在 NuGet 源 {1} 中找不到 {0}。</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
         <source>{0} is not found in NuGet feeds {1}.</source>
-        <target state="translated">在 NuGet 摘要 {1} 中找不到 {0}"。</target>
+        <target state="needs-review-translation">在 NuGet 摘要 {1} 中找不到 {0}"。</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="IsNotFoundInNuGetFeeds">
-        <source>{0} is not found in NuGet feeds {1}".</source>
+        <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">在 NuGet 摘要 {1} 中找不到 {0}"。</target>
         <note />
       </trans-unit>


### PR DESCRIPTION
Remove unbalanced quote from formatted value.

On balance it seemed like a leftover, rather than a missing initial quote. Of any translators who did see the mistake, most seem to have removed it rather than added the missing one (e.g. in German).

I can invert the fix if that was what was actually intended.
