### PR TITLE
Use built-in SourceRevisionId instead of git rev-parse HEAD

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -19,14 +19,14 @@
           BeforeTargets="Build">
 
     <WriteLinesToFile File="$(OutputPath)/.toolsetversion"
-                      Lines="$(GitCommitHash);$(Version);$(Rid)"
+                      Lines="$(SourceRevisionId);$(Version);$(Rid)"
                       Overwrite="true" />
 
     <!-- The .version file in the final product will be the .NET Core SDK version.  But
          for the layout we produce here, use the toolset information, so that we don't
          just always use the stage 0 version. -->
     <WriteLinesToFile File="$(OutputPath)/.version"
-                      Lines="$(GitCommitHash);$(Version);$(Rid)"
+                      Lines="$(SourceRevisionId);$(Version);$(Rid)"
                       Overwrite="true" />
 
 	<!-- Development env and CI loads DotnetFiles type from the following location

--- a/src/Layout/redist/targets/GetRuntimeInformation.targets
+++ b/src/Layout/redist/targets/GetRuntimeInformation.targets
@@ -1,6 +1,5 @@
 <Project>
   <Target Name="GetCurrentRuntimeInformation"
-          DependsOnTargets="GetCoreSdkGitCommitInfo"
           BeforeTargets="Build">
 
     <PropertyGroup>

--- a/src/Layout/redist/targets/Version.targets
+++ b/src/Layout/redist/targets/Version.targets
@@ -1,12 +1,4 @@
 <Project>
-  <Target Name="GetCoreSdkGitCommitInfo">
-    <Exec Command="git rev-parse HEAD"
-          ConsoleToMSBuild="true"
-          Condition=" '$(GitCommitHash)' == '' ">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitHash" />
-    </Exec>
-  </Target>
-
   <PropertyGroup>
     <ArtifactNameSdk>dotnet-toolset-internal</ArtifactNameSdk>
     <ArtifactNameSdkLanguagePack>dotnet-toolset-langpack</ArtifactNameSdkLanguagePack>


### PR DESCRIPTION
With .NET 8, Source Link is included in the SDK. It defines the `SourceRevisionId` property for us, and that property already contains the git commit hash. So lets use that instead of trying to compute it via `git rev-parse HEAD`.

This should not affect source-build mode of the VMR using a tarball. source-build writes the minimal git repository metadata [1] to disk, and that's enough for Source Link to set up `SourceRevisionId` correctly.

[1] https://github.com/dotnet/sourcelink/tree/main/docs#minimal-git-repository-metadata