### PR TITLE
Hide workload update message Fixes #37520

### DIFF
--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Tools
             userProfileDir = CliFolderPathCalculator.DotnetUserProfileFolderPath;
             Task.Run(() => WorkloadManifestUpdater.BackgroundUpdateAdvertisingManifestsAsync(userProfileDir));
             SeparateRestoreCommand = GetSeparateRestoreCommand(msbuildArgs, noRestore, msbuildPath);
-            AdvertiseWorkloadUpdates = advertiseWorkloadUpdates ?? msbuildArgs.All(arg => FlagsThatTriggerSilentRestore.All(f => !arg.Contains(f)));
+            AdvertiseWorkloadUpdates = advertiseWorkloadUpdates ?? msbuildArgs.All(arg => FlagsThatTriggerSilentRestore.All(f => !arg.Contains(f, StringComparison.OrdinalIgnoreCase)));
 
             if (!noRestore)
             {

--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -19,13 +19,13 @@ namespace Microsoft.DotNet.Tools
             bool noRestore,
             string msbuildPath = null,
             string userProfileDir = null,
-            bool advertiseWorkloadUpdates = true)
+            bool? advertiseWorkloadUpdates = null)
             : base(GetCommandArguments(msbuildArgs, noRestore), msbuildPath)
         {
             userProfileDir = CliFolderPathCalculator.DotnetUserProfileFolderPath;
             Task.Run(() => WorkloadManifestUpdater.BackgroundUpdateAdvertisingManifestsAsync(userProfileDir));
             SeparateRestoreCommand = GetSeparateRestoreCommand(msbuildArgs, noRestore, msbuildPath);
-            AdvertiseWorkloadUpdates = advertiseWorkloadUpdates;
+            AdvertiseWorkloadUpdates = advertiseWorkloadUpdates ?? msbuildArgs.All(arg => FlagsThatTriggerSilentRestore.All(f => !arg.Contains(f)));
 
             if (!noRestore)
             {


### PR DESCRIPTION
Fixes #37520

This is based on https://github.com/dotnet/sdk/pull/38956, though the only important part from that PR is a list of the "flags that trigger a silent restore." If any of those flags are specified, we shouldn't be sending a workload update message, so I disable it if any of them are specified.

I was able to reproduce this issue pretty easily using the provided repro. I then introduced ad81a6674793b469bf71cb93833d51388392e7d0 and tried again, and it no longer reproduced.