### PR TITLE
Enhance base image inference for trimmed applications - use -extras when globalization is in use

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
@@ -36,6 +36,7 @@ internal static class KnownStrings
         public static readonly string ContainerRuntimeIdentifier = nameof(ContainerRuntimeIdentifier);
         public static readonly string RuntimeIdentifier = nameof(RuntimeIdentifier);
         public static readonly string PublishAot = nameof(PublishAot);
+        public static readonly string PublishTrimmed = nameof(PublishTrimmed);
         public static readonly string PublishSelfContained = nameof(PublishSelfContained);
         public static readonly string InvariantGlobalization = nameof(InvariantGlobalization);
     }
@@ -52,7 +53,7 @@ internal static class KnownStrings
         public static readonly string CONTAINER1011 = nameof(CONTAINER1011);
         public static readonly string CONTAINER1012 = nameof(CONTAINER1012);
         public static readonly string CONTAINER1013 = nameof(CONTAINER1013);
-        
+
         public static readonly string CONTAINER2005 = nameof(CONTAINER2005);
         public static readonly string CONTAINER2007 = nameof(CONTAINER2007);
         public static readonly string CONTAINER2008 = nameof(CONTAINER2008);

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -110,6 +110,8 @@ Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.FrameworkRefer
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.FrameworkReferences.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsAotPublished.get -> bool
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsAotPublished.set -> void
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsTrimmed.get -> bool
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsTrimmed.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsSelfContained.get -> bool
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsSelfContained.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetRuntimeIdentifier.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -7,6 +7,8 @@ Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.FrameworkRefer
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.FrameworkReferences.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsAotPublished.get -> bool
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsAotPublished.set -> void
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsTrimmed.get -> bool
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsTrimmed.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsSelfContained.get -> bool
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsSelfContained.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetRuntimeIdentifier.get -> string!

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -49,6 +49,7 @@
       FrameworkReferences="@(FrameworkReference)"
       IsSelfContained="$(_ContainerIsSelfContained)"
       IsAotPublished="$(PublishAot)"
+      IsTrimmed="$(PublishTrimmed)"
       UsesInvariantGlobalization="$(InvariantGlobalization)"
       TargetRuntimeIdentifier="$(ContainerRuntimeIdentifier)"
       ContainerFamily="$(ContainerFamily)">

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
@@ -41,6 +41,7 @@ public sealed class ProjectInitializer
         props["TargetFileName"] = "foo.dll";
         props["AssemblyName"] = "foo";
         props["TargetFrameworkVersion"] = "v7.0";
+
         props["TargetFrameworkIdentifier"] = ".NETCoreApp";
         props["TargetFramework"] = "net7.0";
         props["_NativeExecutableExtension"] = ".exe"; //TODO: windows/unix split here


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/556 - a gap where we were leaning hard into AOT apps, not just trimmed.
Also fixes https://github.com/dotnet/sdk-container-builds/issues/533 - the runtime and aspnet base images support -extra now as well.