### PR TITLE
Disable package aliasing tests

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -190,6 +190,7 @@ jobs:
            log/$(_BuildConfig)/**/*	
            TestResults/$(_BuildConfig)/**/*	
            SymStore/$(_BuildConfig)/**/*
+           tmp/$(_BuildConfig)/**/*.binlog
           TargetFolder: '$(Build.ArtifactStagingDirectory)'	
         continueOnError: true	
         condition: always()
@@ -321,6 +322,7 @@ jobs:
               log/$(_BuildConfig)/**/*	
               TestResults/$(_BuildConfig)/**/*	
               SymStore/$(_BuildConfig)/**/*
+              tmp/$(_BuildConfig)/**/*.binlog
             TargetFolder: '$(Build.ArtifactStagingDirectory)'	
           continueOnError: true	
           condition: always()
@@ -463,6 +465,7 @@ jobs:
            log/$(_BuildConfig)/**/*	
            TestResults/$(_BuildConfig)/**/*	
            SymStore/$(_BuildConfig)/**/*
+           tmp/$(_BuildConfig)/**/*.binlog
           TargetFolder: '$(Build.ArtifactStagingDirectory)'	
         continueOnError: true	
         condition: always()

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Build.Tests
         public GivenThatWeHaveAPackageReferenceWithAliases(ITestOutputHelper log) : base(log)
         { }
 
-        [RequiresMSBuildVersionFact("16.8.0")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/39172")]
         public void CanBuildProjectWithPackageReferencesWithConflictingTypes()
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;
@@ -50,7 +50,7 @@ namespace Microsoft.NET.Build.Tests
                 .Pass();
         }
 
-        [RequiresMSBuildVersionFact("16.8.0")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/39172")]
         public void CanBuildProjectWithMultiplePackageReferencesWithAliases()
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;
@@ -95,7 +95,7 @@ namespace Microsoft.NET.Build.Tests
                 .Pass();
         }
 
-        [RequiresMSBuildVersionFact("16.8.0")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/39172")]
         public void CanBuildProjectWithAPackageReferenceWithMultipleAliases()
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
@@ -43,8 +43,9 @@ namespace Microsoft.NET.Build.Tests
             sources.AddRange(packagesPaths);
             NuGetConfigWriter.Write(testAsset.TestRoot, sources);
 
-            var buildCommand = new BuildCommand(testAsset);
-            buildCommand.Execute()
+            var buildCommand = new BuildCommand(testAsset)
+                .WithWorkingDirectory(testAsset.Path);
+            buildCommand.Execute("-bl")
                 .Should()
                 .Pass();
         }
@@ -87,8 +88,9 @@ namespace Microsoft.NET.Build.Tests
             List<string> sources = new() { NuGetConfigWriter.DotnetCoreBlobFeed, Path.GetDirectoryName(packageReferenceA.NupkgPath), Path.GetDirectoryName(packageReferenceB.NupkgPath) };
             NuGetConfigWriter.Write(testAsset.TestRoot, sources);
 
-            var buildCommand = new BuildCommand(testAsset);
-            buildCommand.Execute()
+            var buildCommand = new BuildCommand(testAsset)
+                .WithWorkingDirectory(testAsset.Path);
+            buildCommand.Execute("-bl")
                 .Should()
                 .Pass();
         }
@@ -123,8 +125,9 @@ namespace Microsoft.NET.Build.Tests
             List<string> sources = new() { NuGetConfigWriter.DotnetCoreBlobFeed, Path.GetDirectoryName(packageReferenceA.NupkgPath) };
             NuGetConfigWriter.Write(testAsset.TestRoot, sources);
 
-            var buildCommand = new BuildCommand(testAsset);
-            buildCommand.Execute()
+            var buildCommand = new BuildCommand(testAsset)
+                .WithWorkingDirectory(testAsset.Path);            
+            buildCommand.Execute("-bl")
                 .Should()
                 .Pass();
         }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NET.Build.Tests
         public void CanBuildProjectWithPackageReferencesWithConflictingTypes()
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;
-            var packageReferences = GetPackageReferencesWithConflictingTypes(targetFramework, packageNames: new string[] { "A", "B" });
+            var packageReferences = GetPackageReferencesWithConflictingTypes(targetFramework, packageNames: new string[] { "ConflictingA", "ConflictingB" });
 
             TestProject testProject = new()
             {
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Build.Tests
                 .Pass();
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/38268")]
+        [RequiresMSBuildVersionFact("16.8.0")]
         public void CanBuildProjectWithMultiplePackageReferencesWithAliases()
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;
@@ -98,7 +98,7 @@ namespace Microsoft.NET.Build.Tests
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;
 
-            var packageReferenceA = GetPackageReference(targetFramework, "A", ClassLibMultipleClasses);
+            var packageReferenceA = GetPackageReference(targetFramework, "MultipleClasses", ClassLibMultipleClasses);
 
             TestProject testProject = new()
             {


### PR DESCRIPTION
The tests in `GivenThatWeHaveAPackageReferenceWithAliases` have started failing somewhat consistently in CI.  I haven't been able to reproduce the issue locally.  The failures look something like this:

```
/private/tmp/helix/working/B27409DB/w/A434093A/e/testExecutionDirectory/CanBuildProje---B79B2BCA/Project/Project.cs(9,13): error CS0118: 'First.A' is a namespace but is used like a type [/private/tmp/helix/working/B27409DB/w/A434093A/e/testExecutionDirectory/CanBuildProje---B79B2BCA/Project/Project.csproj]
/private/tmp/helix/working/B27409DB/w/A434093A/e/testExecutionDirectory/CanBuildProje---B79B2BCA/Project/Project.cs(10,20): error CS0234: The type or namespace name 'B' does not exist in the namespace '<global namespace>' (are you missing an assembly reference?) [/private/tmp/helix/working/B27409DB/w/A434093A/e/testExecutionDirectory/CanBuildProje---B79B2BCA/Project/Project.csproj]
```

This seems like it's probably a test issue, perhaps related to the fact that these tests create and then consume NuGet packages within the test.  Because of this, I am going to disable these tests for now.  To further investigate, we probably need to figure out how to get a binlog of the failures in Helix.