### PR TITLE
Don't run PackageInstall test targets when the project is excluded

### DIFF
--- a/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
@@ -1,4 +1,5 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
+
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
   </PropertyGroup>
@@ -11,6 +12,7 @@
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <CanRunTestAsTool>false</CanRunTestAsTool>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cli\dotnet\dotnet.csproj" />
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.Configurer\Microsoft.DotNet.Configurer.csproj" />
@@ -18,6 +20,7 @@
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.ComponentMocks\Microsoft.DotNet.Tools.Tests.ComponentMocks.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <None Update="DotnetToolSettingsMissing.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -59,69 +62,126 @@
     <None Remove="SampleGlobalToolWithDifferentCasing/**" />
   </ItemGroup>
 
-  <Target Name="CreateNupkgFromSource" BeforeTargets="Build">
+  <!-- _SuppressAllTargets condition is necessary as Arcade's ExcludeFrom* infra is sub-optimal
+       which makes the target still run: https://github.com/dotnet/source-build/issues/4047 -->
+  <Target Name="CreateNupkgFromSource"
+          BeforeTargets="Build"
+          Condition="'$(_SuppressAllTargets)' != 'true'">
     <PropertyGroup>
       <testAssetSourceRoot>$(BaseOutputPath)/TestAsset/SampleGlobalTool</testAssetSourceRoot>
     </PropertyGroup>
+
     <Copy SourceFiles="SampleGlobalTool/DotnetToolSettings.xml" DestinationFolder="$(testAssetSourceRoot)" />
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalTool/consoledemo.csproj" Targets="Restore" Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false;ForceRestoreToEvaluateSeparately=1" RemoveProperties="TargetFramework">
-    </MSBuild>
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalTool/consoledemo.csproj" Targets="Build;Publish" Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false" RemoveProperties="TargetFramework">
-    </MSBuild>
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalTool/consoledemo.csproj" Targets="pack" Properties="Configuration=Release;NuspecFile=includepublish.nuspec;NuspecBasePath=$(testAssetSourceRoot);PackageOutputPath=$(OutputPath)TestAssetLocalNugetFeed;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false" RemoveProperties="TargetFramework">
-    </MSBuild>
+
+    <MSBuild Projects="SampleGlobalTool/consoledemo.csproj"
+             Targets="Restore"
+             Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false;ForceRestoreToEvaluateSeparately=1"
+             RemoveProperties="TargetFramework" />
+
+    <MSBuild Projects="SampleGlobalTool/consoledemo.csproj"
+             Targets="Build;Publish"
+             Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false"
+             RemoveProperties="TargetFramework" />
+
+    <MSBuild Projects="SampleGlobalTool/consoledemo.csproj"
+             Targets="Pack"
+             Properties="Configuration=Release;NuspecFile=includepublish.nuspec;NuspecBasePath=$(testAssetSourceRoot);PackageOutputPath=$(OutputPath)TestAssetLocalNugetFeed;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false"
+             RemoveProperties="TargetFramework" />
   </Target>
 
-  <Target Name="CreateNupkgWithPreviewFromSource" BeforeTargets="Build">
+  <Target Name="CreateNupkgWithPreviewFromSource"
+          BeforeTargets="Build"
+          Condition="'$(_SuppressAllTargets)' != 'true'">
     <PropertyGroup>
       <testAssetSourceRoot>$(BaseOutputPath)/TestAsset/SampleGlobalToolWithPreview</testAssetSourceRoot>
     </PropertyGroup>
