### PR TITLE
Remove unnecessary RemoveMSDiaTypeLib target from GenerateLayout.targets

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -395,14 +395,6 @@
                                    AssetPath="%(NuPkgContentForMSBuildExtensionsRelativePaths.Identity)" />
   </Target>
 
-  <!-- The msdia140typelib_clr0200.dll file is not MIT licensed (and it only used on Windows). Remove it, so
-       we can MIT license the published dotnet -->
-  <Target Name="RemoveMSDiaTypeLib"
-          AfterTargets="Build"
-          Condition="'$(OSName)' != 'win'">
-    <Delete Files="$(OutputPath)/TestHost/msdia140typelib_clr0200.dll" />
-  </Target>
-
   <Target Name="PublishSdks"
           AfterTargets="Build">
     <ItemGroup>

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -480,7 +480,6 @@
                             MakeFscRunnableAndMoveToPublishDir;
                             RemoveFscFilesAfterPublish;
                             PublishTargetExtensions;
-                            RemoveMSDiaTypeLib;
                             PublishSdks;
                             ChmodPublishDir;
                             DeleteSymbolsFromPublishDir;


### PR DESCRIPTION
The msdia140typelib_clr0200.dll was removed from vstest in https://github.com/microsoft/vstest/pull/3822

This actually never worked in the Microsoft build (because we're building the SDK layout on Windows) and we shipped the binary in the non-Windows SDKs.