### PR TITLE
Branding for Preview 3  🐺 

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,7 @@
     <PreReleaseVersionLabel Condition="'$(StabilizePackageVersion)' != 'true'">preview</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(StabilizePackageVersion)' == 'true' and $(VersionPrefix.EndsWith('00'))">rtm</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(StabilizePackageVersion)' == 'true' and !$(VersionPrefix.EndsWith('00'))">servicing</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration Condition="'$(StabilizePackageVersion)' != 'true'">2</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration Condition="'$(StabilizePackageVersion)' != 'true'">3</PreReleaseVersionIteration>
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>


### PR DESCRIPTION
Snapped for preview 2, so main is now preview 3.
Example PR for branding 2: https://github.com/dotnet/sdk/commit/d8f3b863c8ee111f5ba2e0a0a5932cd303ae6015

Branding changes used to look like this: https://github.com/dotnet/sdk/pull/33475/files but they are a bit different now (only slightly)