### PR TITLE
Remove the System.Drawing.Common dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,7 +81,6 @@
     <PackageVersion Include="System.Composition.Runtime" Version="$(MicrosoftNETCoreAppRefPackageVersion)"/>
     <PackageVersion Include="System.Composition.TypedParts" Version="$(MicrosoftNETCoreAppRefPackageVersion)"/>
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(MicrosoftNETCoreAppRefPackageVersion)" />
-    <PackageVersion Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <!-- System.Reflection.Metadata and System.Collections.Immutable cannot be pinned here because of hard dependencies within Roslyn on specific versions that have to work both here and in VS -->
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="$(SystemReflectionMetadataLoadContextVersion)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -262,10 +262,6 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>a070c5f4d82e5232937595e2b6db9a9ba2d90a05</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="8.0.0">
-      <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>e4ede9b8979b9d2b1b1d4383f30a791414f0625b</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="9.0.0-preview.3.24126.9">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>6a8083a9c4a6f28c21c8564e08d56bbe48e6b16b</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -163,10 +163,6 @@
     <!-- Dependencies from https://github.com/dotnet/wpf -->
     <MicrosoftNETSdkWindowsDesktopPackageVersion>9.0.0-preview.3.24126.3</MicrosoftNETSdkWindowsDesktopPackageVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- Dependencies from https://github.com/dotnet/winforms -->
-    <SystemDrawingCommonPackageVersion>8.0.0</SystemDrawingCommonPackageVersion>
-  </PropertyGroup>
   <PropertyGroup Label="Manually updated">
     <!-- Dependencies from https://github.com/microsoft/MSBuildLocator -->
     <MicrosoftBuildLocatorPackageVersion>1.6.10</MicrosoftBuildLocatorPackageVersion>


### PR DESCRIPTION
## Summary

I'm told this was added as part of the [transitive pinning PR](https://github.com/dotnet/sdk/pull/34387). However, I'm also told that this was because of MSBuild having some kind of legacy dependency on it, but that is no longer the case. So, let's remove it.

CC @marcpopMSFT 