+
     <Copy SourceFiles="SampleGlobalToolWithPreview/DotnetToolSettings.xml" DestinationFolder="$(testAssetSourceRoot)" />
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalToolWithPreview/consoledemo.csproj" Targets="Restore" Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false;ForceRestoreToEvaluateSeparately=1" RemoveProperties="TargetFramework">
-    </MSBuild>
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalToolWithPreview/consoledemo.csproj" Targets="Build;Publish" Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false" RemoveProperties="TargetFramework">
-    </MSBuild>
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalToolWithPreview/consoledemo.csproj" Targets="pack" Properties="Configuration=Release;NuspecFile=includepublish.nuspec;NuspecBasePath=$(testAssetSourceRoot);PackageOutputPath=$(OutputPath)TestAssetLocalNugetFeed;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false" RemoveProperties="TargetFramework">
-    </MSBuild>
+
+    <MSBuild Projects="SampleGlobalToolWithPreview/consoledemo.csproj"
+             Targets="Restore"
+             Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false;ForceRestoreToEvaluateSeparately=1"
+             RemoveProperties="TargetFramework" />
+
+    <MSBuild Projects="SampleGlobalToolWithPreview/consoledemo.csproj"
+             Targets="Build;Publish"
+             Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false"
+             RemoveProperties="TargetFramework" />
+
+    <MSBuild Projects="SampleGlobalToolWithPreview/consoledemo.csproj"
+             Targets="Pack"
+             Properties="Configuration=Release;NuspecFile=includepublish.nuspec;NuspecBasePath=$(testAssetSourceRoot);PackageOutputPath=$(OutputPath)TestAssetLocalNugetFeed;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false"
+             RemoveProperties="TargetFramework" />
   </Target>
 
-  <Target Name="CreateNupkgWithDifferentCasingFromSource" BeforeTargets="Build">
+  <Target Name="CreateNupkgWithDifferentCasingFromSource"
+          BeforeTargets="Build"
+          Condition="'$(_SuppressAllTargets)' != 'true'">
     <PropertyGroup>
       <testAssetSourceRoot>$(BaseOutputPath)/TestAsset/SampleGlobalToolWithDifferentCasing</testAssetSourceRoot>
     </PropertyGroup>
+
     <Copy SourceFiles="SampleGlobalToolWithDifferentCasing/DotnetToolSettings.xml" DestinationFolder="$(testAssetSourceRoot)" />
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalToolWithDifferentCasing/ConsoleDemoWithCasing.csproj" Targets="Restore" Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false;ForceRestoreToEvaluateSeparately=1" RemoveProperties="TargetFramework">
-    </MSBuild>
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalToolWithDifferentCasing/ConsoleDemoWithCasing.csproj" Targets="Build;Publish" Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false" RemoveProperties="TargetFramework">
-    </MSBuild>
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalToolWithDifferentCasing/ConsoleDemoWithCasing.csproj" Targets="pack" Properties="Configuration=Release;NuspecFile=includepublish.nuspec;NuspecBasePath=$(testAssetSourceRoot);PackageOutputPath=$(OutputPath)TestAssetLocalNugetFeed;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false" RemoveProperties="TargetFramework">
-    </MSBuild>
+
+    <MSBuild Projects="SampleGlobalToolWithDifferentCasing/ConsoleDemoWithCasing.csproj"
+             Targets="Restore"
+             Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false;ForceRestoreToEvaluateSeparately=1"
+             RemoveProperties="TargetFramework" />
+
+    <MSBuild Projects="SampleGlobalToolWithDifferentCasing/ConsoleDemoWithCasing.csproj"
+             Targets="Build;Publish"
+             Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false"
+             RemoveProperties="TargetFramework" />
+
+    <MSBuild Projects="SampleGlobalToolWithDifferentCasing/ConsoleDemoWithCasing.csproj"
+             Targets="Pack"
+             Properties="Configuration=Release;NuspecFile=includepublish.nuspec;NuspecBasePath=$(testAssetSourceRoot);PackageOutputPath=$(OutputPath)TestAssetLocalNugetFeed;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false"
+             RemoveProperties="TargetFramework" />
   </Target>
 
-  <Target Name="CreateNupkgWithShimFromSource" BeforeTargets="Build">
+  <Target Name="CreateNupkgWithShimFromSource"
+          BeforeTargets="Build"
+          Condition="'$(_SuppressAllTargets)' != 'true'">
     <PropertyGroup>
       <testAssetSourceRoot>$(BaseOutputPath)/TestAsset/SampleGlobalToolWithShim</testAssetSourceRoot>
     </PropertyGroup>
