### PR TITLE
[wasm] Move `GenerateJSModuleManifest` from pack to sdk

### DIFF
--- a/src/WasmSdk/Sdk/Sdk.props
+++ b/src/WasmSdk/Sdk/Sdk.props
@@ -22,6 +22,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Disable accelerated builds in Visual Studio as the Wasm SDK needs to post process the outputs from the build and the feature won't work as expected. -->
     <AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
 
+    <!-- JS Modules - We disable the manifest generation because we are going to inline the modules in the blazor.boot.json manifest -->
+    <GenerateJSModuleManifest>false</GenerateJSModuleManifest>
+
     <_WasmSdkImportsMicrosoftNETSdkPublish Condition="'$(UsingMicrosoftNETSdkPublish)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkPublish>
     <_WasmSdkImportsMicrosoftNETSdkStaticWebAssets Condition="'$(UsingMicrosoftNETSdkStaticWebAssets)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkStaticWebAssets>
   </PropertyGroup>


### PR DESCRIPTION
Move `GenerateJSModuleManifest=false` from pack to SDK so that SWA SDK gets the correct value during evaluation

Contributes to https://github.com/dotnet/runtime/issues/99491