### PR TITLE
make globalized, AOT apps no longer require nightly

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
@@ -81,7 +81,7 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
     private bool IsMuslRid => TargetRuntimeIdentifier.StartsWith("linux-musl", StringComparison.Ordinal);
     private bool IsBundledRuntime => IsSelfContained;
 
-    // as of this writing, the -extra images are on stable MCR, but the -aot images are still on nightly. This means AOT, invariant apps need the /nightly/ base.
+    // as of March 2024, the -extra images are on stable MCR, but the -aot images are still on nightly. This means AOT, invariant apps need the /nightly/ base.
     private bool NeedsNightlyImages => IsAotPublished && UsesInvariantGlobalization;
     private bool AllowsExperimentalTagInference => String.IsNullOrEmpty(ContainerFamily);
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
@@ -80,7 +80,9 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
 
     private bool IsMuslRid => TargetRuntimeIdentifier.StartsWith("linux-musl", StringComparison.Ordinal);
     private bool IsBundledRuntime => IsSelfContained;
-    private bool NeedsNightlyImages => IsAotPublished;
+
+    // as of this writing, the -extra images are on stable MCR, but the -aot images are still on nightly. This means AOT, invariant apps need the /nightly/ base.
+    private bool NeedsNightlyImages => IsAotPublished && UsesInvariantGlobalization;
     private bool AllowsExperimentalTagInference => String.IsNullOrEmpty(ContainerFamily);
 
     public ComputeDotnetBaseImageAndTag()

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -295,8 +295,8 @@ public class TargetsTests
         computedBaseImageTag.Should().BeEquivalentTo(expectedImage);
     }
 
-    [InlineData("linux-musl-x64", "mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-alpine-extra")]
-    [InlineData("linux-x64", "mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-extra")]
+    [InlineData("linux-musl-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine-extra")]
+    [InlineData("linux-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra")]
     [Theory]
     public void AOTAppsWithCulturesGetExtraImages(string rid, string expectedImage)
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/555

The `-extra` images for AOT'd, Globalized applications are now available in the stable [`dotnet/runtime-deps`](https://mcr.microsoft.com/en-us/product/dotnet/runtime-deps/tags) repository, instead of requiring the [`dotnet/nightly/runtime-deps`](https://mcr.microsoft.com/en-us/product/dotnet/nightly/runtime-deps/tags) repository. This change updates the SDK to point to those.  We should backport this to 8.0.2xx and 8.0.1xx as well once merged, to migrate users to the stabilized locations for these features.

Users have expressed confusion about the `/nightly/` in the past, and this is one step towards eliminating that confusion.