### PR TITLE
Set ProducesDotNetReleaseShippingAssets property in Publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -5,6 +5,7 @@
     <PublishingVersion>3</PublishingVersion>
     <!-- This repo does its own symbol package generation to avoid generating symbols for a bunch of unrelated test packages. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
+    <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Add a boolean property named `ProducesDotNetReleaseShippingAssets` in `Publishing.props` for repos that produce .NET shipping packages (packages that we ship with the release infra)
Based on this property we will select which packages to ship as part of .NET on release day.

This is a infrastructure only change. It will add extra metadata to the MergedManifest.xml produced during CI build.

Tracking issue: https://github.com/dotnet/release/issues/822