### PR TITLE
Use Ubuntu 24.04 Noble Numbat images by default starting in 8.0.300

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -289,6 +289,9 @@ public class TargetsTests
     [InlineData("8.0.100-preview.2", "v8.0", "jammy-chiseled", "8.0.0-preview.2-jammy-chiseled")]
     [InlineData("8.0.100-rc.2", "v8.0", "jammy-chiseled", "8.0.0-rc.2-jammy-chiseled")]
     [InlineData("8.0.100", "v8.0", "jammy-chiseled", "8.0-jammy-chiseled-extra")]
+    [InlineData("8.0.200", "v8.0", "jammy-chiseled", "8.0-jammy-chiseled-extra")]
+    [InlineData("8.0.300", "v8.0", "noble-chiseled", "8.0-noble-chiseled-extra")]
+    [InlineData("8.0.300", "v8.0", "jammy-chiseled", "8.0-jammy-chiseled-extra")]
     [Theory]
     public void CanTakeContainerBaseFamilyIntoAccount(string sdkVersion, string tfmMajMin, string containerFamily, string expectedTag)
     {
@@ -349,13 +352,13 @@ public class TargetsTests
     }
 
     [InlineData("linux-musl-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine-extra")]
-    [InlineData("linux-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra")]
+    [InlineData("linux-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled-extra")]
     [Theory]
     public void AOTAppsWithCulturesGetExtraImages(string rid, string expectedImage)
     {
         var (project, logger, d) = ProjectInitializer.InitProject(new()
         {
-            ["NetCoreSdkVersion"] = "8.0.100",
+            ["NetCoreSdkVersion"] = "8.0.300",
             ["TargetFrameworkVersion"] = "v8.0",
             [KnownStrings.Properties.ContainerRuntimeIdentifier] = rid,
             [KnownStrings.Properties.PublishSelfContained] = true.ToString(),
@@ -370,13 +373,13 @@ public class TargetsTests
     }
 
     [InlineData("linux-musl-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine-extra")]
-    [InlineData("linux-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra")]
+    [InlineData("linux-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled-extra")]
     [Theory]
     public void TrimmedAppsWithCulturesGetExtraImages(string rid, string expectedImage)
     {
         var (project, logger, d) = ProjectInitializer.InitProject(new()
         {
-            ["NetCoreSdkVersion"] = "8.0.100",
+            ["NetCoreSdkVersion"] = "8.0.300",
             ["TargetFrameworkVersion"] = "v8.0",
             [KnownStrings.Properties.ContainerRuntimeIdentifier] = rid,
             [KnownStrings.Properties.PublishSelfContained] = true.ToString(),
@@ -391,13 +394,13 @@ public class TargetsTests
     }
 
     [InlineData("linux-musl-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine")]
-    [InlineData("linux-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled")]
+    [InlineData("linux-x64", "mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled")]
     [Theory]
     public void TrimmedAppsWithoutCulturesGetbaseImages(string rid, string expectedImage)
     {
         var (project, logger, d) = ProjectInitializer.InitProject(new()
         {
-            ["NetCoreSdkVersion"] = "8.0.100",
+            ["NetCoreSdkVersion"] = "8.0.300",
             ["TargetFrameworkVersion"] = "v8.0",
             [KnownStrings.Properties.ContainerRuntimeIdentifier] = rid,
             [KnownStrings.Properties.PublishSelfContained] = true.ToString(),
@@ -416,16 +419,16 @@ public class TargetsTests
     [InlineData(false, true, "linux-musl-x64", true, "mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-alpine-aot")]
     [InlineData(false, true, "linux-musl-x64", false, "mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine-extra")]
 
-    [InlineData(true, false, "linux-x64", true, "mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled")]
-    [InlineData(true, false, "linux-x64", false, "mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra")]
-    [InlineData(false, true, "linux-x64", true, "mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-aot")]
-    [InlineData(false, true, "linux-x64", false, "mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra")]
+    [InlineData(true, false, "linux-x64", true, "mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled")]
+    [InlineData(true, false, "linux-x64", false, "mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled-extra")]
+    [InlineData(false, true, "linux-x64", true, "mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-noble-chiseled-aot")]
+    [InlineData(false, true, "linux-x64", false, "mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled-extra")]
     [Theory]
     public void TheBigMatrixOfTrimmingInference(bool trimmed, bool aot, string rid, bool invariant, string expectedImage)
     {
         var (project, logger, d) = ProjectInitializer.InitProject(new()
         {
-            ["NetCoreSdkVersion"] = "8.0.100",
+            ["NetCoreSdkVersion"] = "8.0.300",
             ["TargetFrameworkVersion"] = "v8.0",
             [KnownStrings.Properties.ContainerRuntimeIdentifier] = rid,
             [KnownStrings.Properties.PublishSelfContained] = true.ToString(),


### PR DESCRIPTION
## Description

This changes container base image inference to bias towards Ubuntu 24.04 Noble Numbat instead of 22.04 Jammy Jellyfish. This is a change that would have been merged pre-M2-mode, but it relies on the noble .NET base images being available before end-to-end testing is possible, which will only happen later in April.

Fixes https://github.com/dotnet/sdk-container-builds/issues/557.

## Customer Impact

Customers will get `noble` base images for Trimmed/AOT applications where before they would get `jammy` base images.
Customers as always will be able to explicitly specify jammy base images, sidestepping inference to varying degrees.

## Regression

**No** - this is a new feature that is just hard to test until late in the release cycle.

## Risk

**Low**, we have great test coverage over inference and Ubuntu releases are generally quite stable. In addition, users can revert to jammy quite easily with

```xml
<PropertyGroup>
  <ContainerFamily>jammy-chiseled</ContainerFamily>
</PropertyGroup>
```
or `-p ContainerFamily=jammy-chiseled` on the command line.

## Testing

Automated tests verify that we do not regress the inference for older SDKs, and that user-specified ContainerFamily are respected.

NOTE: We should not merge this until https://github.com/dotnet/dotnet-docker/pull/5241 is merged and noble images are published by the docker tools team.

