### PR TITLE
Disable compiler toolset in sdk

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,11 +4,6 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-  <!-- Opt out of certain Arcade features -->
-  <PropertyGroup>
-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
-    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
-  </PropertyGroup>
   <!-- Repo Version Information -->
   <PropertyGroup>
     <VersionPrefix>9.0.100</VersionPrefix>

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" ExcludeAssets="All" GeneratePathProperty="true"/>
     <PackageReference Include="Microsoft.FSharp.Compiler" ExcludeAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Sdk.Razor.SourceGenerators.Transport" GeneratePathProperty="true" />
+    <PackageDownload Include="Microsoft.Net.Compilers.Toolset" Version="[$(MicrosoftNetCompilersToolsetPackageVersion)]" />
 
     <!-- Lift up dependencies of dependencies to prevent build tasks from getting pinned to older versions -->
     <PackageReference Include="System.CodeDom" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/dotnet/issues/1015

There is no need to use the compiler toolset in this repository as the toolset SDK should be recent enough. It gets updated frequently. Avoiding the compiler toolset helps with https://github.com/dotnet/installer/pull/18762 and is general the better approach.