### PR TITLE
Only include containerize.csproj and net472 tasks on Windows SDK layouts

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -217,7 +217,7 @@
       Targets="Publish"
       Projects="$(RepoRoot)/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj"
       Properties="Configuration=$(Configuration);PublishDir=$(OutputPath)/Containers/tasks/net472;TargetFramework=net472"
-      Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+      Condition="'$(OSName)' == 'win'" />
     <MSBuild
       Targets="Publish"
       Projects="$(RepoRoot)/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj"
@@ -226,7 +226,7 @@
       Targets="Publish"
       Projects="$(RepoRoot)/src/Containers/containerize/containerize.csproj"
       Properties="Configuration=$(Configuration);PublishDir=$(OutputPath)/Containers/containerize"
-      Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+      Condition="'$(OSName)' == 'win'" />
   </Target>
 
   <Target Name="GenerateCliRuntimeConfigurationFiles"


### PR DESCRIPTION
We excluded them on source-build but they aren't useful on non-Windows platforms in general.
Alternative to https://github.com/dotnet/installer/pull/16764