### PR TITLE
Remove getX MSBuild flags from restore invocation

### DIFF
--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -79,12 +79,12 @@ namespace Microsoft.DotNet.Tools
         private static readonly string[] switchPrefixes = ["-", "/", "--"];
 
         // these properties trigger a separate restore
-        private static List<string> PropertiesToExcludeFromRestore =
+        private static readonly string[] PropertiesToExcludeFromRestore =
         [
             "TargetFramework"
         ];
 
-        private static List<string> FlagsThatTriggerSilentRestore =
+        private static readonly string[] FlagsThatTriggerSilentRestore =
             [
                 "getProperty",
                 "getItem",
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Tools
 
         //  These arguments don't by themselves require that restore be run in a separate process,
         //  but if there is a separate restore process they shouldn't be passed to it
-        private static List<string> FlagsToExcludeFromRestore =
+        private static readonly string[] FlagsToExcludeFromRestore =
         [
             ..FlagsThatTriggerSilentRestore,
             "t",
@@ -111,6 +111,9 @@ namespace Microsoft.DotNet.Tools
         private static List<string> PropertiesToExcludeFromSeparateRestore =
             ComputePropertySwitches(PropertiesToExcludeFromRestore).ToList();
 
+        // We investigate the arguments we're about to send to a separate restore call and filter out
+        // arguments that negatively influence the restore. In addition, some flags signal different modes of execution
+        // that we need to compensate for, so we might yield new arguments that should be included in the overall restore call.
         private static (string[] newArgumentsToAdd, string[] existingArgumentsToForward) ProcessForwardedArgumentsForSeparateRestore(IEnumerable<string> forwardedArguments)
         {
             HashSet<string> newArgumentsToAdd = new();
@@ -132,7 +135,7 @@ namespace Microsoft.DotNet.Tools
             }
             return (newArgumentsToAdd.ToArray(), existingArgumentsToForward.ToArray());
         }
-        private static IEnumerable<string> ComputePropertySwitches(List<string> properties)
+        private static IEnumerable<string> ComputePropertySwitches(string[] properties)
         {
             foreach (var prefix in switchPrefixes)
             {
@@ -144,7 +147,7 @@ namespace Microsoft.DotNet.Tools
             }
         }
 
-        private static IEnumerable<string> ComputeFlags(List<string> flags)
+        private static IEnumerable<string> ComputeFlags(string[] flags)
         {
             foreach (var prefix in switchPrefixes)
             {

--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Tools
         private static bool HasArgumentToExcludeFromRestore(IEnumerable<string> arguments)
             => arguments.Any(a => IsExcludedFromRestore(a));
 
-        private static readonly string[] propertyPrefixes = new string[] { "-", "/", "--" };
+        private static readonly string[] switchPrefixes = ["-", "/", "--"];
 
         // these properties trigger a separate restore
         private static List<string> PropertiesToExcludeFromRestore =
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Tools
 
         private static IEnumerable<string> ComputePropertySwitches(List<string> properties)
         {
-            foreach (var prefix in propertyPrefixes)
+            foreach (var prefix in switchPrefixes)
             {
                 foreach (var property in properties)
                 {
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Tools
 
         private static IEnumerable<string> ComputeFlags(List<string> flags)
         {
-            foreach (var prefix in propertyPrefixes)
+            foreach (var prefix in switchPrefixes)
             {
                 foreach (var flag in flags)
                 {

--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -159,14 +159,14 @@ namespace Microsoft.DotNet.Tools
         }
 
         private static bool IsExcludedFromRestore(string argument)
-            => PropertiesToExcludeFromSeparateRestore.Any(flag => argument.StartsWith(flag, StringComparison.Ordinal));
+            => PropertiesToExcludeFromSeparateRestore.Any(flag => argument.StartsWith(flag, StringComparison.OrdinalIgnoreCase));
 
 
         private static bool IsExcludedFromSeparateRestore(string argument)
-            => FlagsToExcludeFromSeparateRestore.Any(p => argument.StartsWith(p, StringComparison.Ordinal));
+            => FlagsToExcludeFromSeparateRestore.Any(p => argument.StartsWith(p, StringComparison.OrdinalIgnoreCase));
 
         private static bool TriggersSilentSeparateRestore(string argument)
-            => FlagsThatTriggerSilentSeparateRestore.Any(p => argument.StartsWith(p, StringComparison.Ordinal));
+            => FlagsThatTriggerSilentSeparateRestore.Any(p => argument.StartsWith(p, StringComparison.OrdinalIgnoreCase));
 
         public override int Execute()
         {

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
                                   "-target:Restore -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild",
                                   "-property:TargetFramework=tfm -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild")]
-        [InlineData(new string[] { "-f", "tfm", "-getItem:Compile", "-getProperty:TargetFramework", "-getTargetResult:Build" }, "-target:Restore", "-property:TargetFramework=tfm -getItem:Compile -getProperty:TargetFramework -getTargetResult:Build")]
+        [InlineData(new string[] { "-f", "tfm", "-getItem:Compile", "-getProperty:TargetFramework", "-getTargetResult:Build" }, "-target:Restore -nologo -verbosity:quiet", "-property:TargetFramework=tfm -getItem:Compile -getProperty:TargetFramework -getTargetResult:Build")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(
             string[] args,
             string expectedAdditionalArgsForRestore,

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -64,6 +64,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
                                   "-target:Restore -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild",
                                   "-property:TargetFramework=tfm -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild")]
+        [InlineData(new string[] { "-f", "tfm", "-getItem:Compile", "-getProperty:TargetFramework", "-getTargetResult:Build" }, "-target:Restore", "-property:TargetFramework=tfm -getItem:Compile -getProperty:TargetFramework -getTargetResult:Build")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(
             string[] args,
             string expectedAdditionalArgsForRestore,


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/38944

### Description

Users were experiencing apparently-duplicated output when using the new -getProperty/-getItem/-getTargetResult flags for MSBuild in certain scenarios. This is because the SDK performs an additional, hidden-from-the-user `Restore` call in situations where users pass flags that Restore can't handle. Typically this is any use of the `-f` CLI argument.

This leads to multiple separate MSBuild invocations, each with all of same set of forwarded arguments, and so user-provided `-getItem`, `-getProperty`, etc flags are used for both invocations. Since the expected user behavior is to only apply to the non-Restore build, we filter these flags out from the separate Restore, while also ensuring that any errors during the separate Restore are treated similarly to how they would have been if there had been only one call to MSBuild.

Longer term, https://github.com/dotnet/msbuild/issues/9778 would allow us to remove the entire concept of the 'separate restore', leading to faster build times and removal of this unnecessary SDK code.

### Customer Impact

Customers using the feature are essentially broken anytime a TargetFramework property is passed to the build/publish/etc. call, which happens very often for scenarios like build, test, and publish.  Users of these flags would get double writes of the requested information, and that information would be written in ways that make it hard to use the feature in CI/scripting scenarios. Right now this customer list includes:
* Uno Platform
* Fable Compiler
* The .NET SDK itself

### Regression
**Yes** - these flags worked in 8.0.100, and a MSBuild fix in 8.0.200 surfaced this unfortunate interaction.

### Risk 
**Low** - we have extensive testing around the way these 'separate restores' are invoked, and this new logic only lights up in the specific scenarios, as verified by manual and automated testing.

### Testing

* [x] manual, scenario-based
* [x] automated argument-parsing validation tests