+
     <Copy SourceFiles="SampleGlobalToolWithShim/DotnetToolSettings.xml" DestinationFolder="$(testAssetSourceRoot)" />
     <Copy SourceFiles="SampleGlobalToolWithShim/dummyshim" DestinationFolder="$(testAssetSourceRoot)" />
     <Copy SourceFiles="SampleGlobalToolWithShim/dummyshim.exe" DestinationFolder="$(testAssetSourceRoot)" />
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalToolWithShim/consoledemo.csproj" Targets="Restore" Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false;ForceRestoreToEvaluateSeparately=1" RemoveProperties="TargetFramework">
-    </MSBuild>
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalToolWithShim/consoledemo.csproj" Targets="Build;Publish" Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false" RemoveProperties="TargetFramework">
-    </MSBuild>
-    <MSBuild BuildInParallel="False" Projects="SampleGlobalToolWithShim/consoledemo.csproj" Targets="pack" Properties="Configuration=Release;NuspecFile=includepublish.nuspec;NuspecBasePath=$(testAssetSourceRoot);PackageOutputPath=$(OutputPath)TestAssetLocalNugetFeed;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false" RemoveProperties="TargetFramework">
-    </MSBuild>
+
+    <MSBuild Projects="SampleGlobalToolWithShim/consoledemo.csproj"
+             Targets="Restore"
+             Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false;ForceRestoreToEvaluateSeparately=1"
+             RemoveProperties="TargetFramework" />
+
+    <MSBuild Projects="SampleGlobalToolWithShim/consoledemo.csproj"
+             Targets="Build;Publish"
+             Properties="Configuration=Release;BaseOutputPath=$(testAssetSourceRoot)/bin/;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false"
+             RemoveProperties="TargetFramework" />
+
+    <MSBuild Projects="SampleGlobalToolWithShim/consoledemo.csproj"
+             Targets="Pack"
+             Properties="Configuration=Release;NuspecFile=includepublish.nuspec;NuspecBasePath=$(testAssetSourceRoot);PackageOutputPath=$(OutputPath)TestAssetLocalNugetFeed;BaseIntermediateOutputPath=$(testAssetSourceRoot)/obj/;ImportDirectoryBuildProps=false;ImportDirectoryBuildTargets=false"
+             RemoveProperties="TargetFramework" />
   </Target>
 
-  <Target Name="CopyAssetToPublishFolder" BeforeTargets="Publish" DependsOnTargets="CreateNupkgWithShimFromSource;CreateNupkgFromSource;CreateNupkgWithShimFromSource;CreateNupkgWithPreviewFromSource">
+  <Target Name="CopyAssetToPublishFolder"
+          BeforeTargets="Publish"
+          Condition="'$(_SuppressAllTargets)' != 'true'"
+          DependsOnTargets="CreateNupkgWithShimFromSource;
+                            CreateNupkgFromSource;
+                            CreateNupkgWithShimFromSource;
+                            CreateNupkgWithPreviewFromSource">
     <ItemGroup>
       <TestAssetFiles Include="$(BaseOutputPath)\TestAsset\**\*.*" />
       <TestAssetLocalNugetFeed Include="$(BaseOutputPath)\$(Configuration)\TestAssetLocalNugetFeed\**\*.*" />
     </ItemGroup>
+
     <Copy SourceFiles="@(TestAssetFiles)" DestinationFiles="@(TestAssetFiles->'$(PublishDir)\TestAsset\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(TestAssetLocalNugetFeed)" DestinationFiles="@(TestAssetLocalNugetFeed->'$(PublishDir)\TestAssetLocalNugetFeed\%(RecursiveDir)%(Filename)%(Extension)')" />
-
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
 </Project>


### PR DESCRIPTION
Unblocks https://github.com/dotnet/installer/pull/18762

Add Condition for SuppressAllTargets so that the projects gets correctly excluded when building inside the VMR without tests.

**Aside from the added conditions, all the changes are just formatting to make the project more readable (cause it was a mess...).**