### PR TITLE
Update TestAsTool builds to use 1ES pools

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -122,10 +122,11 @@ stages:
         agentOs: Windows_NT_TestAsTools
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            vmImage: 'windows-2019'
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals 1es-windows-2022-open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2019.amd64
+            demands: ImageOverride -equals 1es-windows-2022
         strategy:
           matrix:
             Build_Debug:


### PR DESCRIPTION
## Summary

With the efforts of merging both the [dotnet/format repo](https://github.com/dotnet/sdk/pull/38857) and the [dotnet/installer repo](https://github.com/dotnet/sdk/pull/38804) into this repo, the TestAsTools build was running into out-of-space issues. This is because it was using the default AzDO build pool to run. This PR updates the TestAsTools build to use the latest public and internal agent pools that the rest of our build jobs utilize.