### PR TITLE
Revert Parallel Copy for 8.0.200

### DIFF
--- a/src/Layout/redist/targets/PublishDotnetWatch.targets
+++ b/src/Layout/redist/targets/PublishDotnetWatch.targets
@@ -9,7 +9,7 @@
   <Target Name="_PublishDotnetWatchToRedist_Inputs">
     <ItemGroup>
       <_DotnetWatchBuildOutput Include="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**"/>
-
+      
       <!--
         To reduce the size of the SDK, we use the compiler dependencies that are located in the `Roslyn/bincore` location
         instead of shipping our own copies in the dotnet-watch tool. These assemblies will be resolved by path in the
@@ -29,12 +29,14 @@
   </Target>
 
   <Target Name="PublishDotnetWatchToRedist"
-          DependsOnTargets="GetDotnetWatchRedistOutputDirectory;_PublishDotnetWatchToRedist_Inputs">
+          DependsOnTargets="GetDotnetWatchRedistOutputDirectory;_PublishDotnetWatchToRedist_Inputs"
+          Inputs="@(_DotnetWatchInputFile)"
+          Outputs="@(_DotnetWatchInputFile->'$(DotnetWatchRedistOutputDirectory)$(DotnetWatchRedistOutputSubdirectory)%(RecursiveDir)%(Filename)%(Extension)')">
 
-    <Copy SourceFiles="@(_DotnetWatchInputFile)" DestinationFiles="@(_DotnetWatchInputFile->'$(DotnetWatchRedistOutputDirectory)$(DotnetWatchRedistOutputSubdirectory)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_DotnetWatchInputFile)" DestinationFiles="$(DotnetWatchRedistOutputDirectory)$(DotnetWatchRedistOutputSubdirectory)%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
 
     <ItemGroup>
-      <FileWrites Include="@(_DotnetWatchInputFile->'$(DotnetWatchRedistOutputDirectory)$(DotnetWatchRedistOutputSubdirectory)%(RecursiveDir)%(Filename)%(Extension)')" />
+      <FileWrites Include="@(_DotnetWatchOutputFile)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
This was a mistake here https://github.com/dotnet/sdk/pull/37312, I did not check to see it was in 8.0.200. We should not have merged this as it would not meet a servicing bar. Instead I ported it into 8.0.300 here https://github.com/dotnet/sdk/pull/38929