### PR TITLE
Ensure watch supports environment variable directives

### DIFF
--- a/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
@@ -237,7 +237,9 @@ Examples:
         errorCode = new CliConfiguration(rootCommand)
         {
             Output = output ?? Console.Out,
-            Error = error ?? Console.Error
+            Error = error ?? Console.Error,
+            Directives = { new EnvironmentVariablesDirective() },
+
         }.Invoke(args);
 
         return options;


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/39020 by applying the same fix as https://github.com/dotnet/sdk/pull/37827, but to dotnet-watch, which sits outside of the main `dotnet` CLI and so sometimes misses fixes made to the core.

### Description

In https://github.com/dotnet/sdk/pull/37827 we fixed a regression in support of environment variable directives (a System.CommandLine feature) but didn't realize that `dotnet watch` isn't a command/part of the 'core' `dotnet` CLI app - it's a separate app. So we need to apply the change from https://github.com/dotnet/sdk/pull/37827 to `dotnet watch` as well.

### Customer Impact

Customers using the `[env:NAME=Value]` syntax to set environment variables on a per-command basis uniformly across OS platforms and shells can't do this with `watch`, and they used to be able to.

### Regression
**Yes** - This is the same regression from https://github.com/dotnet/sdk/pull/37827 but in a different place.

### Risk 
**Low** - the change is well-understood, and while there are other 'tools' that are standalone in the SDK repo, `watch` is the only one that is thought of by users as a 'core' SDK command. Tools like user-secrets/format/etc are not and already have their own, disparate behaviors.