### PR TITLE
Use a more reasonable timeout for HttpClient operations for Container Registry interactions

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
@@ -14,6 +14,14 @@ internal class DefaultRegistryAPI : IRegistryAPI
     private readonly HttpClient _client;
     private readonly ILogger _logger;
 
+    // Empirical value - Unoptimized .NET application layers can be ~200MB
+    // * .NET Runtime (~80MB)
+    // * ASP.NET Runtime (~25MB)
+    // * application and dependencies - variable, but _probably_ not more than the BCL?
+    // Given a 200MB target and a 1Mb/s upload speed, we'd expect an upload speed of 27m:57s.
+    // Making this a round 30 for convenience.
+    private static TimeSpan LongRequestTimeout = TimeSpan.FromMinutes(30);
+
     internal DefaultRegistryAPI(string registryName, Uri baseUri, ILogger logger)
     {
         bool isAmazonECRRegistry = baseUri.IsAmazonECRRegistry();
@@ -33,7 +41,7 @@ internal class DefaultRegistryAPI : IRegistryAPI
         var innerHandler = new SocketsHttpHandler()
         {
             UseCookies = false,
-            // the rest of the HTTP stack has an infinite timeout (see below) but we should still have a reasonable timeout for the initial connection
+            // the rest of the HTTP stack has an very long timeout (see below) but we should still have a reasonable timeout for the initial connection
             ConnectTimeout = TimeSpan.FromSeconds(30)
         };
 
@@ -56,8 +64,7 @@ internal class DefaultRegistryAPI : IRegistryAPI
 
         HttpClient client = new(clientHandler)
         {
-            // blob upload operations can take quite a while, we should allow them to take as long as they need
-            Timeout = Timeout.InfiniteTimeSpan
+            Timeout = LongRequestTimeout
         };
 
         client.DefaultRequestHeaders.Add("User-Agent", $".NET Container Library v{Constants.Version}");

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
@@ -52,7 +52,11 @@ internal class DefaultRegistryAPI : IRegistryAPI
             clientHandler = new AmazonECRMessageHandler(clientHandler);
         }
 
-        HttpClient client = new(clientHandler);
+        HttpClient client = new(clientHandler)
+        {
+            // blob upload operations can take quite a while, we should allow them to take as long as they need
+            Timeout = Timeout.InfiniteTimeSpan
+        };
 
         client.DefaultRequestHeaders.Add("User-Agent", $".NET Container Library v{Constants.Version}");
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
@@ -33,6 +33,8 @@ internal class DefaultRegistryAPI : IRegistryAPI
         var innerHandler = new SocketsHttpHandler()
         {
             UseCookies = false,
+            // the rest of the HTTP stack has an infinite timeout (see below) but we should still have a reasonable timeout for the initial connection
+            ConnectTimeout = TimeSpan.FromSeconds(30)
         };
 
         // Ignore certificate for https localhost repository.


### PR DESCRIPTION
Tentative minimal fix for https://github.com/dotnet/sdk-container-builds/issues/543

## Description

Users with saturated, low, or intermittent network speeds sometimes would hit timeouts when pushing large container image layers due to our use of the default HttpClient timeout of 100 seconds.  This fix is a simple, targeted fix for 8.0.2xx that extends the timeouts while we work on a longer term fix for 8.0.3xx and beyond. We've estimated layer sizes and determined a reasonable top limit that would allow large layers to be uploaded without leading to infinite timeouts.

## Customer Impact
Customers uploading large layers (for example, a self-contained, untrimmed application) would hit unavoidable upload errors if the upload took over 100s. 

## Regression?
**No** - we've had this in a few different scenarios before, and we've done per-registry probing for compat quirks, chunking, etc to mitigate. This is one more such mitigation.

## Risk

**Low** - this only impacts container publish and is a very targeted fix.
