### PR TITLE
Make sure package search exits with 1 or 0 in the SDK side

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-package/search/PackageSearchCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-package/search/PackageSearchCommandParser.cs
@@ -98,11 +98,6 @@ namespace Microsoft.DotNet.Cli
                     parseResult.ShowHelp();
                 }
 
-                if (exitCode == 1)
-                {
-                    parseResult.ShowHelp();
-                }
-
                 if (exitCode != 0)
                 {
                     return 1;

--- a/src/Cli/dotnet/commands/dotnet-package/search/PackageSearchCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-package/search/PackageSearchCommandParser.cs
@@ -97,6 +97,18 @@ namespace Microsoft.DotNet.Cli
                 {
                     parseResult.ShowHelp();
                 }
+
+                if (exitCode == 1)
+                {
+                    parseResult.ShowHelp();
+                }
+
+                if (exitCode != 0)
+                {
+                    return 1;
+                }
+
+                return 0;
             });
 
             return searchCommand;

--- a/src/Cli/dotnet/commands/dotnet-package/search/PackageSearchCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-package/search/PackageSearchCommandParser.cs
@@ -97,13 +97,8 @@ namespace Microsoft.DotNet.Cli
                 {
                     parseResult.ShowHelp();
                 }
-
-                if (exitCode != 0)
-                {
-                    return 1;
-                }
-
-                return 0;
+                // Only return 1 or 0
+                return exitCode == 0 ? 0 : 1;
             });
 
             return searchCommand;


### PR DESCRIPTION
The NuGet side exits with
1 - if help output is required
2- if no help output is required but there was an error
0 - if success

This makes sure the SDK exits with 1 for the first two scenarios and 0 otherwise.
Related PR : https://github.com/NuGet/NuGet.Client/pull/5638
Related issue: https://github.com/NuGet/Home/issues/13161
