### PR TITLE
Set UseAppHost=false in containerize.csproj

### DIFF
--- a/src/Containers/containerize/containerize.csproj
+++ b/src/Containers/containerize/containerize.csproj
@@ -8,6 +8,7 @@
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
     <SignAssembly>true</SignAssembly>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This tool doesn't need an apphost, it is always called from within a dotnet context.

Fixes https://github.com/dotnet/sdk/issues/39289

I noticed this while looking at differences between the current SDK (which is built on Windows) and the VMR-built SDK (which is built on the native host).